### PR TITLE
Simplify BaseGame interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  - Effects duration and test suite for basic effects
  - Pause and resume for effects
  - Fix position bug in parallax effect
+ - Simplification of BaseGame. Removal of addLater (add is now addLater) and rename markForRemoval.
 
 ## 1.0.0-rc1
  - Move all box2d related code and examples to the flame_box2d repo

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -73,12 +73,12 @@ class MyGame extends BaseGame with DoubleTapDetector, TapDetector {
     components.forEach((c) {
       if (c is PositionComponent && c.toRect().overlaps(touchArea)) {
         handled = true;
-        markToRemove(c);
+        remove(c);
       }
     });
 
     if (!handled) {
-      addLater(Square()
+      add(Square()
         ..x = touchArea.left
         ..y = touchArea.top);
     }

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -193,7 +193,7 @@ abstract class PositionComponent extends Component {
 
   void addChild(Game gameRef, Component c) {
     if (gameRef is BaseGame) {
-      gameRef.preAdd(c);
+      gameRef.prepare(c);
     }
     _children.add(c);
   }

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -78,12 +78,12 @@ class BaseGame extends Game with FPSCounter {
     _addLater.addAll(components);
   }
 
-  /// Marks a component to be removed from the components list on the next game loop cycle
+  /// Marks a component to be removed from the components list on the next game tick
   void remove(Component c) {
     _removeLater.add(c);
   }
 
-  /// Marks a list of components to be removed from the components list on the next game loop cycle
+  /// Marks a list of components to be removed from the components list on the next game tick
   void removeAll(Iterable<Component> components) {
     _removeLater.addAll(components);
   }

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -38,7 +38,11 @@ class BaseGame extends Game with FPSCounter {
   /// Camera position; every non-HUD component is translated so that the camera position is the top-left corner of the screen.
   Vector2 camera = Vector2.zero();
 
-  /// Does preparation on a component before any update or render method is called on it
+  /// This method is called for every component added.
+  /// It does preparation on a component before any update or render method is called on it.
+  ///
+  /// You can use this to setup your mixins, pre-calculate stuff on every component, or anything you desire.
+  /// By default, this calls the first time resize for every component, so don't forget to call super.preAdd when overriding.
   @mustCallSuper
   void prepare(Component c) {
     if (c is Tapable) {

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -16,12 +16,13 @@ import 'game.dart';
 
 /// This is a more complete and opinionated implementation of Game.
 ///
-/// It still needs to be subclasses to add your game logic, but the [update], [render] and [resize] methods have default implementations.
+/// BaseGame should be extended to add your game logic.
+/// [update], [render] and [onResize] methods have default implementations.
 /// This is the recommended structure to use for most games.
 /// It is based on the Component system.
 class BaseGame extends Game with FPSCounter {
   /// The list of components to be updated and rendered by the base game.
-  OrderedSet<Component> components =
+  final OrderedSet<Component> components =
       OrderedSet(Comparing.on((c) => c.priority()));
 
   /// Components added by the [addLater] method
@@ -31,17 +32,15 @@ class BaseGame extends Game with FPSCounter {
   final List<Component> _removeLater = [];
 
   /// Current game viewport size, updated every resize via the [resize] method hook
-  Vector2 size;
+  final Vector2 size = Vector2.zero();
+  set size(Vector2 size) => this.size.setFrom(size);
 
   /// Camera position; every non-HUD component is translated so that the camera position is the top-left corner of the screen.
   Vector2 camera = Vector2.zero();
 
-  /// This method is called for every component added, both via [add] and [addLater] methods.
-  ///
-  /// You can use this to setup your mixins, pre-calculate stuff on every component, or anything you desire.
-  /// By default, this calls the first time resize for every component, so don't forget to call super.preAdd when overriding.
+  /// Does preparation on a component before any update or render method is called on it
   @mustCallSuper
-  void preAdd(Component c) {
+  void prepare(Component c) {
     if (c is Tapable) {
       assert(
         this is HasTapableComponents,
@@ -61,30 +60,28 @@ class BaseGame extends Game with FPSCounter {
     if (size != null) {
       c.onGameResize(size);
     }
-
-    c.onMount();
   }
 
-  /// Adds a new component to the components list.
-  ///
-  /// Also calls [preAdd], witch in turn sets the current size on the component (because the resize hook won't be called until a new resize happens).
+  /// Prepares and registers a component to be added on the next game tick
   void add(Component c) {
-    preAdd(c);
-    components.add(c);
-  }
-
-  /// Registers a component to be added on the components on the next tick.
-  ///
-  /// Use this to add components in places where a concurrent issue with the update method might happen.
-  /// Also calls [preAdd] for the component added, immediately.
-  void addLater(Component c) {
-    preAdd(c);
+    prepare(c);
     _addLater.add(c);
   }
 
+  /// Prepares and registers a list of components to be added on the next game tick
+  void addAll(Iterable<Component> components) {
+    components.forEach(prepare);
+    _addLater.addAll(components);
+  }
+
   /// Marks a component to be removed from the components list on the next game loop cycle
-  void markToRemove(Component c) {
+  void remove(Component c) {
     _removeLater.add(c);
+  }
+
+  /// Marks a list of components to be removed from the components list on the next game loop cycle
+  void removeAll(Iterable<Component> components) {
+    _removeLater.addAll(components);
   }
 
   /// This implementation of render basically calls [renderComponent] for every component, making sure the canvas is reset for each one.
@@ -126,6 +123,7 @@ class BaseGame extends Game with FPSCounter {
     _removeLater.clear();
 
     components.addAll(_addLater);
+    _addLater.forEach((component) => component.onMount());
     _addLater.clear();
 
     components.forEach((c) => c.update(t));
@@ -139,7 +137,7 @@ class BaseGame extends Game with FPSCounter {
   @override
   @mustCallSuper
   void onResize(Vector2 size) {
-    this.size = size;
+    this.size.setFrom(size);
     components.forEach((c) => c.onGameResize(size));
   }
 

--- a/test/base_game_test.dart
+++ b/test/base_game_test.dart
@@ -65,6 +65,7 @@ void main() {
 
       game.size = size;
       game.add(component);
+      // The component is not added to the component list until an update has been performed
       game.update(0.0);
       game.onTapDown(1, TapDownDetails(globalPosition: const Offset(0.0, 0.0)));
 
@@ -77,6 +78,7 @@ void main() {
 
       game.size = size;
       game.add(component);
+      // The component is not added to the component list until an update has been performed
       game.update(0.0);
 
       expect(game.components.contains(component), true);

--- a/test/base_game_test.dart
+++ b/test/base_game_test.dart
@@ -1,0 +1,110 @@
+import 'dart:ui';
+
+import 'package:flame/components/position_component.dart';
+import 'package:flame/components/mixins/has_game_ref.dart';
+import 'package:flame/components/mixins/resizable.dart';
+import 'package:flame/components/mixins/tapable.dart';
+import 'package:flame/game/base_game.dart';
+import 'package:flame/extensions/vector2.dart';
+import 'package:flame/game/game_render_box.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart' as flutter;
+
+class MyGame extends BaseGame with HasTapableComponents {}
+
+class MyComponent extends PositionComponent
+    with Tapable, Resizable, HasGameRef {
+  bool tapped = false;
+  bool isUpdateCalled = false;
+  bool isRenderCalled = false;
+
+  @override
+  void onTapDown(TapDownDetails details) {
+    tapped = true;
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    isUpdateCalled = true;
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    isRenderCalled = true;
+  }
+
+  @override
+  bool checkTapOverlap(Rect c, Offset o) => true;
+}
+
+class PositionComponentNoNeedForRect extends PositionComponent with Tapable {}
+
+Vector2 size = Vector2(1.0, 1.0);
+
+void main() {
+  group('BaseGame test', () {
+    test('prepare adds gameRef and calls onGameResize', () {
+      final MyGame game = MyGame();
+      final MyComponent component = MyComponent();
+
+      game.size = size;
+      game.add(component);
+
+      expect(component.gameSize, size);
+      expect(component.gameRef, game);
+    });
+
+    test('component can be tapped', () {
+      final MyGame game = MyGame();
+      final MyComponent component = MyComponent();
+
+      game.size = size;
+      game.add(component);
+      game.update(0.0);
+      game.onTapDown(1, TapDownDetails(globalPosition: const Offset(0.0, 0.0)));
+
+      expect(component.tapped, true);
+    });
+
+    test('component is added to component list', () {
+      final MyGame game = MyGame();
+      final MyComponent component = MyComponent();
+
+      game.size = size;
+      game.add(component);
+      game.update(0.0);
+
+      expect(game.components.contains(component), true);
+    });
+
+    flutter.testWidgets('component render and update is called',
+        (flutter.WidgetTester tester) async {
+      final MyGame game = MyGame();
+      final MyComponent component = MyComponent();
+
+      game.size = size;
+      game.add(component);
+      GameRenderBox renderBox;
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            renderBox = GameRenderBox(context, game);
+            return game.widget;
+          },
+        ),
+      );
+      renderBox.attach(PipelineOwner());
+      renderBox.gameLoopCallback(1.0);
+      expect(component.isUpdateCalled, true);
+      renderBox.paint(
+          PaintingContext(ContainerLayer(), Rect.zero), Offset.zero);
+      expect(component.isRenderCalled, true);
+      renderBox.detach();
+    });
+  });
+}

--- a/test/components/composed_component_test.dart
+++ b/test/components/composed_component_test.dart
@@ -41,6 +41,7 @@ void main() {
 
       game.size = size;
       game.add(wrapper);
+      game.update(0.0);
       game.onTapDown(1, TapDownDetails(globalPosition: const Offset(0.0, 0.0)));
 
       expect(child.gameSize, size);


### PR DESCRIPTION
# Description

Suggested simplification of BaseGame.

I don't think the user needs to be aware from the names of the methods that the components aren't added/removed directly, and if they need to modify the components list directly they can still easily do so.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] The continuous integration (CI) is passing
