### PR TITLE
Fixing Widget Overlay usage over many game instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [next]
  - Fixing Component#onDestroy, which was been called multiple times sometimes
+ - Fixing Widget Overlay usage over many game instances
 
 ## 0.18.3
 - Adding Component#onDestroy

--- a/doc/examples/with_widgets_overlay/lib/example_game.dart
+++ b/doc/examples/with_widgets_overlay/lib/example_game.dart
@@ -36,4 +36,3 @@ class ExampleGame extends Game with HasWidgetsOverlay, TapDetector {
     }
   }
 }
-

--- a/doc/examples/with_widgets_overlay/lib/example_game.dart
+++ b/doc/examples/with_widgets_overlay/lib/example_game.dart
@@ -1,0 +1,39 @@
+import 'package:flame/game.dart';
+import 'package:flame/gestures.dart';
+import 'package:flame/palette.dart';
+
+import 'package:flutter/material.dart';
+
+class ExampleGame extends Game with HasWidgetsOverlay, TapDetector {
+  bool isPaused = false;
+
+  @override
+  void update(double dt) {}
+
+  @override
+  void render(Canvas canvas) {
+    canvas.drawRect(const Rect.fromLTWH(100, 100, 100, 100),
+        Paint()..color = BasicPalette.white.color);
+  }
+
+  @override
+  void onTap() {
+    if (isPaused) {
+      removeWidgetOverlay('PauseMenu');
+      isPaused = false;
+    } else {
+      addWidgetOverlay(
+          'PauseMenu',
+          Center(
+            child: Container(
+              width: 100,
+              height: 100,
+              color: const Color(0xFFFF0000),
+              child: const Center(child: const Text('Paused')),
+            ),
+          ));
+      isPaused = true;
+    }
+  }
+}
+

--- a/doc/examples/with_widgets_overlay/lib/main.dart
+++ b/doc/examples/with_widgets_overlay/lib/main.dart
@@ -1,40 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flame/game.dart';
-import 'package:flame/gestures.dart';
-import 'package:flame/palette.dart';
 
-class ExampleGame extends Game with HasWidgetsOverlay, TapDetector {
-  bool isPaused = false;
-
-  @override
-  void update(double dt) {}
-
-  @override
-  void render(Canvas canvas) {
-    canvas.drawRect(const Rect.fromLTWH(100, 100, 100, 100),
-        Paint()..color = BasicPalette.white.color);
-  }
-
-  @override
-  void onTap() {
-    if (isPaused) {
-      removeWidgetOverlay('PauseMenu');
-      isPaused = false;
-    } else {
-      addWidgetOverlay(
-          'PauseMenu',
-          Center(
-            child: Container(
-              width: 100,
-              height: 100,
-              color: const Color(0xFFFF0000),
-              child: const Center(child: const Text('Paused')),
-            ),
-          ));
-      isPaused = true;
-    }
-  }
-}
+import './example_game.dart';
 
 void main() {
   runApp(ExampleGame().widget);

--- a/doc/examples/with_widgets_overlay/lib/main_dynamic_game.dart
+++ b/doc/examples/with_widgets_overlay/lib/main_dynamic_game.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import './example_game.dart';
+
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  MyHomePage({Key key}) : super(key: key);
+  @override
+  _MyHomePageState createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  ExampleGame _myGame;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text('Testing addingOverlay'),
+        ),
+        body: _myGame == null ? const Text('Wait') : _myGame.widget,
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => newGame(),
+          child: Icon(Icons.add),
+        ));
+  }
+
+  void newGame() {
+    print('New game created');
+    _myGame = ExampleGame();
+    setState(() {});
+  }
+}

--- a/doc/examples/with_widgets_overlay/pubspec.yaml
+++ b/doc/examples/with_widgets_overlay/pubspec.yaml
@@ -15,3 +15,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/lib/game/widget_builder.dart
+++ b/lib/game/widget_builder.dart
@@ -158,7 +158,7 @@ class OverlayGameWidget extends StatefulWidget {
   final Widget gameChild;
   final HasWidgetsOverlay game;
 
-  OverlayGameWidget({Key key, this.gameChild, this.game}): super(key: key);
+  OverlayGameWidget({Key key, this.gameChild, this.game}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _OverlayGameWidgetState();
@@ -197,6 +197,7 @@ class OverlayWidgetBuilder extends WidgetBuilder {
   Widget build(Game game) {
     final container = super.build(game);
 
-    return OverlayGameWidget(gameChild: container, game: game, key: UniqueKey());
+    return OverlayGameWidget(
+        gameChild: container, game: game, key: UniqueKey());
   }
 }

--- a/lib/game/widget_builder.dart
+++ b/lib/game/widget_builder.dart
@@ -158,7 +158,7 @@ class OverlayGameWidget extends StatefulWidget {
   final Widget gameChild;
   final HasWidgetsOverlay game;
 
-  OverlayGameWidget({this.gameChild, this.game});
+  OverlayGameWidget({Key key, this.gameChild, this.game}): super(key: key);
 
   @override
   State<StatefulWidget> createState() => _OverlayGameWidgetState();
@@ -197,6 +197,6 @@ class OverlayWidgetBuilder extends WidgetBuilder {
   Widget build(Game game) {
     final container = super.build(game);
 
-    return OverlayGameWidget(gameChild: container, game: game);
+    return OverlayGameWidget(gameChild: container, game: game, key: UniqueKey());
   }
 }


### PR DESCRIPTION
Widget Overlay was missing its key, so the State was been reused over many number of instances, which was causing a lot of issues when multiple game isntances were used.

Fixes #265 