### PR TITLE
fix bug in the Box2DGame's add and addLater method , when the Compone…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+- fix bug in the Box2DGame's add and addLater method , when the Component extends BodyComponent and mixin HasGameRef or other mixins ,the mixins will not be set correctly
 
 ## 0.25.0
  - Externalizing Tiled support to its own package `flame_tiled`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## [next]
-- fix bug in the Box2DGame's add and addLater method , when the Component extends BodyComponent and mixin HasGameRef or other mixins ,the mixins will not be set correctly
+ - fix bug in the Box2DGame's add and addLater method , when the Component extends BodyComponent and mixin HasGameRef or other mixins ,the mixins will not be set correctly
 
 ## 0.25.0
  - Externalizing Tiled support to its own package `flame_tiled`

--- a/lib/box2d/box2d_game.dart
+++ b/lib/box2d/box2d_game.dart
@@ -16,6 +16,7 @@ class Box2DGame extends BaseGame {
   @override
   void add(Component c) {
     if (c is BodyComponent) {
+      preAdd(c);
       box.add(c);
     } else {
       super.add(c);
@@ -25,6 +26,7 @@ class Box2DGame extends BaseGame {
   @override
   void addLater(Component c) {
     if (c is BodyComponent) {
+      preAdd(c);
       _addLater.add(c);
     } else {
       super.addLater(c);


### PR DESCRIPTION
…nt extends BodyComponent and mixin HasGameRef or other mixins ,the mixins will not be set correctly

# Description
fix bug in the Box2DGame's add and addLater method , when the Component extends BodyComponent and mixin HasGameRef or other mixins ,the mixins will not be set correctly

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
