### PR TITLE
fix _debugPaint stroke width for web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
  - Fix TextBoxComponent rendering
  - Add TextBoxConfig options; margins and growingBox
+ - Fix debugConfig strokeWidth for web
 
 ## 1.0.0-rc2
  - Improve IsometricTileMap and Spritesheet classes

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -83,6 +83,7 @@ abstract class PositionComponent extends Component {
 
   Paint get _debugPaint => Paint()
     ..color = debugColor
+    ..strokeWidth = 1
     ..style = PaintingStyle.stroke;
 
   TextConfig get debugTextConfig => TextConfig(color: debugColor, fontSize: 12);


### PR DESCRIPTION
# Description

In web debug stoke not worked. strokeWidth required. See flutter/flutter#49328

Fixes # (issue number, if there is one)

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `v1.0.0`
- [ ] This PR is targeted to merge into `v1.0.0` (not `master` or `develop`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
