### PR TITLE
Updating Flame to support last stable version (1.7.8+hotfix.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ And start using it!
 
 __Important__
 
-We strive to keep Flame working on the Flutter's stable channel, currently on version 1.5.4-hotfix.2, be sure to check which channel are you using if you encounter any trouble.
+We strive to keep Flame working on the Flutter's stable channel, currently on version v1.7.8+hotfix.2, be sure to check which channel are you using if you encounter any trouble.
 
 ## Documentation
 

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -23,7 +23,7 @@ class Svg {
     }
 
     svgRoot.scaleCanvasToViewBox(canvas, Size(width, height));
-    svgRoot.draw(canvas, null);
+    svgRoot.draw(canvas, null, null);
   }
 
   /// Renders the svg on the [canvas] on the given [position] using the dimmensions provided on [width] and [height]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   tiled: ^0.2.1
   convert: ^2.0.1
   flutter_svg: ^0.13.0+2
-  flare_flutter: ^1.5.3
+  flare_flutter: ^1.5.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,8 +17,8 @@ dependencies:
   synchronized: ^2.1.0
   tiled: ^0.2.1
   convert: ^2.0.1
-  flutter_svg: ^0.11.0
-  flare_flutter: ^1.5.0
+  flutter_svg: ^0.13.0+2
+  flare_flutter: ^1.5.3
 
 dev_dependencies:
   flutter_test:
@@ -27,4 +27,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.2.0 <3.0.0"
-  flutter: ">=1.5.0 <1.6.0"
+  flutter: ">=1.6.0"


### PR DESCRIPTION
This PR updates Flame to work with the latest Flutter stable version.