### PR TITLE
Add lineHeight property to TextConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 - Fix spriteAsWidget deprecation message
+- Add `lineHeight` property to `TextConfig`
 
 ## 0.27.0
  - Improved the accuracy of the `FPSCounter` by using Flutter's internal frame timings.

--- a/doc/text.md
+++ b/doc/text.md
@@ -14,6 +14,7 @@ const TextConfig config = TextConfig(fontSize: 48.0, fontFamily: 'Awesome Font')
 
 * fontFamily : a commonly available font, like Arial (default), or a custom font added in your pubspec (see [here](https://flutter.io/custom-fonts/) how to do it)
 * fontSize : font size, in pts (default `24.0`)
+* lineHeight: height of text line, as a multiple of font size (default `null`)
 * color : the color, as a `ui.Color` (default black)
 
 For more information regarding colors and how to create then, see the [Colors and the Palette](/doc/palette.md) guide.

--- a/lib/text_config.dart
+++ b/lib/text_config.dart
@@ -54,6 +54,9 @@ class TextConfig {
   /// For proper fonts of languages like Hebrew or Arabic, replace this with [TextDirection.rtl].
   final TextDirection textDirection;
 
+  /// The height of line, as a multiple of font size.
+  final double lineHeight;
+
   final MemoryCache _textPainterCache =
       MemoryCache<String, material.TextPainter>();
 
@@ -66,6 +69,7 @@ class TextConfig {
     this.fontFamily = 'Arial',
     this.textAlign = TextAlign.left,
     this.textDirection = TextDirection.ltr,
+    this.lineHeight,
   });
 
   /// Renders a given [text] in a given position [p] using the provided [canvas] and [anchor].
@@ -103,6 +107,7 @@ class TextConfig {
         color: color,
         fontSize: fontSize,
         fontFamily: fontFamily,
+        height: lineHeight,
       );
       final material.TextSpan span = material.TextSpan(
         style: style,


### PR DESCRIPTION
# Description

Add lineHeight property to textConfig (pass through to https://api.flutter.dev/flutter/painting/TextStyle/height.html) so people can specify lineHeight. 

Example:
without property
![Screen Shot 2020-10-18 at 1 44 13 PM](https://user-images.githubusercontent.com/980077/96385415-a6483680-1148-11eb-89c8-e352da9cac19.png)


with property with value 1.5
![Screen Shot 2020-10-18 at 1 44 31 PM](https://user-images.githubusercontent.com/980077/96385417-a811fa00-1148-11eb-8e86-75d1040f4e18.png)


Fixes # (issue number, if there is one)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
