### PR TITLE
Fixes games trying to use gameRef inside the resize function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
 - Adding method to load image bases on base64 data url.
 - Fix Box2DGame to follow render priority
+- Fix games trying to use gameRef inside the resize function
 
 ## 0.20.0
 - Refactor game.dart classes into separate files

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -66,13 +66,13 @@ class BaseGame extends Game with TapDetector {
       c.debugMode = true;
     }
 
+    if (c is HasGameRef) {
+      (c as HasGameRef).gameRef = this;
+    }
+
     // first time resize
     if (size != null) {
       c.resize(size);
-    }
-
-    if (c is HasGameRef) {
-      (c as HasGameRef).gameRef = this;
     }
 
     if (c is ComposedComponent) {


### PR DESCRIPTION
This fixes a bug happening on the current version of BGUG. Components may try to access gameRef inside the resize method and it could sometimes file.