### PR TITLE
Fixing linter on develop

### DIFF
--- a/lib/game/game_render_box.dart
+++ b/lib/game/game_render_box.dart
@@ -54,6 +54,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
     if (!attached) {
       return;
     }
+    // ignore: deprecated_member_use_from_same_package
     game.recordDt(dt);
     game.update(dt);
     markNeedsPaint();


### PR DESCRIPTION
# Description

Please include a summary of the change.

We are calling an intentionally deprecated method to avoid a breaking change on the develop for the FPS improvement. But that has broke our CI build. I am adding an ignore on that line as we can't fix this otherwise without adding a breaking change. This will be automatically solved on v1 when we remove all the deprecated methods.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
