### PR TITLE
Remove Box2D dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Rename Animation to SpriteAnimation
  - Create extension of Vector2 and unify all tuples to use that class
  - Remove Position class in favor of new Vector2 extension
+ - Remove Box2D as a dependency
 
 ## 0.26.0
  - Improving Flame image auto cache

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The goal of this project is to provide a complete set of out-of-the-way solution
 Currently it provides you with:
  - a game loop
  - a component/object system
- - bundles a physics engine (box2d)
+ - a physics engine (box2d)
  - audio support
  - effects and particles
  - gesture and input support

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The goal of this project is to provide a complete set of out-of-the-way solution
 Currently it provides you with:
  - a game loop
  - a component/object system
- - a physics engine (box2d)
+ - a physics engine (box2d, available through [flame_box2d](https://github.com/flame-engine/flame_box2d))
  - audio support
  - effects and particles
  - gesture and input support

--- a/doc/box2d.md
+++ b/doc/box2d.md
@@ -1,10 +1,14 @@
 # Box2D
 
-Although Flame does not fully implement Box2d itself, it bundles a forked and refactored port of the Java Box2d to Dart by Google.
+Although Flame does not fully implement Box2d itself, we maintain a forked and refactored port of the Java Box2d to Dart.
 
 The source of the box2d version that Flame can use can be found [here](https://github.com/flame-engine/box2d.dart).
 
 To use Box2D in your game you should add flame_box2d to your pubspec.yaml, which can be seen in the examples.
+
+It can be a bit confusing at first that there are two projects, [box2d.dart](https://github.com/flame-engine/box2d.dart) and [flame_box2d](https://github.com/flame-engine/flame_box2d), so I'll explain them quickly here:
+* box2d.dart is the actual physics engine, but that one can be used by any dart project, it doesn't have to have any connection to Flame or Flutter.
+* flame_box2d is the bridge between flame and box2d, it contains classes that will make your life a lot easier when using it with flame (for example Box2DGame).
 
 The examples of how to use it can be found [here](https://github.com/flame-engine/flame_box2d/blob/master/examples/), but they are not full game implementations.
 

--- a/doc/box2d.md
+++ b/doc/box2d.md
@@ -1,8 +1,8 @@
 # Box2D
 
-Although Flame does not implement Box2d itself, it bundles a forked port of the Java Box2d to Dart by Google.
+Although Flame does not fully implement Box2d itself, it bundles a forked and refactored port of the Java Box2d to Dart by Google.
 
-The source of the bundled box2d on Flame can be found [here](https://github.com/flame-engine/box2d.dart).
+The source of the box2d version that Flame can use can be found [here](https://github.com/flame-engine/box2d.dart).
 
 To use Box2D in your game you should add flame_box2d to your pubspec.yaml, which can be seen in the examples.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ dependencies:
   audioplayers: ^0.15.1
   ordered_set: ^2.0.0
   path_provider: ^1.6.0
-  box2d_flame: ^0.4.6
   synchronized: ^2.1.0
   convert: ^2.0.1
   flare_flutter: ^2.0.1


### PR DESCRIPTION
# Description

Remove Box2D as a dependency of Flame.
It is based on the vector2d-unification2 branch, so that needs to be merged first.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] The continuous integration (CI) is passing
