### PR TITLE
Rename resize method on the Game to onResize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Ensuring sprite animation and sprite animation components don't get NPEs on initialization
  - Refactor timer class
  - include all changed that are included on 0.28.0
+ - Rename game#resize to game#onResize
 
 ## 1.0.0-rc1
  - Move all box2d related code and examples to the flame_box2d repo

--- a/doc/game.md
+++ b/doc/game.md
@@ -31,7 +31,7 @@ A very simple `BaseGame` implementation example can be seen below:
         MyCrate() : super.fromSprite(16.0, 16.0, new Sprite('crate.png'));
 
         @override
-        void resize(Size size) {
+        void onGameResize(Size size) {
             // we don't need to set the x and y in the constructor, we can set then here
             this.x = (size.width - this.width)/ 2;
             this.y = (size.height - this.height) / 2;

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -138,7 +138,7 @@ class BaseGame extends Game with FPSCounter {
   /// You can override it further to add more custom behaviour, but you should seriously consider calling the super implementation as well.
   @override
   @mustCallSuper
-  void resize(Vector2 size) {
+  void onResize(Vector2 size) {
     this.size = size;
     components.forEach((c) => c.onGameResize(size));
   }

--- a/lib/game/game.dart
+++ b/lib/game/game.dart
@@ -40,7 +40,7 @@ abstract class Game {
   /// This is the resize hook; every time the game widget is resized, this hook is called.
   ///
   /// The default implementation does nothing; override to use the hook.
-  void resize(Vector2 size) {}
+  void onResize(Vector2 size) {}
 
   /// This is the lifecycle state change hook; every time the game is resumed, paused or suspended, this is called.
   ///

--- a/lib/game/game_render_box.dart
+++ b/lib/game/game_render_box.dart
@@ -25,7 +25,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   @override
   void performResize() {
     super.performResize();
-    game.resize(constraints.biggest.toVector2());
+    game.onResize(constraints.biggest.toVector2());
   }
 
   @override

--- a/test/components/resizable_test.dart
+++ b/test/components/resizable_test.dart
@@ -22,7 +22,7 @@ void main() {
     test('game calls resize on add', () {
       final MyComponent a = MyComponent('a');
       final MyGame game = MyGame();
-      game.resize(size);
+      game.onResize(size);
       game.add(a);
       expect(a.gameSize, size);
     });
@@ -30,14 +30,14 @@ void main() {
       final MyComponent a = MyComponent('a');
       final MyGame game = MyGame();
       game.add(a);
-      game.resize(size);
+      game.onResize(size);
       expect(a.gameSize, size);
     });
     test('game calls doesnt change component size', () {
       final MyComponent a = MyComponent('a');
       final MyGame game = MyGame();
       game.add(a);
-      game.resize(size);
+      game.onResize(size);
       expect(a.size, isNot(size));
     });
   });


### PR DESCRIPTION
# Description

Rename resize method on the Game to onResize.

Fixes #517 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `v1.0.0`
- [x] This PR is targeted to merge into `v1.0.0` (not `master`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
