### PR TITLE
Remove new keyword from docs examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If you want to load an image and render it on the `Canvas`, you can use the `Spr
 ```dart
     import 'package:flame/sprite.dart';
 
-    Sprite sprite = new Sprite('player.png');
+    Sprite sprite = Sprite('player.png');
 
     // in your render loop
     sprite.render(canvas, width, height);
@@ -179,10 +179,10 @@ The most commonly used implementation, `SpriteComponent`, can be created with a 
     import 'package:flame/components/component.dart';
 
     // on your constructor or init logic
-    Sprite sprite = new Sprite('player.png');
+    Sprite sprite = Sprite('player.png');
 
     const size = 128.0;
-    final player = new SpriteComponent.fromSprite(size, size, sprite); // width, height, sprite
+    final player = SpriteComponent.fromSprite(size, size, sprite); // width, height, sprite
 
     // screen coordinates
     player.x = ... // 0 by default
@@ -224,7 +224,7 @@ To start, just add your game widget directly to your runApp, like so:
 
 ```dart
     main() {
-        Game game = new MyGameImpl();
+        Game game = MyGameImpl();
         runApp(game.widget);
     }
 ```

--- a/doc/animation_widget_article/article.md
+++ b/doc/animation_widget_article/article.md
@@ -82,7 +82,7 @@ Let's you have your `build` method in one of your pages; pretty normal Flutter s
 ```dart
   @override
   Widget build(BuildContext context) {
-    final key = new GlobalKey<ScaffoldState>();
+    final key = GlobalKey<ScaffoldState>();
     return Scaffold(
       key: key,
       appBar: AppBar(

--- a/doc/audio.md
+++ b/doc/audio.md
@@ -14,7 +14,7 @@ Or, if you prefer:
 ```dart
     import 'package:flame/flame_audio.dart';
 
-    FlameAudio audio = new FlameAudio();
+    FlameAudio audio = FlameAudio();
 
     audio.play('explosion.mp3'); // Or
     audio.playLongAudio('music.mp3');

--- a/doc/components.md
+++ b/doc/components.md
@@ -11,10 +11,10 @@ The most commonly used implementation, `SpriteComponent`, can be created with a 
 ```dart
     import 'package:flame/components/component.dart';
 
-    Sprite sprite = new Sprite('player.png');
+    Sprite sprite = Sprite('player.png');
 
     const size = 128.0;
-    var player = new SpriteComponent.fromSprite(size, size, sprite); // width, height, sprite
+    var player = SpriteComponent.fromSprite(size, size, sprite); // width, height, sprite
 
     // screen coordinates
     player.x = ... // 0 by default
@@ -47,13 +47,13 @@ This will create a simple three frame animation
 
 ```dart
     List<Sprite> sprites = [0, 1, 2].map((i) => new Sprite('player_${i}.png')).toList();
-    this.player = new AnimationComponent(64.0, 64.0, new Animation.spriteList(sprites, stepTime: 0.01));
+    this.player = AnimationComponent(64.0, 64.0, new Animation.spriteList(sprites, stepTime: 0.01));
 ```
 
 If you have a sprite sheet, you can use the `sequenced` constructor, identical to the one provided by the `Animation` class (check more details in [the appropriate section](doc/images.md#Animation)):
 
 ```dart
-    this.player = new AnimationComponent.sequenced(64.0, 64.0, 'player.png', 2);
+    this.player = AnimationComponent.sequenced(64.0, 64.0, 'player.png', 2);
 ```
 
 If you are not using `BaseGame`, don't forget this component needs to be update'd even if static, because the animation object needs to be ticked to move the frames.
@@ -125,7 +125,7 @@ This component simulates this effect, making a very realistic background.
 Create it like so:
 
 ```dart
-    this.bg = new ParallaxComponent();
+    this.bg = ParallaxComponent();
     this.bg.load([ 'bg/1.png', 'bg/2.png', 'bg/3.png' ]);
 ```
 

--- a/doc/game.md
+++ b/doc/game.md
@@ -13,7 +13,7 @@ To start, just add your game widget directly to your runApp, like so:
 
 ```dart
     main() {
-        Game game = new MyGameImpl();
+        Game game = MyGameImpl();
         runApp(game.widget);
     }
 ```

--- a/doc/images.md
+++ b/doc/images.md
@@ -15,13 +15,13 @@ You can create a `Sprite` giving it a pre-loaded `Image` via the `fromImage` con
 For example, this will create a sprite representing the whole image of the file passed, automatically triggering its loading:
 
 ```dart
-    Sprite player = new Sprite('player.png');
+    Sprite player = Sprite('player.png');
 ```
 
 You could also specify the coordinates in the original image where the sprite is located; this allows you to use sprite sheets and reduce the number of images in memory; for example:
 
 ```dart
-    Sprite playerFrame = new Sprite('player.png', x = 32.0, width = 16.0);
+    Sprite playerFrame = Sprite('player.png', x = 32.0, width = 16.0);
 ```
 
 The default values are `0.0` for `x` and `y` and `null` for `width` and `height` (meaning it will use the full width/height of the source image).
@@ -29,7 +29,7 @@ The default values are `0.0` for `x` and `y` and `null` for `width` and `height`
 The `Sprite` class has a `loaded` method that returns whether the image has been loaded, and a render method, that allows you to render the image into a `Canvas`:
 
 ```dart
-    Sprite block = new Sprite('block.png');
+    Sprite block = Sprite('block.png');
 
     // in your render method
     block.render(canvas, 16.0, 16.0); //canvas, width, height
@@ -77,8 +77,8 @@ To load and draw an image, you can use the `load` method, like so:
 
     // or
     Flame.images.load('player.png').then((Image image) {
-      var paint = new Paint()..color = new Color(0xffffffff);
-      var rect = new Rect.fromLTWH(0.0, 0.0, image.width.toDouble(), image.height.toDouble());
+      var paint = Paint()..color = Color(0xffffffff);
+      var rect = Rect.fromLTWH(0.0, 0.0, image.width.toDouble(), image.height.toDouble());
       canvas.drawImageRect(image, rect, rect, paint);
     });
 ```
@@ -98,7 +98,7 @@ The Animation class helps you create a cyclic animation of sprites.
 You can create it by passing a list of equal sized sprites and the stepTime (that is, how many seconds it takes to move to the next frame):
 
 ```dart
-  Animation a = new Animation.spriteList(sprites, stepTime: 0.02);
+  Animation a = Animation.spriteList(sprites, stepTime: 0.02);
 ```
 
 After the animation is created, you need to call its `update` method and render the current frame's sprite on your game instance, for example:

--- a/doc/palette.md
+++ b/doc/palette.md
@@ -19,7 +19,7 @@ Some more complex methods might also take a Paint, which is a more complete opti
 You can create such a Paint like so:
 
 ```dart
-  Paint green = new Paint()..color = const Color(0xFF00FF00);
+  Paint green = Paint()..color = const Color(0xFF00FF00);
 ```
 
 To help that and also keep your game's color palette consistent, Flame adds the Palette class. You can use it to both easily access Colors and Paints where needed and also to define as constants the colors your game use, so you don't get those mixed up.


### PR DESCRIPTION
Since Dart 2 the `new` keyword is no longer needed since it is implicit.