### PR TITLE
Improving image autoloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+- Improving Flame image auto cache
 
 ## 0.25.0
  - Externalizing Tiled support to its own package `flame_tiled`

--- a/doc/examples/particles/lib/main.dart
+++ b/doc/examples/particles/lib/main.dart
@@ -51,6 +51,9 @@ class MyGame extends BaseGame {
   Offset cellSize;
   Offset halfCellSize;
 
+  @override
+  bool recordFps() => true;
+
   MyGame({
     Size screenSize,
   }) {

--- a/doc/examples/particles/lib/main.dart
+++ b/doc/examples/particles/lib/main.dart
@@ -292,7 +292,7 @@ class MyGame extends BaseGame {
   Particle imageParticle() {
     return ImageParticle(
       size: const Size.square(24),
-      image: Flame.images.loadedFiles['zap.png'],
+      image: Flame.images.loadedFiles['zap.png'].loadedImage,
     );
   }
 
@@ -522,7 +522,7 @@ class MyGame extends BaseGame {
     const rows = 8;
     const frames = columns * rows;
     const imagePath = 'boom3.png';
-    final spriteImage = Flame.images.loadedFiles[imagePath];
+    final spriteImage = Flame.images.loadedFiles[imagePath].loadedImage;
     final spritesheet = SpriteSheet(
       rows: rows,
       columns: columns,

--- a/lib/images.dart
+++ b/lib/images.dart
@@ -6,7 +6,7 @@ import 'dart:convert' show base64;
 import 'package:flame/flame.dart';
 
 class Images {
-  Map<String, _ImageAssetLoader> loadedFiles = {};
+  Map<String, ImageAssetLoader> loadedFiles = {};
 
   void clear(String fileName) {
     loadedFiles.remove(fileName);
@@ -22,14 +22,14 @@ class Images {
 
   Future<Image> load(String fileName) async {
     if (!loadedFiles.containsKey(fileName)) {
-      loadedFiles[fileName] = _ImageAssetLoader(_fetchToMemory(fileName));
+      loadedFiles[fileName] = ImageAssetLoader(_fetchToMemory(fileName));
     }
     return await loadedFiles[fileName].retreive();
   }
 
   Future<Image> fromBase64(String fileName, String base64) async {
     if (!loadedFiles.containsKey(fileName)) {
-      loadedFiles[fileName] = _ImageAssetLoader(_fetchFromBase64(base64));
+      loadedFiles[fileName] = ImageAssetLoader(_fetchFromBase64(base64));
     }
     return await loadedFiles[fileName].retreive();
   }
@@ -53,8 +53,8 @@ class Images {
   }
 }
 
-class _ImageAssetLoader {
-  _ImageAssetLoader(this.future);
+class ImageAssetLoader {
+  ImageAssetLoader(this.future);
 
   Image loadedImage;
   Future<Image> future;

--- a/lib/images.dart
+++ b/lib/images.dart
@@ -6,7 +6,7 @@ import 'dart:convert' show base64;
 import 'package:flame/flame.dart';
 
 class Images {
-  Map<String, Image> loadedFiles = {};
+  Map<String, _ImageAssetLoader> loadedFiles = {};
 
   void clear(String fileName) {
     loadedFiles.remove(fileName);
@@ -22,16 +22,16 @@ class Images {
 
   Future<Image> load(String fileName) async {
     if (!loadedFiles.containsKey(fileName)) {
-      loadedFiles[fileName] = await _fetchToMemory(fileName);
+      loadedFiles[fileName] = _ImageAssetLoader(_fetchToMemory(fileName));
     }
-    return loadedFiles[fileName];
+    return await loadedFiles[fileName].retreive();
   }
 
   Future<Image> fromBase64(String fileName, String base64) async {
     if (!loadedFiles.containsKey(fileName)) {
-      loadedFiles[fileName] = await _fetchFromBase64(base64);
+      loadedFiles[fileName] = _ImageAssetLoader(_fetchFromBase64(base64));
     }
-    return loadedFiles[fileName];
+    return await loadedFiles[fileName].retreive();
   }
 
   Future<Image> _fetchFromBase64(String base64Data) async {
@@ -50,5 +50,18 @@ class Images {
     final Completer<Image> completer = Completer();
     decodeImageFromList(bytes, (image) => completer.complete(image));
     return completer.future;
+  }
+}
+
+class _ImageAssetLoader {
+  _ImageAssetLoader(this.future);
+
+  Image loadedImage;
+  Future<Image> future;
+
+  Future<Image> retreive() async {
+    loadedImage ??= await future;
+
+    return loadedImage;
   }
 }


### PR DESCRIPTION
# Description

Flame image autoloading and caching was loading an image into the memory multiples times when it was called in sequence, for example, on the following code

```dart
    Random r = Random();

    int objectCount = 100;

    while (objectCount-- > 0) {
      add(
 // TestComponent is a SpriteComponent where is sprite is autoloaded by flame (i.e: super.square(100, 'ember.png'));
          TestComponent()
          ..x = screenSize.width * r.nextDouble()
          ..y = screenSize.height * r.nextDouble()
          ..anchor = Anchor.center
      );
    }
```
This would make the fetch to memory been called 100 times, since the async load had not finished yet when the next iteration happens.

This PR fixes that, now, it is called only once.

This don't fixes the current perfomance issue we are facing on 1.20.x, but this is a nice, small fix so flame don't put things in memory, without needing to
## Type of change

Please delete options that are not relevant.

- [x] Bug fix

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
