### PR TITLE
Simplify GameLoop using a Ticker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [next]
 - Adding SpriteBatch API, which renders sprites effectively using Canvas.drawAtlas
 - Refactor game.dart classes into separate files
-- Split up gameloop into separate GameLoop class
+- Adding a GameLoop class which uses a Ticker for updating game
 - Adding sprites example
 - Made BaseGame non-abstract and removed SimpleGame
 - Adding SpriteButton Widget

--- a/lib/game/game_loop.dart
+++ b/lib/game/game_loop.dart
@@ -2,29 +2,14 @@ import 'package:flutter/scheduler.dart';
 
 class GameLoop {
   Function callback;
-  int _frameCallbackId;
-  bool _running = false;
   Duration previous = Duration.zero;
+  Ticker _ticker;
 
-  GameLoop(this.callback);
-
-  void scheduleTick() {
-    _running = true;
-    _frameCallbackId = SchedulerBinding.instance.scheduleFrameCallback(_tick);
-  }
-
-  void unscheduleTick() {
-    _running = false;
-    if (_frameCallbackId != null) {
-      SchedulerBinding.instance.cancelFrameCallbackWithId(_frameCallbackId);
-    }
+  GameLoop(this.callback) {
+    _ticker = Ticker(_tick);
   }
 
   void _tick(Duration timestamp) {
-    if (!_running) {
-      return;
-    }
-    scheduleTick();
     final double dt = _computeDeltaT(timestamp);
     callback(dt);
   }
@@ -38,16 +23,20 @@ class GameLoop {
     return delta.inMicroseconds / Duration.microsecondsPerSecond;
   }
 
+  void start() {
+    _ticker.start();
+  }
+
+  void stop() {
+    _ticker.stop();
+  }
+
   void pause() {
-    if (_running) {
-      previous = Duration.zero;
-      unscheduleTick();
-    }
+    _ticker.muted = true;
+    previous = Duration.zero;
   }
 
   void resume() {
-    if (!_running) {
-      scheduleTick();
-    }
+    _ticker.muted = false;
   }
 }

--- a/lib/game/game_render_box.dart
+++ b/lib/game/game_render_box.dart
@@ -35,7 +35,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
     game.resumeEngineFn = gameLoop.resume;
 
     if (game.runOnCreation) {
-      gameLoop.scheduleTick();
+      gameLoop.start();
     }
 
     _bindLifecycleListener();
@@ -45,7 +45,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   void detach() {
     super.detach();
     game.onDetach();
-    gameLoop.unscheduleTick();
+    gameLoop.stop();
     _unbindLifecycleListener();
   }
 


### PR DESCRIPTION
Simplify the `GameLoop` class using a [Ticker](https://api.flutter.dev/flutter/scheduler/Ticker-class.html).

I believe it's essentially doing the same as before as it is an abstraction on `SchedulerBinding.scheduleFrameCallback`.

But please do some testing..