### PR TITLE
Adding a simple doc for box2d on Flame

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -13,3 +13,4 @@ This is the index of the documentation for Flame, updated to version `0.8.3`.
 * [The Game Loop](game.md)
 * [Input](input.md)
 * [Util](util.md)
+* [Box2d](box2d.md)

--- a/doc/box2d.md
+++ b/doc/box2d.md
@@ -1,0 +1,7 @@
+# Box2d
+
+Altough Flame does not implements Box2d itself, it bundles a forked port of the Java Box2d to Dart by Google.
+
+The source of the bundled box2d on Flame can be found [here](https://github.com/feroult/box2d.dart).
+
+There is also a simple example game that can be used as reference of how to use box2d on Flame [here](https://github.com/feroult/haunt).


### PR DESCRIPTION
This may not be the optimal documentation for box2d, but it tries to at least fill the gap of no Docs at all.

Solves #47 