### PR TITLE
Downgrading Flame support to stable channel (1.5.4-hotfix.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## next
+- Downgrading flame support to stable channel.
+
 ## 0.12.2
 - Added more functionality to the Position class (thanks, @illiapoplawski)
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ And start using it!
 
 __Important__
 
-We strive to keep Flame working on the Flutter's dev channel, currently on version 1.6.1, be sure to check which channel are you using if you encounter any trouble.
+We strive to keep Flame working on the Flutter's stable channel, currently on version 1.5.4-hotfix.2, be sure to check which channel are you using if you encounter any trouble.
 
 ## Documentation
 

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -23,7 +23,7 @@ class Svg {
     }
 
     svgRoot.scaleCanvasToViewBox(canvas, Size(width, height));
-    svgRoot.draw(canvas, null, null);
+    svgRoot.draw(canvas, null);
   }
 
   /// Renders the svg on the [canvas] on the given [position] using the dimmensions provided on [width] and [height]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,12 +17,8 @@ dependencies:
   synchronized: ^2.1.0
   tiled: ^0.2.1
   convert: ^2.0.1
-  flutter_svg: ^0.13.0+1
-  flare_flutter:
-    git:
-      url: git://github.com/2d-inc/Flare-Flutter.git
-      ref: dev
-      path: flare_flutter
+  flutter_svg: ^0.11.0
+  flare_flutter: ^1.5.0
 
 dev_dependencies:
   flutter_test:
@@ -31,4 +27,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.2.0 <3.0.0"
-  flutter: ">=1.6.0 <2.0.0"
+  flutter: ">=1.5.0 <1.6.0"


### PR DESCRIPTION
Both svg and flare examples worked like a charm.