### PR TITLE
Fix Box2DComponent render priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+ - Fix Box2DComponent render priority
 
 ## 0.22.0
  - Fixing BaseGame tap detectors issues

--- a/lib/box2d/box2d_component.dart
+++ b/lib/box2d/box2d_component.dart
@@ -3,6 +3,8 @@ import 'dart:ui';
 import 'package:box2d_flame/box2d.dart' hide Timer;
 import 'package:flame/box2d/viewport.dart';
 import 'package:flame/components/component.dart';
+import 'package:ordered_set/comparing.dart';
+import 'package:ordered_set/ordered_set.dart';
 
 abstract class Box2DComponent extends Component {
   static const int DEFAULT_WORLD_POOL_SIZE = 100;
@@ -16,9 +18,11 @@ abstract class Box2DComponent extends Component {
   int velocityIterations;
   int positionIterations;
 
-  World world;
-  List<BodyComponent> components = [];
+  /// The list of components to be updated and rendered by the Box2DComponent.
+  OrderedSet<BodyComponent> components =
+      OrderedSet(Comparing.on((c) => c.priority()));
   Viewport viewport;
+  World world;
 
   Box2DComponent({
     this.dimensions,


### PR DESCRIPTION
# Description

Box2DComponent doesn't currently respect render priority, this is a quick fix for it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
