### PR TITLE
Generalize effects so that they can be used on all components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  - Fix bug with CombinedEffect inside SequenceEffect
  - Fix wrong end angle for relative rotational effects
  - Use a list of Vector2 for Move effect to open up for more advanced move effects
+ - Generalize effects api to include all components
 
 ## [next]
  - Fix spriteAsWidget deprecation message

--- a/doc/effects.md
+++ b/doc/effects.md
@@ -1,7 +1,9 @@
 # Effects
-An effect can be applied to any `PositionComponent`, there are currently two effects that you can use and that is the MoveEffect and the ScaleEffect.
+An effect can be applied to any `Component` that the effect supports.
 
-If you want to create an effect that only runs once only specify the required parameters of your wanted Effect class.
+At the moment there are only `PositionComponentEffect`s, which are applied to PositionComponent`'s, which are presented below.
+
+If you want to create an effect for another component just extend the `ComponentEffect` class and add your created effect to the component by calling `component.addEffect(yourEffect)`.
 
 ## More advanced effects
 Then there are two optional boolean parameters called `isInfinite` and `isAlternating`, by combining them you can get different effects.

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -73,14 +73,14 @@ class MyGame extends BaseGame with TapDetector {
     final combination = CombinedEffect(
       effects: [move2, rotate],
       isAlternating: false,
-      isInfinite: true,
+      isInfinite: false,
     );
 
     final sequence = SequenceEffect(
       effects: [move1, scale, combination],
-      isInfinite: true,
-      isAlternating: false,
+      isInfinite: false,
+      isAlternating: true,
     );
-    greenSquare.addEffect(combination);
+    greenSquare.addEffect(sequence);
   }
 }

--- a/doc/examples/effects/sequence_effect/lib/main.dart
+++ b/doc/examples/effects/sequence_effect/lib/main.dart
@@ -72,14 +72,15 @@ class MyGame extends BaseGame with TapDetector {
 
     final combination = CombinedEffect(
       effects: [move2, rotate],
-      isAlternating: true,
+      isAlternating: false,
+      isInfinite: true,
     );
 
     final sequence = SequenceEffect(
       effects: [move1, scale, combination],
-      isInfinite: false,
-      isAlternating: true,
+      isInfinite: true,
+      isAlternating: false,
     );
-    greenSquare.addEffect(sequence);
+    greenSquare.addEffect(combination);
   }
 }

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -2,7 +2,6 @@ import 'dart:ui';
 
 import 'package:flame/effects/effects.dart';
 import 'package:flutter/painting.dart';
-import 'package:meta/meta.dart';
 
 import '../extensions/vector2.dart';
 
@@ -20,7 +19,6 @@ abstract class Component {
   /// The time [t] in seconds (with microseconds precision provided by Flutter) since the last update cycle.
   /// This time can vary according to hardware capacity, so make sure to update your state considering this.
   /// All components on [BaseGame] are always updated by the same amount. The time each one takes to update adds up to the next update cycle.
-  @mustCallSuper
   void update(double dt) {
     _effects.forEach((e) => e.update(dt));
     _effects.removeWhere((e) => e.hasFinished());

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -1,6 +1,8 @@
 import 'dart:ui';
 
+import 'package:flame/effects/effects.dart';
 import 'package:flutter/painting.dart';
+import 'package:meta/meta.dart';
 
 import '../extensions/vector2.dart';
 
@@ -10,12 +12,19 @@ import '../extensions/vector2.dart';
 /// Anything that either renders or updates can be added to the list on [BaseGame]. It will deal with calling those methods for you.
 /// Components also have other methods that can help you out if you want to overwrite them.
 abstract class Component {
+  /// The effects that should run on the component
+  final List<ComponentEffect> _effects = [];
+
   /// This method is called periodically by the game engine to request that your component updates itself.
   ///
   /// The time [t] in seconds (with microseconds precision provided by Flutter) since the last update cycle.
   /// This time can vary according to hardware capacity, so make sure to update your state considering this.
   /// All components on [BaseGame] are always updated by the same amount. The time each one takes to update adds up to the next update cycle.
-  void update(double t);
+  @mustCallSuper
+  void update(double dt) {
+    _effects.forEach((e) => e.update(dt));
+    _effects.removeWhere((e) => e.hasFinished());
+  }
 
   /// Renders this component on the provided Canvas [c].
   void render(Canvas c);
@@ -58,4 +67,19 @@ abstract class Component {
 
   /// Called right before the component is destroyed and removed from the game
   void onDestroy() {}
+
+  /// Add an effect to the component
+  void addEffect(ComponentEffect effect) {
+    _effects.add(effect..initialize(this));
+  }
+
+  /// Mark an effect for removal on the component
+  void removeEffect(ComponentEffect effect) {
+    effect.dispose();
+  }
+
+  /// Remove all effects
+  void clearEffects() {
+    _effects.forEach(removeEffect);
+  }
 }

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -1,8 +1,8 @@
 import 'dart:ui';
 
-import 'package:flame/effects/effects.dart';
 import 'package:flutter/painting.dart';
 
+import '../effects/effects.dart';
 import '../extensions/vector2.dart';
 
 /// This represents a Component for your game.

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -77,7 +77,6 @@ abstract class PositionComponent extends Component {
   /// You can also manually override this for certain components in order to identify issues.
   bool debugMode = false;
 
-  final List<PositionComponentEffect> _effects = [];
   final OrderedSet<Component> _children =
       OrderedSet(Comparing.on((c) => c.priority()));
 
@@ -136,25 +135,6 @@ abstract class PositionComponent extends Component {
       canvas.scale(renderFlipX ? -1.0 : 1.0, renderFlipY ? -1.0 : 1.0);
       canvas.translate(-width / 2, -height / 2);
     }
-  }
-
-  void addEffect(PositionComponentEffect effect) {
-    _effects.add(effect..initialize(this));
-  }
-
-  void removeEffect(PositionComponentEffect effect) {
-    effect.dispose();
-  }
-
-  void clearEffects() {
-    _effects.forEach(removeEffect);
-  }
-
-  @mustCallSuper
-  @override
-  void update(double dt) {
-    _effects.forEach((e) => e.update(dt));
-    _effects.removeWhere((e) => e.hasFinished());
   }
 
   /// This function recursively propagates an action to every children and grandchildren (and so on) of this component,

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -5,7 +5,6 @@ import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
 
 import '../anchor.dart';
-import '../effects/effects.dart';
 import '../game.dart';
 import '../text_config.dart';
 import '../extensions/offset.dart';
@@ -182,6 +181,10 @@ abstract class PositionComponent extends Component {
     _children.forEach((comp) => _renderChild(canvas, comp));
     canvas.restore();
   }
+
+  @mustCallSuper
+  @override
+  void update(double dt) => super.update(dt);
 
   void _renderChild(Canvas canvas, Component c) {
     if (!c.loaded()) {

--- a/lib/effects/combined_effect.dart
+++ b/lib/effects/combined_effect.dart
@@ -96,6 +96,11 @@ class CombinedEffect extends PositionComponentEffect {
     }
   }
 
+  @override
+  bool hasFinished() {
+    return super.hasFinished() && effects.every((e) => e.hasFinished());
+  }
+
   void _maybeReverse(PositionComponentEffect effect) {
     if (isAlternating && !effect.isAlternating && effect.isMax()) {
       // Make the effect go in reverse

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -1,9 +1,9 @@
 import 'dart:math';
 
-import 'package:flame/components/component.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../components/component.dart';
 import '../components/position_component.dart';
 import '../extensions/vector2.dart';
 

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -60,7 +60,7 @@ abstract class PositionComponentEffect {
     if (isAlternating) {
       curveDirection = isMax() ? -1 : (isMin() ? 1 : curveDirection);
     } else if (isInfinite && isMax()) {
-      reset();
+      currentTime = 0.0;
     }
     final driftMultiplier = (isAlternating && isMax() ? 2 : 1) * curveDirection;
     if (!hasFinished()) {

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -130,9 +130,9 @@ abstract class PositionComponentEffect
 
   @mustCallSuper
   @override
-  void initialize(PositionComponent _comp) {
-    super.initialize(_comp);
-    component = _comp;
+  void initialize(PositionComponent component) {
+    super.initialize(component);
+    this.component = component;
     originalPosition = component.position;
     originalAngle = component.angle;
     originalSize = component.size;
@@ -140,8 +140,8 @@ abstract class PositionComponentEffect
     /// If these aren't modified by the extending effect it is assumed that the
     /// effect didn't bring the component to another state than the one it
     /// started in
-    endPosition = _comp.position;
-    endAngle = _comp.angle;
-    endSize = _comp.size;
+    endPosition = component.position;
+    endAngle = component.angle;
+    endSize = component.size;
   }
 }

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -51,7 +51,7 @@ abstract class ComponentEffect<T extends Component> {
     if (isAlternating) {
       curveDirection = isMax() ? -1 : (isMin() ? 1 : curveDirection);
     } else if (isInfinite && isMax()) {
-      currentTime = 0.0;
+      reset();
     }
     final driftMultiplier = (isAlternating && isMax() ? 2 : 1) * curveDirection;
     if (!hasFinished()) {

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flame/components/component.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -11,8 +12,8 @@ export './rotate_effect.dart';
 export './scale_effect.dart';
 export './sequence_effect.dart';
 
-abstract class PositionComponentEffect {
-  PositionComponent component;
+abstract class ComponentEffect<T extends Component> {
+  T component;
   Function() onComplete;
 
   bool _isDisposed = false;
@@ -31,26 +32,16 @@ abstract class PositionComponentEffect {
   double driftTime = 0.0;
   int curveDirection = 1;
 
-  /// Used to be able to determine the start state of the component
-  Vector2 originalPosition;
-  double originalAngle;
-  Vector2 originalSize;
-
-  /// Used to be able to determine the end state of a sequence of effects
-  Vector2 endPosition;
-  double endAngle;
-  Vector2 endSize;
-
   /// If the effect is alternating the travel time is double the normal
   /// travel time
   double get totalTravelTime => travelTime * (isAlternating ? 2 : 1);
 
-  PositionComponentEffect(
-    this._initialIsInfinite,
-    this._initialIsAlternating, {
-    this.isRelative = false,
-    this.onComplete,
-  }) {
+  ComponentEffect(
+      this._initialIsInfinite,
+      this._initialIsAlternating, {
+        this.isRelative = false,
+        this.onComplete,
+      }) {
     isInfinite = _initialIsInfinite;
     isAlternating = _initialIsAlternating;
   }
@@ -73,22 +64,12 @@ abstract class PositionComponentEffect {
   }
 
   @mustCallSuper
-  void initialize(PositionComponent _comp) {
-    component = _comp;
-    originalPosition = component.position;
-    originalAngle = component.angle;
-    originalSize = component.size;
+  void initialize(T component) {
+    this.component = component;
 
     /// You need to set the travelTime during the initialization of the
     /// extending effect
     travelTime = null;
-
-    /// If these aren't modified by the extending effect it is assumed that the
-    /// effect didn't bring the component to another state than the one it
-    /// started in
-    endPosition = _comp.position;
-    endAngle = _comp.angle;
-    endSize = _comp.size;
   }
 
   void dispose() => _isDisposed = true;
@@ -120,5 +101,46 @@ abstract class PositionComponentEffect {
     } else {
       driftTime = 0;
     }
+  }
+}
+
+abstract class PositionComponentEffect extends ComponentEffect<PositionComponent> {
+  /// Used to be able to determine the start state of the component
+  Vector2 originalPosition;
+  double originalAngle;
+  Vector2 originalSize;
+
+  /// Used to be able to determine the end state of a sequence of effects
+  Vector2 endPosition;
+  double endAngle;
+  Vector2 endSize;
+
+  PositionComponentEffect(
+    initialIsInfinite,
+    initialIsAlternating, {
+    isRelative = false,
+    onComplete,
+  }) : super(
+      initialIsInfinite,
+      initialIsAlternating,
+      isRelative: isRelative,
+      onComplete: onComplete,
+  );
+
+  @mustCallSuper
+  @override
+  void initialize(PositionComponent _comp) {
+    super.initialize(_comp);
+    component = _comp;
+    originalPosition = component.position;
+    originalAngle = component.angle;
+    originalSize = component.size;
+
+    /// If these aren't modified by the extending effect it is assumed that the
+    /// effect didn't bring the component to another state than the one it
+    /// started in
+    endPosition = _comp.position;
+    endAngle = _comp.angle;
+    endSize = _comp.size;
   }
 }

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -37,11 +37,11 @@ abstract class ComponentEffect<T extends Component> {
   double get totalTravelTime => travelTime * (isAlternating ? 2 : 1);
 
   ComponentEffect(
-      this._initialIsInfinite,
-      this._initialIsAlternating, {
-        this.isRelative = false,
-        this.onComplete,
-      }) {
+    this._initialIsInfinite,
+    this._initialIsAlternating, {
+    this.isRelative = false,
+    this.onComplete,
+  }) {
     isInfinite = _initialIsInfinite;
     isAlternating = _initialIsAlternating;
   }
@@ -104,7 +104,8 @@ abstract class ComponentEffect<T extends Component> {
   }
 }
 
-abstract class PositionComponentEffect extends ComponentEffect<PositionComponent> {
+abstract class PositionComponentEffect
+    extends ComponentEffect<PositionComponent> {
   /// Used to be able to determine the start state of the component
   Vector2 originalPosition;
   double originalAngle;
@@ -121,11 +122,11 @@ abstract class PositionComponentEffect extends ComponentEffect<PositionComponent
     isRelative = false,
     onComplete,
   }) : super(
-      initialIsInfinite,
-      initialIsAlternating,
-      isRelative: isRelative,
-      onComplete: onComplete,
-  );
+          initialIsInfinite,
+          initialIsAlternating,
+          isRelative: isRelative,
+          onComplete: onComplete,
+        );
 
   @mustCallSuper
   @override

--- a/lib/effects/move_effect.dart
+++ b/lib/effects/move_effect.dart
@@ -52,7 +52,7 @@ class MoveEffect extends PositionComponentEffect {
     if (isRelative) {
       Vector2 lastPosition = _startPosition;
       _movePath = [];
-      for(Vector2 v in path) {
+      for (Vector2 v in path) {
         final nextPosition = v + lastPosition;
         _movePath.add(nextPosition);
         lastPosition = nextPosition;
@@ -92,11 +92,11 @@ class MoveEffect extends PositionComponentEffect {
     }
     travelTime = pathLength / speed;
   }
-  
+
   @override
   void reset() {
     super.reset();
-    if(_percentagePath?.isNotEmpty ?? false) {
+    if (_percentagePath?.isNotEmpty ?? false) {
       _currentSubPath = _percentagePath.first;
     }
   }
@@ -117,7 +117,6 @@ class MoveEffect extends PositionComponentEffect {
     final double localPercentage =
         (progress - lastEndAt) / (_currentSubPath.endAt - lastEndAt);
     component.position = _currentSubPath.previous +
-        ((_currentSubPath.v - _currentSubPath.previous) *
-            localPercentage);
+        ((_currentSubPath.v - _currentSubPath.previous) * localPercentage);
   }
 }

--- a/lib/effects/move_effect.dart
+++ b/lib/effects/move_effect.dart
@@ -25,7 +25,6 @@ class MoveEffect extends PositionComponentEffect {
   double speed;
   Curve curve;
   Vector2 _startPosition;
-  Vector2 _peakPosition;
 
   MoveEffect({
     @required this.path,
@@ -61,10 +60,10 @@ class MoveEffect extends PositionComponentEffect {
     } else {
       _movePath = path;
     }
-    print(_movePath);
-    _peakPosition = isRelative ? path.last : path.last - _startPosition;
     if (!isAlternating) {
-      endPosition = _peakPosition;
+      endPosition = _movePath.last;
+    } else {
+      endPosition = _startPosition;
     }
 
     double pathLength = 0;
@@ -91,8 +90,15 @@ class MoveEffect extends PositionComponentEffect {
       );
       lastPosition = v;
     }
-    print(_percentagePath);
     travelTime = pathLength / speed;
+  }
+  
+  @override
+  void reset() {
+    super.reset();
+    if(_percentagePath?.isNotEmpty ?? false) {
+      _currentSubPath = _percentagePath.first;
+    }
   }
 
   @override

--- a/lib/effects/move_effect.dart
+++ b/lib/effects/move_effect.dart
@@ -25,6 +25,7 @@ class MoveEffect extends PositionComponentEffect {
   double speed;
   Curve curve;
   Vector2 _startPosition;
+  Vector2 _peakPosition;
 
   MoveEffect({
     @required this.path,
@@ -52,7 +53,7 @@ class MoveEffect extends PositionComponentEffect {
     if (isRelative) {
       Vector2 lastPosition = _startPosition;
       _movePath = [];
-      for (Vector2 v in path) {
+      for(Vector2 v in path) {
         final nextPosition = v + lastPosition;
         _movePath.add(nextPosition);
         lastPosition = nextPosition;
@@ -60,10 +61,10 @@ class MoveEffect extends PositionComponentEffect {
     } else {
       _movePath = path;
     }
+    print(_movePath);
+    _peakPosition = isRelative ? path.last : path.last - _startPosition;
     if (!isAlternating) {
-      endPosition = _movePath.last;
-    } else {
-      endPosition = _startPosition;
+      endPosition = _peakPosition;
     }
 
     double pathLength = 0;
@@ -90,15 +91,8 @@ class MoveEffect extends PositionComponentEffect {
       );
       lastPosition = v;
     }
+    print(_percentagePath);
     travelTime = pathLength / speed;
-  }
-
-  @override
-  void reset() {
-    super.reset();
-    if (_percentagePath?.isNotEmpty ?? false) {
-      _currentSubPath = _percentagePath.first;
-    }
   }
 
   @override
@@ -117,6 +111,7 @@ class MoveEffect extends PositionComponentEffect {
     final double localPercentage =
         (progress - lastEndAt) / (_currentSubPath.endAt - lastEndAt);
     component.position = _currentSubPath.previous +
-        ((_currentSubPath.v - _currentSubPath.previous) * localPercentage);
+        ((_currentSubPath.v - _currentSubPath.previous) *
+            localPercentage);
   }
 }

--- a/lib/effects/sequence_effect.dart
+++ b/lib/effects/sequence_effect.dart
@@ -20,6 +20,10 @@ class SequenceEffect extends PositionComponentEffect {
       effects.every((effect) => effect.component == null),
       "No effects can be added to components from the start",
     );
+    assert(
+      effects.every((effect) => !effect.isInfinite),
+      "No effects added to the sequence can be infinite",
+    );
   }
 
   @override
@@ -63,9 +67,9 @@ class SequenceEffect extends PositionComponentEffect {
       _driftModifier = currentEffect.driftTime;
       _currentIndex++;
       final iterationSize = isAlternating ? effects.length * 2 : effects.length;
-      if (_currentIndex != 0
-          && _currentIndex == iterationSize
-          && (currentEffect.isAlternating ||
+      if (_currentIndex != 0 &&
+          _currentIndex == iterationSize &&
+          (currentEffect.isAlternating ||
               currentEffect.isAlternating == isAlternating)) {
         isInfinite ? reset() : dispose();
         return;
@@ -92,10 +96,12 @@ class SequenceEffect extends PositionComponentEffect {
   @override
   void reset() {
     super.reset();
-    component.position = originalPosition;
-    component.angle = originalAngle;
-    component.size = originalSize;
-    initialize(component);
-    //effects.forEach((e) => e.reset());
+    effects.forEach((e) => e.reset());
+    if (component != null) {
+      component.position = originalPosition;
+      component.angle = originalAngle;
+      component.size = originalSize;
+      initialize(component);
+    }
   }
 }

--- a/lib/effects/sequence_effect.dart
+++ b/lib/effects/sequence_effect.dart
@@ -63,9 +63,9 @@ class SequenceEffect extends PositionComponentEffect {
       _driftModifier = currentEffect.driftTime;
       _currentIndex++;
       final iterationSize = isAlternating ? effects.length * 2 : effects.length;
-      if (_currentIndex != 0 &&
-          _currentIndex == iterationSize &&
-          (currentEffect.isAlternating ||
+      if (_currentIndex != 0
+          && _currentIndex == iterationSize
+          && (currentEffect.isAlternating ||
               currentEffect.isAlternating == isAlternating)) {
         isInfinite ? reset() : dispose();
         return;
@@ -92,12 +92,10 @@ class SequenceEffect extends PositionComponentEffect {
   @override
   void reset() {
     super.reset();
-    effects.forEach((e) => e.reset());
-    if (component != null) {
-      component.position = originalPosition;
-      component.angle = originalAngle;
-      component.size = originalSize;
-      initialize(component);
-    }
+    component.position = originalPosition;
+    component.angle = originalAngle;
+    component.size = originalSize;
+    initialize(component);
+    //effects.forEach((e) => e.reset());
   }
 }


### PR DESCRIPTION
# Description

Currently we only support effects for `PositionComponent`, but in theory an effect can run on any component, this PR generalizes the API so it opens up that possibility.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] The continuous integration (CI) is passing
