### PR TITLE
Added game loop abstraction for GameRenderBox

### DIFF
--- a/lib/game/game_loop.dart
+++ b/lib/game/game_loop.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/scheduler.dart';
+
+class GameLoop {
+  Function callback;
+  int _frameCallbackId;
+  bool _running = false;
+  Duration previous = Duration.zero;
+
+  GameLoop(this.callback);
+
+  void scheduleTick() {
+    _running = true;
+    _frameCallbackId = SchedulerBinding.instance.scheduleFrameCallback(_tick);
+  }
+
+  void unscheduleTick() {
+    _running = false;
+    if (_frameCallbackId != null) {
+      SchedulerBinding.instance.cancelFrameCallbackWithId(_frameCallbackId);
+    }
+  }
+
+  void _tick(Duration timestamp) {
+    if (!_running) {
+      return;
+    }
+    scheduleTick();
+    final double dt = _computeDeltaT(timestamp);
+    callback(dt);
+  }
+
+  double _computeDeltaT(Duration now) {
+    Duration delta = now - previous;
+    if (previous == Duration.zero) {
+      delta = Duration.zero;
+    }
+    previous = now;
+    return delta.inMicroseconds / Duration.microsecondsPerSecond;
+  }
+
+  void pause() {
+    if (_running) {
+      previous = Duration.zero;
+      unscheduleTick();
+    }
+  }
+
+  void resume() {
+    if (!_running) {
+      scheduleTick();
+    }
+  }
+}


### PR DESCRIPTION
I added a `GameLoop` class which abstracts the game loop from `GameRenderBox`, to clean things up a bit.

Functionwise it should be the same. I do now check for `running` instead of `attached` in `GameLoop._tick`, but i think it should work the same.

A callback is passed for updates.

