### PR TITLE
Check if the component has been successfully loaded before rendering

### DIFF
--- a/lib/components/composed_component.dart
+++ b/lib/components/composed_component.dart
@@ -49,6 +49,9 @@ mixin ComposedComponent on Component, HasGameRef, Tapable {
   }
 
   void _renderComponent(Canvas canvas, Component c) {
+    if (!c.loaded()) {
+      return;
+    }
     c.render(canvas);
     canvas.restore();
     canvas.save();


### PR DESCRIPTION
Today when I used `FlareComponent` to create a Flare animation, the console prompts the following error log.

```
════════ Exception caught by rendering library ════════
The following NoSuchMethodError was thrown during paint():
The method 'render' was called on null.
Receiver: null
Tried calling: render(Instance of 'Canvas', x: 0.0, y: 0.0)

When the exception was thrown, this was the stack: 
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:53:5)
#1      FlareComponent.render (package:flame/components/flare_component.dart:35:21)
#2      ComposedComponent._renderComponent (package:flame/components/composed_component.dart:55:7)
#3      ComposedComponent.render.<anonymous closure> (package:flame/components/composed_component.dart:47:34)
#4      IterableMixin.forEach (dart:collection/iterable.dart:46:30)
```

This is because in the `render` method of the `ComposedComponent`, we don't check if the component has been successfully loaded.