### PR TITLE
Utilize Vector2 for Sprite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'
+      - run: git clean -xffd # https://github.com/dart-lang/sdk/issues/39792
       - run: flutter --version
       - run: flutter pub get
       - run: ./scripts/lint.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
  - Use a list of Vector2 for Move effect to open up for more advanced move effects
  - Generalize effects api to include all components
  - Extract all the audio related capabilities to a new package, flame_audio
+ - Fix bug that sprite crashes without a position
 
 ## [next]
  - Fix spriteAsWidget deprecation message

--- a/doc/examples/animation_widget/lib/main.dart
+++ b/doc/examples/animation_widget/lib/main.dart
@@ -15,7 +15,7 @@ SpriteAnimation _animation;
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final image = await Flame.images.load('minotaur.png');
-  _sprite = Sprite(image, size: Vector2.all(96));
+  _sprite = Sprite(image, srcSize: Vector2.all(96));
 
   final _animationSpriteSheet = SpriteSheet(
     image: image,

--- a/doc/examples/isometric/lib/main.dart
+++ b/doc/examples/isometric/lib/main.dart
@@ -25,7 +25,7 @@ class Selector extends SpriteComponent {
 
   Selector(double s, Image image)
       : super.fromSprite(
-            Vector2.all(s), Sprite(image, size: Vector2.all(32.0)));
+            Vector2.all(s), Sprite(image, srcSize: Vector2.all(32.0)));
 
   @override
   void render(Canvas canvas) {

--- a/lib/components/isometric_tile_map_component.dart
+++ b/lib/components/isometric_tile_map_component.dart
@@ -46,7 +46,7 @@ class IsometricTileset {
     final j = tileId ~/ columns;
     final s = size.toDouble();
     return Sprite(tileset,
-        srcPosition: Vector2(s * i, s * j), size: Vector2.all(s));
+        srcPosition: Vector2(s * i, s * j), srcSize: Vector2.all(s));
   }
 }
 

--- a/lib/components/isometric_tile_map_component.dart
+++ b/lib/components/isometric_tile_map_component.dart
@@ -46,7 +46,7 @@ class IsometricTileset {
     final j = tileId ~/ columns;
     final s = size.toDouble();
     return Sprite(tileset,
-        position: Vector2(s * i, s * j), size: Vector2.all(s));
+        srcPosition: Vector2(s * i, s * j), size: Vector2.all(s));
   }
 }
 

--- a/lib/components/sprite_animation_component.dart
+++ b/lib/components/sprite_animation_component.dart
@@ -77,8 +77,7 @@ class SpriteAnimationComponent extends PositionComponent {
     super.render(canvas);
     animation.getSprite().render(
           canvas,
-          width: width,
-          height: height,
+          size: size,
           overridePaint: overridePaint,
         );
   }

--- a/lib/components/sprite_component.dart
+++ b/lib/components/sprite_component.dart
@@ -36,8 +36,7 @@ class SpriteComponent extends PositionComponent {
     super.render(canvas);
     sprite.render(
       canvas,
-      width: width,
-      height: height,
+      size: size,
       overridePaint: overridePaint,
     );
   }

--- a/lib/nine_tile_box.dart
+++ b/lib/nine_tile_box.dart
@@ -31,7 +31,7 @@ class NineTileBox {
   /// If [destTileSize] is not provided, the evaluated [tileSize] is used instead
   /// (so no scaling happens).
   NineTileBox(this.sprite, {int tileSize, int destTileSize}) {
-    this.tileSize = tileSize ?? sprite.src.width.toInt();
+    this.tileSize = tileSize ?? sprite.bounds.width.toInt();
     this.destTileSize = destTileSize ?? tileSize;
   }
 
@@ -83,8 +83,8 @@ class NineTileBox {
   double get _destTileSizeDouble => destTileSize.toDouble();
 
   void _drawTile(Canvas c, Rect dest, int i, int j) {
-    final xSrc = sprite.src.left + _tileSizeDouble * i;
-    final ySrc = sprite.src.top + _tileSizeDouble * j;
+    final xSrc = sprite.bounds.left + _tileSizeDouble * i;
+    final ySrc = sprite.bounds.top + _tileSizeDouble * j;
     final src = Rect.fromLTWH(xSrc, ySrc, _tileSizeDouble, _tileSizeDouble);
     c.drawImageRect(sprite.image, src, dest, BasicPalette.white.paint);
   }

--- a/lib/nine_tile_box.dart
+++ b/lib/nine_tile_box.dart
@@ -31,7 +31,7 @@ class NineTileBox {
   /// If [destTileSize] is not provided, the evaluated [tileSize] is used instead
   /// (so no scaling happens).
   NineTileBox(this.sprite, {int tileSize, int destTileSize}) {
-    this.tileSize = tileSize ?? sprite.bounds.width.toInt();
+    this.tileSize = tileSize ?? sprite.src.width.toInt();
     this.destTileSize = destTileSize ?? tileSize;
   }
 
@@ -83,8 +83,8 @@ class NineTileBox {
   double get _destTileSizeDouble => destTileSize.toDouble();
 
   void _drawTile(Canvas c, Rect dest, int i, int j) {
-    final xSrc = sprite.bounds.left + _tileSizeDouble * i;
-    final ySrc = sprite.bounds.top + _tileSizeDouble * j;
+    final xSrc = sprite.src.left + _tileSizeDouble * i;
+    final ySrc = sprite.src.top + _tileSizeDouble * j;
     final src = Rect.fromLTWH(xSrc, ySrc, _tileSizeDouble, _tileSizeDouble);
     c.drawImageRect(sprite.image, src, dest, BasicPalette.white.paint);
   }

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -1,12 +1,13 @@
 import 'dart:ui';
 
+import 'extensions/offset.dart';
 import 'extensions/vector2.dart';
 import 'palette.dart';
 
 class Sprite {
   Paint paint = BasicPalette.white.paint;
   Image image;
-  Rect src;
+  Rect bounds;
 
   Sprite(
     this.image, {
@@ -14,7 +15,7 @@ class Sprite {
     Vector2 size,
   }) : assert(image != null, "image can't be null") {
     size ??= Vector2(image.width.toDouble(), image.height.toDouble());
-    src = position.toPositionedRect(size);
+    this.position = position;
   }
 
   double get _imageWidth => image.width.toDouble();
@@ -23,7 +24,13 @@ class Sprite {
 
   Vector2 get originalSize => Vector2(_imageWidth, _imageHeight);
 
-  Vector2 get size => Vector2(src.width, src.height);
+  Vector2 get size => Vector2(bounds.width, bounds.height);
+
+  Vector2 get position => bounds.topLeft.toVector2();
+
+  set position(Vector2 position) {
+    bounds = (position ?? Vector2.zero()).toPositionedRect(size);
+  }
 
   /// Renders this Sprite on the position [p], scaled by the [scale] factor provided.
   ///
@@ -51,14 +58,11 @@ class Sprite {
 
   void render(
     Canvas canvas, {
-    double width,
-    double height,
+    Vector2 size,
     Paint overridePaint,
   }) {
-    width ??= size.x;
-    height ??= size.y;
-    renderRect(canvas, Rect.fromLTWH(0.0, 0.0, width, height),
-        overridePaint: overridePaint);
+    size ??= this.size;
+    renderRect(canvas, size.toRect(), overridePaint: overridePaint);
   }
 
   /// Renders this sprite centered in the position [p], i.e., on [p] - [size] / 2.
@@ -72,9 +76,11 @@ class Sprite {
     Paint overridePaint,
   }) {
     size ??= this.size;
-    renderRect(canvas,
-        Rect.fromLTWH(p.x - size.x / 2, p.y - size.y / 2, size.x, size.y),
-        overridePaint: overridePaint);
+    renderRect(
+      canvas,
+      (p - size / 2).toPositionedRect(size),
+      overridePaint: overridePaint,
+    );
   }
 
   void renderRect(
@@ -82,6 +88,6 @@ class Sprite {
     Rect dst, {
     Paint overridePaint,
   }) {
-    canvas.drawImageRect(image, src, dst, overridePaint ?? paint);
+    canvas.drawImageRect(image, bounds, dst, overridePaint ?? paint);
   }
 }

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -24,12 +24,12 @@ class Sprite {
 
   Vector2 get originalSize => Vector2(_imageWidth, _imageHeight);
 
-  Vector2 get size => Vector2(src.width, src.height);
+  Vector2 get srcSize => Vector2(src.width, src.height);
 
   Vector2 get srcPosition => src.topLeft.toVector2();
 
   set srcPosition(Vector2 position) {
-    src = (position ?? Vector2.zero()).toPositionedRect(size);
+    src = (position ?? Vector2.zero()).toPositionedRect(srcSize);
   }
 
   /// Renders this Sprite on the position [p], scaled by the [scale] factor provided.
@@ -43,7 +43,8 @@ class Sprite {
     double scale = 1.0,
     Paint overridePaint,
   }) {
-    renderPosition(canvas, p, size: size * scale, overridePaint: overridePaint);
+    renderPosition(canvas, p,
+        size: srcSize * scale, overridePaint: overridePaint);
   }
 
   void renderPosition(
@@ -52,7 +53,7 @@ class Sprite {
     Vector2 size,
     Paint overridePaint,
   }) {
-    size ??= this.size;
+    size ??= this.srcSize;
     renderRect(canvas, p.toPositionedRect(size), overridePaint: overridePaint);
   }
 
@@ -61,7 +62,7 @@ class Sprite {
     Vector2 size,
     Paint overridePaint,
   }) {
-    size ??= this.size;
+    size ??= this.srcSize;
     renderRect(canvas, size.toRect(), overridePaint: overridePaint);
   }
 
@@ -75,7 +76,7 @@ class Sprite {
     Vector2 size,
     Paint overridePaint,
   }) {
-    size ??= this.size;
+    size ??= this.srcSize;
     renderRect(
       canvas,
       (p - size / 2).toPositionedRect(size),

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -7,15 +7,15 @@ import 'palette.dart';
 class Sprite {
   Paint paint = BasicPalette.white.paint;
   Image image;
-  Rect bounds;
+  Rect src;
 
   Sprite(
     this.image, {
-    Vector2 position,
+    Vector2 srcPosition,
     Vector2 size,
   }) : assert(image != null, "image can't be null") {
     size ??= Vector2(image.width.toDouble(), image.height.toDouble());
-    this.position = position;
+    this.srcPosition = srcPosition;
   }
 
   double get _imageWidth => image.width.toDouble();
@@ -24,12 +24,12 @@ class Sprite {
 
   Vector2 get originalSize => Vector2(_imageWidth, _imageHeight);
 
-  Vector2 get size => Vector2(bounds.width, bounds.height);
+  Vector2 get size => Vector2(src.width, src.height);
 
-  Vector2 get position => bounds.topLeft.toVector2();
+  Vector2 get srcPosition => src.topLeft.toVector2();
 
-  set position(Vector2 position) {
-    bounds = (position ?? Vector2.zero()).toPositionedRect(size);
+  set srcPosition(Vector2 position) {
+    src = (position ?? Vector2.zero()).toPositionedRect(size);
   }
 
   /// Renders this Sprite on the position [p], scaled by the [scale] factor provided.
@@ -88,6 +88,6 @@ class Sprite {
     Rect dst, {
     Paint overridePaint,
   }) {
-    canvas.drawImageRect(image, bounds, dst, overridePaint ?? paint);
+    canvas.drawImageRect(image, src, dst, overridePaint ?? paint);
   }
 }

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -12,9 +12,9 @@ class Sprite {
   Sprite(
     this.image, {
     Vector2 srcPosition,
-    Vector2 size,
+    Vector2 srcSize,
   }) : assert(image != null, "image can't be null") {
-    size ??= Vector2(image.width.toDouble(), image.height.toDouble());
+    this.srcSize = srcSize;
     this.srcPosition = srcPosition;
   }
 
@@ -26,7 +26,12 @@ class Sprite {
 
   Vector2 get srcSize => Vector2(src.width, src.height);
 
-  Vector2 get srcPosition => src.topLeft.toVector2();
+  set srcSize(Vector2 size) {
+    size ??= Vector2(image.width.toDouble(), image.height.toDouble());
+    src = (srcPosition ?? Vector2.zero()).toPositionedRect(size);
+  }
+
+  Vector2 get srcPosition => (src?.topLeft ?? Offset.zero).toVector2();
 
   set srcPosition(Vector2 position) {
     src = (position ?? Vector2.zero()).toPositionedRect(srcSize);
@@ -43,8 +48,12 @@ class Sprite {
     double scale = 1.0,
     Paint overridePaint,
   }) {
-    renderPosition(canvas, p,
-        size: srcSize * scale, overridePaint: overridePaint);
+    renderPosition(
+      canvas,
+      p,
+      size: srcSize * scale,
+      overridePaint: overridePaint,
+    );
   }
 
   void renderPosition(
@@ -53,7 +62,7 @@ class Sprite {
     Vector2 size,
     Paint overridePaint,
   }) {
-    size ??= this.srcSize;
+    size ??= srcSize;
     renderRect(canvas, p.toPositionedRect(size), overridePaint: overridePaint);
   }
 
@@ -62,7 +71,7 @@ class Sprite {
     Vector2 size,
     Paint overridePaint,
   }) {
-    size ??= this.srcSize;
+    size ??= srcSize;
     renderRect(canvas, size.toRect(), overridePaint: overridePaint);
   }
 
@@ -76,7 +85,7 @@ class Sprite {
     Vector2 size,
     Paint overridePaint,
   }) {
-    size ??= this.srcSize;
+    size ??= srcSize;
     renderRect(
       canvas,
       (p - size / 2).toPositionedRect(size),

--- a/lib/sprite_animation.dart
+++ b/lib/sprite_animation.dart
@@ -109,7 +109,7 @@ class SpriteAnimation {
       final Sprite sprite = Sprite(
         image,
         srcPosition: position,
-        size: textureSize,
+        srcSize: textureSize,
       );
       frames[i] = SpriteAnimationFrame(sprite, stepTimes[i]);
     }
@@ -138,7 +138,7 @@ class SpriteAnimation {
       final Sprite sprite = Sprite(
         image,
         srcPosition: Vector2Extension.fromInts(x, y),
-        size: Vector2Extension.fromInts(width, height),
+        srcSize: Vector2Extension.fromInts(width, height),
       );
 
       return SpriteAnimationFrame(sprite, stepTime);

--- a/lib/sprite_animation.dart
+++ b/lib/sprite_animation.dart
@@ -108,7 +108,7 @@ class SpriteAnimation {
       );
       final Sprite sprite = Sprite(
         image,
-        position: position,
+        srcPosition: position,
         size: textureSize,
       );
       frames[i] = SpriteAnimationFrame(sprite, stepTimes[i]);
@@ -137,7 +137,7 @@ class SpriteAnimation {
 
       final Sprite sprite = Sprite(
         image,
-        position: Vector2Extension.fromInts(x, y),
+        srcPosition: Vector2Extension.fromInts(x, y),
         size: Vector2Extension.fromInts(width, height),
       );
 

--- a/lib/spritesheet.dart
+++ b/lib/spritesheet.dart
@@ -42,7 +42,7 @@ class SpriteSheet {
     return Sprite(
       image,
       srcPosition: Vector2(x.toDouble(), y.toDouble())..multiply(size),
-      size: size,
+      srcSize: size,
     );
   }
 

--- a/lib/spritesheet.dart
+++ b/lib/spritesheet.dart
@@ -41,7 +41,7 @@ class SpriteSheet {
     final size = Vector2(textureWidth.toDouble(), textureHeight.toDouble());
     return Sprite(
       image,
-      position: Vector2(x.toDouble(), y.toDouble())..multiply(size),
+      srcPosition: Vector2(x.toDouble(), y.toDouble())..multiply(size),
       size: size,
     );
   }

--- a/lib/widgets/nine_tile_box.dart
+++ b/lib/widgets/nine_tile_box.dart
@@ -19,7 +19,7 @@ class _Painter extends widgets.CustomPainter {
   });
 
   Sprite _getSpriteTile(double x, double y) =>
-      Sprite(image, srcPosition: Vector2(x, y), size: Vector2.all(tileSize));
+      Sprite(image, srcPosition: Vector2(x, y), srcSize: Vector2.all(tileSize));
 
   @override
   void paint(Canvas canvas, Size size) {

--- a/lib/widgets/nine_tile_box.dart
+++ b/lib/widgets/nine_tile_box.dart
@@ -19,7 +19,7 @@ class _Painter extends widgets.CustomPainter {
   });
 
   Sprite _getSpriteTile(double x, double y) =>
-      Sprite(image, position: Vector2(x, y), size: Vector2.all(tileSize));
+      Sprite(image, srcPosition: Vector2(x, y), size: Vector2.all(tileSize));
 
   @override
   void paint(Canvas canvas, Size size) {

--- a/lib/widgets/sprite_widget.dart
+++ b/lib/widgets/sprite_widget.dart
@@ -44,11 +44,11 @@ class _SpritePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final widthRate = size.width / _sprite.size.x;
-    final heightRate = size.height / _sprite.size.y;
+    final widthRate = size.width / _sprite.srcSize.x;
+    final heightRate = size.height / _sprite.srcSize.y;
     final rate = min(widthRate, heightRate);
 
-    final paintSize = _sprite.size * rate;
+    final paintSize = _sprite.srcSize * rate;
     final anchorPosition = _anchor.relativePosition;
     final anchoredPosition = size.toVector2()..multiply(anchorPosition);
     final delta = (anchoredPosition - paintSize)..multiply(anchorPosition);

--- a/lib/widgets/sprite_widget.dart
+++ b/lib/widgets/sprite_widget.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
 
+import 'package:flame/extensions/vector2.dart';
+import 'package:flame/extensions/size.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
@@ -45,20 +47,14 @@ class _SpritePainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final widthRate = size.width / _sprite.size.x;
     final heightRate = size.height / _sprite.size.y;
-
     final rate = min(widthRate, heightRate);
 
-    final w = _sprite.size.x * rate;
-    final h = _sprite.size.y * rate;
+    final paintSize = _sprite.size * rate;
+    final anchorPosition = _anchor.relativePosition;
+    final anchoredPosition = size.toVector2()..multiply(anchorPosition);
+    final delta = (anchoredPosition - paintSize)..multiply(anchorPosition);
 
-    final double dx = _anchor.relativePosition.x * size.width;
-    final double dy = _anchor.relativePosition.y * size.height;
-
-    canvas.translate(
-      dx - w * _anchor.relativePosition.x,
-      dy - h * _anchor.relativePosition.y,
-    );
-
-    _sprite.render(canvas, width: w, height: h);
+    canvas.translate(delta.x, delta.y);
+    _sprite.render(canvas, size: paintSize);
   }
 }

--- a/lib/widgets/sprite_widget.dart
+++ b/lib/widgets/sprite_widget.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 
-import 'package:flame/extensions/vector2.dart';
 import 'package:flame/extensions/size.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';


### PR DESCRIPTION
# Description

Fixes the issue with Sprite crashing in the constructor if it doesn't get the optional position argument.
(Also converts size to Vector2 where it makes sense)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
