### PR TITLE
Improve cleanup script to shed a few hundred MBs

### DIFF
--- a/doc/examples/cleanup.sh
+++ b/doc/examples/cleanup.sh
@@ -6,3 +6,4 @@ rm -rf */ios
 rm -rf */web
 rm -rf */macos
 rm -rf */test
+rm -rf */.dart_tool


### PR DESCRIPTION
# Description

Improving the cleanup script to also delete the .dart_tools folder. Though apparently small this really stacks up with the number of examples we have, and this will free a few hundred MBs in total.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)