### PR TITLE
Moving to flutter analyze instead of dartanalayzer, which was causing confusion

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -16,19 +16,14 @@ for f in doc/examples/**/pubspec.yaml; do
   cd - > /dev/null
 done
 
-analyzer() {
-  cd $1
-  flutter pub get
-  result=$(flutter analyze .)
-  if ! echo "$result" | grep -q "No issues found!"; then
-    echo "$result"
-    echo "flutter analyze issue: $1"
-    exit 1
-  fi
-  cd - > /dev/null
-}
-
-analyzer .
+cd .
+flutter pub get
+result=$(flutter analyze .)
+if ! echo "$result" | grep -q "No issues found!"; then
+  echo "$result"
+  echo "flutter analyze issue: $1"
+  exit 1
+fi
 
 echo "success"
 exit 0

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -22,7 +22,7 @@ analyzer() {
   result=$(flutter analyze .)
   if ! echo "$result" | grep -q "No issues found!"; then
     echo "$result"
-    echo "dartanalyzer issue: $1"
+    echo "flutter analyze issue: $1"
     exit 1
   fi
   cd - > /dev/null

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,7 +7,7 @@ if [[ $(flutter format -n .) ]]; then
 fi
 
 flutter pub get
-result=$(dartanalyzer lib/)
+result=$(flutter analyze .)
 if ! echo "$result" | grep -q "No issues found!"; then
   echo "$result"
   echo "dartanalyzer issue: lib"
@@ -17,7 +17,7 @@ fi
 analyzer() {
   cd $1
   flutter pub get
-  result=$(dartanalyzer .)
+  result=$(flutter analyze .)
   if ! echo "$result" | grep -q "No issues found!"; then
     echo "$result"
     echo "dartanalyzer issue: $1"

--- a/test/has_game_ref_test.dart
+++ b/test/has_game_ref_test.dart
@@ -15,9 +15,6 @@ class MyGame extends BaseGame {
 
 class MyComponent extends PositionComponent with HasGameRef<MyGame> {
   @override
-  void update(double dt) {}
-
-  @override
   void render(Canvas c) {}
 
   void foo() {

--- a/test/resizable_test.dart
+++ b/test/resizable_test.dart
@@ -16,9 +16,6 @@ class MyComponent extends PositionComponent with Resizable {
   Iterable<Resizable> resizableChildren() => myChildren;
 
   @override
-  void update(double dt) {}
-
-  @override
   void render(Canvas c) {}
 }
 


### PR DESCRIPTION
# Description

This PR changes the linter script to have a more consistent result when the it is ran on the CI and on our own development machines.

I was also going to change the flutter format to the dart format command, but they seems to be removing the deprecating warning from the command, so I decided to keep it, more here: https://github.com/flutter/flutter/pull/58817

Also, apparently, flutter analyze is very smart, and it will find issues inside the `docs/examples folder`, so it is faster now and we don't need to detect which example were changed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
