### PR TITLE
Added alternative for Component destroy handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Upgrade tiled and flutter_svg dependencies
  - onComplete callback for effects
  - Adding Layers
+ - Adding alternative for Component destroy handling
  
 ## 0.22.1
  - Fix Box2DComponent render priority

--- a/doc/components.md
+++ b/doc/components.md
@@ -35,6 +35,8 @@ The `resize` method is called whenever the screen is resized, and in the beginni
 
 The `destroy` method can be implemented to return true and warn the `BaseGame` that your object is marked for destruction, and it will be remove after the current update loop. It will then no longer be rendered or updated.
 
+The `prepareDestroy` method can be use as an alternative for destroy handling, forcing the `destroy` method to return true.
+
 The `isHUD` method can be implemented to return true (default false) to make the `BaseGame` ignore the `camera` for this element.
 
 The `onMount` method can be overridden to run initialization code for the component. When this method is called, BaseGame ensures that all the mixins which would change this component behaviour are already resolved.

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -39,10 +39,17 @@ abstract class Component {
   /// Note that for a more consistent experience, you can pre-load all your assets beforehand with Flame.images.loadAll.
   bool loaded() => true;
 
+  /// Holds the value used for [Component.destroy] method.
+  bool _mustDestroy = false;
+
+  /// Force the [Component.destroy] to return true.
+  /// It's an alternative for handling the component destruction, otherwise use the overriden of [Component.destroy] method.
+  void prepareDestroy => _mustDestroy = true;
+
   /// Whether this should be destroyed or not.
   ///
   /// It will be called once per component per loop, and if it returns true, [BaseGame] will mark your component for deletion and remove it before the next loop.
-  bool destroy() => false;
+  bool destroy() => _mustDestroy;
 
   /// Whether this component is HUD object or not.
   ///


### PR DESCRIPTION
# Description

Added alternative for Component destroy handling.
The alternative is for using a method to mark the component to be destroyed directly.

Instead to use this:

```
bool boolForDestroy = false;

...
foo() {
  if (someCondition) {
    boolForDestroy = true;
  }
}

@override
void onDestroy() => boolForDestroy;
```

We will use this:
```
foo() {
  if (someCondition) {
    prepareDestroy();
  }
}
```

This way we have the freedom to choice which way we want to develop the handling to destroy the components. 


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [X] This branch is based on `develop`
- [X] This PR is targeted to merge into `develop` (not `master`)
- [X] I have added an entry under `[next]` in `CHANGELOG.md`
- [X] I have formatted my code with `flutter format`
- [X] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
