### PR TITLE
Fix resizable conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
  - Remove Box2D as a dependency
  - Use isRelative on effects
  - Use Vector2 for position and size on PositionComponent
+ - Rename `resize` method on components to `onGameResize`
+ - Make `Resizable` have a `gameSize` property instead of `size`
 
 ## 0.27.0
  - Improved the accuracy of the `FPSCounter` by using Flutter's internal frame timings.

--- a/FAQ.md
+++ b/FAQ.md
@@ -44,7 +44,7 @@ If you want a more full-fledged game, please check [BGUG](https://github.com/fir
 
 `Game` is the most barebones interface that Flame exposes. If you crete a Game, you will need to implement a lot of stuff. Flame will hook you up on the game loop, so you will get to implement `render` and `update` yourself. From scratch. If you wanna use the component system, you can, but you don't need to. You do everything yourself.
 
-`BaseGame` extends `Game` and adds lots of functionality on top of that. Just drop your components, it works! They are rendered, updated, resized, automatically. You might still want to override some of `BaseGame`'s methods to add custom functionality, but you will probably be calling the super method to let `BaseGame` do its work.
+`BaseGame` extends `Game` and adds lots of functionality on top of that. Just drop your components, it works! They are rendered and updated, automatically. You might still want to override some of `BaseGame`'s methods to add custom functionality, but you will probably be calling the super method to let `BaseGame` do its work.
 
 ## How does the Camera work?
 

--- a/doc/examples/debug/lib/main.dart
+++ b/doc/examples/debug/lib/main.dart
@@ -25,7 +25,7 @@ class AndroidComponent extends SpriteComponent with Resizable {
   @override
   void update(double dt) {
     super.update(dt);
-    if (size == null) {
+    if (gameSize == null) {
       return;
     }
 
@@ -34,14 +34,14 @@ class AndroidComponent extends SpriteComponent with Resizable {
     final rect = toRect();
 
     if ((x <= 0 && xDirection == -1) ||
-        (rect.right >= size.x && xDirection == 1)) {
+        (rect.right >= gameSize.x && xDirection == 1)) {
       xDirection = xDirection * -1;
     }
 
     y += yDirection * SPEED * dt;
 
     if ((y <= 0 && yDirection == -1) ||
-        (rect.bottom >= size.y && yDirection == 1)) {
+        (rect.bottom >= gameSize.y && yDirection == 1)) {
       yDirection = yDirection * -1;
     }
   }

--- a/doc/examples/joystick/lib/player.dart
+++ b/doc/examples/joystick/lib/player.dart
@@ -43,14 +43,14 @@ class Player extends Component implements JoystickListener {
   }
 
   @override
-  void resize(Vector2 size) {
+  void onGameResize(Vector2 size) {
     _rect = Rect.fromLTWH(
       (size.x / 2) - 25,
       (size.y / 2) - 25,
       50,
       50,
     );
-    super.resize(size);
+    super.onGameResize(size);
   }
 
   @override

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -20,11 +20,11 @@ abstract class Component {
   /// Renders this component on the provided Canvas [c].
   void render(Canvas c);
 
-  /// This is a hook called by [BaseGame] to let this component know that the screen (or flame draw area) has been update.
+  /// It receives the new game size.
+  /// Executed right after the component is attached to a game and right before [onMount] is called
   ///
-  /// It receives the new size.
-  /// You can use the [Resizable] mixin if you want an implementation of this hook that keeps track of the current size.
-  void resize(Vector2 size) {}
+  /// Use [Resizable] to save the gameSize in a component.
+  void onGameResize(Vector2 gameSize) {}
 
   /// Whether this component has been loaded yet. If not loaded, [BaseGame] will not try to render it.
   ///
@@ -53,7 +53,7 @@ abstract class Component {
   /// Called when the component has been added and prepared by the game instance.
   ///
   /// This can be used to make initializations on your component as, when this method is called,
-  /// things like resize (and other mixins) are already set and usable.
+  /// things like [onGameResize] are already set and usable.
   void onMount() {}
 
   /// Called right before the component is destroyed and removed from the game

--- a/lib/components/joystick/joystick_component.dart
+++ b/lib/components/joystick/joystick_component.dart
@@ -70,10 +70,10 @@ class JoystickComponent extends JoystickController {
   }
 
   @override
-  void resize(Vector2 size) {
+  void onGameResize(Vector2 size) {
     directional?.initialize(size, this);
     actions?.forEach((action) => action.initialize(size, this));
-    super.resize(size);
+    super.onGameResize(size);
   }
 
   @override

--- a/lib/components/mixins/resizable.dart
+++ b/lib/components/mixins/resizable.dart
@@ -1,21 +1,18 @@
+import 'package:meta/meta.dart';
 import '../../extensions/vector2.dart';
+import '../component.dart';
 
-/// Useful mixin to add to your components if you want to hold a reference to the current screen size.
-///
-/// This mixin implements the resize method in order to hold an updated reference to the current screen [size].
-/// Also, it updates its [children], if any.
-class Resizable {
+/// A [Component] mixin to make your component keep track of the size of the game viewport.
+mixin Resizable on Component {
   /// This is the current updated screen size.
-  Vector2 size;
+  Vector2 gameSize;
 
   /// Implementation provided by this mixin to the resize hook.
-  void resize(Vector2 size) {
-    this.size = size;
-    resizableChildren().forEach((e) => e?.resize(size));
+  /// This is a hook called by [BaseGame] to let this component know that the screen (or flame draw area) has been update.
+  @override
+  @mustCallSuper
+  void onGameResize(Vector2 gameSize) {
+    super.onGameResize(gameSize);
+    this.gameSize = gameSize;
   }
-
-  /// Overwrite this to add children to this [Resizable].
-  ///
-  /// If a [Resizable] has children, its children as resized as well.
-  Iterable<Resizable> resizableChildren() => [];
 }

--- a/lib/components/parallax_component.dart
+++ b/lib/components/parallax_component.dart
@@ -179,8 +179,8 @@ class ParallaxComponent extends PositionComponent {
 
   @mustCallSuper
   @override
-  void resize(Vector2 size) {
-    super.resize(size);
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
     _layers.forEach((layer) => layer.resize(size));
   }
 

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -184,9 +184,9 @@ abstract class PositionComponent extends Component {
 
   @mustCallSuper
   @override
-  void resize(Vector2 size) {
-    super.resize(size);
-    _children.forEach((child) => child.resize(size));
+  void onGameResize(Vector2 gameSize) {
+    super.onGameResize(gameSize);
+    _children.forEach((child) => child.onGameResize(gameSize));
   }
 
   @mustCallSuper

--- a/lib/components/text_box_component.dart
+++ b/lib/components/text_box_component.dart
@@ -148,7 +148,7 @@ class TextBoxComponent extends PositionComponent with Resizable {
 
   Future<Image> _redrawCache() {
     final PictureRecorder recorder = PictureRecorder();
-    final Canvas c = Canvas(recorder, size.toRect());
+    final Canvas c = Canvas(recorder, gameSize.toRect());
     _fullRender(c);
     return recorder.endRecording().toImage(width.toInt(), height.toInt());
   }

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -30,7 +30,7 @@ class BaseGame extends Game with FPSCounter {
   /// Components to be removed on the next update
   final List<Component> _removeLater = [];
 
-  /// Current screen size, updated every resize via the [resize] method hook
+  /// Current game viewport size, updated every resize via the [resize] method hook
   Vector2 size;
 
   /// Camera position; every non-HUD component is translated so that the camera position is the top-left corner of the screen.
@@ -59,7 +59,7 @@ class BaseGame extends Game with FPSCounter {
 
     // first time resize
     if (size != null) {
-      c.resize(size);
+      c.onGameResize(size);
     }
 
     c.onMount();
@@ -140,7 +140,7 @@ class BaseGame extends Game with FPSCounter {
   @mustCallSuper
   void resize(Vector2 size) {
     this.size = size;
-    components.forEach((c) => c.resize(size));
+    components.forEach((c) => c.onGameResize(size));
   }
 
   /// Returns whether this [Game] is in debug mode or not.

--- a/test/components/composed_component_test.dart
+++ b/test/components/composed_component_test.dart
@@ -43,7 +43,7 @@ void main() {
       game.add(wrapper);
       game.onTapDown(1, TapDownDetails(globalPosition: const Offset(0.0, 0.0)));
 
-      expect(child.size, size);
+      expect(child.gameSize, size);
       expect(child.tapped, true);
     });
   });

--- a/test/components/resizable_test.dart
+++ b/test/components/resizable_test.dart
@@ -7,12 +7,10 @@ import 'package:flame/components/mixins/resizable.dart';
 
 class MyComponent extends PositionComponent with Resizable {
   String name;
-  List<MyComponent> myChildren;
-
-  MyComponent(this.name, {this.myChildren = const []});
-
   @override
-  Iterable<Resizable> resizableChildren() => myChildren;
+  Vector2 size = Vector2(2.0, 2.0);
+
+  MyComponent(this.name);
 }
 
 class MyGame extends BaseGame {}
@@ -21,27 +19,26 @@ Vector2 size = Vector2(1.0, 1.0);
 
 void main() {
   group('resizable test', () {
-    test('propagate resize to children', () {
-      final MyComponent a = MyComponent('a');
-      final MyComponent b = MyComponent('b', myChildren: [a]);
-      b.resize(size);
-      expect(a.size, size);
-    });
-
     test('game calls resize on add', () {
       final MyComponent a = MyComponent('a');
       final MyGame game = MyGame();
       game.resize(size);
       game.add(a);
-      expect(a.size, size);
+      expect(a.gameSize, size);
     });
-
     test('game calls resize after added', () {
       final MyComponent a = MyComponent('a');
       final MyGame game = MyGame();
       game.add(a);
       game.resize(size);
-      expect(a.size, size);
+      expect(a.gameSize, size);
+    });
+    test('game calls doesnt change component size', () {
+      final MyComponent a = MyComponent('a');
+      final MyGame game = MyGame();
+      game.add(a);
+      game.resize(size);
+      expect(a.size, isNot(size));
     });
   });
 }


### PR DESCRIPTION
There is a confusion between what is a component size and a game viewport size. 

`PositionComponent` now has the size property, that obviously refers to the size of the component not the size fo the game viewport. 
Ant then we have `Resizable`, a (should be) mixin for components that keeps track of the game viewport size by storing its value on a also named `size` property. 

Using `PositionComponent` alongside `Resizable` leads to a bug. 


Solution proposed:
- Make clear that `.resize` on components are about the game viewport size, not about the component size. Renaming it to `onGameResize`.
- Make `Resizable` have a gameSize property instead of `size`.
- Remove the concern of having 

### Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [ ] The continuous integration (CI) is passing
