### PR TITLE
Move fps to mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  - Externalizing Tiled support to its own package
  - Preventing some crashed that could happen on web when some methods were called
  - Add mustCallSuper to BaseGame `update` and `render` methods
- - Moved FPS code from BaseGame to a mixin, BaseGame used the new mixin.
+ - Moved FPS code from BaseGame to a mixin, BaseGame uses the new mixin.
 
 ## 0.24.0
  - Outsourcing SVG support to an external package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Externalizing Tiled support to its own package
  - Preventing some crashed that could happen on web when some methods were called
  - Add mustCallSuper to BaseGame `update` and `render` methods
+ - Moved FPS code from BaseGame to a mixin, BaseGame used the new mixin.
 
 ## 0.24.0
  - Outsourcing SVG support to an external package

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -1,7 +1,20 @@
-## Debug features
+# Debug features
+
+## FPS recording
+
+Flame provides the `FPS` mixin for recording the fps, this mixin can be applied on any class that extends from `Game`. When applied you have to implemented the `recordFps` method and it should return `true` if you want to access the current fps by using the `fps` method`.
+
+```dart
+class MyGame extends Game with FPS {
+  @override
+  bool recordFps() => true;
+}
+```
+
+## BaseGame features
 
 Flame provides some features for debugging, these features are enabled when the method `debugMode` from the `BaseGame` class is overridden, and returning `true`. When it's enabled all `PositionComponent`s will be wrapped into a rectangle, and have its position rendered on the screen, so you can visually verify the component boundaries and position.
 
-In addition to the debugMode, you can also ask BaseGame to record the fps, that is enabled by overriding the `recordFps` method to return `true`, by doing so, you can access the current fps by using the method `fps`.
+In addition to the debugMode, you can also ask `BaseGame` to record the fps(the `BaseGame` used the [FPS](fps-recording) mixin). To enable it you have to override the `recordFps` method to return `true`, by doing so, you can access the current fps by using the method `fps`.
 
-To see a working example of the debugging features, [check this example](/doc/examples/debug).
+To see a working example of the debugging features of the `BaseGame`, [check this example](/doc/examples/debug).

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -1,8 +1,8 @@
 # Debug features
 
-## FPS recording
+## FPS counter
 
-Flame provides the `FPS` mixin for recording the fps, this mixin can be applied on any class that extends from `Game`. When applied you have to implemented the `recordFps` method and it should return `true` if you want to access the current fps by using the `fps` method`.
+Flame provides the `FPSCounter` mixin for recording the fps, this mixin can be applied on any class that extends from `Game`. When applied you have to implemented the `recordFps` method and it should return `true` if you want to access the current fps by using the `fps` method`.
 
 ```dart
 class MyGame extends Game with FPS {
@@ -15,6 +15,6 @@ class MyGame extends Game with FPS {
 
 Flame provides some features for debugging, these features are enabled when the method `debugMode` from the `BaseGame` class is overridden, and returning `true`. When it's enabled all `PositionComponent`s will be wrapped into a rectangle, and have its position rendered on the screen, so you can visually verify the component boundaries and position.
 
-In addition to the debugMode, you can also ask `BaseGame` to record the fps(the `BaseGame` used the [FPS](fps-recording) mixin). To enable it you have to override the `recordFps` method to return `true`, by doing so, you can access the current fps by using the method `fps`.
+In addition to the debugMode, you can also ask `BaseGame` to record the fps(the `BaseGame` used the [FPSCounter](fps-counter) mixin). To enable it you have to override the `recordFps` method to return `true`, by doing so, you can access the current fps by using the method `fps`.
 
 To see a working example of the debugging features of the `BaseGame`, [check this example](/doc/examples/debug).

--- a/lib/fps.dart
+++ b/lib/fps.dart
@@ -1,0 +1,39 @@
+import 'dart:math' as math;
+
+import 'game/game.dart';
+
+mixin FPS on Game {
+  /// List of deltas used in debug mode to calculate FPS
+  final List<double> _dts = [];
+
+  /// Returns whether this [Game] is should record fps or not
+  ///
+  /// Returns `false` by default. Override to use the `fps` counter method.
+  /// In recording fps, the [recordDt] method actually records every `dt` for statistics.
+  /// Then, you can use the [fps] method to check the game FPS.
+  bool recordFps();
+
+  /// This is a hook that comes from the RenderBox to allow recording of render times and statistics.
+  @override
+  void recordDt(double dt) {
+    if (recordFps()) {
+      _dts.add(dt);
+    }
+  }
+
+  /// Returns the average FPS for the last [average] measures.
+  ///
+  /// The values are only saved if in debug mode (override [recordFps] to use this).
+  /// Selects the last [average] dts, averages then, and returns the inverse value.
+  /// So it's technically updates per second, but the relation between updates and renders is 1:1.
+  /// Returns 0 if empty.
+  double fps([int average = 1]) {
+    final List<double> dts = _dts.sublist(math.max(0, _dts.length - average));
+    if (dts.isEmpty) {
+      return 0.0;
+    }
+    final double dtSum = dts.reduce((s, t) => s + t);
+    final double averageDt = dtSum / average;
+    return 1 / averageDt;
+  }
+}

--- a/lib/fps_counter.dart
+++ b/lib/fps_counter.dart
@@ -2,7 +2,7 @@ import 'dart:math' as math;
 
 import 'game/game.dart';
 
-mixin FPS on Game {
+mixin FPSCounter on Game {
   /// List of deltas used in debug mode to calculate FPS
   final List<double> _dts = [];
 

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -1,7 +1,7 @@
-import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flame/components/composed_component.dart';
+import 'package:flame/fps.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart' hide WidgetBuilder;
 import 'package:flutter/foundation.dart';
@@ -19,7 +19,7 @@ import 'game.dart';
 /// It still needs to be subclasses to add your game logic, but the [update], [render] and [resize] methods have default implementations.
 /// This is the recommended structure to use for most games.
 /// It is based on the Component system.
-class BaseGame extends Game {
+class BaseGame extends Game with FPS {
   /// The list of components to be updated and rendered by the base game.
   OrderedSet<Component> components =
       OrderedSet(Comparing.on((c) => c.priority()));
@@ -35,9 +35,6 @@ class BaseGame extends Game {
 
   /// Camera position; every non-HUD component is translated so that the camera position is the top-left corner of the screen.
   Position camera = Position.empty();
-
-  /// List of deltas used in debug mode to calculate FPS
-  final List<double> _dts = [];
 
   /// This method is called for every component added, both via [add] and [addLater] methods.
   ///
@@ -156,36 +153,8 @@ class BaseGame extends Game {
   /// You can use this value to enable debug behaviors for your game, many components show extra information on screen when on debug mode
   bool debugMode() => false;
 
-  /// Returns whether this [Game] is should record fps or not
-  ///
-  /// Returns `false` by default. Override to use the `fps` counter method.
-  /// In recording fps, the [recordDt] method actually records every `dt` for statistics.
-  /// Then, you can use the [fps] method to check the game FPS.
-  bool recordFps() => false;
-
-  /// This is a hook that comes from the RenderBox to allow recording of render times and statistics.
   @override
-  void recordDt(double dt) {
-    if (recordFps()) {
-      _dts.add(dt);
-    }
-  }
-
-  /// Returns the average FPS for the last [average] measures.
-  ///
-  /// The values are only saved if in debug mode (override [recordFps] to use this).
-  /// Selects the last [average] dts, averages then, and returns the inverse value.
-  /// So it's technically updates per second, but the relation between updates and renders is 1:1.
-  /// Returns 0 if empty.
-  double fps([int average = 1]) {
-    final List<double> dts = _dts.sublist(math.max(0, _dts.length - average));
-    if (dts.isEmpty) {
-      return 0.0;
-    }
-    final double dtSum = dts.reduce((s, t) => s + t);
-    final double averageDt = dtSum / average;
-    return 1 / averageDt;
-  }
+  bool recordFps() => false;
 
   /// Returns the current time in seconds with microseconds precision.
   ///

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
 import 'package:flame/components/composed_component.dart';
-import 'package:flame/fps.dart';
+import 'package:flame/fps_counter.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart' hide WidgetBuilder;
 import 'package:flutter/foundation.dart';
@@ -19,7 +19,7 @@ import 'game.dart';
 /// It still needs to be subclasses to add your game logic, but the [update], [render] and [resize] methods have default implementations.
 /// This is the recommended structure to use for most games.
 /// It is based on the Component system.
-class BaseGame extends Game with FPS {
+class BaseGame extends Game with FPSCounter {
   /// The list of components to be updated and rendered by the base game.
   OrderedSet<Component> components =
       OrderedSet(Comparing.on((c) => c.priority()));


### PR DESCRIPTION
# Description

Moved the FPS code to its own mixin so people can use it with the `Game` class instead of having to extend from `BaseGame` when they dont use components.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
