### PR TITLE
Remove unused size field on Embedded widget

### DIFF
--- a/lib/game/embedded_game_widget.dart
+++ b/lib/game/embedded_game_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart' hide WidgetBuilder;
 
-import '../extensions/vector2.dart';
 import 'game.dart';
 import 'game_render_box.dart';
 
@@ -13,16 +12,14 @@ import 'game_render_box.dart';
 /// You can bind Gesture Recognizers immediately around this to add controls to your widgets, with easy coordinate conversions.
 class EmbeddedGameWidget extends LeafRenderObjectWidget {
   final Game game;
-  final Vector2 size;
 
-  EmbeddedGameWidget(this.game, {this.size});
+  EmbeddedGameWidget(this.game);
 
   @override
   RenderBox createRenderObject(BuildContext context) {
     return RenderConstrainedBox(
       child: GameRenderBox(context, game),
-      additionalConstraints:
-          BoxConstraints.expand(width: size?.x, height: size?.y),
+      additionalConstraints: const BoxConstraints.expand(),
     );
   }
 
@@ -33,7 +30,6 @@ class EmbeddedGameWidget extends LeafRenderObjectWidget {
   ) {
     renderBox
       ..child = GameRenderBox(context, game)
-      ..additionalConstraints =
-          BoxConstraints.expand(width: size?.x, height: size?.y);
+      ..additionalConstraints = const BoxConstraints.expand();
   }
 }


### PR DESCRIPTION
# Description

`EmbeddedGameWidget` has a size attribute that is never used nor set. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (kind of?)

# Checklist:

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `v1.0.0` (not `master` or `develop`)
- [ ] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
