### PR TITLE
Add mustCallSuper to BaseGame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
  - Externalizing Tiled support to its own package
  - Preventing some crashed that could happen on web when some methods were called
+ - Add mustCallSuper to BaseGame methods
 
 ## 0.24.0
  - Outsourcing SVG support to an external package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [next]
  - Externalizing Tiled support to its own package
  - Preventing some crashed that could happen on web when some methods were called
- - Add mustCallSuper to BaseGame methods
+ - Add mustCallSuper to BaseGame `update` and `render` methods
 
 ## 0.24.0
  - Outsourcing SVG support to an external package

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -99,6 +99,7 @@ class BaseGame extends Game {
   /// You can override it further to add more custom behaviour.
   /// Beware of however you are rendering components if not using this; you must be careful to save and restore the canvas to avoid components messing up with each other.
   @override
+  @mustCallSuper
   void render(Canvas canvas) {
     canvas.save();
     components.forEach((comp) => renderComponent(canvas, comp));
@@ -126,6 +127,7 @@ class BaseGame extends Game {
   /// It also actually adds the components that were added by the [addLater] method, and remove those that are marked for destruction via the [Component.destroy] method.
   /// You can override it further to add more custom behaviour.
   @override
+  @mustCallSuper
   void update(double t) {
     _removeLater.forEach((c) => components.remove(c));
     _removeLater.clear();


### PR DESCRIPTION
# Description

Add mustCallSuper to BaseGame. All implementations of Base Game should at some point call the super of render and update to make sure the components are rendered/updated.

Fixes #431 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
