### PR TITLE
Unify naming standard for removal of components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  - Pause and resume for effects
  - Fix position bug in parallax effect
  - Simplification of BaseGame. Removal of addLater (add is now addLater) and rename markForRemoval.
+ - Unify naming for removal of components from BaseGame
 
 ## 1.0.0-rc1
  - Move all box2d related code and examples to the flame_box2d repo

--- a/doc/components.md
+++ b/doc/components.md
@@ -32,13 +32,13 @@ Every `Component` has a few other methods that you can optionally implement, tha
 
 The `resize` method is called whenever the screen is resized, and in the beginning once when the component is added via the `add` method. You need to apply here any changes to the x, y, width and height of your component, or any other changes, due to the screen resizing. You can start these variables here, as the sprite won't be rendered until everything is set.
 
-The `destroy` method can be implemented to return true and warn the `BaseGame` that your object is marked for destruction, and it will be remove after the current update loop. It will then no longer be rendered or updated.
+The `shouldRemove` method can be implemented to return true and `BaseGame` will remove it before the next update loop. It will then no longer be rendered or updated. Note that `game.remove(Component c)` can also be used to remove components.
 
 The `isHUD` method can be implemented to return true (default false) to make the `BaseGame` ignore the `camera` for this element.
 
 The `onMount` method can be overridden to run initialization code for the component. When this method is called, BaseGame ensures that all the mixins which would change this component behaviour are already resolved.
 
-The `onDestroy` method can be overridden to run code before the component is removed from the game.
+The `onRemove` method can be overridden to run code before the component is removed from the game.
 
 There are also other implementations:
 

--- a/doc/components.md
+++ b/doc/components.md
@@ -38,7 +38,7 @@ The `isHUD` method can be implemented to return true (default false) to make the
 
 The `onMount` method can be overridden to run initialization code for the component. When this method is called, BaseGame ensures that all the mixins which would change this component behaviour are already resolved.
 
-The `onRemove` method can be overridden to run code before the component is removed from the game.
+The `onRemove` method can be overridden to run code before the component is removed from the game, it is only run once even if the component is removed both by using the `BaseGame` remove method and the ´Component´ remove method.
 
 There are also other implementations:
 

--- a/doc/examples/animations/lib/main.dart
+++ b/doc/examples/animations/lib/main.dart
@@ -46,7 +46,7 @@ class MyGame extends BaseGame with TapDetector {
       textureSize: size,
       stepTime: 0.15,
       loop: false,
-      destroyOnFinish: true,
+      removeOnFinish: true,
     );
 
     animationComponent.position = animationComponent.position - size / 2;

--- a/doc/images.md
+++ b/doc/images.md
@@ -205,7 +205,7 @@ In which you pass the file name, the number of frames and the sprite sheet is au
 * textureY : y position on the original image to start (defaults to 0)
 * textureWidth : width of each frame (defaults to null, that is, full width of the sprite sheet)
 * textureHeight : height of each frame (defaults to null, that is, full height of the sprite sheet)
-* destroyOnFinish : a bool indicating if this AnimationComponent should be destroyed when the animation has reached its end
+* removeOnFinish : a bool indicating if this AnimationComponent should be removed when the animation has reached its end
 
 So, in our example, we are saying that we have 8 frames for our player animation, and they are displayed in a row. So if the player height is also 16 pixels, the sprite sheet is 128x16, containing 8 16x16 frames.
 

--- a/doc/particles.md
+++ b/doc/particles.md
@@ -12,7 +12,7 @@ import 'package:flame/components/particle_component.dart';
 game.add(
     // Wrapping a [Particle] with [ParticleComponent]
     // which maps [Component] lifecycle hooks to [Particle] ones
-    // and embeds a trigger for destroying the component.
+    // and embeds a trigger for removing the component.
     ParticleComponent(
         particle: CircleParticle()
     )
@@ -100,7 +100,7 @@ You can find more examples of using different built-int particles in various com
 
 ## Lifecycle
 
-Behavior common to all `Particle`s is that all of them accept `lifespan` parameter. This value is used to make `ParticleComponent` self-destroy, once its internal `Particle` has reached the end of its life. Time within the `Particle` itself is tracked using the Flame `Timer`. It could be configured with `double`, representing seconds (with microsecond precision) by passing it into the corresponding `Particle` constructor. 
+Behavior common to all `Particle`s is that all of them accept a `lifespan` parameter. This value is used to make the `ParticleComponent` self-remove, once its internal `Particle` has reached the end of its life. Time within the `Particle` itself is tracked using the Flame `Timer`. It could be configured with a `double`, representing seconds (with microsecond precision) by passing it into the corresponding `Particle` constructor.
 
 ```dart
 Particle(lifespan: .2); // will live for 200ms

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -32,12 +32,14 @@ abstract class Component {
   /// The smaller the priority, the sooner your component will be updated/rendered.
   /// It can be any integer (negative, zero, or positive).
   /// If two components share the same priority, they will probably be drawn in the order they were added.
-  final int priority = 0;
+  final int priority;
 
   /// Whether this component should be removed or not.
   ///
   /// It will be checked once per component per tick, and if it is true, [BaseGame] will remove it.
   bool shouldRemove = false;
+
+  Component({this.priority = 0});
 
   /// This method is called periodically by the game engine to request that your component updates itself.
   ///

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -40,10 +40,10 @@ abstract class Component {
   /// Note that for a more consistent experience, you can pre-load all your assets beforehand with Flame.images.loadAll.
   bool loaded() => true;
 
-  /// Whether this should be destroyed or not.
+  /// Whether this should be removed or not.
   ///
-  /// It will be called once per component per loop, and if it returns true, [BaseGame] will mark your component for deletion and remove it before the next loop.
-  bool destroy() => false;
+  /// It will be called once per component per tick, and if it returns true, [BaseGame] will remove it.
+  bool shouldRemove() => false;
 
   /// Whether this component is HUD object or not.
   ///
@@ -64,8 +64,8 @@ abstract class Component {
   /// things like [onGameResize] are already set and usable.
   void onMount() {}
 
-  /// Called right before the component is destroyed and removed from the game
-  void onDestroy() {}
+  /// Called right before the component is removed from the game
+  void onRemove() {}
 
   /// Add an effect to the component
   void addEffect(ComponentEffect effect) {

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -15,6 +15,30 @@ import '../extensions/vector2.dart';
 abstract class Component {
   final EffectsHandler _effectsHandler = EffectsHandler();
 
+  /// Whether this component has been loaded yet. If not loaded, [BaseGame] will not try to render it.
+  ///
+  /// Sprite based components can use this to let [BaseGame] know not to try to render when the [Sprite] has not been loaded yet.
+  /// Note that for a more consistent experience, you can pre-load all your assets beforehand with Flame.images.loadAll.
+  bool loaded = true;
+
+  /// Whether this component is HUD object or not.
+  ///
+  /// HUD objects ignore the [BaseGame.camera] when rendered (so their position coordinates are considered relative to the device screen).
+  bool isHud = false;
+
+  /// Render priority of this component. This allows you to control the order in which your components are rendered.
+  ///
+  /// Components are always updated and rendered in the order defined by what this number is when the component is added to the game.
+  /// The smaller the priority, the sooner your component will be updated/rendered.
+  /// It can be any integer (negative, zero, or positive).
+  /// If two components share the same priority, they will probably be drawn in the order they were added.
+  final int priority = 0;
+
+  /// Whether this component should be removed or not.
+  ///
+  /// It will be checked once per component per tick, and if it is true, [BaseGame] will remove it.
+  bool shouldRemove = false;
+
   /// This method is called periodically by the game engine to request that your component updates itself.
   ///
   /// The time [t] in seconds (with microseconds precision provided by Flutter) since the last update cycle.
@@ -34,32 +58,8 @@ abstract class Component {
   /// Use [Resizable] to save the gameSize in a component.
   void onGameResize(Vector2 gameSize) {}
 
-  /// Whether this component should be removed or not.
-  ///
-  /// It will be checked once per component per tick, and if it is true, [BaseGame] will remove it.
-  bool shouldRemove = false;
-
   /// Remove the component from the game it is added to in the next tick
   void remove() => shouldRemove = true;
-
-  /// Whether this component has been loaded yet. If not loaded, [BaseGame] will not try to render it.
-  ///
-  /// Sprite based components can use this to let [BaseGame] know not to try to render when the [Sprite] has not been loaded yet.
-  /// Note that for a more consistent experience, you can pre-load all your assets beforehand with Flame.images.loadAll.
-  bool loaded = true;
-
-  /// Whether this component is HUD object or not.
-  ///
-  /// HUD objects ignore the [BaseGame.camera] when rendered (so their position coordinates are considered relative to the device screen).
-  bool isHud = false;
-
-  /// Render priority of this component. This allows you to control the order in which your components are rendered.
-  ///
-  /// Components are always updated and rendered in the order defined by this number.
-  /// The smaller the priority, the sooner your component will be updated/rendered.
-  /// It can be any integer (negative, zero, or positive).
-  /// If two components share the same priority, they will probably be drawn in the order they were added.
-  int priority = 0;
 
   /// Called when the component has been added and prepared by the game instance.
   ///

--- a/lib/components/component.dart
+++ b/lib/components/component.dart
@@ -34,21 +34,24 @@ abstract class Component {
   /// Use [Resizable] to save the gameSize in a component.
   void onGameResize(Vector2 gameSize) {}
 
+  /// Whether this component should be removed or not.
+  ///
+  /// It will be checked once per component per tick, and if it is true, [BaseGame] will remove it.
+  bool shouldRemove = false;
+
+  /// Remove the component from the game it is added to in the next tick
+  void remove() => shouldRemove = true;
+
   /// Whether this component has been loaded yet. If not loaded, [BaseGame] will not try to render it.
   ///
   /// Sprite based components can use this to let [BaseGame] know not to try to render when the [Sprite] has not been loaded yet.
   /// Note that for a more consistent experience, you can pre-load all your assets beforehand with Flame.images.loadAll.
-  bool loaded() => true;
-
-  /// Whether this should be removed or not.
-  ///
-  /// It will be called once per component per tick, and if it returns true, [BaseGame] will remove it.
-  bool shouldRemove() => false;
+  bool loaded = true;
 
   /// Whether this component is HUD object or not.
   ///
   /// HUD objects ignore the [BaseGame.camera] when rendered (so their position coordinates are considered relative to the device screen).
-  bool isHud() => false;
+  bool isHud = false;
 
   /// Render priority of this component. This allows you to control the order in which your components are rendered.
   ///
@@ -56,7 +59,7 @@ abstract class Component {
   /// The smaller the priority, the sooner your component will be updated/rendered.
   /// It can be any integer (negative, zero, or positive).
   /// If two components share the same priority, they will probably be drawn in the order they were added.
-  int priority() => 0;
+  int priority = 0;
 
   /// Called when the component has been added and prepared by the game instance.
   ///

--- a/lib/components/joystick/joystick_component.dart
+++ b/lib/components/joystick/joystick_component.dart
@@ -32,18 +32,19 @@ abstract class JoystickController extends Component with HasGameRef<BaseGame> {
   void onReceiveDrag(DragEvent drag) {}
 
   @override
-  bool isHud() => true;
+  bool isHud = true;
 }
 
 class JoystickComponent extends JoystickController {
   final List<JoystickAction> actions;
   final JoystickDirectional directional;
-  final int componentPriority;
+  @override
+  int priority;
 
   JoystickComponent({
     this.actions,
     this.directional,
-    this.componentPriority = 0,
+    this.priority = 0,
   });
 
   void addAction(JoystickAction action) {
@@ -81,10 +82,5 @@ class JoystickComponent extends JoystickController {
   void onReceiveDrag(DragEvent event) {
     directional?.onReceiveDrag(event);
     actions?.forEach((action) => action.onReceiveDrag(event));
-  }
-
-  @override
-  int priority() {
-    return componentPriority;
   }
 }

--- a/lib/components/parallax_component.dart
+++ b/lib/components/parallax_component.dart
@@ -160,7 +160,6 @@ class ParallaxComponent extends PositionComponent {
   Vector2 baseSpeed;
   Vector2 layerDelta;
   List<ParallaxLayer> _layers;
-  bool _loaded = false;
 
   ParallaxComponent(
     List<ParallaxImage> images, {
@@ -176,9 +175,6 @@ class ParallaxComponent extends PositionComponent {
   /// if you want to transition the parallax to a certain position.
   Vector2 currentOffset() => _layers[0].currentOffset();
 
-  @override
-  bool loaded() => _loaded;
-
   @mustCallSuper
   @override
   void onGameResize(Vector2 size) {
@@ -189,7 +185,7 @@ class ParallaxComponent extends PositionComponent {
   @override
   void update(double t) {
     super.update(t);
-    if (!loaded()) {
+    if (!loaded) {
       return;
     }
     _layers.forEach((layer) {
@@ -200,7 +196,7 @@ class ParallaxComponent extends PositionComponent {
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    if (!loaded()) {
+    if (!loaded) {
       return;
     }
     super.render(canvas);
@@ -212,6 +208,6 @@ class ParallaxComponent extends PositionComponent {
   void _load(List<ParallaxImage> images) {
     _layers = images.map((image) => ParallaxLayer(image)).toList();
     Future.wait(_layers.map((layer) => layer.future))
-        .then((_) => _loaded = true);
+        .then((_) => loaded = true);
   }
 }

--- a/lib/components/particle_component.dart
+++ b/lib/components/particle_component.dart
@@ -16,10 +16,9 @@ class ParticleComponent extends Component {
     @required this.particle,
   });
 
-  /// This [Component] will be automatically destroyed
-  /// as soon as
+  /// This [ParticleComponent] will be removed by [BaseGame]
   @override
-  bool destroy() => particle.destroy();
+  bool shouldRemove() => particle.shouldRemove();
 
   /// Returns progress of the child [Particle]
   /// so could be used by external code for something

--- a/lib/components/particle_component.dart
+++ b/lib/components/particle_component.dart
@@ -18,7 +18,7 @@ class ParticleComponent extends Component {
 
   /// This [ParticleComponent] will be removed by [BaseGame]
   @override
-  bool shouldRemove() => particle.shouldRemove();
+  bool get shouldRemove => particle.shouldRemove();
 
   /// Returns progress of the child [Particle]
   /// so could be used by external code for something

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -77,7 +77,7 @@ abstract class PositionComponent extends Component {
   bool debugMode = false;
 
   final OrderedSet<Component> _children =
-      OrderedSet(Comparing.on((c) => c.priority()));
+      OrderedSet(Comparing.on((c) => c.priority));
 
   Color get debugColor => const Color(0xFFFF00FF);
 
@@ -183,7 +183,7 @@ abstract class PositionComponent extends Component {
   }
 
   void _renderChild(Canvas canvas, Component c) {
-    if (!c.loaded()) {
+    if (!c.loaded) {
       return;
     }
     c.render(canvas);

--- a/lib/components/sprite_animation_component.dart
+++ b/lib/components/sprite_animation_component.dart
@@ -9,12 +9,12 @@ import 'position_component.dart';
 class SpriteAnimationComponent extends PositionComponent {
   SpriteAnimation animation;
   Paint overridePaint;
-  bool destroyOnFinish = false;
+  bool removeOnFinish = false;
 
   SpriteAnimationComponent(
     Vector2 size,
     this.animation, {
-    this.destroyOnFinish = false,
+    this.removeOnFinish = false,
   }) : assert(animation != null) {
     super.size.setFrom(size);
   }
@@ -30,7 +30,7 @@ class SpriteAnimationComponent extends PositionComponent {
     @required double stepTime,
     Vector2 textureSize,
     bool loop = true,
-    this.destroyOnFinish = false,
+    this.removeOnFinish = false,
   }) {
     super.size.setFrom(size);
     animation = SpriteAnimation.sequenced(
@@ -68,7 +68,7 @@ class SpriteAnimationComponent extends PositionComponent {
   }
 
   @override
-  bool destroy() => destroyOnFinish && animation.isLastFrame;
+  bool shouldRemove() => removeOnFinish && animation.isLastFrame;
 
   @mustCallSuper
   @override

--- a/lib/components/sprite_animation_component.dart
+++ b/lib/components/sprite_animation_component.dart
@@ -68,7 +68,7 @@ class SpriteAnimationComponent extends PositionComponent {
   }
 
   @override
-  bool shouldRemove() => removeOnFinish && animation.isLastFrame;
+  bool get shouldRemove => removeOnFinish && animation.isLastFrame;
 
   @mustCallSuper
   @override

--- a/lib/components/timer_component.dart
+++ b/lib/components/timer_component.dart
@@ -19,5 +19,5 @@ class TimerComponent extends Component {
   void render(Canvas canvas) {}
 
   @override
-  bool shouldRemove() => timer.finished;
+  bool get shouldRemove => timer.finished;
 }

--- a/lib/components/timer_component.dart
+++ b/lib/components/timer_component.dart
@@ -19,5 +19,5 @@ class TimerComponent extends Component {
   void render(Canvas canvas) {}
 
   @override
-  bool destroy() => timer.finished;
+  bool shouldRemove() => timer.finished;
 }

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -74,8 +74,7 @@ class BaseGame extends Game with FPSCounter {
 
   /// Prepares and registers a list of components to be added on the next game tick
   void addAll(Iterable<Component> components) {
-    components.forEach(prepare);
-    _addLater.addAll(components);
+    components.forEach(add);
   }
 
   /// Marks a component to be removed from the components list on the next game tick

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -23,7 +23,7 @@ import 'game.dart';
 class BaseGame extends Game with FPSCounter {
   /// The list of components to be updated and rendered by the base game.
   final OrderedSet<Component> components =
-      OrderedSet(Comparing.on((c) => c.priority()));
+      OrderedSet(Comparing.on((c) => c.priority));
 
   /// Components added by the [addLater] method
   final List<Component> _addLater = [];
@@ -105,10 +105,10 @@ class BaseGame extends Game with FPSCounter {
   /// It translates the camera unless hud, call the render method and restore the canvas.
   /// This makes sure the canvas is not messed up by one component and all components render independently.
   void renderComponent(Canvas canvas, Component c) {
-    if (!c.loaded()) {
+    if (!c.loaded) {
       return;
     }
-    if (!c.isHud()) {
+    if (!c.isHud) {
       canvas.translate(-camera.x, -camera.y);
     }
     c.render(canvas);
@@ -123,7 +123,7 @@ class BaseGame extends Game with FPSCounter {
   @override
   @mustCallSuper
   void update(double t) {
-    _removeLater.addAll(components.where((c) => c.shouldRemove()));
+    _removeLater.addAll(components.where((c) => c.shouldRemove));
     _removeLater.forEach((c) {
       c.onRemove();
       components.remove(c);

--- a/lib/particle.dart
+++ b/lib/particle.dart
@@ -40,7 +40,7 @@ abstract class Particle {
 
   /// Internal timer defining how long
   /// this [Particle] will live. [Particle] will
-  /// be marked for destroy when this timer is over.
+  /// be marked for removal when this timer is over.
   Timer _timer;
 
   /// Stores desired lifespan of the
@@ -49,7 +49,7 @@ abstract class Particle {
 
   /// Will be set to true by update hook
   /// when this [Particle] reaches end of its lifespan
-  bool _shouldBeDestroyed = false;
+  bool _shouldBeRemoved = false;
 
   Particle({
     /// Particle lifespan in [Timer] format,
@@ -62,9 +62,9 @@ abstract class Particle {
   /// This method will return true as
   /// soon as particle reaches an end of its
   /// lifespan, which means it's ready to be
-  /// destroyed by a wrapping container.
+  /// removed by a wrapping container.
   /// Follows same style as [Component].
-  bool destroy() => _shouldBeDestroyed;
+  bool shouldRemove() => _shouldBeRemoved;
 
   /// Getter which should be used by subclasses
   /// to get overall progress. Also allows to substitute
@@ -81,7 +81,7 @@ abstract class Particle {
 
   /// Updates internal [Timer] of this [Particle]
   /// which defines its position on the lifespan.
-  /// Marks [Particle] for destroy when it is over.
+  /// Marks [Particle] for removal when it is over.
   void update(double dt) {
     _timer.update(dt);
   }
@@ -94,12 +94,12 @@ abstract class Particle {
   void setLifespan(double lifespan) {
     _lifespan = lifespan;
     _timer?.stop();
-    final void Function() destroyCallback = () => _shouldBeDestroyed = true;
-    _timer = Timer(lifespan, callback: destroyCallback);
+    final void Function() removeCallback = () => _shouldBeRemoved = true;
+    _timer = Timer(lifespan, callback: removeCallback);
     _timer.start();
   }
 
-  /// Wtaps this particle with [TranslatedParticle]
+  /// Wraps this particle with [TranslatedParticle]
   /// statically repositioning it for the time
   /// of the lifespan.
   Particle translated(Offset offset) {

--- a/test/base_game_test.dart
+++ b/test/base_game_test.dart
@@ -20,6 +20,7 @@ class MyComponent extends PositionComponent
   bool tapped = false;
   bool isUpdateCalled = false;
   bool isRenderCalled = false;
+  int onRemoveCallCounter = 0;
 
   @override
   void onTapDown(TapDownDetails details) {
@@ -40,6 +41,9 @@ class MyComponent extends PositionComponent
 
   @override
   bool checkTapOverlap(Rect c, Offset o) => true;
+
+  @override
+  void onRemove() => ++onRemoveCallCounter;
 }
 
 class PositionComponentNoNeedForRect extends PositionComponent with Tapable {}
@@ -107,6 +111,25 @@ void main() {
           PaintingContext(ContainerLayer(), Rect.zero), Offset.zero);
       expect(component.isRenderCalled, true);
       renderBox.detach();
+    });
+
+    test('onRemove is only called once on component', () {
+      final MyGame game = MyGame();
+      final MyComponent component = MyComponent();
+
+      game.size = size;
+      game.add(component);
+      // The component is not added to the component list until an update has been performed
+      game.update(0.0);
+      // The component is removed both by removing it on the game instance and
+      // by the function on the component, but the onRemove callback should
+      // only be called once.
+      component.remove();
+      game.remove(component);
+      // The component is not removed from the component list until an update has been performed
+      game.update(0.0);
+
+      expect(component.onRemoveCallCounter, 1);
     });
   });
 }


### PR DESCRIPTION
# Description

I think it is a bit confusing for the user to have `destroy` returning a boolean to mark it for removal, since destroy is a verb.
This change also unifies that there is no difference in whether `onRemove` (`onDestroy` before) is called if the component is removed from within or from the `BaseGame` instance.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] The continuous integration (CI) is passing
