### PR TITLE
Improved the accuracy of the `FPSCounter` by using Flutter's internal frame timings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+ - Improved the accuracy of the `FPSCounter` by using Flutter's internal frame timings.
 
 ## 0.26.0
  - Improving Flame image auto cache

--- a/lib/fps_counter.dart
+++ b/lib/fps_counter.dart
@@ -1,39 +1,33 @@
-import 'dart:math' as math;
+import 'package:flutter/scheduler.dart';
 
 import 'game/game.dart';
 
-mixin FPSCounter on Game {
-  /// List of deltas used in debug mode to calculate FPS
-  final List<double> _dts = [];
+const _maxFrames = 60;
+const frameInterval =
+    Duration(microseconds: Duration.microsecondsPerSecond ~/ _maxFrames);
 
-  /// Returns whether this [Game] is should record fps or not
+mixin FPSCounter on Game {
+  List<FrameTiming> _previousTimings = [];
+
+  @override
+  void onTimingsCallback(List<FrameTiming> timings) =>
+      _previousTimings = timings;
+
+  /// Returns whether this [Game] is should record fps or not.
   ///
   /// Returns `false` by default. Override to use the `fps` counter method.
   /// In recording fps, the [recordDt] method actually records every `dt` for statistics.
   /// Then, you can use the [fps] method to check the game FPS.
+  @Deprecated('Flame is now using Flutter frame times, will be removed in v1')
   bool recordFps();
 
-  /// This is a hook that comes from the RenderBox to allow recording of render times and statistics.
-  @override
-  void recordDt(double dt) {
-    if (recordFps()) {
-      _dts.add(dt);
-    }
-  }
-
-  /// Returns the average FPS for the last [average] measures.
-  ///
-  /// The values are only saved if in debug mode (override [recordFps] to use this).
-  /// Selects the last [average] dts, averages then, and returns the inverse value.
-  /// So it's technically updates per second, but the relation between updates and renders is 1:1.
-  /// Returns 0 if empty.
+  /// Returns the FPS based on the frame times from [onTimingsCallback].
   double fps([int average = 1]) {
-    final List<double> dts = _dts.sublist(math.max(0, _dts.length - average));
-    if (dts.isEmpty) {
-      return 0.0;
-    }
-    final double dtSum = dts.reduce((s, t) => s + t);
-    final double averageDt = dtSum / average;
-    return 1 / averageDt;
+    return _previousTimings.length *
+        _maxFrames /
+        _previousTimings.map((t) {
+          return (t.totalSpan.inMicroseconds ~/ frameInterval.inMicroseconds) +
+              1;
+        }).fold(0, (a, b) => a + b);
   }
 }

--- a/lib/game/game.dart
+++ b/lib/game/game.dart
@@ -44,7 +44,11 @@ abstract class Game {
   void lifecycleStateChange(AppLifecycleState state) {}
 
   /// Used for debugging
+  @Deprecated('Gets called for backward compatibility, will be removed in v1')
   void recordDt(double dt) {}
+
+  /// Use for caluclating the FPS.
+  void onTimingsCallback(List<FrameTiming> timings) {}
 
   /// Returns the game widget. Put this in your structure to start rendering and updating the game.
   /// You can add it directly to the runApp method or inside your widget structure (if you use vanilla screens and widgets).

--- a/lib/game/game_render_box.dart
+++ b/lib/game/game_render_box.dart
@@ -15,6 +15,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
 
   GameRenderBox(this.context, this.game) {
     gameLoop = GameLoop(gameLoopCallback);
+    WidgetsBinding.instance.addTimingsCallback(game.onTimingsCallback);
   }
 
   @override


### PR DESCRIPTION
# Description

Changed the way the FPS gets calculated, instead of using the delta values from the update loop I am using `WidgetsBinding.instance.addTimingsCallback`, Flutter calls this with a list of `FrameTiming` which we can use to calculate the FPS value. 

This does mean that it is no longer required to return `true` in `recordFPS` because the values will always get recorded by Flutter. It also means that `recordDt()` will no longer have any purpose, but I kept it in, in case someone is using it for something else. 

Quite from the Discord:
> Well I do think it is more accurate. For instance in my 3D game I noticed the flame FPS sometimes dropped to 29.90 and then back to 60 within a single frame. Which is strange for that to happen in a single frame. With my variant I can see it dropping to 48 and then 30 and then to 48 and back to 60 again(just a random example not actual numbers)
> 
> Spread over multiple frames as a FPS drop should be. Making me think that the flame FPS is kind off averaging out and approximating the value instead of being true to the Flutter render cycle.

**Notes**: I would recommend that this gets tested a bit more to see if my assumptions are correct.

## Type of change

Please delete options that are not relevant.

- [X] Improvement?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
