### PR TITLE
fix _debugPaint stroke width for web

### DIFF
--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -83,6 +83,7 @@ abstract class PositionComponent extends Component {
 
   Paint get _debugPaint => Paint()
     ..color = debugColor
+    ..strokeWidth = 1
     ..style = PaintingStyle.stroke;
 
   TextConfig get debugTextConfig => TextConfig(color: debugColor, fontSize: 12);


### PR DESCRIPTION
# Description

In web debug stoke not worked. strokeWidth required. See https://github.com/flutter/flutter/issues/49328

## Type of change

Please delete options that are not relevant.

- [х] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `v1.0.0`
- [ ] This PR is targeted to merge into `v1.0.0` (not `master` or `develop`)
- [ ] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
