### PR TITLE
Adding AssetsCache.readBinaryFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 - Updated the doc structure and minor language fixes
+- Adding AssetsCache.readBinaryFile
 
 ## 0.20.2
 - Fix text component bug with anchor being applied twice

--- a/docs/examples/animations/.gitignore
+++ b/docs/examples/animations/.gitignore
@@ -68,3 +68,8 @@
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+lib/generated_plugin_registrant.dart
+macos/
+test/
+web/

--- a/docs/examples/aseprite/.gitignore
+++ b/docs/examples/aseprite/.gitignore
@@ -68,3 +68,8 @@
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+lib/generated_plugin_registrant.dart
+macos/
+test/
+web/

--- a/docs/examples/aseprite/lib/main.dart
+++ b/docs/examples/aseprite/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flame/components/animation_component.dart';
 import 'package:flutter/material.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   final Size size = await Flame.util.initialDimensions();
   runApp(MyGame(size).widget);
 }

--- a/lib/assets_cache.dart
+++ b/lib/assets_cache.dart
@@ -24,7 +24,7 @@ class AssetsCache {
     }
 
     assert(_files[fileName] is _StringAsset,
-        '"${fileName}" is not a String Asset');
+        '"$fileName" is not a String Asset');
 
     return _files[fileName].value;
   }
@@ -36,7 +36,7 @@ class AssetsCache {
     }
 
     assert(_files[fileName] is _BinaryAsset,
-        '"${fileName}" is not a Binary Asset');
+        '"$fileName" is not a Binary Asset');
 
     return _files[fileName].value;
   }

--- a/lib/assets_cache.dart
+++ b/lib/assets_cache.dart
@@ -23,8 +23,8 @@ class AssetsCache {
       _files[fileName] = await _readFile(fileName);
     }
 
-    assert(_files[fileName] is _StringAsset,
-        '"$fileName" is not a String Asset');
+    assert(
+        _files[fileName] is _StringAsset, '"$fileName" is not a String Asset');
 
     return _files[fileName].value;
   }
@@ -35,8 +35,8 @@ class AssetsCache {
       _files[fileName] = await _readBinary(fileName);
     }
 
-    assert(_files[fileName] is _BinaryAsset,
-        '"$fileName" is not a Binary Asset');
+    assert(
+        _files[fileName] is _BinaryAsset, '"$fileName" is not a Binary Asset');
 
     return _files[fileName].value;
   }

--- a/lib/assets_cache.dart
+++ b/lib/assets_cache.dart
@@ -23,7 +23,8 @@ class AssetsCache {
       _files[fileName] = await _readFile(fileName);
     }
 
-    assert(_files[fileName] is _StringAsset, '"${fileName}" is not a String Asset');
+    assert(_files[fileName] is _StringAsset,
+        '"${fileName}" is not a String Asset');
 
     return _files[fileName].value;
   }
@@ -34,7 +35,8 @@ class AssetsCache {
       _files[fileName] = await _readBinary(fileName);
     }
 
-    assert(_files[fileName] is _BinaryAsset, '"${fileName}" is not a Binary Asset');
+    assert(_files[fileName] is _BinaryAsset,
+        '"${fileName}" is not a Binary Asset');
 
     return _files[fileName].value;
   }
@@ -53,9 +55,10 @@ class AssetsCache {
   }
 }
 
-class _Asset <T> {
+class _Asset<T> {
   T value;
 }
 
-class _StringAsset extends _Asset<String>{}
-class _BinaryAsset extends _Asset<List<int>>{}
+class _StringAsset extends _Asset<String> {}
+
+class _BinaryAsset extends _Asset<List<int>> {}

--- a/lib/assets_cache.dart
+++ b/lib/assets_cache.dart
@@ -1,31 +1,61 @@
 import 'package:flutter/services.dart' show rootBundle;
+import 'dart:typed_data';
 
 /// A class that loads, and cache files
 ///
 /// it automatically looks for files on the assets folder
 class AssetsCache {
-  Map<String, String> textFiles = {};
+  final Map<String, _Asset> _files = {};
 
   /// Removes the file from the cache
   void clear(String file) {
-    textFiles.remove(file);
+    _files.remove(file);
   }
 
   /// Removes all the files from the cache
   void clearCache() {
-    textFiles.clear();
+    _files.clear();
   }
 
   /// Reads a file from assets folder
   Future<String> readFile(String fileName) async {
-    if (!textFiles.containsKey(fileName)) {
-      textFiles[fileName] = await _readFile(fileName);
+    if (!_files.containsKey(fileName)) {
+      _files[fileName] = await _readFile(fileName);
     }
 
-    return textFiles[fileName];
+    assert(_files[fileName] is _StringAsset, '"${fileName}" is not a String Asset');
+
+    return _files[fileName].value;
   }
 
-  Future<String> _readFile(String fileName) async {
-    return await rootBundle.loadString('assets/$fileName');
+  /// Reads a binary file from assets folder
+  Future<List<int>> readBinaryFile(String fileName) async {
+    if (!_files.containsKey(fileName)) {
+      _files[fileName] = await _readBinary(fileName);
+    }
+
+    assert(_files[fileName] is _BinaryAsset, '"${fileName}" is not a Binary Asset');
+
+    return _files[fileName].value;
+  }
+
+  Future<_StringAsset> _readFile(String fileName) async {
+    final string = await rootBundle.loadString('assets/$fileName');
+    return _StringAsset()..value = string;
+  }
+
+  Future<_BinaryAsset> _readBinary(String fileName) async {
+    final data = await rootBundle.load('assets/$fileName');
+    final Uint8List list = Uint8List.view(data.buffer);
+
+    final bytes = List.from(list).cast<int>();
+    return _BinaryAsset()..value = bytes;
   }
 }
+
+class _Asset <T> {
+  T value;
+}
+
+class _StringAsset extends _Asset<String>{}
+class _BinaryAsset extends _Asset<List<int>>{}

--- a/lib/assets_cache.dart
+++ b/lib/assets_cache.dart
@@ -24,7 +24,9 @@ class AssetsCache {
     }
 
     assert(
-        _files[fileName] is _StringAsset, '"$fileName" is not a String Asset');
+      _files[fileName] is _StringAsset,
+      '"$fileName" is not a String Asset',
+    );
 
     return _files[fileName].value;
   }
@@ -36,7 +38,9 @@ class AssetsCache {
     }
 
     assert(
-        _files[fileName] is _BinaryAsset, '"$fileName" is not a Binary Asset');
+      _files[fileName] is _BinaryAsset,
+      '"$fileName" is not a Binary Asset',
+    );
 
     return _files[fileName].value;
   }


### PR DESCRIPTION
# Description

Adding a simple method to load binary files from the assets, and caching it, I need this for the the Fire Atlas package, as the atlases will be exported in a binary format to save space.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
