### PR TITLE
Fix cleanup

### DIFF
--- a/doc/examples/cleanup.sh
+++ b/doc/examples/cleanup.sh
@@ -1,9 +1,11 @@
 #!/bin/bash -xe
 
-rm -rf */build
-rm -rf */android
-rm -rf */ios
-rm -rf */web
-rm -rf */macos
-rm -rf */test
-rm -rf */.dart_tool
+shopt -s globstar
+
+rm -rf **/build
+rm -rf **/android
+rm -rf **/ios
+rm -rf **/web
+rm -rf **/macos
+rm -rf **/test
+rm -rf **/.dart_tool


### PR DESCRIPTION
The cleanup script wasn't cleaning the nested examples we have.

Just the effects example folder is 1.2 GB w/o cleanup.

This might be a bit aggressive as it would delete folders called build, test, inside the srcs of examples but I think that will never be a problem since examples are very small.
