### PR TITLE
Vector2d unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
  - Upgrade tiled and flutter_svg dependencies
  - onComplete callback for effects
  - Adding Layers
+ - Rename Position to Vector2d
+ - Utilize .. for Vector2d instead of returning "this"
  
 ## 0.22.1
  - Fix Box2DComponent render priority

--- a/doc/animation_widget_article/article.md
+++ b/doc/animation_widget_article/article.md
@@ -123,7 +123,7 @@ Note that it could be any component, however complex, inside your widgets tree. 
 ```dart
 import 'package:flame/animation.dart' as animation; // imports the Animation class under animation.Animation
 import 'package:flame/flame.dart'; // imports the Flame helper class
-import 'package:flame/position.dart'; // imports the Position class
+import 'vector2d.dart'; // imports the Position class
 ```
 
 How we do the magic then? Just add the following to your widget tree:

--- a/doc/animation_widget_article/article.md
+++ b/doc/animation_widget_article/article.md
@@ -123,22 +123,22 @@ Note that it could be any component, however complex, inside your widgets tree. 
 ```dart
 import 'package:flame/animation.dart' as animation; // imports the Animation class under animation.Animation
 import 'package:flame/flame.dart'; // imports the Flame helper class
-import 'vector2d.dart'; // imports the Position class
+import 'package:flame/vector2d.dart'; // imports the Position class
 ```
 
-How we do the magic then? Just add the following to your widget tree:
+How do we do the magic then? Just add the following to your widget tree:
 
 ```dart
-    Flame.util.animationAsWidget(Position(WIDTH, HEIGHT), animation.Animation.sequenced('minotaur.png', AMOUNT, textureWidth: FRAME_WIDTH))
+    Flame.util.animationAsWidget(Vector2d(width, height), animation.Animation.sequenced('minotaur.png', amount, textureWidth: frameWidth))
 ```
 
-The first parameter's `WIDTH` and `HEIGHT` are the actual size of the widget on the screen. This does not need to match the sprite size, as Flame will scale it for you. You might, however, wanna keep the aspect, so things don't get distorted. In your case, the minotaur asset is a row of 96x96 pixels, so squares, therefore we can scale keeping `WIDTH/HEIGHT = 1`. We will choose the size as 256 px. The `sequenced` constructor is a helper that easily creates the animation assuming equal-sized frames in a row, in order. You can configure the start x, start y, texture width and height, but those will default gracefully to (0,0) and the actual width and height of the file. You can create your animation passing in the frame list, each frame with a different step time and sprite (source rectangle).
+The first parameter's `width` and `height` are the actual size of the widget on the screen. This does not need to match the sprite size, as Flame will scale it for you. You might, however, wanna keep the aspect, so things don't get distorted. In your case, the minotaur asset is a row of 96x96 pixels, so squares, therefore we can scale keeping `width/height = 1`. We will choose the size as 256 px. The `sequenced` constructor is a helper that easily creates the animation assuming equal-sized frames in a row, in order. You can configure the start x, start y, texture width and height, but those will default gracefully to (0,0) and the actual width and height of the file. You can create your animation passing in the frame list, each frame with a different step time and sprite (source rectangle).
 
-In our case, we only need to set the `textureWidth` to 96.0, as the original width for the image is actually 19 x 96. Don't mix up texture coordinates, or source coordinates, that's the x, y inside the sprite sheet image and the size relating to that file, and the actual place and size the image/animation is going to be drawn on screen! Those are two very distinct things. We don't need to set the actual position as the widget tree will dictate that for us, we just provide the size as it's going to be a fixed size widget.
+In our case, we only need to set the `textureWidth` to 96.0, since the original width for the image is actually 19 x 96. Don't mix up texture coordinates, or source coordinates, that's the (x, y) inside the sprite sheet image and the size relating to that file, and the actual place and size the image/animation is going to be drawn on screen! Those are two very distinct things. We don't need to set the actual position since the widget tree will dictate that for us, we just provide the size since it's going to be a fixed size widget.
 
 ## Results
 
-Now, just run your app, and, hurray!, we get a slick animation!
+Now just run your app, and hurray! We get a slick animation!
 
 <p align="center">
     <img width="30%" src="result.gif" />

--- a/doc/examples/animation_widget/lib/main.dart
+++ b/doc/examples/animation_widget/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flame/flame.dart';
 import 'package:flame/animation.dart' as animation;
 import 'package:flame/sprite.dart';
 import 'package:flame/spritesheet.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/widgets/animation_widget.dart';
 import 'package:flame/widgets/sprite_widget.dart';
 import 'package:flutter/material.dart';
@@ -50,7 +50,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  Position _position = Position(256.0, 256.0);
+  Vector2d _position = Vector2d(256.0, 256.0);
 
   @override
   void initState() {
@@ -61,7 +61,7 @@ class _MyHomePageState extends State<MyHomePage> {
   void changePosition() async {
     await Future.delayed(const Duration(seconds: 1));
     setState(() {
-      _position = Position(10 + _position.x, 10 + _position.y);
+      _position = Vector2d(10 + _position.x, 10 + _position.y);
     });
   }
 

--- a/doc/examples/audiopool/lib/main.dart
+++ b/doc/examples/audiopool/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:flame/audio_pool.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
 import 'package:flame/palette.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/text_config.dart';
 import 'package:flame/gestures.dart';
 import 'package:flutter/material.dart';
@@ -29,7 +29,7 @@ class MyGame extends BaseGame with TapDetector {
   void render(Canvas canvas) {
     canvas.drawRect(Rect.fromLTWH(0.0, 0.0, size.width, size.height),
         BasicPalette.black.paint);
-    regular.render(canvas, 'hit me!', Position.fromSize(size).div(2),
+    regular.render(canvas, 'hit me!', Vector2d.fromSize(size).div(2),
         anchor: Anchor.center);
     super.render(canvas);
   }

--- a/doc/examples/audiopool/lib/main.dart
+++ b/doc/examples/audiopool/lib/main.dart
@@ -29,7 +29,7 @@ class MyGame extends BaseGame with TapDetector {
   void render(Canvas canvas) {
     canvas.drawRect(Rect.fromLTWH(0.0, 0.0, size.width, size.height),
         BasicPalette.black.paint);
-    regular.render(canvas, 'hit me!', Vector2d.fromSize(size).div(2),
+    regular.render(canvas, 'hit me!', Vector2d.fromSize(size)..div(2),
         anchor: Anchor.center);
     super.render(canvas);
   }

--- a/doc/examples/debug/lib/main.dart
+++ b/doc/examples/debug/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flame/game.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/svg.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/components/component.dart' show SvgComponent;
 import 'package:flame/components/mixins/resizable.dart';
 import 'package:flame/text_config.dart';
@@ -82,7 +82,7 @@ class MyGame extends BaseGame {
     super.render(canvas);
 
     if (debugMode()) {
-      fpsTextConfig.render(canvas, fps(120).toString(), Position(0, 50));
+      fpsTextConfig.render(canvas, fps(120).toString(), Vector2d(0, 50));
     }
   }
 }

--- a/doc/examples/effects/combined_effects/lib/main.dart
+++ b/doc/examples/effects/combined_effects/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flame/effects/move_effect.dart';
 import 'package:flame/effects/scale_effect.dart';
 import 'package:flame/effects/rotate_effect.dart';
 import 'package:flame/gestures.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
@@ -37,7 +37,7 @@ class MyGame extends BaseGame with TapDetector {
     greenSquare.clearEffects();
 
     final move = MoveEffect(
-      destination: Position(dx, dy),
+      destination: Vector2d(dx, dy),
       speed: 250.0,
       curve: Curves.linear,
       isInfinite: false,

--- a/doc/examples/effects/infinite_effects/lib/main.dart
+++ b/doc/examples/effects/infinite_effects/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flame/effects/move_effect.dart';
 import 'package:flame/effects/scale_effect.dart';
 import 'package:flame/effects/rotate_effect.dart';
 import 'package:flame/gestures.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
@@ -44,7 +44,7 @@ class MyGame extends BaseGame with TapDetector {
     orangeSquare.clearEffects();
 
     greenSquare.addEffect(MoveEffect(
-      destination: Position(dx, dy),
+      destination: Vector2d(dx, dy),
       speed: 250.0,
       curve: Curves.bounceInOut,
       isInfinite: true,

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flame/effects/scale_effect.dart';
 import 'package:flame/effects/rotate_effect.dart';
 import 'package:flame/effects/sequence_effect.dart';
 import 'package:flame/gestures.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
@@ -34,7 +34,7 @@ class MyGame extends BaseGame with TapDetector {
     greenSquare.clearEffects();
 
     final move1 = MoveEffect(
-      destination: Position(dx, dy),
+      destination: Vector2d(dx, dy),
       speed: 250.0,
       curve: Curves.bounceInOut,
       isInfinite: false,
@@ -42,7 +42,7 @@ class MyGame extends BaseGame with TapDetector {
     );
 
     final move2 = MoveEffect(
-      destination: Position(dx, dy + 150),
+      destination: Vector2d(dx, dy + 150),
       speed: 150.0,
       curve: Curves.easeIn,
       isInfinite: false,

--- a/doc/examples/effects/simple/lib/main_move.dart
+++ b/doc/examples/effects/simple/lib/main_move.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flame/game.dart';
 import 'package:flame/gestures.dart';
 import 'package:flame/effects/effects.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 
 import './square.dart';
 
@@ -17,7 +17,7 @@ class MyGame extends BaseGame with TapDetector {
   @override
   void onTapUp(details) {
     square.addEffect(MoveEffect(
-      destination: Position(
+      destination: Vector2d(
         details.localPosition.dx,
         details.localPosition.dy,
       ),

--- a/doc/examples/flare/lib/main.dart
+++ b/doc/examples/flare/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flame/game.dart';
 import 'package:flame/flare_animation.dart';
 import 'package:flame/components/flare_component.dart';
 import 'package:flame/text_config.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 
 import 'package:flutter/material.dart';
 
@@ -90,7 +90,7 @@ class MyGame extends BaseGame with TapDetector {
     }
 
     if (debugMode()) {
-      fpsTextConfig.render(canvas, fps(120).toString(), Position(0, 10));
+      fpsTextConfig.render(canvas, fps(120).toString(), Vector2d(0, 10));
     }
   }
 

--- a/doc/examples/flare/lib/main_component.dart
+++ b/doc/examples/flare/lib/main_component.dart
@@ -3,7 +3,7 @@ import 'package:flame/gestures.dart';
 import 'package:flame/game.dart';
 import 'package:flame/components/flare_component.dart';
 import 'package:flame/text_config.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/palette.dart';
 
 import 'package:flutter/material.dart';
@@ -67,7 +67,7 @@ class MyGame extends BaseGame with TapDetector, DoubleTapDetector {
     super.render(canvas);
 
     if (debugMode()) {
-      fpsTextConfig.render(canvas, fps(120).toString(), Position(0, 10));
+      fpsTextConfig.render(canvas, fps(120).toString(), Vector2d(0, 10));
     }
   }
 }

--- a/doc/examples/particles/lib/main.dart
+++ b/doc/examples/particles/lib/main.dart
@@ -23,7 +23,7 @@ import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
 import 'package:flame/time.dart' as flame_time;
 import 'package:flame/particle.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/sprite.dart';
 import 'package:flame/spritesheet.dart';
 import 'package:flame/text_config.dart';
@@ -388,7 +388,7 @@ class MyGame extends BaseGame {
   Particle spriteParticle() {
     return SpriteParticle(
       sprite: Sprite('zap.png'),
-      size: Position.fromOffset(cellSize * .5),
+      size: Vector2d.fromOffset(cellSize * .5),
     );
   }
 
@@ -397,7 +397,7 @@ class MyGame extends BaseGame {
   Particle animationParticle() {
     return AnimationParticle(
       animation: getBoomAnimation(),
-      size: Position(128, 128),
+      size: Vector2d(128, 128),
     );
   }
 
@@ -529,7 +529,7 @@ class MyGame extends BaseGame {
 
     if (debugMode()) {
       fpsTextConfig.render(canvas, '${fps(120).toStringAsFixed(2)}fps',
-          Position(0, size.height - 24));
+          Vector2d(0, size.height - 24));
     }
   }
 

--- a/doc/examples/svg/lib/main.dart
+++ b/doc/examples/svg/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flame/game.dart';
 import 'package:flame/svg.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/components/component.dart' show SvgComponent;
 
 import 'package:flutter/material.dart';
@@ -33,6 +33,6 @@ class MyGame extends BaseGame {
   void render(Canvas canvas) {
     super.render(canvas);
 
-    svgInstance.renderPosition(canvas, Position(100, 200), 300, 300);
+    svgInstance.renderPosition(canvas, Vector2d(100, 200), 300, 300);
   }
 }

--- a/doc/examples/timer/lib/main.dart
+++ b/doc/examples/timer/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flame/game.dart';
 import 'package:flame/time.dart';
 import 'package:flame/text_config.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 import 'package:flame/gestures.dart';
 import 'package:flame/components/timer_component.dart';
 
@@ -41,7 +41,7 @@ class RenderedTimeComponent extends TimerComponent {
   @override
   void render(Canvas canvas) {
     textConfig.render(
-        canvas, "Elapsed time: ${timer.current}", Position(10, 150));
+        canvas, "Elapsed time: ${timer.current}", Vector2d(10, 150));
   }
 }
 
@@ -87,7 +87,7 @@ class MyGame extends Game with TapDetector {
   @override
   void render(Canvas canvas) {
     textConfig.render(canvas, "Countdown: ${countdown.current.toString()}",
-        Position(10, 100));
-    textConfig.render(canvas, "Elapsed time: $elapsedSecs", Position(10, 150));
+        Vector2d(10, 100));
+    textConfig.render(canvas, "Elapsed time: $elapsedSecs", Vector2d(10, 150));
   }
 }

--- a/doc/util.md
+++ b/doc/util.md
@@ -58,7 +58,7 @@ __Countdown example:__
 import 'dart:ui';
 
 import 'package:flame/game.dart';
-import 'package:flame/position.dart';
+import 'vector2d.dart';
 import 'package:flame/text_config.dart';
 import 'package:flame/time.dart';
 
@@ -93,7 +93,7 @@ __Interval example:__
 import 'dart:ui';
 
 import 'package:flame/game.dart';
-import 'package:flame/position.dart';
+import 'vector2d.dart';
 import 'package:flame/text_config.dart';
 import 'package:flame/time.dart';
 

--- a/lib/anchor.dart
+++ b/lib/anchor.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'vector2d.dart';
 
 class Anchor {

--- a/lib/anchor.dart
+++ b/lib/anchor.dart
@@ -3,22 +3,22 @@ import 'dart:ui';
 import 'vector2d.dart';
 
 class Anchor {
-  static const Anchor topLeft = Anchor(Offset(0.0, 0.0));
-  static const Anchor topCenter = Anchor(Offset(0.5, 0.0));
-  static const Anchor topRight = Anchor(Offset(1.0, 0.0));
-  static const Anchor centerLeft = Anchor(Offset(0.0, 0.5));
-  static const Anchor center = Anchor(Offset(0.5, 0.5));
-  static const Anchor centerRight = Anchor(Offset(1.0, 0.5));
-  static const Anchor bottomLeft = Anchor(Offset(0.0, 1.0));
-  static const Anchor bottomCenter = Anchor(Offset(0.5, 1.0));
-  static const Anchor bottomRight = Anchor(Offset(1.0, 1.0));
+  static const Anchor topLeft = Anchor(0.0, 0.0);
+  static const Anchor topCenter = Anchor(0.5, 0.0);
+  static const Anchor topRight = Anchor(1.0, 0.0);
+  static const Anchor centerLeft = Anchor(0.0, 0.5);
+  static const Anchor center = Anchor(0.5, 0.5);
+  static const Anchor centerRight = Anchor(1.0, 0.5);
+  static const Anchor bottomLeft = Anchor(0.0, 1.0);
+  static const Anchor bottomCenter = Anchor(0.5, 1.0);
+  static const Anchor bottomRight = Anchor(1.0, 1.0);
 
-  final Offset relativePosition;
+  final double x;
+  final double y;
 
-  const Anchor(this.relativePosition);
+  const Anchor(this.x, this.y);
 
   Vector2d translate(Vector2d p, Vector2d size) {
-    return p.clone().minus(
-        Vector2d(size.x * relativePosition.dx, size.y * relativePosition.dy));
+    return p - Vector2d(x, y)..multiplyVector(size);
   }
 }

--- a/lib/anchor.dart
+++ b/lib/anchor.dart
@@ -19,6 +19,6 @@ class Anchor {
   const Anchor(this.x, this.y);
 
   Vector2d translate(Vector2d p, Vector2d size) {
-    return p - Vector2d(x, y)..multiplyVector(size);
+    return p - Vector2d(x, y)..multiply(size);
   }
 }

--- a/lib/anchor.dart
+++ b/lib/anchor.dart
@@ -19,6 +19,7 @@ class Anchor {
   const Anchor(this.x, this.y);
 
   Vector2d translate(Vector2d p, Vector2d size) {
-    return p - Vector2d(x, y)..multiply(size);
+    return p - Vector2d(x, y)
+      ..multiply(size);
   }
 }

--- a/lib/anchor.dart
+++ b/lib/anchor.dart
@@ -17,7 +17,6 @@ class Anchor {
   const Anchor(this.x, this.y);
 
   Vector2d translate(Vector2d p, Vector2d size) {
-    return p - Vector2d(x, y)
-      ..multiply(size);
+    return p - (Vector2d(x, y)..multiply(size));
   }
 }

--- a/lib/anchor.dart
+++ b/lib/anchor.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'position.dart';
+import 'vector2d.dart';
 
 class Anchor {
   static const Anchor topLeft = Anchor(Offset(0.0, 0.0));
@@ -17,8 +17,8 @@ class Anchor {
 
   const Anchor(this.relativePosition);
 
-  Position translate(Position p, Position size) {
+  Vector2d translate(Vector2d p, Vector2d size) {
     return p.clone().minus(
-        Position(size.x * relativePosition.dx, size.y * relativePosition.dy));
+        Vector2d(size.x * relativePosition.dx, size.y * relativePosition.dy));
   }
 }

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -100,8 +100,8 @@ abstract class PositionComponent extends Component {
     height = size.y;
   }
 
-  Rect toRect() => Rect.fromLTWH(x - anchor.x * width, y - anchor.y * height,
-      width, height);
+  Rect toRect() =>
+      Rect.fromLTWH(x - anchor.x * width, y - anchor.y * height, width, height);
   void setByRect(Rect rect) {
     x = rect.left + anchor.x * rect.width;
     y = rect.top + anchor.y * rect.height;

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 
 import '../svg.dart';
 import '../sprite.dart';
-import '../position.dart';
+import '../vector2d.dart';
 import '../anchor.dart';
 import '../text_config.dart';
 import '../effects/effects.dart';
@@ -88,14 +88,14 @@ abstract class PositionComponent extends Component {
 
   TextConfig get debugTextConfig => TextConfig(color: debugColor, fontSize: 12);
 
-  Position toPosition() => Position(x, y);
-  void setByPosition(Position position) {
+  Vector2d toPosition() => Vector2d(x, y);
+  void setByPosition(Vector2d position) {
     x = position.x;
     y = position.y;
   }
 
-  Position toSize() => Position(width, height);
-  void setBySize(Position size) {
+  Vector2d toSize() => Vector2d(width, height);
+  void setBySize(Vector2d size) {
     width = size.x;
     height = size.y;
   }
@@ -122,7 +122,7 @@ abstract class PositionComponent extends Component {
     debugTextConfig.render(
         canvas,
         "x: ${x.toStringAsFixed(2)} y:${y.toStringAsFixed(2)}",
-        Position(-50, -15));
+        Vector2d(-50, -15));
 
     final Rect rect = toRect();
     final dx = rect.right;
@@ -130,7 +130,7 @@ abstract class PositionComponent extends Component {
     debugTextConfig.render(
         canvas,
         "x:${dx.toStringAsFixed(2)} y:${dy.toStringAsFixed(2)}",
-        Position(width - 50, height));
+        Vector2d(width - 50, height));
   }
 
   void prepareCanvas(Canvas canvas) {

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -100,11 +100,11 @@ abstract class PositionComponent extends Component {
     height = size.y;
   }
 
-  Rect toRect() => Rect.fromLTWH(x - anchor.relativePosition.dx * width,
-      y - anchor.relativePosition.dy * height, width, height);
+  Rect toRect() => Rect.fromLTWH(x - anchor.x * width, y - anchor.y * height,
+      width, height);
   void setByRect(Rect rect) {
-    x = rect.left + anchor.relativePosition.dx * rect.width;
-    y = rect.top + anchor.relativePosition.dy * rect.height;
+    x = rect.left + anchor.x * rect.width;
+    y = rect.top + anchor.y * rect.height;
     width = rect.width;
     height = rect.height;
   }
@@ -137,8 +137,8 @@ abstract class PositionComponent extends Component {
     canvas.translate(x, y);
 
     canvas.rotate(angle);
-    final double dx = -anchor.relativePosition.dx * width;
-    final double dy = -anchor.relativePosition.dy * height;
+    final double dx = -anchor.x * width;
+    final double dy = -anchor.y * height;
     canvas.translate(dx, dy);
 
     // Handle inverted rendering by moving center and flipping.

--- a/lib/components/text_box_component.dart
+++ b/lib/components/text_box_component.dart
@@ -7,7 +7,7 @@ import 'component.dart';
 import 'mixins/resizable.dart';
 import '../text_config.dart';
 import '../palette.dart';
-import '../position.dart';
+import '../vector2d.dart';
 
 class TextBoxConfig {
   final double maxWidth;
@@ -27,7 +27,7 @@ class TextBoxComponent extends PositionComponent with Resizable {
   static final Paint _imagePaint = BasicPalette.white.paint
     ..filterQuality = FilterQuality.high;
 
-  Position p = Position.empty();
+  Vector2d p = Vector2d.zero();
 
   String _text;
   TextConfig _config;

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -3,7 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../components/component.dart';
-import '../position.dart';
+import '../vector2d.dart';
 
 export './move_effect.dart';
 export './scale_effect.dart';
@@ -30,9 +30,9 @@ abstract class PositionComponentEffect {
   int curveDirection = 1;
 
   /// Used to be able to determine the end state of a sequence of effects
-  Position endPosition;
+  Vector2d endPosition;
   double endAngle;
-  Position endSize;
+  Vector2d endSize;
 
   /// If the effect is alternating the travel time is double the normal
   /// travel time

--- a/lib/effects/move_effect.dart
+++ b/lib/effects/move_effect.dart
@@ -4,13 +4,13 @@ import 'package:meta/meta.dart';
 import 'dart:math';
 
 import './effects.dart';
-import '../position.dart';
+import '../vector2d.dart';
 
 double _direction(double p, double d) => (p - d).sign;
 double _distance(double a, double b) => (a - b).abs();
 
 class MoveEffect extends PositionComponentEffect {
-  Position destination;
+  Vector2d destination;
   double speed;
   Curve curve;
 

--- a/lib/effects/scale_effect.dart
+++ b/lib/effects/scale_effect.dart
@@ -5,7 +5,7 @@ import 'dart:ui';
 import 'dart:math';
 
 import './effects.dart';
-import '../position.dart';
+import '../vector2d.dart';
 
 double _direction(double p, double d) => (p - d).sign;
 double _size(double a, double b) => (a - b).abs();
@@ -17,7 +17,7 @@ class ScaleEffect extends PositionComponentEffect {
 
   Size _original;
   Size _diff;
-  final Position _dir = Position.empty();
+  final Vector2d _dir = Vector2d.zero();
 
   ScaleEffect({
     @required this.size,
@@ -32,7 +32,7 @@ class ScaleEffect extends PositionComponentEffect {
   void initialize(_comp) {
     super.initialize(_comp);
     if (!isAlternating) {
-      endSize = Position.fromSize(size);
+      endSize = Vector2d.fromSize(size);
     }
 
     _original = Size(component.width, component.height);

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -11,7 +11,7 @@ import 'package:ordered_set/ordered_set.dart';
 import '../components/component.dart';
 import '../components/mixins/has_game_ref.dart';
 import '../components/mixins/tapable.dart';
-import '../position.dart';
+import '../vector2d.dart';
 import 'game.dart';
 
 /// This is a more complete and opinionated implementation of Game.
@@ -34,7 +34,7 @@ class BaseGame extends Game {
   Size size;
 
   /// Camera position; every non-HUD component is translated so that the camera position is the top-left corner of the screen.
-  Position camera = Position.empty();
+  Vector2d camera = Vector2d.zero();
 
   /// List of deltas used in debug mode to calculate FPS
   final List<double> _dts = [];

--- a/lib/game/embedded_game_widget.dart
+++ b/lib/game/embedded_game_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart' hide WidgetBuilder;
 
-import '../position.dart';
+import '../vector2d.dart';
 
 import 'game_render_box.dart';
 import 'game.dart';
@@ -14,7 +14,7 @@ import 'game.dart';
 /// You can bind Gesture Recognizers immediately around this to add controls to your widgets, with easy coordinate conversions.
 class EmbeddedGameWidget extends LeafRenderObjectWidget {
   final Game game;
-  final Position size;
+  final Vector2d size;
 
   EmbeddedGameWidget(this.game, {this.size});
 

--- a/lib/particles/animation_particle.dart
+++ b/lib/particles/animation_particle.dart
@@ -4,11 +4,11 @@ import 'package:flutter/foundation.dart';
 
 import '../animation.dart';
 import '../particle.dart';
-import '../position.dart';
+import '../vector2d.dart';
 
 class AnimationParticle extends Particle {
   final Animation animation;
-  final Position size;
+  final Vector2d size;
   final Paint overridePaint;
   final bool alignAnimationTime;
 
@@ -36,7 +36,7 @@ class AnimationParticle extends Particle {
   void render(Canvas canvas) {
     animation.getSprite().renderCentered(
           canvas,
-          Position.empty(),
+          Vector2d.zero(),
           overridePaint: overridePaint,
           size: size,
         );

--- a/lib/particles/component_particle.dart
+++ b/lib/particles/component_particle.dart
@@ -3,12 +3,12 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 
 import '../particle.dart';
-import '../position.dart';
+import '../vector2d.dart';
 import '../components/component.dart';
 
 class ComponentParticle extends Particle {
   final Component component;
-  final Position size;
+  final Vector2d size;
   final Paint overridePaint;
 
   ComponentParticle({

--- a/lib/particles/sprite_particle.dart
+++ b/lib/particles/sprite_particle.dart
@@ -3,12 +3,12 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 
 import '../particle.dart';
-import '../position.dart';
+import '../vector2d.dart';
 import '../sprite.dart';
 
 class SpriteParticle extends Particle {
   final Sprite sprite;
-  final Position size;
+  final Vector2d size;
   final Paint overridePaint;
 
   SpriteParticle({
@@ -24,7 +24,7 @@ class SpriteParticle extends Particle {
   void render(Canvas canvas) {
     sprite.renderCentered(
       canvas,
-      Position.empty(),
+      Vector2d.zero(),
       overridePaint: overridePaint,
       size: size,
     );

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -84,7 +84,7 @@ class Sprite {
       return;
     }
     renderPosition(canvas, p,
-        size: size.multiply(scale), overridePaint: overridePaint);
+        size: size..scale(scale), overridePaint: overridePaint);
   }
 
   void renderPosition(Canvas canvas, Vector2d p,

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -84,7 +84,7 @@ class Sprite {
       return;
     }
     renderPosition(canvas, p,
-        size: size.times(scale), overridePaint: overridePaint);
+        size: size.multiply(scale), overridePaint: overridePaint);
   }
 
   void renderPosition(Canvas canvas, Vector2d p,

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'dart:async';
 import 'flame.dart';
-import 'position.dart';
+import 'vector2d.dart';
 import 'palette.dart';
 
 class Sprite {
@@ -62,15 +62,15 @@ class Sprite {
 
   double get _imageHeight => image.height.toDouble();
 
-  Position get originalSize {
+  Vector2d get originalSize {
     if (!loaded()) {
       return null;
     }
-    return Position(_imageWidth, _imageHeight);
+    return Vector2d(_imageWidth, _imageHeight);
   }
 
-  Position get size {
-    return Position(src.width, src.height);
+  Vector2d get size {
+    return Vector2d(src.width, src.height);
   }
 
   /// Renders this Sprite on the position [p], scaled by the [scale] factor provided.
@@ -78,7 +78,7 @@ class Sprite {
   /// It renders with src size multiplied by [scale] in both directions.
   /// Anchor is on top left as default.
   /// If not loaded, does nothing.
-  void renderScaled(Canvas canvas, Position p,
+  void renderScaled(Canvas canvas, Vector2d p,
       {double scale = 1.0, Paint overridePaint}) {
     if (!loaded()) {
       return;
@@ -87,13 +87,13 @@ class Sprite {
         size: size.times(scale), overridePaint: overridePaint);
   }
 
-  void renderPosition(Canvas canvas, Position p,
-      {Position size, Paint overridePaint}) {
+  void renderPosition(Canvas canvas, Vector2d p,
+      {Vector2d size, Paint overridePaint}) {
     if (!loaded()) {
       return;
     }
     size ??= this.size;
-    renderRect(canvas, Position.rectFrom(p, size),
+    renderRect(canvas, Vector2d.rectFrom(p, size),
         overridePaint: overridePaint);
   }
 
@@ -112,8 +112,8 @@ class Sprite {
   ///
   /// If [size] is not provided, the original size of the src image is used.
   /// If the asset is not yet loaded, it does nothing.
-  void renderCentered(Canvas canvas, Position p,
-      {Position size, Paint overridePaint}) {
+  void renderCentered(Canvas canvas, Vector2d p,
+      {Vector2d size, Paint overridePaint}) {
     if (!loaded()) {
       return;
     }

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 import 'package:flutter_svg/flutter_svg.dart';
 
 import 'flame.dart';
-import 'position.dart';
+import 'vector2d.dart';
 
 class Svg {
   DrawableRoot svgRoot;
@@ -31,7 +31,7 @@ class Svg {
   /// If not loaded, does nothing
   void renderPosition(
     Canvas canvas,
-    Position position,
+    Vector2d position,
     double width,
     double height,
   ) {

--- a/lib/text_config.dart
+++ b/lib/text_config.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 import 'package:flame/components/text_component.dart';
 import 'package:flutter/material.dart' as material;
 
-import 'position.dart';
+import 'vector2d.dart';
 import 'anchor.dart';
 
 /// A Text Config contains all typographical information required to render texts; i.e., font size and color, family, etc.
@@ -72,11 +72,11 @@ class TextConfig {
   ///
   ///     const TextConfig config = TextConfig(fontSize: 48.0, fontFamily: 'Awesome Font');
   ///     config.render(c, Offset(size.width - 10, size.height - 10, anchor: Anchor.bottomRight);
-  void render(Canvas canvas, String text, Position p,
+  void render(Canvas canvas, String text, Vector2d p,
       {Anchor anchor = Anchor.topLeft}) {
     final material.TextPainter tp = toTextPainter(text);
-    final Position translatedPosition =
-        anchor.translate(p, Position.fromSize(tp.size));
+    final Vector2d translatedPosition =
+        anchor.translate(p, Vector2d.fromSize(tp.size));
     tp.paint(canvas, translatedPosition.toOffset());
   }
 

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -10,7 +10,7 @@ import 'game/base_game.dart';
 import 'game/embedded_game_widget.dart';
 import 'sprite.dart';
 import 'components/animation_component.dart';
-import 'position.dart';
+import 'vector2d.dart';
 
 /// Some utilities that did not fit anywhere else.
 ///
@@ -144,7 +144,7 @@ class Util {
   ///
   /// Some render methods don't allow to pass a offset.
   /// This method translate the canvas, draw what you want, and then translate back.
-  void drawWhere(Canvas c, Position p, void Function(Canvas) fn) {
+  void drawWhere(Canvas c, Vector2d p, void Function(Canvas) fn) {
     c.translate(p.x, p.y);
     fn(c);
     c.translate(-p.x, -p.y);
@@ -157,7 +157,7 @@ class Util {
   /// This is intended to be used by non-game apps that want to add a sprite sheet animation.
   ///
   @Deprecated('Use SpriteAnimation instead')
-  widgets.Widget animationAsWidget(Position size, Animation animation) {
+  widgets.Widget animationAsWidget(Vector2d size, Animation animation) {
     return EmbeddedGameWidget(
       BaseGame()..add(AnimationComponent(size.x, size.y, animation)),
       size: size,

--- a/lib/vector2d.dart
+++ b/lib/vector2d.dart
@@ -2,74 +2,74 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:box2d_flame/box2d.dart' as b2d;
 
-/// An ordered pair representation (point, position, offset).
+/// An ordered pair representation (point, position, offset, vector2).
 ///
 /// It differs from the default implementations provided (math.Point and ui.Offset) as it's mutable.
 /// Also, it offers helpful converters and a some useful methods for manipulation.
 /// It always uses double values to store the coordinates.
-class Position {
+class Vector2d {
   /// Coordinates
   double x, y;
 
   /// Basic constructor
-  Position(this.x, this.y);
+  Vector2d(this.x, this.y);
 
-  /// Creates a point at the origin
-  Position.empty() : this(0.0, 0.0);
+  /// Creates a [Vector2d] with 0 splat into both lanes of the vector
+  Vector2d.zero() : this(0.0, 0.0);
 
-  /// Creates converting integers to double.
+  /// Creates a [Vector2d] by converting integers to double.
   ///
   /// Internal representation is still using double, the conversion is made in the constructor only.
-  Position.fromInts(int x, int y) : this(x.toDouble(), y.toDouble());
+  Vector2d.fromInts(int x, int y) : this(x.toDouble(), y.toDouble());
 
-  /// Creates using an [ui.Offset]
-  Position.fromOffset(ui.Offset offset) : this(offset.dx, offset.dy);
+  /// Creates a [Vector2d] using an [ui.Offset]
+  Vector2d.fromOffset(ui.Offset offset) : this(offset.dx, offset.dy);
 
-  /// Creates using an [ui.Size]
-  Position.fromSize(ui.Size size) : this(size.width, size.height);
+  /// Creates a [Vector2d] using an [ui.Size]
+  Vector2d.fromSize(ui.Size size) : this(size.width, size.height);
 
-  /// Creates using an [math.Point]
-  Position.fromPoint(math.Point point) : this(point.x, point.y);
+  /// Creates a [Vector2d] using an [math.Point]
+  Vector2d.fromPoint(math.Point point) : this(point.x, point.y);
 
-  /// Creates using another [Position]; i.e., clones this position.
+  /// Clones a [Vector2d]
   ///
   /// This is useful because this class is mutable, so beware of mutability issues.
-  Position.fromPosition(Position position) : this(position.x, position.y);
+  Vector2d.fromPosition(Vector2d position) : this(position.x, position.y);
 
-  /// Creates using a [b2d.Vector2]
-  Position.fromVector(b2d.Vector2 vector) : this(vector.x, vector.y);
+  /// Creates a [Vector2d] using a [b2d.Vector2]
+  Vector2d.fromVector2(b2d.Vector2 vector) : this(vector.x, vector.y);
 
   /// Adds the coordinates from another vector.
   ///
   /// This method changes `this` instance and returns itself.
-  Position add(Position other) {
+  Vector2d add(Vector2d other) {
     x += other.x;
     y += other.y;
     return this;
   }
 
-  /// Substracts the coordinates from another vector.
+  /// Subtracts the coordinates from another vector.
   ///
   /// This method changes `this` instance and returns itself.
-  Position minus(Position other) {
+  Vector2d minus(Vector2d other) {
     return add(other.clone().opposite());
   }
 
-  Position times(double scalar) {
+  Vector2d times(double scalar) {
     x *= scalar;
     y *= scalar;
     return this;
   }
 
-  Position opposite() {
+  Vector2d opposite() {
     return times(-1.0);
   }
 
-  Position div(double scalar) {
+  Vector2d div(double scalar) {
     return times(1 / scalar);
   }
 
-  double dotProduct(Position p) {
+  double dotProduct(Vector2d p) {
     return x * p.x + y * p.y;
   }
 
@@ -79,7 +79,7 @@ class Position {
   }
 
   /// Rotate around origin; [angle] in radians.
-  Position rotate(double angle) {
+  Vector2d rotate(double angle) {
     final double nx = math.cos(angle) * x - math.sin(angle) * y;
     final double ny = math.sin(angle) * x + math.cos(angle) * y;
     x = nx;
@@ -88,17 +88,17 @@ class Position {
   }
 
   /// Rotate around origin; [angle] in degrees.
-  Position rotateDeg(double angle) {
+  Vector2d rotateDeg(double angle) {
     return rotate(angle * math.pi / 180);
   }
 
   /// Change current rotation by delta angle; [angle] in radians.
-  Position rotateDelta(double radians) {
+  Vector2d rotateDelta(double radians) {
     return rotate(angle() + radians);
   }
 
   /// Change current rotation by delta angle; [angle] in degrees.
-  Position rotateDeltaDeg(double degrees) {
+  Vector2d rotateDeltaDeg(double degrees) {
     return rotateDeg(angleDeg() + degrees);
   }
 
@@ -112,8 +112,8 @@ class Position {
     return angle() * 180 / math.pi;
   }
 
-  /// Returns the angle of this vector from another [Position] in radians.
-  double angleFrom(Position other) {
+  /// Returns the angle of this vector from another [Vector2d] in radians.
+  double angleFrom(Vector2d other) {
     // Technically the origin is not a vector so you cannot find the angle between
     // itself and another vector so just default to calculating the angle between
     // the non-origin point and the origin to avoid division by zero
@@ -127,19 +127,19 @@ class Position {
     return math.acos(dotProduct(other) / (length() * other.length()));
   }
 
-  /// Returns the angle of this vector from another [Position] in degrees.
-  double angleFromDeg(Position other) {
+  /// Returns the angle of this vector from another [Vector2d] in degrees.
+  double angleFromDeg(Vector2d other) {
     return angleFrom(other) * 180 / math.pi;
   }
 
-  double distance(Position other) {
+  double distance(Vector2d other) {
     return clone().minus(other).length();
   }
 
   /// Changes the [length] of this vector to the one provided, without chaning direction.
   ///
   /// If you try to scale the zero (empty) vector, it will remain unchanged, and no error will be thrown.
-  Position scaleTo(double newLength) {
+  Vector2d scaleTo(double newLength) {
     final l = length();
     if (l == 0) {
       return this;
@@ -148,14 +148,14 @@ class Position {
   }
 
   /// Normalizes this vector, without changing direction.
-  Position normalize() {
+  Vector2d normalize() {
     return scaleTo(1.0);
   }
 
   /// Limits the [length] of this vector to the one provided, without changing direction.
   ///
   /// If this vector's length is bigger than [maxLength], it becomes [maxLength]; otherwise, nothing changes.
-  Position limit(double maxLength) {
+  Vector2d limit(double maxLength) {
     final newLength = length().clamp(0.0, maxLength.abs());
     return scaleTo(newLength);
   }
@@ -172,37 +172,37 @@ class Position {
     return math.Point(x, y);
   }
 
-  b2d.Vector2 toVector() {
+  b2d.Vector2 toVector2() {
     return b2d.Vector2(x, y);
   }
 
-  Position clone() {
-    return Position.fromPosition(this);
+  Vector2d clone() {
+    return Vector2d.fromPosition(this);
   }
 
-  bool equals(Position p) {
+  bool equals(Vector2d p) {
     return p.x == x && p.y == y;
   }
 
   @override
   bool operator ==(other) {
-    return other is Position && equals(other);
+    return other is Vector2d && equals(other);
   }
 
   /// Negate.
-  Position operator -() => clone()..opposite();
+  Vector2d operator -() => clone()..opposite();
 
   /// Subtract two vectors.
-  Position operator -(Position other) => clone()..minus(other);
+  Vector2d operator -(Vector2d other) => clone()..minus(other);
 
   /// Add two vectors.
-  Position operator +(Position other) => clone()..add(other);
+  Vector2d operator +(Vector2d other) => clone()..add(other);
 
   /// Scale.
-  Position operator /(double scale) => clone()..div(scale);
+  Vector2d operator /(double scale) => clone()..div(scale);
 
   /// Scale.
-  Position operator *(double scale) => clone()..times(scale);
+  Vector2d operator *(double scale) => clone()..times(scale);
 
   @override
   int get hashCode => toString().hashCode;
@@ -212,11 +212,11 @@ class Position {
     return '($x, $y)';
   }
 
-  static ui.Rect rectFrom(Position topLeft, Position size) {
+  static ui.Rect rectFrom(Vector2d topLeft, Vector2d size) {
     return ui.Rect.fromLTWH(topLeft.x, topLeft.y, size.x, size.y);
   }
 
-  static ui.Rect bounds(List<Position> pts) {
+  static ui.Rect bounds(List<Vector2d> pts) {
     final double minx = pts.map((e) => e.x).reduce(math.min);
     final double maxx = pts.map((e) => e.x).reduce(math.max);
     final double miny = pts.map((e) => e.y).reduce(math.min);

--- a/lib/vector2d.dart
+++ b/lib/vector2d.dart
@@ -137,7 +137,7 @@ class Vector2d {
 
   /// Returns the distance between two vectors
   double distance(Vector2d other) {
-    return (this-other).length();
+    return (this - other).length();
   }
 
   /// Changes the [length] of this vector to the one provided, without changing the direction.

--- a/lib/vector2d.dart
+++ b/lib/vector2d.dart
@@ -55,18 +55,24 @@ class Vector2d {
     return add(other.clone().opposite());
   }
 
-  Vector2d times(double scalar) {
+  Vector2d multiply(double scalar) {
     x *= scalar;
     y *= scalar;
     return this;
   }
 
+  Vector2d multiplyVector(Vector2d vector) {
+    x *= vector.x;
+    y *= vector.y;
+    return this;
+  }
+
   Vector2d opposite() {
-    return times(-1.0);
+    return multiply(-1.0);
   }
 
   Vector2d div(double scalar) {
-    return times(1 / scalar);
+    return multiply(1 / scalar);
   }
 
   double dotProduct(Vector2d p) {
@@ -144,7 +150,7 @@ class Vector2d {
     if (l == 0) {
       return this;
     }
-    return times(newLength.abs() / l);
+    return multiply(newLength.abs() / l);
   }
 
   /// Normalizes this vector, without changing direction.
@@ -202,7 +208,7 @@ class Vector2d {
   Vector2d operator /(double scale) => clone()..div(scale);
 
   /// Scale.
-  Vector2d operator *(double scale) => clone()..times(scale);
+  Vector2d operator *(double scale) => clone()..multiply(scale);
 
   @override
   int get hashCode => toString().hashCode;

--- a/lib/vector2d.dart
+++ b/lib/vector2d.dart
@@ -34,45 +34,42 @@ class Vector2d {
   /// Clones a [Vector2d]
   ///
   /// This is useful because this class is mutable, so beware of mutability issues.
-  Vector2d.fromPosition(Vector2d position) : this(position.x, position.y);
+  Vector2d.fromVector2d(Vector2d position) : this(position.x, position.y);
 
   /// Creates a [Vector2d] using a [b2d.Vector2]
   Vector2d.fromVector2(b2d.Vector2 vector) : this(vector.x, vector.y);
 
   /// Adds the coordinates from another vector.
-  ///
-  /// This method changes `this` instance and returns itself.
-  Vector2d add(Vector2d other) {
+  void add(Vector2d other) {
     x += other.x;
     y += other.y;
-    return this;
   }
 
   /// Subtracts the coordinates from another vector.
-  ///
-  /// This method changes `this` instance and returns itself.
-  Vector2d minus(Vector2d other) {
-    return add(other.clone().opposite());
+  void minus(Vector2d other) {
+    x -= other.x;
+    y -= other.y;
   }
 
-  Vector2d multiply(double scalar) {
+  /// Scales the vector by a factor [scalar]
+  void scale(double scalar) {
     x *= scalar;
     y *= scalar;
-    return this;
   }
 
-  Vector2d multiplyVector(Vector2d vector) {
+  /// Divides (scales down) by a factor [scalar]
+  void div(double scalar) {
+    scale(1 / scalar);
+  }
+
+  /// Vector multiplication
+  void multiply(Vector2d vector) {
     x *= vector.x;
     y *= vector.y;
-    return this;
   }
 
   Vector2d opposite() {
-    return multiply(-1.0);
-  }
-
-  Vector2d div(double scalar) {
-    return multiply(1 / scalar);
+    return clone()..scale(-1.0);
   }
 
   double dotProduct(Vector2d p) {
@@ -138,52 +135,37 @@ class Vector2d {
     return angleFrom(other) * 180 / math.pi;
   }
 
+  /// Returns the distance between two vectors
   double distance(Vector2d other) {
-    return clone().minus(other).length();
+    return (this-other).length();
   }
 
-  /// Changes the [length] of this vector to the one provided, without chaning direction.
+  /// Changes the [length] of this vector to the one provided, without changing the direction.
   ///
   /// If you try to scale the zero (empty) vector, it will remain unchanged, and no error will be thrown.
-  Vector2d scaleTo(double newLength) {
+  void scaleTo(double newLength) {
     final l = length();
     if (l == 0) {
-      return this;
+      return;
     }
-    return multiply(newLength.abs() / l);
+    scale(newLength.abs() / l);
   }
 
   /// Normalizes this vector, without changing direction.
-  Vector2d normalize() {
-    return scaleTo(1.0);
+  void normalize() {
+    scaleTo(1.0);
   }
 
   /// Limits the [length] of this vector to the one provided, without changing direction.
   ///
   /// If this vector's length is bigger than [maxLength], it becomes [maxLength]; otherwise, nothing changes.
-  Vector2d limit(double maxLength) {
+  void limit(double maxLength) {
     final newLength = length().clamp(0.0, maxLength.abs());
-    return scaleTo(newLength);
-  }
-
-  ui.Offset toOffset() {
-    return ui.Offset(x, y);
-  }
-
-  ui.Size toSize() {
-    return ui.Size(x, y);
-  }
-
-  math.Point toPoint() {
-    return math.Point(x, y);
-  }
-
-  b2d.Vector2 toVector2() {
-    return b2d.Vector2(x, y);
+    scaleTo(newLength);
   }
 
   Vector2d clone() {
-    return Vector2d.fromPosition(this);
+    return Vector2d.fromVector2d(this);
   }
 
   bool equals(Vector2d p) {
@@ -208,7 +190,23 @@ class Vector2d {
   Vector2d operator /(double scale) => clone()..div(scale);
 
   /// Scale.
-  Vector2d operator *(double scale) => clone()..multiply(scale);
+  Vector2d operator *(double scale) => clone()..scale(scale);
+
+  ui.Offset toOffset() {
+    return ui.Offset(x, y);
+  }
+
+  ui.Size toSize() {
+    return ui.Size(x, y);
+  }
+
+  math.Point toPoint() {
+    return math.Point(x, y);
+  }
+
+  b2d.Vector2 toVector2() {
+    return b2d.Vector2(x, y);
+  }
 
   @override
   int get hashCode => toString().hashCode;

--- a/lib/widgets/sprite_widget.dart
+++ b/lib/widgets/sprite_widget.dart
@@ -43,12 +43,12 @@ class _SpritePainer extends CustomPainter {
     final w = _sprite.size.x * rate;
     final h = _sprite.size.y * rate;
 
-    final double dx = _anchor.relativePosition.dx * size.width;
-    final double dy = _anchor.relativePosition.dy * size.height;
+    final double dx = _anchor.x * size.width;
+    final double dy = _anchor.y * size.height;
 
     canvas.translate(
-      dx - w * _anchor.relativePosition.dx,
-      dy - h * _anchor.relativePosition.dy,
+      dx - w * _anchor.x,
+      dy - h * _anchor.y,
     );
 
     _sprite.render(canvas, width: w, height: h);

--- a/test/components/component_test.dart
+++ b/test/components/component_test.dart
@@ -2,7 +2,7 @@ import 'package:test/test.dart';
 import 'dart:ui';
 
 import 'package:flame/components/component.dart';
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 
 void main() {
   group('component test', () {
@@ -13,7 +13,7 @@ void main() {
       expect(c.toPosition().x, 2.2);
       expect(c.toPosition().y, 3.4);
 
-      c.setByPosition(Position(1.0, 0.0));
+      c.setByPosition(Vector2d(1.0, 0.0));
       expect(c.x, 1.0);
       expect(c.y, 0.0);
     });
@@ -25,7 +25,7 @@ void main() {
       expect(c.toSize().x, 2.2);
       expect(c.toSize().y, 3.4);
 
-      c.setBySize(Position(1.0, 0.0));
+      c.setBySize(Vector2d(1.0, 0.0));
       expect(c.width, 1.0);
       expect(c.height, 0.0);
     });

--- a/test/position_test.dart
+++ b/test/position_test.dart
@@ -1,7 +1,7 @@
 import 'package:test/test.dart';
 import 'dart:math' as math;
 
-import 'package:flame/position.dart';
+import 'package:flame/vector2d.dart';
 
 void expectDouble(double d1, double d2) {
   expect((d1 - d2).abs() <= 0.0001, true);
@@ -10,16 +10,16 @@ void expectDouble(double d1, double d2) {
 void main() {
   group('position test', () {
     test('test add', () {
-      final Position p = Position(0.0, 5.0);
-      final Position p2 = p.add(Position(5.0, 5.0));
+      final Vector2d p = Vector2d(0.0, 5.0);
+      final Vector2d p2 = p.add(Vector2d(5.0, 5.0));
       expect(p, p2);
       expectDouble(p.x, 5.0);
       expectDouble(p.y, 10.0);
     });
 
     test('test clone', () {
-      final Position p = Position(1.0, 0.0);
-      final Position clone = p.clone();
+      final Vector2d p = Vector2d(1.0, 0.0);
+      final Vector2d clone = p.clone();
 
       clone.times(2.0);
       expectDouble(p.x, 1.0);
@@ -27,49 +27,49 @@ void main() {
     });
 
     test('test rotate', () {
-      final Position p = Position(1.0, 0.0).rotate(math.pi / 2);
+      final Vector2d p = Vector2d(1.0, 0.0).rotate(math.pi / 2);
       expectDouble(p.x, 0.0);
       expectDouble(p.y, 1.0);
     });
 
     test('test length', () {
-      final Position p1 = Position(3.0, 4.0);
+      final Vector2d p1 = Vector2d(3.0, 4.0);
       expectDouble(p1.length(), 5.0);
 
-      final Position p2 = Position(2.0, 0.0);
+      final Vector2d p2 = Vector2d(2.0, 0.0);
       expectDouble(p2.length(), 2.0);
 
-      final Position p3 = Position(0.0, 1.5);
+      final Vector2d p3 = Vector2d(0.0, 1.5);
       expectDouble(p3.length(), 1.5);
     });
 
     test('test distance', () {
-      final Position p1 = Position(10.0, 20.0);
-      final Position p2 = Position(13.0, 24.0);
+      final Vector2d p1 = Vector2d(10.0, 20.0);
+      final Vector2d p2 = Vector2d(13.0, 24.0);
       final double result = p1.distance(p2);
       expectDouble(result, 5.0);
     });
 
     test('equality', () {
-      final Position p1 = Position.empty();
-      final Position p2 = Position.empty();
+      final Vector2d p1 = Vector2d.zero();
+      final Vector2d p2 = Vector2d.zero();
       expect(p1 == p2, true);
     });
 
     test('non equality', () {
-      final Position p1 = Position.empty();
-      final Position p2 = Position(1.0, 0.0);
+      final Vector2d p1 = Vector2d.zero();
+      final Vector2d p2 = Vector2d(1.0, 0.0);
       expect(p1 == p2, false);
     });
 
     test('hashCode', () {
-      final Position p1 = Position(2.0, -1.0);
-      final Position p2 = Position(1.0, 0.0);
+      final Vector2d p1 = Vector2d(2.0, -1.0);
+      final Vector2d p2 = Vector2d(1.0, 0.0);
       expect(p1.hashCode == p2.hashCode, false);
     });
 
     test('scaleTo', () {
-      final Position p = Position(1.0, 0.0);
+      final Vector2d p = Vector2d(1.0, 0.0);
 
       p.rotate(math.pi / 4).scaleTo(2.0);
       expect(p.length(), 2.0);
@@ -81,18 +81,18 @@ void main() {
     });
 
     test('scaleTo the zero vector', () {
-      final Position p = Position.empty();
+      final Vector2d p = Vector2d.zero();
       expect(p.scaleTo(1.0).length(), 0.0);
     });
 
     test('limit', () {
-      final Position p1 = Position(1.0, 0.0);
+      final Vector2d p1 = Vector2d(1.0, 0.0);
       p1.limit(0.75);
       expect(p1.length(), 0.75);
       expect(p1.x, 0.75);
       expect(p1.y, 0.0);
 
-      final Position p2 = Position(1.0, 1.0);
+      final Vector2d p2 = Vector2d(1.0, 1.0);
       p2.limit(3.0);
       expectDouble(p2.length(), math.sqrt(2));
       expect(p2.x, 1.0);

--- a/test/position_test.dart
+++ b/test/position_test.dart
@@ -21,7 +21,7 @@ void main() {
       final Vector2d p = Vector2d(1.0, 0.0);
       final Vector2d clone = p.clone();
 
-      clone.times(2.0);
+      clone.multiply(2.0);
       expectDouble(p.x, 1.0);
       expectDouble(clone.x, 2.0);
     });

--- a/test/position_test.dart
+++ b/test/position_test.dart
@@ -11,7 +11,7 @@ void main() {
   group('position test', () {
     test('test add', () {
       final Vector2d p = Vector2d(0.0, 5.0);
-      final Vector2d p2 = p.add(Vector2d(5.0, 5.0));
+      final Vector2d p2 = p..add(Vector2d(5.0, 5.0));
       expect(p, p2);
       expectDouble(p.x, 5.0);
       expectDouble(p.y, 10.0);
@@ -21,7 +21,7 @@ void main() {
       final Vector2d p = Vector2d(1.0, 0.0);
       final Vector2d clone = p.clone();
 
-      clone.multiply(2.0);
+      clone.scale(2.0);
       expectDouble(p.x, 1.0);
       expectDouble(clone.x, 2.0);
     });
@@ -82,7 +82,7 @@ void main() {
 
     test('scaleTo the zero vector', () {
       final Vector2d p = Vector2d.zero();
-      expect(p.scaleTo(1.0).length(), 0.0);
+      expect((p..scaleTo(1.0)).length(), 0.0);
     });
 
     test('limit', () {


### PR DESCRIPTION
# Description

Rename and remake the Position class to be more general.

The vector_math vector2 was built around factories which made it hard to extend it, so box2d interaction will still need to convert between the vector formats. I will look into converting box2d to use this vector instead.

Fixes #373

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] The continuous integration (CI) is passing
