### PR TITLE
Fixing Tapable conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+ - Fixing BaseGame tap detectors issues
 
 ## 0.21.0
 - Adding AssetsCache.readBinaryFile

--- a/doc/examples/gestures/lib/main.dart
+++ b/doc/examples/gestures/lib/main.dart
@@ -9,10 +9,11 @@ void main() {
 }
 
 /// Includes an example including basic detectors
-class MyGame extends Game with TapDetector, DoubleTapDetector, PanDetector {
+class MyGame extends Game with TapDetector, DoubleTapDetector, PanDetector, LongPressDetector {
   final _whitePaint = BasicPalette.white.paint;
   final _bluePaint = Paint()..color = const Color(0xFF0000FF);
   final _greenPaint = Paint()..color = const Color(0xFF00FF00);
+  final _redPaint = Paint()..color = const Color(0xFFFF0000);
 
   Paint _paint;
 
@@ -30,6 +31,11 @@ class MyGame extends Game with TapDetector, DoubleTapDetector, PanDetector {
   @override
   void onDoubleTap() {
     _paint = _greenPaint;
+  }
+
+  @override
+  void onLongPress() {
+    _paint = _redPaint;
   }
 
   @override

--- a/doc/examples/gestures/lib/main.dart
+++ b/doc/examples/gestures/lib/main.dart
@@ -9,7 +9,8 @@ void main() {
 }
 
 /// Includes an example including basic detectors
-class MyGame extends Game with TapDetector, DoubleTapDetector, PanDetector, LongPressDetector {
+class MyGame extends Game
+    with TapDetector, DoubleTapDetector, PanDetector, LongPressDetector {
   final _whitePaint = BasicPalette.white.paint;
   final _bluePaint = Paint()..color = const Color(0xFF0000FF);
   final _greenPaint = Paint()..color = const Color(0xFF00FF00);

--- a/doc/examples/gestures/lib/main_tapables.dart
+++ b/doc/examples/gestures/lib/main_tapables.dart
@@ -28,11 +28,6 @@ class TapableSquare extends PositionComponent with Tapable {
   }
 
   @override
-  void update(double dt) {
-    super.update(dt);
-  }
-
-  @override
   void render(Canvas canvas) {
     canvas.drawRect(toRect(), _beenPressed ? _grey : _white);
   }
@@ -53,9 +48,9 @@ class TapableSquare extends PositionComponent with Tapable {
   }
 }
 
-class MyGame extends BaseGame {
+class MyGame extends BaseGame with HasTapableComponents {
   MyGame() {
-    add(TapableSquare(x: 300, y: 100));
     add(TapableSquare(y: 100));
+    add(TapableSquare(y: 250));
   }
 }

--- a/doc/input.md
+++ b/doc/input.md
@@ -95,7 +95,7 @@ You can also check a more complete example [here](/doc/examples/gestures).
 
 ## Tapable components
 
-Flame also offers a simple helper to make it easier to handle tap events on `PositionComponent`. By added the `HasTapableComponents` mixin to your game, and using the mixin `Tapable` your components can override the following methods, enabling easy to use tap events on your Component.
+Flame also offers a simple helper to make it easier to handle tap events on `PositionComponent`. By adding the `HasTapableComponents` mixin to your game, and using the mixin `Tapable` on your components can override the following methods, enabling easy to use tap events on yours components.
 
 ```dart
   void onTapCancel() {}

--- a/doc/input.md
+++ b/doc/input.md
@@ -93,7 +93,7 @@ You can also check a more complete example [here](/doc/examples/gestures).
 
 ## Tapable components
 
-Flame also offers a simple helper to make it easier to handle tap events on `PositionComponent`. By using the mixin `Tapable` your components can override the following methods, enabling easy to use tap events on your Component.
+Flame also offers a simple helper to make it easier to handle tap events on `PositionComponent`. By added the `HasTapableComponents` mixin to your game, and using the mixin `Tapable` your components can override the following methods, enabling easy to use tap events on your Component.
 
 ```dart
   void onTapCancel() {}
@@ -124,6 +124,12 @@ class TapableComponent extends PositionComponent with Tapable {
   @override
   void onTapCancel() {
     print("tap cancel");
+  }
+}
+
+class MyGame extends BaseGame with HasTapableComponents {
+  MyGame() {
+    add(TapableComponent());
   }
 }
 ```

--- a/doc/input.md
+++ b/doc/input.md
@@ -70,7 +70,9 @@ Inside `package:flame/gestures.dart` you can find a whole set of `mixin`s which 
 
 Many of these detectors can conflict with each other. For example, you can't register both Vertical and Horizontal drags, so not all of them can be used together.
 
-All of these methods are basically a mirror from the callbacks available on the [GestureDetector widget](https://api.flutter.dev/flutter/widgets/GestureDetector-class.html), you can also read more about Flutter's gestures [here](https://api.flutter.dev/flutter/gestures/gestures-library.html).
+It is also not possible to mix advanced detectors (`MultiTouch*`) with basic detectors as they will *always win the gesture arena* and the basic detectors will never be triggered. So for example, you can use both `MultiTouchDragDetector` and `MultiTouchDragDetector` together, but if you try to use `MultiTouchTapDetector` and `PanDetector`, no events will be triggered for the later.
+
+Flame's GestureApi is provided byt Flutter's Gestures Widgets, including [GestureDetector widget](https://api.flutter.dev/flutter/widgets/GestureDetector-class.html) and [RawGestureDetector widget](https://api.flutter.dev/flutter/widgets/RawGestureDetector-class.html), you can also read more about Flutter's gestures [here](https://api.flutter.dev/flutter/gestures/gestures-library.html).
 
 ## Example
 

--- a/lib/components/mixins/tapable.dart
+++ b/lib/components/mixins/tapable.dart
@@ -2,6 +2,8 @@ import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
 
+import '../../game/base_game.dart';
+
 mixin Tapable {
   Rect toRect();
 
@@ -43,4 +45,21 @@ mixin Tapable {
   ///
   /// If a [Tapable] has children, its children be taped as well.
   Iterable<Tapable> tapableChildren() => [];
+}
+
+mixin HasTapableComponents on BaseGame {
+  Iterable<Tapable> get _tapableComponents =>
+      components.where((c) => c is Tapable).cast();
+
+  void onTapCancel(int pointerId) {
+    _tapableComponents.forEach((c) => c.handleTapCancel(pointerId));
+  }
+
+  void onTapDown(int pointerId, TapDownDetails details) {
+    _tapableComponents.forEach((c) => c.handleTapDown(pointerId, details));
+  }
+
+  void onTapUp(int pointerId, TapUpDetails details) {
+    _tapableComponents.forEach((c) => c.handleTapUp(pointerId, details));
+  }
 }

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -44,8 +44,8 @@ class BaseGame extends Game {
   void preAdd(Component c) {
     if (c is Tapable) {
       assert(
-          this is HasTapableComponents,
-          'Tapable Components can only be added to a BaseGame with HasTapableComponents',
+        this is HasTapableComponents,
+        'Tapable Components can only be added to a BaseGame with HasTapableComponents',
       );
     }
 

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -2,7 +2,6 @@ import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flame/components/composed_component.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart' hide WidgetBuilder;
 import 'package:flutter/foundation.dart';
@@ -13,7 +12,6 @@ import '../components/component.dart';
 import '../components/mixins/has_game_ref.dart';
 import '../components/mixins/tapable.dart';
 import '../position.dart';
-import '../gestures.dart';
 import 'game.dart';
 
 /// This is a more complete and opinionated implementation of Game.
@@ -21,7 +19,7 @@ import 'game.dart';
 /// It still needs to be subclasses to add your game logic, but the [update], [render] and [resize] methods have default implementations.
 /// This is the recommended structure to use for most games.
 /// It is based on the Component system.
-class BaseGame extends Game with MultiTouchTapDetector {
+class BaseGame extends Game {
   /// The list of components to be updated and rendered by the base game.
   OrderedSet<Component> components =
       OrderedSet(Comparing.on((c) => c.priority()));
@@ -38,30 +36,19 @@ class BaseGame extends Game with MultiTouchTapDetector {
   /// List of deltas used in debug mode to calculate FPS
   final List<double> _dts = [];
 
-  Iterable<Tapable> get _tapableComponents =>
-      components.where((c) => c is Tapable).cast();
-
-  @override
-  void onTapCancel(int pointerId) {
-    _tapableComponents.forEach((c) => c.handleTapCancel(pointerId));
-  }
-
-  @override
-  void onTapDown(int pointerId, TapDownDetails details) {
-    _tapableComponents.forEach((c) => c.handleTapDown(pointerId, details));
-  }
-
-  @override
-  void onTapUp(int pointerId, TapUpDetails details) {
-    _tapableComponents.forEach((c) => c.handleTapUp(pointerId, details));
-  }
-
   /// This method is called for every component added, both via [add] and [addLater] methods.
   ///
   /// You can use this to setup your mixins, pre-calculate stuff on every component, or anything you desire.
   /// By default, this calls the first time resize for every component, so don't forget to call super.preAdd when overriding.
   @mustCallSuper
   void preAdd(Component c) {
+    if (c is Tapable) {
+      assert(
+          this is HasTapableComponents,
+          'Tapable Components can only be added to a BaseGame with HasTapableComponents',
+      );
+    }
+
     if (debugMode() && c is PositionComponent) {
       c.debugMode = true;
     }

--- a/lib/game/widget_builder.dart
+++ b/lib/game/widget_builder.dart
@@ -26,62 +26,61 @@ class _GenericTapEventHandler {
   void Function(int pointerId) onTap;
   void Function(int pointerId) onTapCancel;
   void Function(int pointerId, TapDownDetails details) onTapDown;
-  void Function (int pointerId, TapUpDetails details) onTapUp;
+  void Function(int pointerId, TapUpDetails details) onTapUp;
 }
 
 Widget _applyAdvancedGesturesDetectors(Game game, Widget child) {
-  final Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{};
+  final Map<Type, GestureRecognizerFactory> gestures =
+      <Type, GestureRecognizerFactory>{};
 
   final List<_GenericTapEventHandler> _tapHandlers = [];
 
   if (game is HasTapableComponents) {
-    _tapHandlers.add(
-        _GenericTapEventHandler()
-        ..onTapDown = game.onTapDown
-        ..onTapUp = game.onTapUp
-        ..onTapCancel = game.onTapCancel
-    );
+    _tapHandlers.add(_GenericTapEventHandler()
+      ..onTapDown = game.onTapDown
+      ..onTapUp = game.onTapUp
+      ..onTapCancel = game.onTapCancel);
   }
 
   if (game is MultiTouchTapDetector) {
-    _tapHandlers.add(
-        _GenericTapEventHandler()
-        ..onTapDown = game.onTapDown
-        ..onTapUp = game.onTapUp
-        ..onTapCancel = game.onTapCancel
-    );
+    _tapHandlers.add(_GenericTapEventHandler()
+      ..onTapDown = game.onTapDown
+      ..onTapUp = game.onTapUp
+      ..onTapCancel = game.onTapCancel);
   }
 
   if (_tapHandlers.isNotEmpty) {
-      gestures[MultiTapGestureRecognizer] =
-          GestureRecognizerFactoryWithHandlers<MultiTapGestureRecognizer>(
-              () => MultiTapGestureRecognizer(),
-              (MultiTapGestureRecognizer instance) {
-          instance.onTapDown =
-              (pointerId, d) => _tapHandlers.forEach((h) => h.onTapDown?.call(pointerId, d));
-          instance.onTapUp =
-              (pointerId, d) => _tapHandlers.forEach((h) => h.onTapUp?.call(pointerId, d));
-          instance.onTapCancel =
-              (pointerId) => _tapHandlers.forEach((h) => h.onTapCancel?.call(pointerId));
-          instance.onTap = (pointerId) => _tapHandlers.forEach((h) => h.onTap?.call(pointerId));
-      });
+    gestures[MultiTapGestureRecognizer] =
+        GestureRecognizerFactoryWithHandlers<MultiTapGestureRecognizer>(
+            () => MultiTapGestureRecognizer(),
+            (MultiTapGestureRecognizer instance) {
+      instance.onTapDown = (pointerId, d) =>
+          _tapHandlers.forEach((h) => h.onTapDown?.call(pointerId, d));
+      instance.onTapUp = (pointerId, d) =>
+          _tapHandlers.forEach((h) => h.onTapUp?.call(pointerId, d));
+      instance.onTapCancel = (pointerId) =>
+          _tapHandlers.forEach((h) => h.onTapCancel?.call(pointerId));
+      instance.onTap =
+          (pointerId) => _tapHandlers.forEach((h) => h.onTap?.call(pointerId));
+    });
   }
 
   if (game is MultiTouchDragDetector) {
-      gestures[ImmediateMultiDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<
-          ImmediateMultiDragGestureRecognizer>(
-        () => ImmediateMultiDragGestureRecognizer(),
-        (ImmediateMultiDragGestureRecognizer instance) {
-          instance
-            ..onStart =  (Offset o) {
-                    final drag = DragEvent();
-                    drag.initialPosition = o;
+    gestures[ImmediateMultiDragGestureRecognizer] =
+        GestureRecognizerFactoryWithHandlers<
+                ImmediateMultiDragGestureRecognizer>(
+            () => ImmediateMultiDragGestureRecognizer(),
+            (ImmediateMultiDragGestureRecognizer instance) {
+      instance
+        ..onStart = (Offset o) {
+          final drag = DragEvent();
+          drag.initialPosition = o;
 
-                    game.onReceiveDrag(drag);
+          game.onReceiveDrag(drag);
 
-                    return drag;
-                  };
-        });
+          return drag;
+        };
+    });
   }
 
   return RawGestureDetector(
@@ -97,89 +96,66 @@ Widget _applyBasicGesturesDetectors(Game game, Widget child) {
   return GestureDetector(
     // Taps
     onTap: game is TapDetector ? () => game.onTap() : null,
-    onTapCancel:
-        game is TapDetector ? () => game.onTapCancel() : null,
-    onTapDown: game is TapDetector
-        ? (TapDownDetails d) => game.onTapDown(d)
-        : null,
-    onTapUp: game is TapDetector
-        ? (TapUpDetails d) => game.onTapUp(d)
-        : null,
+    onTapCancel: game is TapDetector ? () => game.onTapCancel() : null,
+    onTapDown:
+        game is TapDetector ? (TapDownDetails d) => game.onTapDown(d) : null,
+    onTapUp: game is TapDetector ? (TapUpDetails d) => game.onTapUp(d) : null,
 
     // Secondary taps
     onSecondaryTapDown: game is SecondaryTapDetector
-        ? (TapDownDetails d) =>
-            game.onSecondaryTapDown(d)
+        ? (TapDownDetails d) => game.onSecondaryTapDown(d)
         : null,
     onSecondaryTapUp: game is SecondaryTapDetector
         ? (TapUpDetails d) => game.onSecondaryTapUp(d)
         : null,
-    onSecondaryTapCancel: game is SecondaryTapDetector
-        ? () => game.onSecondaryTapCancel()
-        : null,
+    onSecondaryTapCancel:
+        game is SecondaryTapDetector ? () => game.onSecondaryTapCancel() : null,
 
     // Double tap
-    onDoubleTap: game is DoubleTapDetector
-        ? () => game.onDoubleTap()
-        : null,
+    onDoubleTap: game is DoubleTapDetector ? () => game.onDoubleTap() : null,
 
     // Long presses
-    onLongPress: game is LongPressDetector
-        ? () => game.onLongPress()
-        : null,
+    onLongPress: game is LongPressDetector ? () => game.onLongPress() : null,
     onLongPressStart: game is LongPressDetector
-        ? (LongPressStartDetails d) =>
-            game.onLongPressStart(d)
+        ? (LongPressStartDetails d) => game.onLongPressStart(d)
         : null,
     onLongPressMoveUpdate: game is LongPressDetector
-        ? (LongPressMoveUpdateDetails d) =>
-            game.onLongPressMoveUpdate(d)
+        ? (LongPressMoveUpdateDetails d) => game.onLongPressMoveUpdate(d)
         : null,
-    onLongPressUp: game is LongPressDetector
-        ? () => game.onLongPressUp()
-        : null,
+    onLongPressUp:
+        game is LongPressDetector ? () => game.onLongPressUp() : null,
     onLongPressEnd: game is LongPressDetector
-        ? (LongPressEndDetails d) =>
-            game.onLongPressEnd(d)
+        ? (LongPressEndDetails d) => game.onLongPressEnd(d)
         : null,
 
     // Vertical drag
     onVerticalDragDown: game is VerticalDragDetector
-        ? (DragDownDetails d) =>
-            game.onVerticalDragDown(d)
+        ? (DragDownDetails d) => game.onVerticalDragDown(d)
         : null,
     onVerticalDragStart: game is VerticalDragDetector
-        ? (DragStartDetails d) =>
-            game.onVerticalDragStart(d)
+        ? (DragStartDetails d) => game.onVerticalDragStart(d)
         : null,
     onVerticalDragUpdate: game is VerticalDragDetector
-        ? (DragUpdateDetails d) =>
-            game.onVerticalDragUpdate(d)
+        ? (DragUpdateDetails d) => game.onVerticalDragUpdate(d)
         : null,
     onVerticalDragEnd: game is VerticalDragDetector
-        ? (DragEndDetails d) =>
-            game.onVerticalDragEnd(d)
+        ? (DragEndDetails d) => game.onVerticalDragEnd(d)
         : null,
-    onVerticalDragCancel: game is VerticalDragDetector
-        ? () => game.onVerticalDragCancel()
-        : null,
+    onVerticalDragCancel:
+        game is VerticalDragDetector ? () => game.onVerticalDragCancel() : null,
 
     // Horizontal drag
     onHorizontalDragDown: game is HorizontalDragDetector
-        ? (DragDownDetails d) =>
-            game.onHorizontalDragDown(d)
+        ? (DragDownDetails d) => game.onHorizontalDragDown(d)
         : null,
     onHorizontalDragStart: game is HorizontalDragDetector
-        ? (DragStartDetails d) =>
-            game.onHorizontalDragStart(d)
+        ? (DragStartDetails d) => game.onHorizontalDragStart(d)
         : null,
     onHorizontalDragUpdate: game is HorizontalDragDetector
-        ? (DragUpdateDetails d) =>
-            game.onHorizontalDragUpdate(d)
+        ? (DragUpdateDetails d) => game.onHorizontalDragUpdate(d)
         : null,
     onHorizontalDragEnd: game is HorizontalDragDetector
-        ? (DragEndDetails d) =>
-            game.onHorizontalDragEnd(d)
+        ? (DragEndDetails d) => game.onHorizontalDragEnd(d)
         : null,
     onHorizontalDragCancel: game is HorizontalDragDetector
         ? () => game.onHorizontalDragCancel()
@@ -187,37 +163,29 @@ Widget _applyBasicGesturesDetectors(Game game, Widget child) {
 
     // Force presses
     onForcePressStart: game is ForcePressDetector
-        ? (ForcePressDetails d) =>
-            game.onForcePressStart(d)
+        ? (ForcePressDetails d) => game.onForcePressStart(d)
         : null,
     onForcePressPeak: game is ForcePressDetector
-        ? (ForcePressDetails d) =>
-            game.onForcePressPeak(d)
+        ? (ForcePressDetails d) => game.onForcePressPeak(d)
         : null,
     onForcePressUpdate: game is ForcePressDetector
-        ? (ForcePressDetails d) =>
-            game.onForcePressUpdate(d)
+        ? (ForcePressDetails d) => game.onForcePressUpdate(d)
         : null,
     onForcePressEnd: game is ForcePressDetector
-        ? (ForcePressDetails d) =>
-            game.onForcePressEnd(d)
+        ? (ForcePressDetails d) => game.onForcePressEnd(d)
         : null,
 
     // Pan
-    onPanDown: game is PanDetector
-        ? (DragDownDetails d) => game.onPanDown(d)
-        : null,
-    onPanStart: game is PanDetector
-        ? (DragStartDetails d) => game.onPanStart(d)
-        : null,
+    onPanDown:
+        game is PanDetector ? (DragDownDetails d) => game.onPanDown(d) : null,
+    onPanStart:
+        game is PanDetector ? (DragStartDetails d) => game.onPanStart(d) : null,
     onPanUpdate: game is PanDetector
         ? (DragUpdateDetails d) => game.onPanUpdate(d)
         : null,
-    onPanEnd: game is PanDetector
-        ? (DragEndDetails d) => game.onPanEnd(d)
-        : null,
-    onPanCancel:
-        game is PanDetector ? () => game.onPanCancel() : null,
+    onPanEnd:
+        game is PanDetector ? (DragEndDetails d) => game.onPanEnd(d) : null,
+    onPanCancel: game is PanDetector ? () => game.onPanCancel() : null,
 
     // Scales
     onScaleStart: game is ScaleDetector

--- a/lib/game/widget_builder.dart
+++ b/lib/game/widget_builder.dart
@@ -52,35 +52,37 @@ Widget _applyAdvancedGesturesDetectors(Game game, Widget child) {
   if (_tapHandlers.isNotEmpty) {
     gestures[MultiTapGestureRecognizer] =
         GestureRecognizerFactoryWithHandlers<MultiTapGestureRecognizer>(
-            () => MultiTapGestureRecognizer(),
-            (MultiTapGestureRecognizer instance) {
-      instance.onTapDown = (pointerId, d) =>
-          _tapHandlers.forEach((h) => h.onTapDown?.call(pointerId, d));
-      instance.onTapUp = (pointerId, d) =>
-          _tapHandlers.forEach((h) => h.onTapUp?.call(pointerId, d));
-      instance.onTapCancel = (pointerId) =>
-          _tapHandlers.forEach((h) => h.onTapCancel?.call(pointerId));
-      instance.onTap =
-          (pointerId) => _tapHandlers.forEach((h) => h.onTap?.call(pointerId));
-    });
+      () => MultiTapGestureRecognizer(),
+      (MultiTapGestureRecognizer instance) {
+        instance.onTapDown = (pointerId, d) =>
+            _tapHandlers.forEach((h) => h.onTapDown?.call(pointerId, d));
+        instance.onTapUp = (pointerId, d) =>
+            _tapHandlers.forEach((h) => h.onTapUp?.call(pointerId, d));
+        instance.onTapCancel = (pointerId) =>
+            _tapHandlers.forEach((h) => h.onTapCancel?.call(pointerId));
+        instance.onTap = (pointerId) =>
+            _tapHandlers.forEach((h) => h.onTap?.call(pointerId));
+      },
+    );
   }
 
   if (game is MultiTouchDragDetector) {
     gestures[ImmediateMultiDragGestureRecognizer] =
         GestureRecognizerFactoryWithHandlers<
-                ImmediateMultiDragGestureRecognizer>(
-            () => ImmediateMultiDragGestureRecognizer(),
-            (ImmediateMultiDragGestureRecognizer instance) {
-      instance
-        ..onStart = (Offset o) {
-          final drag = DragEvent();
-          drag.initialPosition = o;
+            ImmediateMultiDragGestureRecognizer>(
+      () => ImmediateMultiDragGestureRecognizer(),
+      (ImmediateMultiDragGestureRecognizer instance) {
+        instance
+          ..onStart = (Offset o) {
+            final drag = DragEvent();
+            drag.initialPosition = o;
 
-          game.onReceiveDrag(drag);
+            game.onReceiveDrag(drag);
 
-          return drag;
-        };
-    });
+            return drag;
+          };
+      },
+    );
   }
 
   return RawGestureDetector(

--- a/lib/gestures.dart
+++ b/lib/gestures.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/gestures.dart';
 
+import './game/game.dart';
+
 // Multi touch detector
-mixin MultiTouchTapDetector {
+mixin MultiTouchTapDetector on Game {
   void onTap(int pointerId) {}
   void onTapCancel(int pointerId) {}
   void onTapDown(int pointerId, TapDownDetails details) {}
@@ -31,29 +33,29 @@ class DragEvent extends Drag {
   }
 }
 
-mixin MultiTouchDragDetector {
+mixin MultiTouchDragDetector on Game {
   void onReceiveDrag(DragEvent drag) {}
 }
 
 // Basic touch detectors
-mixin TapDetector {
+mixin TapDetector on Game {
   void onTap() {}
   void onTapCancel() {}
   void onTapDown(TapDownDetails details) {}
   void onTapUp(TapUpDetails details) {}
 }
 
-mixin SecondaryTapDetector {
+mixin SecondaryTapDetector on Game {
   void onSecondaryTapDown(TapDownDetails details) {}
   void onSecondaryTapUp(TapUpDetails details) {}
   void onSecondaryTapCancel() {}
 }
 
-mixin DoubleTapDetector {
+mixin DoubleTapDetector on Game {
   void onDoubleTap() {}
 }
 
-mixin LongPressDetector {
+mixin LongPressDetector on Game {
   void onLongPress() {}
   void onLongPressStart(LongPressStartDetails details) {}
   void onLongPressMoveUpdate(LongPressMoveUpdateDetails details) {}
@@ -61,7 +63,7 @@ mixin LongPressDetector {
   void onLongPressEnd(LongPressEndDetails details) {}
 }
 
-mixin VerticalDragDetector {
+mixin VerticalDragDetector on Game {
   void onVerticalDragDown(DragDownDetails details) {}
   void onVerticalDragStart(DragStartDetails details) {}
   void onVerticalDragUpdate(DragUpdateDetails details) {}
@@ -69,7 +71,7 @@ mixin VerticalDragDetector {
   void onVerticalDragCancel() {}
 }
 
-mixin HorizontalDragDetector {
+mixin HorizontalDragDetector on Game {
   void onHorizontalDragDown(DragDownDetails details) {}
   void onHorizontalDragStart(DragStartDetails details) {}
   void onHorizontalDragUpdate(DragUpdateDetails details) {}
@@ -77,14 +79,14 @@ mixin HorizontalDragDetector {
   void onHorizontalDragCancel() {}
 }
 
-mixin ForcePressDetector {
+mixin ForcePressDetector on Game {
   void onForcePressStart(ForcePressDetails details) {}
   void onForcePressPeak(ForcePressDetails details) {}
   void onForcePressUpdate(ForcePressDetails details) {}
   void onForcePressEnd(ForcePressDetails details) {}
 }
 
-mixin PanDetector {
+mixin PanDetector on Game {
   void onPanDown(DragDownDetails details) {}
   void onPanStart(DragStartDetails details) {}
   void onPanUpdate(DragUpdateDetails details) {}
@@ -92,7 +94,7 @@ mixin PanDetector {
   void onPanCancel() {}
 }
 
-mixin ScaleDetector {
+mixin ScaleDetector on Game {
   void onScaleStart(ScaleStartDetails details) {}
   void onScaleUpdate(ScaleUpdateDetails details) {}
   void onScaleEnd(ScaleEndDetails details) {}

--- a/test/composed_component_test.dart
+++ b/test/composed_component_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 
 import 'package:flame/components/component.dart';
 
-class MyGame extends BaseGame {}
+class MyGame extends BaseGame with HasTapableComponents {}
 
 class MyTap extends PositionComponent with Tapable, Resizable {
   bool tapped = false;


### PR DESCRIPTION
# Description

Tapable components support was causing some issues. Since it made BaseGame use the `MultiTouchTapDetector` it was preventing any other simple detector to work on BaseGame, as multi touch detectors always wins the arena over single touch detectors.

In addition to that, it caused conflicts if the user used the `MultiTouchTapDetector` mixin on the base game class, causing a lot of confusion.

Now, `Tapable` support on BaseGame is enable by the `HasTapableComponents` mixin, and it is directly hooked on the widget builder class, so no more conflicts exists, and the developer can use both `Tapable` components, and have `MultiTouchTapDetector` events on their game.

Fixes #199

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
