### PR TITLE
amend type for width and height property

### DIFF
--- a/lib/components/animation_component.dart
+++ b/lib/components/animation_component.dart
@@ -16,8 +16,8 @@ class AnimationComponent extends PositionComponent {
   AnimationComponent.empty();
 
   AnimationComponent.sequenced(
-    width,
-    height,
+    double width,
+    double height,
     String imagePath,
     int amount, {
     double textureX = 0.0,


### PR DESCRIPTION
Because the default type of a property is dynamic, an error will be prompted when assigning an int type.

```
type 'int' is not a subtype of type 'double'
```