### PR TITLE
Followup fix imports with new version of vscode-dart-import

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -48,6 +48,7 @@ linter:
     - prefer_initializing_formals
     - prefer_is_empty
     - prefer_is_not_empty
+    - prefer_relative_imports
     - prefer_typing_uninitialized_variables
     - recursive_getters
     - slash_for_doc_comments

--- a/lib/components/joystick/joystick_action.dart
+++ b/lib/components/joystick/joystick_action.dart
@@ -1,15 +1,15 @@
 import 'dart:math';
 import 'dart:ui';
 
-import 'joystick_component.dart';
-import 'joystick_events.dart';
-import '../../gestures.dart';
-import '../../sprite.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../extensions/offset.dart';
 import '../../extensions/vector2.dart';
+import '../../gestures.dart';
+import '../../sprite.dart';
+import 'joystick_component.dart';
+import 'joystick_events.dart';
 
 enum JoystickActionAlign { TOP_LEFT, BOTTOM_LEFT, TOP_RIGHT, BOTTOM_RIGHT }
 

--- a/lib/components/mixins/resizable.dart
+++ b/lib/components/mixins/resizable.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+
 import '../../extensions/vector2.dart';
 import '../component.dart';
 

--- a/lib/components/parallax_component.dart
+++ b/lib/components/parallax_component.dart
@@ -4,8 +4,8 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 
-import '../extensions/vector2.dart';
 import '../extensions/rect.dart';
+import '../extensions/vector2.dart';
 import '../flame.dart';
 import 'position_component.dart';
 

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -5,10 +5,10 @@ import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
 
 import '../anchor.dart';
-import '../game.dart';
-import '../text_config.dart';
 import '../extensions/offset.dart';
 import '../extensions/vector2.dart';
+import '../game.dart';
+import '../text_config.dart';
 import 'component.dart';
 
 /// A [Component] implementation that represents a component that has a

--- a/lib/components/sprite_animation_component.dart
+++ b/lib/components/sprite_animation_component.dart
@@ -1,8 +1,8 @@
 import 'dart:ui';
 
-import 'package:flame/extensions/vector2.dart';
 import 'package:flutter/foundation.dart';
 
+import '../extensions/vector2.dart';
 import '../sprite_animation.dart';
 import 'position_component.dart';
 

--- a/lib/components/sprite_component.dart
+++ b/lib/components/sprite_component.dart
@@ -1,8 +1,8 @@
 import 'dart:ui';
 
-import 'package:flame/extensions/vector2.dart';
 import 'package:flutter/foundation.dart';
 
+import '../extensions/vector2.dart';
 import '../sprite.dart';
 import 'component.dart';
 import 'position_component.dart';

--- a/lib/components/text_box_component.dart
+++ b/lib/components/text_box_component.dart
@@ -4,9 +4,9 @@ import 'dart:ui';
 
 import 'package:flutter/widgets.dart' as widgets;
 
+import '../extensions/vector2.dart';
 import '../palette.dart';
 import '../text_config.dart';
-import '../extensions/vector2.dart';
 import 'mixins/resizable.dart';
 import 'position_component.dart';
 

--- a/lib/components/timer_component.dart
+++ b/lib/components/timer_component.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
-import './component.dart';
 import '../time.dart';
+import 'component.dart';
 
 /// Simple component which wraps a [Timer] instance allowing it to be easily used inside a [BaseGame] game.
 class TimerComponent extends Component {

--- a/lib/effects/combined_effect.dart
+++ b/lib/effects/combined_effect.dart
@@ -2,8 +2,8 @@ import 'dart:math';
 
 import 'package:meta/meta.dart';
 
-import './effects.dart';
 import '../components/position_component.dart';
+import 'effects.dart';
 
 class CombinedEffect extends PositionComponentEffect {
   final List<PositionComponentEffect> effects;

--- a/lib/effects/rotate_effect.dart
+++ b/lib/effects/rotate_effect.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/animation.dart';
 import 'package:meta/meta.dart';
 
-import './effects.dart';
+import 'effects.dart';
 
 class RotateEffect extends PositionComponentEffect {
   double radians;

--- a/lib/extensions/offset.dart
+++ b/lib/extensions/offset.dart
@@ -1,9 +1,9 @@
-export 'dart:ui' show Offset;
-
 import 'dart:math';
 import 'dart:ui';
 
 import './vector2.dart';
+
+export 'dart:ui' show Offset;
 
 extension OffsetExtension on Offset {
   /// Creates an [Vector2] from the [Offset]

--- a/lib/extensions/rect.dart
+++ b/lib/extensions/rect.dart
@@ -1,9 +1,9 @@
-export 'dart:ui' show Rect;
-
 import 'dart:math';
 import 'dart:ui';
 
 import './vector2.dart';
+
+export 'dart:ui' show Rect;
 
 extension RectExtension on Rect {
   /// Creates an [Offset] from the [Vector2]

--- a/lib/extensions/size.dart
+++ b/lib/extensions/size.dart
@@ -1,9 +1,9 @@
-export 'dart:ui' show Size;
-
 import 'dart:math';
 import 'dart:ui';
 
 import 'vector2.dart';
+
+export 'dart:ui' show Size;
 
 extension SizeExtension on Size {
   /// Creates an [Offset] from the [Size]

--- a/lib/extensions/vector2.dart
+++ b/lib/extensions/vector2.dart
@@ -1,9 +1,9 @@
-export 'package:vector_math/vector_math_64.dart' show Vector2;
-
 import 'dart:math';
 import 'dart:ui';
 
 import 'package:vector_math/vector_math_64.dart';
+
+export 'package:vector_math/vector_math_64.dart' show Vector2;
 
 extension Vector2Extension on Vector2 {
   /// Creates an [Offset] from the [Vector2]

--- a/lib/game/game.dart
+++ b/lib/game/game.dart
@@ -7,8 +7,8 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart' hide WidgetBuilder;
 
-import '../assets/images.dart';
 import '../assets/assets_cache.dart';
+import '../assets/images.dart';
 import '../extensions/vector2.dart';
 import '../keyboard.dart';
 import 'widget_builder.dart';

--- a/lib/gestures.dart
+++ b/lib/gestures.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/gestures.dart';
 
-import './game/game.dart';
+import 'game/game.dart';
 
 // Multi touch detector
 mixin MultiTouchTapDetector on Game {

--- a/lib/keyboard.dart
+++ b/lib/keyboard.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/services.dart';
 
-import './game.dart';
+import 'game.dart';
 
 mixin KeyboardEvents on Game {
   void onKeyEvent(RawKeyEvent event);

--- a/lib/layer/layer.dart
+++ b/lib/layer/layer.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 
 import 'processors.dart';
 
-export './processors.dart';
+export 'processors.dart';
 
 abstract class Layer {
   List<LayerProcessor> preProcessors = [];

--- a/lib/layer/layer.dart
+++ b/lib/layer/layer.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:meta/meta.dart';
 
-import './processors.dart';
+import 'processors.dart';
 
 export './processors.dart';
 

--- a/lib/particles/animation_particle.dart
+++ b/lib/particles/animation_particle.dart
@@ -2,9 +2,9 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
-import '../sprite_animation.dart';
-import '../particle.dart';
 import '../extensions/vector2.dart';
+import '../particle.dart';
+import '../sprite_animation.dart';
 
 class SpriteAnimationParticle extends Particle {
   final SpriteAnimation animation;

--- a/lib/particles/image_particle.dart
+++ b/lib/particles/image_particle.dart
@@ -2,8 +2,8 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
-import '../particle.dart';
 import '../extensions/vector2.dart';
+import '../particle.dart';
 
 /// A [Particle] which renders given [Image] on a [Canvas]
 /// image is centered. If any other behavior is needed, consider

--- a/lib/sprite_batch.dart
+++ b/lib/sprite_batch.dart
@@ -2,8 +2,8 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
-import 'flame.dart';
 import 'extensions/vector2.dart';
+import 'flame.dart';
 
 /// sprite atlas with an image and a set of rects and transforms
 class SpriteBatch {

--- a/lib/spritesheet.dart
+++ b/lib/spritesheet.dart
@@ -2,9 +2,9 @@ import 'dart:ui';
 
 import 'package:meta/meta.dart';
 
+import 'extensions/vector2.dart';
 import 'sprite.dart';
 import 'sprite_animation.dart';
-import 'extensions/vector2.dart';
 
 /// Utility class to help extract animations and sprites from a sprite sheet image.
 ///

--- a/lib/text_config.dart
+++ b/lib/text_config.dart
@@ -4,9 +4,9 @@ import 'package:flutter/material.dart' as material;
 
 import 'anchor.dart';
 import 'components/text_component.dart';
-import 'memory_cache.dart';
 import 'extensions/size.dart';
 import 'extensions/vector2.dart';
+import 'memory_cache.dart';
 
 /// A Text Config contains all typographical information required to render texts; i.e., font size and color, family, etc.
 ///

--- a/lib/widgets/animation_widget.dart
+++ b/lib/widgets/animation_widget.dart
@@ -1,11 +1,9 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart' hide Animation;
-import 'package:flame/sprite_animation.dart';
 
 import '../anchor.dart';
 import '../sprite_animation.dart';
-
 import 'sprite_widget.dart';
 
 /// A [StatefulWidget] that render a [SpriteAnimation].

--- a/lib/widgets/sprite_widget.dart
+++ b/lib/widgets/sprite_widget.dart
@@ -1,10 +1,10 @@
 import 'dart:math';
 
-import 'package:flame/extensions/size.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
 import '../anchor.dart';
+import '../extensions/size.dart';
 import '../sprite.dart';
 import 'animation_widget.dart';
 


### PR DESCRIPTION
This is a followup to @spydon 's comment here: https://github.com/flame-engine/flame/pull/469#discussion_r492371603

I updated my plugin to standardize `./foo` imports into `foo`.

Would be good to have a linter rule for imports so we don't get so much inconsistency, specially between relative/absolute imports that cause hard to debug problems.