### PR TITLE
Update box2d with torque fix version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
  - Fix Box2DComponent render priority
+ - Update to newest box2d_flame that fixes torque bug
 
 ## 0.22.0
  - Fixing BaseGame tap detectors issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   audioplayers: ^0.15.1
   ordered_set: ^2.0.0
   path_provider: ^1.6.0
-  box2d_flame: ^0.4.5
+  box2d_flame: ^0.4.6
   synchronized: ^2.1.0
   tiled: ^0.2.1
   convert: ^2.0.1


### PR DESCRIPTION
# Description

Box2d_flame had a bug with torque modification that is fixed in 0.4.6
The box2d_flame PR (https://github.com/flame-engine/box2d.dart/pull/8) needs to be merged first, and a new version published.

Fixes #374

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
