### PR TITLE
added missing imports & fixed inheritance in timer examples

### DIFF
--- a/doc/util.md
+++ b/doc/util.md
@@ -111,7 +111,9 @@ class MyGame extends Game {
   }
 
   @override
-  void update(double dt) {}
+  void update(double dt) {
+    interval.update(dt);
+  }
 
   @override
   void render(Canvas canvas) {

--- a/doc/util.md
+++ b/doc/util.md
@@ -55,11 +55,14 @@ Flame provides a simple utility class to help you handle countdowns and event li
 __Countdown example:__
 
 ```dart
-import 'package:flame/game.dart';
-import 'package:flame/time.dart';
-import 'package:flame/text_config.dart';
+import 'dart:ui';
 
-class MyGame extends MyGame {
+import 'package:flame/game.dart';
+import 'package:flame/position.dart';
+import 'package:flame/text_config.dart';
+import 'package:flame/time.dart';
+
+class MyGame extends Game {
   final TextConfig textConfig = TextConfig(color: const Color(0xFFFFFFFF));
   final countdown = Timer(2);
 
@@ -77,7 +80,8 @@ class MyGame extends MyGame {
 
   @override
   void render(Canvas canvas) {
-    textConfig.render(canvas, "Countdown: ${countdown.current.toString()}", Position(10, 100));
+    textConfig.render(canvas, "Countdown: ${countdown.current.toString()}",
+        Position(10, 100));
   }
 }
 
@@ -86,11 +90,14 @@ class MyGame extends MyGame {
 __Interval example:__
 
 ```dart
-import 'package:flame/game.dart';
-import 'package:flame/time.dart';
-import 'package:flame/text_config.dart';
+import 'dart:ui';
 
-class MyGame extends MyGame {
+import 'package:flame/game.dart';
+import 'package:flame/position.dart';
+import 'package:flame/text_config.dart';
+import 'package:flame/time.dart';
+
+class MyGame extends Game {
   final TextConfig textConfig = TextConfig(color: const Color(0xFFFFFFFF));
   Timer interval;
 
@@ -104,8 +111,7 @@ class MyGame extends MyGame {
   }
 
   @override
-  void update(double dt) {
-  }
+  void update(double dt) {}
 
   @override
   void render(Canvas canvas) {


### PR DESCRIPTION
While I was reading the [util documentation](https://github.com/Felithium/flame/blob/master/doc/util.md) I saw an error in the timer examples. In both examples ```MyGame``` extends ```MyGame```, but ```MyGame``` should probably inherit from ```Game```. (or maybe ```BaseGame```?)

```dart
...
class MyGame extends MyGame {
...
```

changed to

```dart
...
class MyGame extends Game {
...
```
<br>

While I was at it I fixed the **imports**. Now the code can by executed right away after copying.
<br>

When you run the **'Interval example'** you will see the following:

<img width="200" src="https://user-images.githubusercontent.com/41200990/68226686-be37b080-fff2-11e9-9db7-55132553130a.jpg">

But nothing is changing. I doubt that is the intended behaviour. Correct me if I am wrong.

**Edit: Fixed it by updating the timer object.**
<br>

When I run the **'Countdown example'** it works as intended but the displayed time does not stop at exactly 2.0 seconds.

<img width="200" src="https://user-images.githubusercontent.com/41200990/68226819-ff2fc500-fff2-11e9-8340-0a0941fd93eb.jpg">

I would not allow the ```current field``` in the ```Timer class``` to exceed the value of the ```limit field``` that is specified in the constructor.

If you agree I could fix that aswell.