### PR TITLE
Adding Component#onMount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [next]
 - Add loop for AnimationComponent.sequenced()
 - TextComponent optimization (thanks @Gericop)
+- Adding Component#onMount
 
 ## 0.18.1
 - Expose stepTime paramter from the Animation class to the animation component

--- a/doc/components.md
+++ b/doc/components.md
@@ -37,6 +37,8 @@ The `destroy` method can be implemented to return true and warn the `BaseGame` t
 
 The `isHUD` method can be implemented to return true (default false) to make the `BaseGame` ignore the `camera` for this element.
 
+The `onMount` method can be overridden to run initializations code for the component, when this method is called, BaseGame has make sure that all the mixin which would change this component behaviour, is already resolved.
+
 There are also other implementations:
 
 * The `AnimationComponent` takes an `Animation` object and renders a cyclic animated sprite (more details about Animations [here](/doc/images.md#Animation))

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:flame/anchor.dart';
 import 'package:flame/components/component.dart';
+import 'package:flame/components/mixins/has_game_ref.dart';
 import 'package:flame/game.dart';
 import 'package:flame/palette.dart';
 import 'package:flutter/material.dart';
@@ -15,13 +16,8 @@ class Palette {
   static const PaletteEntry blue = PaletteEntry(Color(0xFF0000FF));
 }
 
-class Square extends PositionComponent {
+class Square extends PositionComponent with HasGameRef<MyGame> {
   static const SPEED = 0.25;
-
-  Square(double size) {
-    width = height = size;
-    anchor = Anchor.center;
-  }
 
   @override
   void resize(Size size) {
@@ -43,10 +39,18 @@ class Square extends PositionComponent {
     angle += SPEED * t;
     angle %= 2 * math.pi;
   }
+
+  @override
+  void onMount() {
+    width = height = gameRef.squareSize;
+    anchor = Anchor.center;
+  }
 }
 
 class MyGame extends BaseGame {
+  final double squareSize = 128;
+
   MyGame() {
-    add(Square(64.0));
+    add(Square());
   }
 }

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -54,6 +54,12 @@ abstract class Component {
   /// It can be any integer (negative, zero, or positive).
   /// If two components share the same priority, they will probably be drawn in the order they were added.
   int priority() => 0;
+
+  /// Called when the component has been added and preperad by the game instance
+  ///
+  /// This can be used to make initializations on your component as when this method is called
+  /// things like resize, and mixins are already set for the component.
+  void onMount() {}
 }
 
 /// A [Component] implementation that represents a component that has a specific, possibly dynamic position on the screen.

--- a/lib/game/game.dart
+++ b/lib/game/game.dart
@@ -165,6 +165,7 @@ abstract class BaseGame extends Game with TapDetector {
   void add(Component c) {
     preAdd(c);
     components.add(c);
+    c.onMount();
   }
 
   /// Registers a component to be added on the components on the next tick.


### PR DESCRIPTION
This PR adds a simple utility method to enable using things like `gameRef` on components during its initialization.

This can supply for the limitation where you weren't able to use `gameRef` on the component construtor.