### PR TITLE
Use a Vector2 path for MoveEffect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  - Fix bug with CombinedEffect inside SequenceEffect
  - Fix wrong end angle for relative rotational effects
  - Use a list of Vector2 for Move effect to open up for more advanced move effects
+ - Generalize effects api to include all components
 
 ## [next]
  - Fix spriteAsWidget deprecation message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  - Make `Resizable` have a `gameSize` property instead of `size`
  - Fix bug with CombinedEffect inside SequenceEffect
  - Fix wrong end angle for relative rotational effects
+ - Use a list of Vector2 for Move effect to open up for more capabilities
 
 ## [next]
  - Fix spriteAsWidget deprecation message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
  - Make `Resizable` have a `gameSize` property instead of `size`
  - Fix bug with CombinedEffect inside SequenceEffect
  - Fix wrong end angle for relative rotational effects
- - Use a list of Vector2 for Move effect to open up for more capabilities
+ - Use a list of Vector2 for Move effect to open up for more advanced move effects
 
 ## [next]
  - Fix spriteAsWidget deprecation message

--- a/doc/effects.md
+++ b/doc/effects.md
@@ -20,7 +20,7 @@ When an effect is completed the callback `onComplete` will be called, it can be 
 
 ## MoveEffect
 
-Applied to `PositionComponent`s, this effect can be used to move the component to a new positions, using an [animation curve](https://api.flutter.dev/flutter/animation/Curves-class.html).
+Applied to `PositionComponent`s, this effect can be used to move the component to new positions, using an [animation curve](https://api.flutter.dev/flutter/animation/Curves-class.html).
 
 Usage example:
 ```dart

--- a/doc/effects.md
+++ b/doc/effects.md
@@ -20,7 +20,7 @@ When an effect is completed the callback `onComplete` will be called, it can be 
 
 ## MoveEffect
 
-Applied to `PositionComponent`s, this effect can be used to move the component to a new position, using an [animation curve](https://api.flutter.dev/flutter/animation/Curves-class.html).
+Applied to `PositionComponent`s, this effect can be used to move the component to a new positions, using an [animation curve](https://api.flutter.dev/flutter/animation/Curves-class.html).
 
 Usage example:
 ```dart
@@ -28,11 +28,17 @@ import 'package:flame/effects/effects.dart';
 
 // Square is a PositionComponent
 square.addEffect(MoveEffect(
-  destination: Position(200, 200),
+  path: [Vector2(200, 200), Vector2(200, 100), Vector(0, 50)],
   speed: 250.0,
   curve: Curves.bounceInOut,
+  isRelative: false,
 ));
 ```
+
+If you want the positions in the path list to be relative to the components last position, and not absolute values on the screen, then you can set `isRelative = true`.
+When you use that, the next position in the list will be relative to the previous position in the list, or if it is the first element of the list it is relative to the components position.
+So if you have a component which is positioned at `Vector2(100, 100)` and you use `isRelative = true` with the following path list `path: [Vector(20, 0), Vector(0, 50)]`, then the component will
+first move to `(120, 0)` and then to `(120, 100)`.
 
 ## ScaleEffect
 

--- a/doc/effects.md
+++ b/doc/effects.md
@@ -1,7 +1,9 @@
 # Effects
-An effect can be applied to any `PositionComponent`, there are currently two effects that you can use and that is the MoveEffect and the ScaleEffect.
+An effect can be applied to any `Component` that the effect supports.
 
-If you want to create an effect that only runs once only specify the required parameters of your wanted Effect class.
+At the moment there are only `PositionComponentEffect`s, which are applied to PositionComponent`'s, which are presented below.
+
+If you want to create an effect for another component just extend the `ComponentEffect` class and add your created effect to the component by calling `component.addEffect(yourEffect)`.
 
 ## More advanced effects
 Then there are two optional boolean parameters called `isInfinite` and `isAlternating`, by combining them you can get different effects.

--- a/doc/examples/effects/combined_effects/lib/main.dart
+++ b/doc/examples/effects/combined_effects/lib/main.dart
@@ -37,7 +37,7 @@ class MyGame extends BaseGame with TapDetector {
     greenSquare.clearEffects();
 
     final move = MoveEffect(
-      destination: Vector2(dx, dy),
+      path: [Vector2(dx, dy)],
       speed: 250.0,
       curve: Curves.linear,
       isInfinite: false,

--- a/doc/examples/effects/infinite_effects/lib/main.dart
+++ b/doc/examples/effects/infinite_effects/lib/main.dart
@@ -44,7 +44,7 @@ class MyGame extends BaseGame with TapDetector {
     orangeSquare.clearEffects();
 
     greenSquare.addEffect(MoveEffect(
-      destination: Vector2(dx, dy),
+      path: [Vector2(dx, dy)],
       speed: 250.0,
       curve: Curves.bounceInOut,
       isInfinite: true,

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -72,7 +72,8 @@ class MyGame extends BaseGame with TapDetector {
 
     final combination = CombinedEffect(
       effects: [move2, rotate],
-      isAlternating: true,
+      isAlternating: false,
+      isInfinite: false,
     );
 
     final sequence = SequenceEffect(

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -56,7 +56,7 @@ class MyGame extends BaseGame with TapDetector {
 
     final scale = ScaleEffect(
       size: Vector2(dx, dy),
-      speed: 250.0,
+      speed: 100.0,
       curve: Curves.easeInCubic,
       isInfinite: false,
       isAlternating: false,
@@ -72,15 +72,14 @@ class MyGame extends BaseGame with TapDetector {
 
     final combination = CombinedEffect(
       effects: [move2, rotate],
-      isAlternating: false,
-      isInfinite: true,
+      isAlternating: true,
     );
 
     final sequence = SequenceEffect(
       effects: [move1, scale, combination],
-      isInfinite: true,
-      isAlternating: false,
+      isInfinite: false,
+      isAlternating: true,
     );
-    greenSquare.addEffect(combination);
+    greenSquare.addEffect(sequence);
   }
 }

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -35,7 +35,7 @@ class MyGame extends BaseGame with TapDetector {
     greenSquare.clearEffects();
 
     final move1 = MoveEffect(
-      destination: Vector2(dx, dy),
+      path: [Vector2(dx, dy)],
       speed: 250.0,
       curve: Curves.bounceInOut,
       isInfinite: false,
@@ -43,7 +43,11 @@ class MyGame extends BaseGame with TapDetector {
     );
 
     final move2 = MoveEffect(
-      destination: Vector2(dx, dy + 150),
+      path: [
+        Vector2(dx, dy + 20),
+        Vector2(dx - 20, dy - 20),
+        Vector2(dx + 20, dy),
+      ],
       speed: 150.0,
       curve: Curves.easeIn,
       isInfinite: false,

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -64,7 +64,7 @@ class MyGame extends BaseGame with TapDetector {
 
     final rotate = RotateEffect(
       radians: (dx + dy) % pi,
-      speed: 2.0,
+      speed: 0.8,
       curve: Curves.decelerate,
       isInfinite: false,
       isAlternating: false,

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -44,9 +44,9 @@ class MyGame extends BaseGame with TapDetector {
 
     final move2 = MoveEffect(
       path: [
-        Vector2(dx, dy + 20),
-        Vector2(dx - 20, dy - 20),
-        Vector2(dx + 20, dy),
+        Vector2(dx, dy + 50),
+        Vector2(dx - 50, dy - 50),
+        Vector2(dx + 50, dy),
       ],
       speed: 150.0,
       curve: Curves.easeIn,
@@ -72,14 +72,15 @@ class MyGame extends BaseGame with TapDetector {
 
     final combination = CombinedEffect(
       effects: [move2, rotate],
-      isAlternating: true,
+      isAlternating: false,
+      isInfinite: true,
     );
 
     final sequence = SequenceEffect(
       effects: [move1, scale, combination],
-      isInfinite: false,
-      isAlternating: true,
+      isInfinite: true,
+      isAlternating: false,
     );
-    greenSquare.addEffect(sequence);
+    greenSquare.addEffect(combination);
   }
 }

--- a/doc/examples/effects/simple/lib/main_move.dart
+++ b/doc/examples/effects/simple/lib/main_move.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flame/extensions/vector2.dart';
 import 'package:flame/game.dart';
 import 'package:flame/gestures.dart';
 import 'package:flame/effects/effects.dart';
@@ -17,9 +18,19 @@ class MyGame extends BaseGame with TapDetector {
   @override
   void onTapUp(details) {
     square.addEffect(MoveEffect(
-      path: [details.localPosition.toVector2()],
+      path: [
+        details.localPosition.toVector2().clone(),
+        Vector2(100, 100),
+        Vector2(50, 120),
+        Vector2(200, 400),
+        Vector2(150, 0),
+        Vector2(100, 300),
+      ],
       speed: 250.0,
       curve: Curves.bounceInOut,
+      isRelative: false,
+      isInfinite: true,
+      isAlternating: true,
     ));
   }
 }

--- a/doc/examples/effects/simple/lib/main_move.dart
+++ b/doc/examples/effects/simple/lib/main_move.dart
@@ -17,7 +17,7 @@ class MyGame extends BaseGame with TapDetector {
   @override
   void onTapUp(details) {
     square.addEffect(MoveEffect(
-      destination: details.localPosition.toVector2(),
+      path: [details.localPosition.toVector2()],
       speed: 250.0,
       curve: Curves.bounceInOut,
     ));

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/painting.dart';
 
+import '../effects/effects.dart';
 import '../extensions/vector2.dart';
 
 /// This represents a Component for your game.
@@ -10,12 +11,18 @@ import '../extensions/vector2.dart';
 /// Anything that either renders or updates can be added to the list on [BaseGame]. It will deal with calling those methods for you.
 /// Components also have other methods that can help you out if you want to overwrite them.
 abstract class Component {
+  /// The effects that should run on the component
+  final List<ComponentEffect> _effects = [];
+
   /// This method is called periodically by the game engine to request that your component updates itself.
   ///
   /// The time [t] in seconds (with microseconds precision provided by Flutter) since the last update cycle.
   /// This time can vary according to hardware capacity, so make sure to update your state considering this.
   /// All components on [BaseGame] are always updated by the same amount. The time each one takes to update adds up to the next update cycle.
-  void update(double t);
+  void update(double dt) {
+    _effects.forEach((e) => e.update(dt));
+    _effects.removeWhere((e) => e.hasFinished());
+  }
 
   /// Renders this component on the provided Canvas [c].
   void render(Canvas c);
@@ -58,4 +65,19 @@ abstract class Component {
 
   /// Called right before the component is destroyed and removed from the game
   void onDestroy() {}
+
+  /// Add an effect to the component
+  void addEffect(ComponentEffect effect) {
+    _effects.add(effect..initialize(this));
+  }
+
+  /// Mark an effect for removal on the component
+  void removeEffect(ComponentEffect effect) {
+    effect.dispose();
+  }
+
+  /// Remove all effects
+  void clearEffects() {
+    _effects.forEach(removeEffect);
+  }
 }

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -5,7 +5,6 @@ import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
 
 import '../anchor.dart';
-import '../effects/effects.dart';
 import '../game.dart';
 import '../text_config.dart';
 import '../extensions/offset.dart';
@@ -77,7 +76,6 @@ abstract class PositionComponent extends Component {
   /// You can also manually override this for certain components in order to identify issues.
   bool debugMode = false;
 
-  final List<PositionComponentEffect> _effects = [];
   final OrderedSet<Component> _children =
       OrderedSet(Comparing.on((c) => c.priority()));
 
@@ -138,25 +136,6 @@ abstract class PositionComponent extends Component {
     }
   }
 
-  void addEffect(PositionComponentEffect effect) {
-    _effects.add(effect..initialize(this));
-  }
-
-  void removeEffect(PositionComponentEffect effect) {
-    effect.dispose();
-  }
-
-  void clearEffects() {
-    _effects.forEach(removeEffect);
-  }
-
-  @mustCallSuper
-  @override
-  void update(double dt) {
-    _effects.forEach((e) => e.update(dt));
-    _effects.removeWhere((e) => e.hasFinished());
-  }
-
   /// This function recursively propagates an action to every children and grandchildren (and so on) of this component,
   /// by keeping track of their positions by composing the positions of their parents.
   /// For example, if this has a child that itself has a child, this will invoke handler for this (with no translation),
@@ -202,6 +181,10 @@ abstract class PositionComponent extends Component {
     _children.forEach((comp) => _renderChild(canvas, comp));
     canvas.restore();
   }
+
+  @mustCallSuper
+  @override
+  void update(double dt) => super.update(dt);
 
   void _renderChild(Canvas canvas, Component c) {
     if (!c.loaded()) {

--- a/lib/effects/combined_effect.dart
+++ b/lib/effects/combined_effect.dart
@@ -64,10 +64,13 @@ class CombinedEffect extends PositionComponentEffect {
   @override
   void reset() {
     super.reset();
-    effects.forEach((effect) => effect.reset());
     if (component != null) {
+      component.position = originalPosition;
+      component.angle = originalAngle;
+      component.size = originalSize;
       initialize(component);
     }
+    effects.forEach((effect) => effect.reset());
   }
 
   @override

--- a/lib/effects/combined_effect.dart
+++ b/lib/effects/combined_effect.dart
@@ -96,6 +96,11 @@ class CombinedEffect extends PositionComponentEffect {
     }
   }
 
+  @override
+  bool hasFinished() {
+    return super.hasFinished() && effects.every((e) => e.hasFinished());
+  }
+
   void _maybeReverse(PositionComponentEffect effect) {
     if (isAlternating && !effect.isAlternating && effect.isMax()) {
       // Make the effect go in reverse

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -35,7 +35,7 @@ abstract class PositionComponentEffect {
   Vector2 originalPosition;
   double originalAngle;
   Vector2 originalSize;
-  
+
   /// Used to be able to determine the end state of a sequence of effects
   Vector2 endPosition;
   double endAngle;

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../components/component.dart';
 import '../components/position_component.dart';
 import '../extensions/vector2.dart';
 
@@ -11,8 +12,8 @@ export './rotate_effect.dart';
 export './scale_effect.dart';
 export './sequence_effect.dart';
 
-abstract class PositionComponentEffect {
-  PositionComponent component;
+abstract class ComponentEffect<T extends Component> {
+  T component;
   Function() onComplete;
 
   bool _isDisposed = false;
@@ -31,21 +32,11 @@ abstract class PositionComponentEffect {
   double driftTime = 0.0;
   int curveDirection = 1;
 
-  /// Used to be able to determine the start state of the component
-  Vector2 originalPosition;
-  double originalAngle;
-  Vector2 originalSize;
-
-  /// Used to be able to determine the end state of a sequence of effects
-  Vector2 endPosition;
-  double endAngle;
-  Vector2 endSize;
-
   /// If the effect is alternating the travel time is double the normal
   /// travel time
   double get totalTravelTime => travelTime * (isAlternating ? 2 : 1);
 
-  PositionComponentEffect(
+  ComponentEffect(
     this._initialIsInfinite,
     this._initialIsAlternating, {
     this.isRelative = false,
@@ -73,22 +64,12 @@ abstract class PositionComponentEffect {
   }
 
   @mustCallSuper
-  void initialize(PositionComponent _comp) {
-    component = _comp;
-    originalPosition = component.position;
-    originalAngle = component.angle;
-    originalSize = component.size;
+  void initialize(T component) {
+    this.component = component;
 
     /// You need to set the travelTime during the initialization of the
     /// extending effect
     travelTime = null;
-
-    /// If these aren't modified by the extending effect it is assumed that the
-    /// effect didn't bring the component to another state than the one it
-    /// started in
-    endPosition = _comp.position;
-    endAngle = _comp.angle;
-    endSize = _comp.size;
   }
 
   void dispose() => _isDisposed = true;
@@ -120,5 +101,47 @@ abstract class PositionComponentEffect {
     } else {
       driftTime = 0;
     }
+  }
+}
+
+abstract class PositionComponentEffect
+    extends ComponentEffect<PositionComponent> {
+  /// Used to be able to determine the start state of the component
+  Vector2 originalPosition;
+  double originalAngle;
+  Vector2 originalSize;
+
+  /// Used to be able to determine the end state of a sequence of effects
+  Vector2 endPosition;
+  double endAngle;
+  Vector2 endSize;
+
+  PositionComponentEffect(
+    initialIsInfinite,
+    initialIsAlternating, {
+    isRelative = false,
+    onComplete,
+  }) : super(
+          initialIsInfinite,
+          initialIsAlternating,
+          isRelative: isRelative,
+          onComplete: onComplete,
+        );
+
+  @mustCallSuper
+  @override
+  void initialize(PositionComponent component) {
+    super.initialize(component);
+    this.component = component;
+    originalPosition = component.position;
+    originalAngle = component.angle;
+    originalSize = component.size;
+
+    /// If these aren't modified by the extending effect it is assumed that the
+    /// effect didn't bring the component to another state than the one it
+    /// started in
+    endPosition = component.position;
+    endAngle = component.angle;
+    endSize = component.size;
   }
 }

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -31,6 +31,11 @@ abstract class PositionComponentEffect {
   double driftTime = 0.0;
   int curveDirection = 1;
 
+  /// Used to be able to determine the start state of the component
+  Vector2 originalPosition;
+  double originalAngle;
+  Vector2 originalSize;
+  
   /// Used to be able to determine the end state of a sequence of effects
   Vector2 endPosition;
   double endAngle;
@@ -70,6 +75,9 @@ abstract class PositionComponentEffect {
   @mustCallSuper
   void initialize(PositionComponent _comp) {
     component = _comp;
+    originalPosition = component.position;
+    originalAngle = component.angle;
+    originalSize = component.size;
 
     /// You need to set the travelTime during the initialization of the
     /// extending effect

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -60,7 +60,7 @@ abstract class PositionComponentEffect {
     if (isAlternating) {
       curveDirection = isMax() ? -1 : (isMin() ? 1 : curveDirection);
     } else if (isInfinite && isMax()) {
-      currentTime = 0.0;
+      reset();
     }
     final driftMultiplier = (isAlternating && isMax() ? 2 : 1) * curveDirection;
     if (!hasFinished()) {

--- a/lib/effects/move_effect.dart
+++ b/lib/effects/move_effect.dart
@@ -52,7 +52,7 @@ class MoveEffect extends PositionComponentEffect {
     if (isRelative) {
       Vector2 lastPosition = _startPosition;
       _movePath = [];
-      for(Vector2 v in path) {
+      for (Vector2 v in path) {
         final nextPosition = v + lastPosition;
         _movePath.add(nextPosition);
         lastPosition = nextPosition;
@@ -92,11 +92,11 @@ class MoveEffect extends PositionComponentEffect {
     }
     travelTime = pathLength / speed;
   }
-  
+
   @override
   void reset() {
     super.reset();
-    if(_percentagePath?.isNotEmpty ?? false) {
+    if (_percentagePath?.isNotEmpty ?? false) {
       _currentSubPath = _percentagePath.first;
     }
   }
@@ -117,7 +117,6 @@ class MoveEffect extends PositionComponentEffect {
     final double localPercentage =
         (progress - lastEndAt) / (_currentSubPath.endAt - lastEndAt);
     component.position = _currentSubPath.previous +
-        ((_currentSubPath.v - _currentSubPath.previous) *
-            localPercentage);
+        ((_currentSubPath.v - _currentSubPath.previous) * localPercentage);
   }
 }

--- a/lib/effects/move_effect.dart
+++ b/lib/effects/move_effect.dart
@@ -4,15 +4,31 @@ import 'package:meta/meta.dart';
 import '../extensions/vector2.dart';
 import 'effects.dart';
 
+class Vector2Percentage {
+  final Vector2 v;
+  final Vector2 previous;
+  final double startAt;
+  final double endAt;
+
+  Vector2Percentage(
+    this.v,
+    this.previous,
+    this.startAt,
+    this.endAt,
+  );
+}
+
 class MoveEffect extends PositionComponentEffect {
-  Vector2 destination;
+  List<Vector2> path;
+  Vector2Percentage _currentSubPath;
+  List<Vector2Percentage> _percentagePath;
   double speed;
   Curve curve;
   Vector2 _startPosition;
-  Vector2 _delta;
+  Vector2 _peakPosition;
 
   MoveEffect({
-    @required this.destination,
+    @required this.path,
     @required this.speed,
     this.curve,
     isInfinite = false,
@@ -29,18 +45,73 @@ class MoveEffect extends PositionComponentEffect {
   @override
   void initialize(_comp) {
     super.initialize(_comp);
-    if (!isAlternating) {
-      endPosition = destination;
-    }
+    List<Vector2> _movePath;
     _startPosition = component.position.clone();
-    _delta = isRelative ? destination : destination - _startPosition;
-    travelTime = _delta.length / speed;
+    // With relative here we mean that any vector in the list is relative
+    // to the previous vector in the list, except the first one which is
+    // relative to the start position of the component.
+    if (isRelative) {
+      Vector2 lastPosition = _startPosition;
+      _movePath = [];
+      for(Vector2 v in path) {
+        final nextPosition = v + lastPosition;
+        _movePath.add(nextPosition);
+        lastPosition = nextPosition;
+      }
+    } else {
+      _movePath = path;
+    }
+    print(_movePath);
+    _peakPosition = isRelative ? path.last : path.last - _startPosition;
+    if (!isAlternating) {
+      endPosition = _peakPosition;
+    }
+
+    double pathLength = 0;
+    Vector2 lastPosition = _startPosition;
+    for (Vector2 v in _movePath) {
+      pathLength += v.distanceTo(lastPosition);
+      lastPosition = v;
+    }
+
+    _percentagePath = <Vector2Percentage>[];
+    lastPosition = _startPosition;
+    for (Vector2 v in _movePath) {
+      final lengthToPrevious = lastPosition.distanceTo(v);
+      final lastEndAt =
+          _percentagePath.isNotEmpty ? _percentagePath.last.endAt : 0.0;
+      final endPercentage = lastEndAt + lengthToPrevious / pathLength;
+      _percentagePath.add(
+        Vector2Percentage(
+          v,
+          lastPosition,
+          lastEndAt,
+          _movePath.last == v ? 1.0 : endPercentage,
+        ),
+      );
+      lastPosition = v;
+    }
+    print(_percentagePath);
+    travelTime = pathLength / speed;
   }
 
   @override
   void update(double dt) {
+    if (hasFinished()) {
+      return;
+    }
     super.update(dt);
     final double progress = curve?.transform(percentage) ?? 1.0;
-    component.position = _startPosition + _delta * progress;
+    _currentSubPath ??= _percentagePath.first;
+    if (!curveDirection.isNegative && _currentSubPath.endAt < progress ||
+        curveDirection.isNegative && _currentSubPath.startAt > progress) {
+      _currentSubPath = _percentagePath.firstWhere((v) => v.endAt >= progress);
+    }
+    final double lastEndAt = _currentSubPath.startAt;
+    final double localPercentage =
+        (progress - lastEndAt) / (_currentSubPath.endAt - lastEndAt);
+    component.position = _currentSubPath.previous +
+        ((_currentSubPath.v - _currentSubPath.previous) *
+            localPercentage);
   }
 }

--- a/lib/effects/move_effect.dart
+++ b/lib/effects/move_effect.dart
@@ -25,7 +25,6 @@ class MoveEffect extends PositionComponentEffect {
   double speed;
   Curve curve;
   Vector2 _startPosition;
-  Vector2 _peakPosition;
 
   MoveEffect({
     @required this.path,
@@ -61,10 +60,10 @@ class MoveEffect extends PositionComponentEffect {
     } else {
       _movePath = path;
     }
-    print(_movePath);
-    _peakPosition = isRelative ? path.last : path.last - _startPosition;
     if (!isAlternating) {
-      endPosition = _peakPosition;
+      endPosition = _movePath.last;
+    } else {
+      endPosition = _startPosition;
     }
 
     double pathLength = 0;
@@ -91,8 +90,15 @@ class MoveEffect extends PositionComponentEffect {
       );
       lastPosition = v;
     }
-    print(_percentagePath);
     travelTime = pathLength / speed;
+  }
+  
+  @override
+  void reset() {
+    super.reset();
+    if(_percentagePath?.isNotEmpty ?? false) {
+      _currentSubPath = _percentagePath.first;
+    }
   }
 
   @override

--- a/lib/effects/sequence_effect.dart
+++ b/lib/effects/sequence_effect.dart
@@ -92,10 +92,12 @@ class SequenceEffect extends PositionComponentEffect {
   @override
   void reset() {
     super.reset();
-    component.position = originalPosition;
-    component.angle = originalAngle;
-    component.size = originalSize;
-    initialize(component);
-    //effects.forEach((e) => e.reset());
+    effects.forEach((e) => e.reset());
+    if(component != null) {
+      component.position = originalPosition;
+      component.angle = originalAngle;
+      component.size = originalSize;
+      initialize(component);
+    }
   }
 }

--- a/lib/effects/sequence_effect.dart
+++ b/lib/effects/sequence_effect.dart
@@ -63,9 +63,9 @@ class SequenceEffect extends PositionComponentEffect {
       _driftModifier = currentEffect.driftTime;
       _currentIndex++;
       final iterationSize = isAlternating ? effects.length * 2 : effects.length;
-      if (_currentIndex != 0
-          && _currentIndex == iterationSize
-          && (currentEffect.isAlternating ||
+      if (_currentIndex != 0 &&
+          _currentIndex == iterationSize &&
+          (currentEffect.isAlternating ||
               currentEffect.isAlternating == isAlternating)) {
         isInfinite ? reset() : dispose();
         return;
@@ -93,7 +93,7 @@ class SequenceEffect extends PositionComponentEffect {
   void reset() {
     super.reset();
     effects.forEach((e) => e.reset());
-    if(component != null) {
+    if (component != null) {
       component.position = originalPosition;
       component.angle = originalAngle;
       component.size = originalSize;

--- a/lib/effects/sequence_effect.dart
+++ b/lib/effects/sequence_effect.dart
@@ -20,6 +20,10 @@ class SequenceEffect extends PositionComponentEffect {
       effects.every((effect) => effect.component == null),
       "No effects can be added to components from the start",
     );
+    assert(
+      effects.every((effect) => !effect.isInfinite),
+      "No effects added to the sequence can be infinite",
+    );
   }
 
   @override

--- a/lib/effects/sequence_effect.dart
+++ b/lib/effects/sequence_effect.dart
@@ -5,10 +5,10 @@ import 'effects.dart';
 
 class SequenceEffect extends PositionComponentEffect {
   final List<PositionComponentEffect> effects;
-  int _currentIndex = 0;
+  int _currentIndex;
   PositionComponentEffect currentEffect;
   bool _currentWasAlternating;
-  double _driftModifier = 0.0;
+  double _driftModifier;
 
   SequenceEffect({
     @required this.effects,
@@ -26,9 +26,7 @@ class SequenceEffect extends PositionComponentEffect {
   void initialize(PositionComponent _comp) {
     super.initialize(_comp);
     _currentIndex = 0;
-    final originalSize = _comp.size;
-    final originalPosition = _comp.position;
-    final originalAngle = _comp.angle;
+    _driftModifier = 0.0;
     effects.forEach((effect) {
       effect.reset();
       _comp.size = endSize;
@@ -43,9 +41,9 @@ class SequenceEffect extends PositionComponentEffect {
       0,
       (time, effect) => time + effect.totalTravelTime,
     );
-    component.size = originalSize;
     component.position = originalPosition;
     component.angle = originalAngle;
+    component.size = originalSize;
     currentEffect = effects.first;
     _currentWasAlternating = currentEffect.isAlternating;
   }
@@ -57,20 +55,30 @@ class SequenceEffect extends PositionComponentEffect {
     }
     super.update(dt);
 
+    // If the last effect's time to completion overshot its total time, add that
+    // time to the first time step of the next effect.
     currentEffect.update(dt + _driftModifier);
     _driftModifier = 0.0;
     if (currentEffect.hasFinished()) {
       _driftModifier = currentEffect.driftTime;
-      currentEffect.isAlternating = _currentWasAlternating;
       _currentIndex++;
       final iterationSize = isAlternating ? effects.length * 2 : effects.length;
-      if (_currentIndex != 0 && _currentIndex % iterationSize == 0) {
+      if (_currentIndex != 0
+          && _currentIndex == iterationSize
+          && (currentEffect.isAlternating ||
+              currentEffect.isAlternating == isAlternating)) {
         isInfinite ? reset() : dispose();
         return;
       }
       final orderedEffects =
           curveDirection.isNegative ? effects.reversed.toList() : effects;
+      // Make sure the current effect has the `isAlternating` value it
+      // initially started with
+      currentEffect.isAlternating = _currentWasAlternating;
+      // Get the next effect that should be executed
       currentEffect = orderedEffects[_currentIndex % effects.length];
+      // Keep track of what value of `isAlternating` the effect had from the
+      // start
       _currentWasAlternating = currentEffect.isAlternating;
       if (isAlternating &&
           !currentEffect.isAlternating &&
@@ -84,6 +92,10 @@ class SequenceEffect extends PositionComponentEffect {
   @override
   void reset() {
     super.reset();
+    component.position = originalPosition;
+    component.angle = originalAngle;
+    component.size = originalSize;
     initialize(component);
+    //effects.forEach((e) => e.reset());
   }
 }


### PR DESCRIPTION
# Description

There are some general bug fixes for the effects, but the main thing is that the MoveEffect now takes a list of Vector2 that it goes through, instead of just one position.

Fixes #395

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
