### PR TITLE
Fix effects bugs, use Vector2 path for MoveEffect and generalize effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
  - Use Vector2 for position and size on PositionComponent
  - Rename `resize` method on components to `onGameResize`
  - Make `Resizable` have a `gameSize` property instead of `size`
+ - Fix bug with CombinedEffect inside SequenceEffect
+ - Fix wrong end angle for relative rotational effects
 
 ## [next]
  - Fix spriteAsWidget deprecation message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
  - Make `Resizable` have a `gameSize` property instead of `size`
  - Fix bug with CombinedEffect inside SequenceEffect
  - Fix wrong end angle for relative rotational effects
+ - Use a list of Vector2 for Move effect to open up for more advanced move effects
+ - Generalize effects api to include all components
 
 ## [next]
  - Fix spriteAsWidget deprecation message

--- a/doc/effects.md
+++ b/doc/effects.md
@@ -1,7 +1,9 @@
 # Effects
-An effect can be applied to any `PositionComponent`, there are currently two effects that you can use and that is the MoveEffect and the ScaleEffect.
+An effect can be applied to any `Component` that the effect supports.
 
-If you want to create an effect that only runs once only specify the required parameters of your wanted Effect class.
+At the moment there are only `PositionComponentEffect`s, which are applied to PositionComponent`'s, which are presented below.
+
+If you want to create an effect for another component just extend the `ComponentEffect` class and add your created effect to the component by calling `component.addEffect(yourEffect)`.
 
 ## More advanced effects
 Then there are two optional boolean parameters called `isInfinite` and `isAlternating`, by combining them you can get different effects.
@@ -20,7 +22,7 @@ When an effect is completed the callback `onComplete` will be called, it can be 
 
 ## MoveEffect
 
-Applied to `PositionComponent`s, this effect can be used to move the component to a new position, using an [animation curve](https://api.flutter.dev/flutter/animation/Curves-class.html).
+Applied to `PositionComponent`s, this effect can be used to move the component to new positions, using an [animation curve](https://api.flutter.dev/flutter/animation/Curves-class.html).
 
 Usage example:
 ```dart
@@ -28,11 +30,17 @@ import 'package:flame/effects/effects.dart';
 
 // Square is a PositionComponent
 square.addEffect(MoveEffect(
-  destination: Position(200, 200),
+  path: [Vector2(200, 200), Vector2(200, 100), Vector(0, 50)],
   speed: 250.0,
   curve: Curves.bounceInOut,
+  isRelative: false,
 ));
 ```
+
+If you want the positions in the path list to be relative to the components last position, and not absolute values on the screen, then you can set `isRelative = true`.
+When you use that, the next position in the list will be relative to the previous position in the list, or if it is the first element of the list it is relative to the components position.
+So if you have a component which is positioned at `Vector2(100, 100)` and you use `isRelative = true` with the following path list `path: [Vector(20, 0), Vector(0, 50)]`, then the component will
+first move to `(120, 0)` and then to `(120, 100)`.
 
 ## ScaleEffect
 

--- a/doc/examples/effects/combined_effects/lib/main.dart
+++ b/doc/examples/effects/combined_effects/lib/main.dart
@@ -37,7 +37,7 @@ class MyGame extends BaseGame with TapDetector {
     greenSquare.clearEffects();
 
     final move = MoveEffect(
-      destination: Vector2(dx, dy),
+      path: [Vector2(dx, dy)],
       speed: 250.0,
       curve: Curves.linear,
       isInfinite: false,

--- a/doc/examples/effects/infinite_effects/lib/main.dart
+++ b/doc/examples/effects/infinite_effects/lib/main.dart
@@ -44,7 +44,7 @@ class MyGame extends BaseGame with TapDetector {
     orangeSquare.clearEffects();
 
     greenSquare.addEffect(MoveEffect(
-      destination: Vector2(dx, dy),
+      path: [Vector2(dx, dy)],
       speed: 250.0,
       curve: Curves.bounceInOut,
       isInfinite: true,

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flame/effects/combined_effect.dart';
 import 'package:flame/effects/move_effect.dart';
 import 'package:flame/effects/scale_effect.dart';
 import 'package:flame/effects/rotate_effect.dart';
@@ -46,7 +47,7 @@ class MyGame extends BaseGame with TapDetector {
       speed: 150.0,
       curve: Curves.easeIn,
       isInfinite: false,
-      isAlternating: true,
+      isAlternating: false,
     );
 
     final scale = ScaleEffect(
@@ -65,9 +66,14 @@ class MyGame extends BaseGame with TapDetector {
       isAlternating: false,
     );
 
+    final combination = CombinedEffect(
+      effects: [move2, rotate],
+      isAlternating: true,
+    );
+
     final sequence = SequenceEffect(
-      effects: [move1, scale, move2, rotate],
-      isInfinite: true,
+      effects: [move1, scale, combination],
+      isInfinite: false,
       isAlternating: true,
     );
     greenSquare.addEffect(sequence);

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -35,7 +35,7 @@ class MyGame extends BaseGame with TapDetector {
     greenSquare.clearEffects();
 
     final move1 = MoveEffect(
-      destination: Vector2(dx, dy),
+      path: [Vector2(dx, dy)],
       speed: 250.0,
       curve: Curves.bounceInOut,
       isInfinite: false,
@@ -43,7 +43,11 @@ class MyGame extends BaseGame with TapDetector {
     );
 
     final move2 = MoveEffect(
-      destination: Vector2(dx, dy + 150),
+      path: [
+        Vector2(dx, dy + 50),
+        Vector2(dx - 50, dy - 50),
+        Vector2(dx + 50, dy),
+      ],
       speed: 150.0,
       curve: Curves.easeIn,
       isInfinite: false,
@@ -52,7 +56,7 @@ class MyGame extends BaseGame with TapDetector {
 
     final scale = ScaleEffect(
       size: Vector2(dx, dy),
-      speed: 250.0,
+      speed: 100.0,
       curve: Curves.easeInCubic,
       isInfinite: false,
       isAlternating: false,
@@ -60,7 +64,7 @@ class MyGame extends BaseGame with TapDetector {
 
     final rotate = RotateEffect(
       radians: (dx + dy) % pi,
-      speed: 2.0,
+      speed: 0.8,
       curve: Curves.decelerate,
       isInfinite: false,
       isAlternating: false,
@@ -68,7 +72,8 @@ class MyGame extends BaseGame with TapDetector {
 
     final combination = CombinedEffect(
       effects: [move2, rotate],
-      isAlternating: true,
+      isAlternating: false,
+      isInfinite: false,
     );
 
     final sequence = SequenceEffect(

--- a/doc/examples/effects/simple/lib/main_move.dart
+++ b/doc/examples/effects/simple/lib/main_move.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flame/extensions/vector2.dart';
 import 'package:flame/game.dart';
 import 'package:flame/gestures.dart';
 import 'package:flame/effects/effects.dart';
@@ -17,9 +18,19 @@ class MyGame extends BaseGame with TapDetector {
   @override
   void onTapUp(details) {
     square.addEffect(MoveEffect(
-      destination: details.localPosition.toVector2(),
+      path: [
+        details.localPosition.toVector2().clone(),
+        Vector2(100, 100),
+        Vector2(50, 120),
+        Vector2(200, 400),
+        Vector2(150, 0),
+        Vector2(100, 300),
+      ],
       speed: 250.0,
       curve: Curves.bounceInOut,
+      isRelative: false,
+      isInfinite: true,
+      isAlternating: true,
     ));
   }
 }

--- a/doc/examples/effects/simple/lib/main_move.dart
+++ b/doc/examples/effects/simple/lib/main_move.dart
@@ -16,10 +16,10 @@ class MyGame extends BaseGame with TapDetector {
   }
 
   @override
-  void onTapUp(details) {
+  void onTapUp(TapUpDetails details) {
     square.addEffect(MoveEffect(
       path: [
-        details.localPosition.toVector2().clone(),
+        details.localPosition.toVector2(),
         Vector2(100, 100),
         Vector2(50, 120),
         Vector2(200, 400),

--- a/doc/examples/joystick/lib/player.dart
+++ b/doc/examples/joystick/lib/player.dart
@@ -37,6 +37,7 @@ class Player extends Component implements JoystickListener {
 
   @override
   void update(double dt) {
+    super.update(dt);
     if (_move) {
       moveFromAngle(dt);
     }

--- a/doc/examples/particles/lib/main.dart
+++ b/doc/examples/particles/lib/main.dart
@@ -590,6 +590,7 @@ class TrafficLightComponent extends Component {
 
   @override
   void update(double dt) {
+    super.update(dt);
     colorChangeTimer.update(dt);
   }
 

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/painting.dart';
 
+import '../effects/effects.dart';
 import '../extensions/vector2.dart';
 
 /// This represents a Component for your game.
@@ -10,12 +11,18 @@ import '../extensions/vector2.dart';
 /// Anything that either renders or updates can be added to the list on [BaseGame]. It will deal with calling those methods for you.
 /// Components also have other methods that can help you out if you want to overwrite them.
 abstract class Component {
+  /// The effects that should run on the component
+  final List<ComponentEffect> _effects = [];
+
   /// This method is called periodically by the game engine to request that your component updates itself.
   ///
   /// The time [t] in seconds (with microseconds precision provided by Flutter) since the last update cycle.
   /// This time can vary according to hardware capacity, so make sure to update your state considering this.
   /// All components on [BaseGame] are always updated by the same amount. The time each one takes to update adds up to the next update cycle.
-  void update(double t);
+  void update(double dt) {
+    _effects.forEach((e) => e.update(dt));
+    _effects.removeWhere((e) => e.hasFinished());
+  }
 
   /// Renders this component on the provided Canvas [c].
   void render(Canvas c);
@@ -58,4 +65,19 @@ abstract class Component {
 
   /// Called right before the component is destroyed and removed from the game
   void onDestroy() {}
+
+  /// Add an effect to the component
+  void addEffect(ComponentEffect effect) {
+    _effects.add(effect..initialize(this));
+  }
+
+  /// Mark an effect for removal on the component
+  void removeEffect(ComponentEffect effect) {
+    effect.dispose();
+  }
+
+  /// Remove all effects
+  void clearEffects() {
+    _effects.forEach(removeEffect);
+  }
 }

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/painting.dart';
+import 'package:meta/meta.dart';
 
 import '../effects/effects.dart';
 import '../extensions/vector2.dart';
@@ -19,6 +20,7 @@ abstract class Component {
   /// The time [t] in seconds (with microseconds precision provided by Flutter) since the last update cycle.
   /// This time can vary according to hardware capacity, so make sure to update your state considering this.
   /// All components on [BaseGame] are always updated by the same amount. The time each one takes to update adds up to the next update cycle.
+  @mustCallSuper
   void update(double dt) {
     _effects.forEach((e) => e.update(dt));
     _effects.removeWhere((e) => e.hasFinished());

--- a/lib/components/joystick/joystick_component.dart
+++ b/lib/components/joystick/joystick_component.dart
@@ -65,6 +65,7 @@ class JoystickComponent extends JoystickController {
 
   @override
   void update(double t) {
+    super.update(t);
     directional?.update(t);
     actions?.forEach((action) => action.update(t));
   }

--- a/lib/components/particle_component.dart
+++ b/lib/components/particle_component.dart
@@ -35,6 +35,7 @@ class ParticleComponent extends Component {
   /// Passes update chain to child [Particle].
   @override
   void update(double dt) {
+    super.update(dt);
     particle.update(dt);
   }
 }

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -5,7 +5,6 @@ import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
 
 import '../anchor.dart';
-import '../effects/effects.dart';
 import '../game.dart';
 import '../text_config.dart';
 import '../extensions/offset.dart';
@@ -77,7 +76,6 @@ abstract class PositionComponent extends Component {
   /// You can also manually override this for certain components in order to identify issues.
   bool debugMode = false;
 
-  final List<PositionComponentEffect> _effects = [];
   final OrderedSet<Component> _children =
       OrderedSet(Comparing.on((c) => c.priority()));
 
@@ -138,25 +136,6 @@ abstract class PositionComponent extends Component {
     }
   }
 
-  void addEffect(PositionComponentEffect effect) {
-    _effects.add(effect..initialize(this));
-  }
-
-  void removeEffect(PositionComponentEffect effect) {
-    effect.dispose();
-  }
-
-  void clearEffects() {
-    _effects.forEach(removeEffect);
-  }
-
-  @mustCallSuper
-  @override
-  void update(double dt) {
-    _effects.forEach((e) => e.update(dt));
-    _effects.removeWhere((e) => e.hasFinished());
-  }
-
   /// This function recursively propagates an action to every children and grandchildren (and so on) of this component,
   /// by keeping track of their positions by composing the positions of their parents.
   /// For example, if this has a child that itself has a child, this will invoke handler for this (with no translation),
@@ -202,6 +181,10 @@ abstract class PositionComponent extends Component {
     _children.forEach((comp) => _renderChild(canvas, comp));
     canvas.restore();
   }
+
+  @mustCallSuper
+  @override
+  void update(double dt) => super.update(dt);
 
   void _renderChild(Canvas canvas, Component c) {
     if (!c.loaded()) {

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -182,10 +182,6 @@ abstract class PositionComponent extends Component {
     canvas.restore();
   }
 
-  @mustCallSuper
-  @override
-  void update(double dt) => super.update(dt);
-
   void _renderChild(Canvas canvas, Component c) {
     if (!c.loaded()) {
       return;

--- a/lib/components/sprite_batch_component.dart
+++ b/lib/components/sprite_batch_component.dart
@@ -25,7 +25,4 @@ class SpriteBatchComponent extends Component {
       paint: paint,
     );
   }
-
-  @override
-  void update(double t) {}
 }

--- a/lib/components/timer_component.dart
+++ b/lib/components/timer_component.dart
@@ -10,7 +10,10 @@ class TimerComponent extends Component {
   TimerComponent(this.timer);
 
   @override
-  void update(double dt) => timer.update(dt);
+  void update(double dt) {
+    super.update(dt);
+    timer.update(dt);
+  }
 
   @override
   void render(Canvas canvas) {}

--- a/lib/effects/combined_effect.dart
+++ b/lib/effects/combined_effect.dart
@@ -18,7 +18,7 @@ class CombinedEffect extends PositionComponentEffect {
   }) : super(isInfinite, isAlternating, onComplete: onComplete) {
     assert(
       effects.every((effect) => effect.component == null),
-      "No effects can be added to components from the start",
+      'Each effect can only be added once',
     );
     final types = effects.map((e) => e.runtimeType);
     assert(

--- a/lib/effects/combined_effect.dart
+++ b/lib/effects/combined_effect.dart
@@ -16,6 +16,10 @@ class CombinedEffect extends PositionComponentEffect {
     bool isAlternating = false,
     Function onComplete,
   }) : super(isInfinite, isAlternating, onComplete: onComplete) {
+    assert(
+      effects.every((effect) => effect.component == null),
+      "No effects can be added to components from the start",
+    );
     final types = effects.map((e) => e.runtimeType);
     assert(
       types.toSet().length == types.length,
@@ -47,7 +51,9 @@ class CombinedEffect extends PositionComponentEffect {
     super.update(dt);
     effects.forEach((effect) => _updateEffect(effect, dt));
     if (effects.every((effect) => effect.hasFinished())) {
-      if (isInfinite) {
+      if (isAlternating && curveDirection.isNegative) {
+        effects.forEach((effect) => effect.isAlternating = true);
+      } else if (isInfinite) {
         reset();
       } else if (isAlternating && isMin()) {
         dispose();
@@ -59,7 +65,9 @@ class CombinedEffect extends PositionComponentEffect {
   void reset() {
     super.reset();
     effects.forEach((effect) => effect.reset());
-    initialize(component);
+    if (component != null) {
+      initialize(component);
+    }
   }
 
   @override

--- a/lib/effects/combined_effect.dart
+++ b/lib/effects/combined_effect.dart
@@ -64,10 +64,13 @@ class CombinedEffect extends PositionComponentEffect {
   @override
   void reset() {
     super.reset();
-    effects.forEach((effect) => effect.reset());
     if (component != null) {
+      component.position = originalPosition;
+      component.angle = originalAngle;
+      component.size = originalSize;
       initialize(component);
     }
+    effects.forEach((effect) => effect.reset());
   }
 
   @override
@@ -91,6 +94,11 @@ class CombinedEffect extends PositionComponentEffect {
     if (isMax()) {
       _maybeReverse(effect);
     }
+  }
+
+  @override
+  bool hasFinished() {
+    return super.hasFinished() && effects.every((e) => e.hasFinished());
   }
 
   void _maybeReverse(PositionComponentEffect effect) {

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../components/component.dart';
 import '../components/position_component.dart';
 import '../extensions/vector2.dart';
 
@@ -11,8 +12,8 @@ export './rotate_effect.dart';
 export './scale_effect.dart';
 export './sequence_effect.dart';
 
-abstract class PositionComponentEffect {
-  PositionComponent component;
+abstract class ComponentEffect<T extends Component> {
+  T component;
   Function() onComplete;
 
   bool _isDisposed = false;
@@ -31,16 +32,11 @@ abstract class PositionComponentEffect {
   double driftTime = 0.0;
   int curveDirection = 1;
 
-  /// Used to be able to determine the end state of a sequence of effects
-  Vector2 endPosition;
-  double endAngle;
-  Vector2 endSize;
-
   /// If the effect is alternating the travel time is double the normal
   /// travel time
   double get totalTravelTime => travelTime * (isAlternating ? 2 : 1);
 
-  PositionComponentEffect(
+  ComponentEffect(
     this._initialIsInfinite,
     this._initialIsAlternating, {
     this.isRelative = false,
@@ -55,7 +51,7 @@ abstract class PositionComponentEffect {
     if (isAlternating) {
       curveDirection = isMax() ? -1 : (isMin() ? 1 : curveDirection);
     } else if (isInfinite && isMax()) {
-      currentTime = 0.0;
+      reset();
     }
     final driftMultiplier = (isAlternating && isMax() ? 2 : 1) * curveDirection;
     if (!hasFinished()) {
@@ -68,19 +64,12 @@ abstract class PositionComponentEffect {
   }
 
   @mustCallSuper
-  void initialize(PositionComponent _comp) {
-    component = _comp;
+  void initialize(T component) {
+    this.component = component;
 
     /// You need to set the travelTime during the initialization of the
     /// extending effect
     travelTime = null;
-
-    /// If these aren't modified by the extending effect it is assumed that the
-    /// effect didn't bring the component to another state than the one it
-    /// started in
-    endPosition = _comp.position;
-    endAngle = _comp.angle;
-    endSize = _comp.size;
   }
 
   void dispose() => _isDisposed = true;
@@ -112,5 +101,47 @@ abstract class PositionComponentEffect {
     } else {
       driftTime = 0;
     }
+  }
+}
+
+abstract class PositionComponentEffect
+    extends ComponentEffect<PositionComponent> {
+  /// Used to be able to determine the start state of the component
+  Vector2 originalPosition;
+  double originalAngle;
+  Vector2 originalSize;
+
+  /// Used to be able to determine the end state of a sequence of effects
+  Vector2 endPosition;
+  double endAngle;
+  Vector2 endSize;
+
+  PositionComponentEffect(
+    initialIsInfinite,
+    initialIsAlternating, {
+    isRelative = false,
+    onComplete,
+  }) : super(
+          initialIsInfinite,
+          initialIsAlternating,
+          isRelative: isRelative,
+          onComplete: onComplete,
+        );
+
+  @mustCallSuper
+  @override
+  void initialize(PositionComponent component) {
+    super.initialize(component);
+    this.component = component;
+    originalPosition = component.position;
+    originalAngle = component.angle;
+    originalSize = component.size;
+
+    /// If these aren't modified by the extending effect it is assumed that the
+    /// effect didn't bring the component to another state than the one it
+    /// started in
+    endPosition = component.position;
+    endAngle = component.angle;
+    endSize = component.size;
   }
 }

--- a/lib/effects/rotate_effect.dart
+++ b/lib/effects/rotate_effect.dart
@@ -32,7 +32,7 @@ class RotateEffect extends PositionComponentEffect {
       endAngle = _comp.angle + radians;
     }
     _startAngle = component.angle;
-    _delta = isRelative ? radians : _startAngle + radians;
+    _delta = isRelative ? radians : radians - _startAngle;
     travelTime = (_delta / speed).abs();
   }
 

--- a/lib/effects/sequence_effect.dart
+++ b/lib/effects/sequence_effect.dart
@@ -18,11 +18,11 @@ class SequenceEffect extends PositionComponentEffect {
   }) : super(isInfinite, isAlternating, onComplete: onComplete) {
     assert(
       effects.every((effect) => effect.component == null),
-      "No effects can be added to components from the start",
+      'Each effect can only be added once',
     );
     assert(
       effects.every((effect) => !effect.isInfinite),
-      "No effects added to the sequence can be infinite",
+      'No effects added to the sequence can be infinite',
     );
   }
 

--- a/lib/effects/sequence_effect.dart
+++ b/lib/effects/sequence_effect.dart
@@ -77,7 +77,6 @@ class SequenceEffect extends PositionComponentEffect {
           curveDirection.isNegative) {
         // Make the effect go in reverse
         currentEffect.isAlternating = true;
-        currentEffect.percentage = 1.0;
       }
     }
   }


### PR DESCRIPTION
# Description

Fixes two effects bugs, one with the relative rotation ending in the wrong angle and one with the `CombinedEffect` resulting in NPE when using it inside a `SequenceEffect`.

Also contains:
* Generalize effects so that they can be used on all components #484 
* Use a Vector2 path for MoveEffect #482 

Fixes #463

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
