### PR TITLE
Adding override paint method to Sprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next
 - Refactoring ParallaxComponent (thanks @spydon)
 - Fixing flare animation with embed images
+- Adding override paint parameter to Sprite, and refactoring it have named optional parameters
 
 ## 0.14.2
 - Refactoring BaseGame debugMode

--- a/doc/images.md
+++ b/doc/images.md
@@ -39,6 +39,8 @@ You must pass the size to the render method, and the image will be resized accor
 
 The render method will do nothing while the sprite has not been loaded, so you don't need to worry. The image is cached in the `Images` class, so you can safely create many sprites with the same fileName.
 
+All render methods from the Sprite class can receive a `Paint` instance on the optional named parameter `overridePaint` that parameter will override the current `Sprite` paint instance for that render call.
+
 Sprites can also be used as widgets, to do so, just use `Flame.util.spriteAsWidget`
 
 A complete example of using sprite as widegets can be found [here](examples/animation_widget).

--- a/lib/components/animation_component.dart
+++ b/lib/components/animation_component.dart
@@ -47,7 +47,7 @@ class AnimationComponent extends PositionComponent {
   @override
   void render(Canvas canvas) {
     prepareCanvas(canvas);
-    animation.getSprite().render(canvas, width, height);
+    animation.getSprite().render(canvas, width: width, height: height);
   }
 
   @override

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -156,7 +156,7 @@ class SpriteComponent extends PositionComponent {
   @override
   void render(Canvas canvas) {
     prepareCanvas(canvas);
-    sprite.render(canvas, width, height);
+    sprite.render(canvas, width: width, height: height);
   }
 
   @override

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -78,47 +78,53 @@ class Sprite {
   /// It renders with src size multiplied by [scale] in both directions.
   /// Anchor is on top left as default.
   /// If not loaded, does nothing.
-  void renderScaled(Canvas canvas, Position p, [double scale = 1.0]) {
+  void renderScaled(Canvas canvas, Position p,
+      [double scale = 1.0, Paint overridePaint]) {
     if (!loaded()) {
       return;
     }
-    renderPosition(canvas, p, size.times(scale));
+    renderPosition(canvas, p, size.times(scale), overridePaint);
   }
 
-  void renderPosition(Canvas canvas, Position p, [Position size]) {
+  void renderPosition(Canvas canvas, Position p,
+      [Position size, Paint overridePaint]) {
     if (!loaded()) {
       return;
     }
     size ??= this.size;
-    renderRect(canvas, Position.rectFrom(p, size));
+    renderRect(canvas, Position.rectFrom(p, size), overridePaint);
   }
 
-  void render(Canvas canvas, [double width, double height]) {
+  void render(Canvas canvas,
+      [double width, double height, Paint overridePaint]) {
     if (!loaded()) {
       return;
     }
     width ??= size.x;
     height ??= size.y;
-    renderRect(canvas, Rect.fromLTWH(0.0, 0.0, width, height));
-  }
-
-  void renderRect(Canvas canvas, Rect dst) {
-    if (!loaded()) {
-      return;
-    }
-    canvas.drawImageRect(image, src, dst, paint);
+    renderRect(canvas, Rect.fromLTWH(0.0, 0.0, width, height), overridePaint);
   }
 
   /// Renders this sprite centered in the position [p], i.e., on [p] - [size] / 2.
   ///
   /// If [size] is not provided, the original size of the src image is used.
   /// If the asset is not yet loaded, it does nothing.
-  void renderCentered(Canvas canvas, Position p, [Position size]) {
+  void renderCentered(Canvas canvas, Position p,
+      [Position size, Paint overridePaint]) {
     if (!loaded()) {
       return;
     }
     size ??= this.size;
-    renderRect(canvas,
-        Rect.fromLTWH(p.x - size.x / 2, p.y - size.y / 2, size.x, size.y));
+    renderRect(
+        canvas,
+        Rect.fromLTWH(p.x - size.x / 2, p.y - size.y / 2, size.x, size.y),
+        overridePaint);
+  }
+
+  void renderRect(Canvas canvas, Rect dst, [Paint overridePaint]) {
+    if (!loaded()) {
+      return;
+    }
+    canvas.drawImageRect(image, src, dst, overridePaint ?? paint);
   }
 }

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -79,30 +79,30 @@ class Sprite {
   /// Anchor is on top left as default.
   /// If not loaded, does nothing.
   void renderScaled(Canvas canvas, Position p,
-      [double scale = 1.0, Paint overridePaint]) {
+      {double scale = 1.0, Paint overridePaint}) {
     if (!loaded()) {
       return;
     }
-    renderPosition(canvas, p, size.times(scale), overridePaint);
+    renderPosition(canvas, p, size: size.times(scale), overridePaint: overridePaint);
   }
 
   void renderPosition(Canvas canvas, Position p,
-      [Position size, Paint overridePaint]) {
+      {Position size, Paint overridePaint}) {
     if (!loaded()) {
       return;
     }
     size ??= this.size;
-    renderRect(canvas, Position.rectFrom(p, size), overridePaint);
+    renderRect(canvas, Position.rectFrom(p, size), overridePaint: overridePaint);
   }
 
   void render(Canvas canvas,
-      [double width, double height, Paint overridePaint]) {
+      {double width, double height, Paint overridePaint}) {
     if (!loaded()) {
       return;
     }
     width ??= size.x;
     height ??= size.y;
-    renderRect(canvas, Rect.fromLTWH(0.0, 0.0, width, height), overridePaint);
+    renderRect(canvas, Rect.fromLTWH(0.0, 0.0, width, height), overridePaint: overridePaint);
   }
 
   /// Renders this sprite centered in the position [p], i.e., on [p] - [size] / 2.
@@ -110,7 +110,7 @@ class Sprite {
   /// If [size] is not provided, the original size of the src image is used.
   /// If the asset is not yet loaded, it does nothing.
   void renderCentered(Canvas canvas, Position p,
-      [Position size, Paint overridePaint]) {
+      {Position size, Paint overridePaint}) {
     if (!loaded()) {
       return;
     }
@@ -118,10 +118,10 @@ class Sprite {
     renderRect(
         canvas,
         Rect.fromLTWH(p.x - size.x / 2, p.y - size.y / 2, size.x, size.y),
-        overridePaint);
+        overridePaint: overridePaint);
   }
 
-  void renderRect(Canvas canvas, Rect dst, [Paint overridePaint]) {
+  void renderRect(Canvas canvas, Rect dst, {Paint overridePaint}) {
     if (!loaded()) {
       return;
     }

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -83,7 +83,8 @@ class Sprite {
     if (!loaded()) {
       return;
     }
-    renderPosition(canvas, p, size: size.times(scale), overridePaint: overridePaint);
+    renderPosition(canvas, p,
+        size: size.times(scale), overridePaint: overridePaint);
   }
 
   void renderPosition(Canvas canvas, Position p,
@@ -92,7 +93,8 @@ class Sprite {
       return;
     }
     size ??= this.size;
-    renderRect(canvas, Position.rectFrom(p, size), overridePaint: overridePaint);
+    renderRect(canvas, Position.rectFrom(p, size),
+        overridePaint: overridePaint);
   }
 
   void render(Canvas canvas,
@@ -102,7 +104,8 @@ class Sprite {
     }
     width ??= size.x;
     height ??= size.y;
-    renderRect(canvas, Rect.fromLTWH(0.0, 0.0, width, height), overridePaint: overridePaint);
+    renderRect(canvas, Rect.fromLTWH(0.0, 0.0, width, height),
+        overridePaint: overridePaint);
   }
 
   /// Renders this sprite centered in the position [p], i.e., on [p] - [size] / 2.
@@ -115,8 +118,7 @@ class Sprite {
       return;
     }
     size ??= this.size;
-    renderRect(
-        canvas,
+    renderRect(canvas,
         Rect.fromLTWH(p.x - size.x / 2, p.y - size.y / 2, size.x, size.y),
         overridePaint: overridePaint);
   }

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -106,7 +106,7 @@ class _SpriteCustomPainter extends widgets.CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     if (_sprite.loaded()) {
-      _sprite.render(canvas, size.width, size.height);
+      _sprite.render(canvas, width: size.width, height: size.height);
     }
   }
 


### PR DESCRIPTION
This is a simple PR that adds a new parameter to the renders methods of the Sprite class.

Although the Sprite class already have a paint attribute, sometimes you may want to change it just for a single render, in my opinion having a parameter for that is more convenient than setting the attribute, rendering the sprite and reseting the attribute.

You can see an usage of this need on this feature: https://github.com/fireslime/bounce_box/commit/a638e6f1bfb4722f062dea09e0c8a6c6cd2570a9#diff-d02dcf32571d773232d836d3c98753e1R46

I wanted to use a color filter to make some sprites darker like you can see on the following image:

![Screen Shot 2019-07-24 at 23 11 24](https://user-images.githubusercontent.com/835641/61840693-607ac080-ae68-11e9-80f9-3e47f1f82fc5.png)