### PR TITLE
[WIP] TiledComponent makes use of the SpriteBatch API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+ - Updated the TiledComponent to use the SpriteBatch API for efficient drawing to canvas.
 
 ## 0.24.0
  - Outsourcing SVG support to an external package

--- a/doc/examples/tiled/lib/main.dart
+++ b/doc/examples/tiled/lib/main.dart
@@ -15,7 +15,10 @@ void main() {
 
 class TiledGame extends BaseGame {
   TiledGame() {
-    final TiledComponent tiledMap = TiledComponent('map.tmx', 16.0);
+    final TiledComponent tiledMap = TiledComponent(
+      'map.tmx',
+      destTileSize: const Size(16.0, 16.0),
+    );
     add(tiledMap);
     _addCoinsInMap(tiledMap);
   }

--- a/lib/components/tiled_component.dart
+++ b/lib/components/tiled_component.dart
@@ -94,7 +94,7 @@ class TiledComponent extends Component {
     map = await _loadMap();
     image = await Flame.images.load(map.tilesets[0].image.source);
     batches = await _loadImages(map);
-    _drawTiles(map);
+    generate();
     _loaded = true;
   }
 
@@ -115,7 +115,15 @@ class TiledComponent extends Component {
     return result;
   }
 
-  void _drawTiles(TileMap map) async {
+  /// Generate the sprite batches from the existing tilemap.
+  void generate() {
+    for (var batch in batches.keys) {
+      batches[batch].clear;
+    }
+    _drawTiles(map);
+  }
+
+  void _drawTiles(TileMap map) {
     map.layers.where((layer) => layer.visible).forEach((layer) {
       layer.tiles.forEach((tileRow) {
         tileRow.forEach((tile) {


### PR DESCRIPTION
# Description
The current `TiledComponent` draws each tile individually on the canvas, switching to the `SpriteBatch` API will give a enormous performance gain because it will only do a single call to the canvas drawing all tiles using a single atlas.

**Note 1**: Because of how I implemented it, a developer wont be able to toggle the visibility of a layer. Because all the tiles are added to the `SpriteBatch` on creation, instead of drawn each frame, where the visibility check originally was.

**Note 2**: I also updated the constructor to accept a optional `Size` parameter for the destination instead of a required `double`. I made it optional so that it will grab the default tile size if non was given and so a developer could easily use irregular shaped tiles, which Tiled it self supports. But this has the side effect that the scaling wont properly work with irregular shaped tiles. But this will also be the case using a required `double` destination that does not fit with either the `width` or `height` depending on which value we use to calculate the scale.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
