### PR TITLE
AnimationComponent.empty was breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next
 - Refactoring BaseGame debugMode
 - Adding SpriteSheet class
+- Fixing AnimationComponent.empty()
 
 ## 0.14.1
 - Fixed build on travis

--- a/lib/components/animation_component.dart
+++ b/lib/components/animation_component.dart
@@ -5,7 +5,7 @@ import 'package:flame/animation.dart';
 
 class AnimationComponent extends PositionComponent {
   Animation animation;
-  bool destroyOnFinish;
+  bool destroyOnFinish = false;
 
   AnimationComponent(double width, double height, this.animation,
       {this.destroyOnFinish = false}) {


### PR DESCRIPTION
Apparently the new `destroyOnFinish` flag was breaking when an `AnimationComponent` was created by the `empty` constructor.