### PR TITLE
Upgrade Flutter SVG to fix for flame web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
  - Fixing BaseGame tap detectors issues
+ - Upgrade Flutter SVG to fix for flame web
 
 ## 0.21.0
 - Adding AssetsCache.readBinaryFile

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   synchronized: ^2.1.0
   tiled: ^0.2.1
   convert: ^2.0.1
-  flutter_svg: ^0.17.1
+  flutter_svg: ^0.17.4
   flare_flutter: ^2.0.1
   meta: ^1.1.8
 


### PR DESCRIPTION
# Description

The previous version of Flutter SVG apparently doesn't work with flutter web for some reason.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
