### PR TITLE
Export the full vector math library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
  - Improve IsometricTileMap and Spritesheet classes
+ - Export full vector_math library from extension
 
 ## 1.0.0-rc1
  - Move all box2d related code and examples to the flame_box2d repo

--- a/lib/extensions/vector2.dart
+++ b/lib/extensions/vector2.dart
@@ -3,7 +3,7 @@ import 'dart:ui';
 
 import 'package:vector_math/vector_math_64.dart';
 
-export 'package:vector_math/vector_math_64.dart' show Vector2;
+export 'package:vector_math/vector_math_64.dart' hide Colors;
 
 extension Vector2Extension on Vector2 {
   /// Creates an [Offset] from the [Vector2]


### PR DESCRIPTION
# Description

Exports the whole vector_math library so that the users won't have troubles with doing the imports.

Fixes #507

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
