### PR TITLE
Fix advanced gesture detector duplicated code

### DIFF
--- a/lib/game/widget_builder.dart
+++ b/lib/game/widget_builder.dart
@@ -89,10 +89,7 @@ Widget _applyAdvancedGesturesDetectors(Game game, Widget child) {
 
   return RawGestureDetector(
     gestures: gestures,
-    child: Container(
-        color: game.backgroundColor(),
-        child: Directionality(
-            textDirection: TextDirection.ltr, child: EmbeddedGameWidget(game))),
+    child: child,
   );
 }
 
@@ -241,9 +238,7 @@ class WidgetBuilder {
 
     if (hasBasicDetectors) {
       widget = _applyBasicGesturesDetectors(game, widget);
-    }
-
-    if (hasAdvancedDetectors) {
+    } else if (hasAdvancedDetectors) {
       widget = _applyAdvancedGesturesDetectors(game, widget);
     }
 
@@ -252,13 +247,14 @@ class WidgetBuilder {
     }
 
     return FutureBuilder(
-        future: game.onLoad(),
-        builder: (_, snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            return widget;
-          }
-          return game.loadingWidget();
-        });
+      future: game.onLoad(),
+      builder: (_, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done) {
+          return widget;
+        }
+        return game.loadingWidget();
+      },
+    );
   }
 }
 


### PR DESCRIPTION
# Description
When applying advanced gesture detectors on `WidgetBuilder` we create a duplicated code and never do anything with the `child` param on  `_applyAdvancedGesturesDetectors`. This PR fixes that

## Type of change

- [x] Bug fix (code improvement)

# Checklist:

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` 
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
