### PR TITLE
Take angle into account for taps and propagate to children differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Update Forge2D docs
  - Update PR template with removal of develop branch
  - Translate README to Russian
+ - Split up Component and PositionComponent to BaseComponent
 
 ## 1.0.0-rc2
  - Improve IsometricTileMap and Spritesheet classes

--- a/doc/components.md
+++ b/doc/components.md
@@ -10,7 +10,7 @@ If you want to skip reading about abstract classes you can jump directly to [Pos
 
 Every `Component` has a few methods that you can optionally implement, that are used by the `BaseGame` class. If you are not using the base game, you can alternatively use these methods on your own game loop.
 
-The `resize` method is called whenever the screen is resized, and in the beginning once when the component is added via the `add` method. You need to apply here any changes to the x, y, width and height of your component, or any other changes, due to the screen resizing. You can start these variables here, as the sprite won't be rendered until everything is set.
+The `resize` method is called whenever the screen is resized, and in the beginning once when the component is added via the `add` method.
 
 The `shouldRemove` variable can be overridden or set to true and `BaseGame` will remove the component before the next update loop. It will then no longer be rendered or updated. Note that `game.remove(Component c)` can also be used to remove components.
 

--- a/doc/components.md
+++ b/doc/components.md
@@ -1,5 +1,27 @@
 # Components
 
+## Component
+All components inherit from the abstract class `Component`.
+
+If you want to skip reading about abstract classes you can jump directly to [PositionComponent](./components.md#PositionComponent).
+
+Every `Component` has a few methods that you can optionally implement, that are used by the `BaseGame` class. If you are not using the base game, you can alternatively use these methods on your own game loop.
+
+The `resize` method is called whenever the screen is resized, and in the beginning once when the component is added via the `add` method. You need to apply here any changes to the x, y, width and height of your component, or any other changes, due to the screen resizing. You can start these variables here, as the sprite won't be rendered until everything is set.
+
+The `shouldRemove` variable can be overridden or set to true and `BaseGame` will remove the component before the next update loop. It will then no longer be rendered or updated. Note that `game.remove(Component c)` can also be used to remove components.
+
+The `isHUD` variable can be overridden or set to true (default false) to make the `BaseGame` ignore the `camera` for this element, make it static in relation to the screen that is.
+
+The `onMount` method can be overridden to run initialization code for the component. When this method is called, BaseGame ensures that all the mixins which would change this component's behaviour are already resolved.
+
+The `onRemove` method can be overridden to run code before the component is removed from the game, it is only run once even if the component is removed both by using the `BaseGame` remove method and the ´Component´ remove method.
+
+## BaseComponent
+Usually if you are going to make your own component you want to extend `PositionComponent`, but if you want to be able to handle effects and child components but handle the positioning differently you can extend the BaseComponent.
+
+It is used by `SpriteBodyComponent` and `BodyComponent` in Forge2D since those components doesn't have their position in relation to the screen, but in relation to the Forge2D world.
+
 ## PositionComponent
 
 This class represent a single object on the screen, being a floating rectangle or a rotating sprite.
@@ -28,26 +50,6 @@ The most commonly used implementation of `PositionComponent` is `SpriteComponent
 
     player.render(canvas); // it will render only if the image is loaded and the position and size parameters are not null
 ```
-
-## Component
-All components inherit from the abstract class `Component`.
-
-Every `Component` has a few methods that you can optionally implement, that are used by the `BaseGame` class. If you are not using the base game, you can alternatively use these methods on your own game loop.
-
-The `resize` method is called whenever the screen is resized, and in the beginning once when the component is added via the `add` method. You need to apply here any changes to the x, y, width and height of your component, or any other changes, due to the screen resizing. You can start these variables here, as the sprite won't be rendered until everything is set.
-
-The `shouldRemove` variable can be overridden or set to true and `BaseGame` will remove the component before the next update loop. It will then no longer be rendered or updated. Note that `game.remove(Component c)` can also be used to remove components.
-
-The `isHUD` variable can be overridden or set to true (default false) to make the `BaseGame` ignore the `camera` for this element, make it static in relation to the screen that is.
-
-The `onMount` method can be overridden to run initialization code for the component. When this method is called, BaseGame ensures that all the mixins which would change this component's behaviour are already resolved.
-
-The `onRemove` method can be overridden to run code before the component is removed from the game, it is only run once even if the component is removed both by using the `BaseGame` remove method and the ´Component´ remove method.
-
-## BaseComponent
-Usually if you are going to make your own component you want to extend `PositionComponent`, but if you want to be able to handle effects and child components but handle the positioning differently you can extend the BaseComponent.
-
-It is used by `SpriteBodyComponent` and `BodyComponent` in Forge2D since those components doesn't have their position in relation to the screen, but in relation to the Forge2D world.
 
 ## SpriteAnimationComponent
 

--- a/doc/components.md
+++ b/doc/components.md
@@ -138,7 +138,8 @@ For a working example, check this [source file](/doc/examples/flare/lib/main_com
 
 ## Composability of components
 
-Sometimes it is useful to make your `Component` wrap other components. For example by grouping visual components through a hierarchy.
+Sometimes it is useful to make your component wrap other components. For example by grouping visual components through a hierarchy.
+You can do this by having child components on any component that extends `BaseComponent`, for example `PositionComponent` or `BodyComponent`.
 When you have child components on a component every time the parent is updated and rendered, all the children are rendered and updated with the same conditions.
 
 Example of usage, where visibility of two components are handled by a wrapper:

--- a/doc/components.md
+++ b/doc/components.md
@@ -9,7 +9,7 @@ A `PositionComponent` has a `position`, `size` and `angle`, as well as some usef
 In the event that you want to change the direction of your components rendering, you can also use
 `renderFlipX` and `renderFlipY` to flip anything drawn to canvas during `render(Canvas canvas)`.
 This is available on all `PositionComponent` objects, and is especially useful on `SpriteComponent` and
-`AnimationComponent`. For example set `component.renderFlipX = true` to reverse the horizontal rendering.
+`SpriteAnimationComponent`. For example set `component.renderFlipX = true` to reverse the horizontal rendering.
 
 ## SpriteComponent
 The most commonly used implementation of `PositionComponent` is `SpriteComponent`, and it can be created with a `Sprite`:
@@ -49,7 +49,7 @@ Usually if you are going to make your own component you want to extend `Position
 
 It is used by `SpriteBodyComponent` and `BodyComponent` in Forge2D since those components doesn't have their position in relation to the screen, but in relation to the Forge2D world.
 
-## SpriteAnimation
+## SpriteAnimationComponent
 
 This class is used to represent a Component that has a sprite that runs a single cyclic animation.
 
@@ -58,14 +58,14 @@ This will create a simple three frame animation
 ```dart
     List<Sprite> sprites = [0, 1, 2].map((i) => Sprite('player_${i}.png')).toList();
     final size = Vector2.all(64.0);
-    this.player = SpriteAnimation(size, new Animation.spriteList(sprites, stepTime: 0.01));
+    this.player = SpriteAnimationComponent(size, new Animation.spriteList(sprites, stepTime: 0.01));
 ```
 
 If you have a sprite sheet, you can use the `sequenced` constructor, identical to the one provided by the `Animation` class (check more details in [the appropriate section](/doc/images.md#Animation)):
 
 ```dart
     final size = Vector2.all(64.0);
-    this.player = SpriteAnimation.sequenced(size, 'player.png', 2);
+    this.player = SpriteAnimationComponent.sequenced(size, 'player.png', 2);
 ```
 
 If you are not using `BaseGame`, don't forget this component needs to be update'd even if static, because the animation object needs to be ticked to move the frames.
@@ -216,7 +216,7 @@ Advanced example:
 
 Once you are done with setting the parameters to your needs, render the ParallaxComponent as any other component.
 
-Like the AnimationComponent, even if your parallax is static, you must call update on this component, so it runs its animation.
+Like the SpriteAnimationComponent, even if your parallax is static, you must call update on this component, so it runs its animation.
 Also, don't forget to add you images to the `pubspec.yaml` file as assets or they wont be found.
 
 An example implementation can be found in the [examples directory](/doc/examples/parallax).

--- a/doc/components.md
+++ b/doc/components.md
@@ -21,9 +21,41 @@ The `onMount` method can be overridden to run initialization code for the compon
 The `onRemove` method can be overridden to run code before the component is removed from the game, it is only run once even if the component is removed both by using the `BaseGame` remove method and the ´Component´ remove method.
 
 ## BaseComponent
-Usually if you are going to make your own component you want to extend `PositionComponent`, but if you want to be able to handle effects and child components but handle the positioning differently you can extend the BaseComponent.
+Usually if you are going to make your own component you want to extend `PositionComponent`, but if you want to be able to handle effects and child components but handle the positioning differently you can extend the `BaseComponent`.
 
 It is used by `SpriteBodyComponent` and `BodyComponent` in Forge2D since those components doesn't have their position in relation to the screen, but in relation to the Forge2D world.
+
+### Composability of components
+
+Sometimes it is useful to make your component wrap other components. For example by grouping visual components through a hierarchy.
+You can do this by having child components on any component that extends `BaseComponent`, for example `PositionComponent` or `BodyComponent`.
+When you have child components on a component every time the parent is updated and rendered, all the children are rendered and updated with the same conditions.
+
+Example of usage, where visibility of two components are handled by a wrapper:
+
+```dart
+class GameOverPanel extends PositionComponent with HasGameRef<MyGame> {
+  bool visible = false;
+
+  GameOverText gameOverText;
+  GameOverButton gameOverButton;
+
+  GameOverPanel(Image spriteImage) : super() {
+    gameOverText = GameOverText(spriteImage); // GameOverText is a Component
+    gameOverButton = GameOverButton(spriteImage); // GameOverRestart is a SpriteComponent
+
+    addChild(gameRef, gameOverText);
+    addChild(gameRef, gameOverButton);
+  }
+
+  @override
+  void render(Canvas canvas) {
+    if (visible) {
+      super.render(canvas);
+    } // If not visible none of the children will be rendered
+  }
+}
+```
 
 ## PositionComponent
 
@@ -140,38 +172,6 @@ it also can receive a FlareController that can play multiple animations and cont
 You can also change the current playing animation using the `updateAnimation` method.
 
 For a working example, check this [source file](/doc/examples/flare/lib/main_component.dart).
-
-## Composability of components
-
-Sometimes it is useful to make your component wrap other components. For example by grouping visual components through a hierarchy.
-You can do this by having child components on any component that extends `BaseComponent`, for example `PositionComponent` or `BodyComponent`.
-When you have child components on a component every time the parent is updated and rendered, all the children are rendered and updated with the same conditions.
-
-Example of usage, where visibility of two components are handled by a wrapper:
-
-```dart
-class GameOverPanel extends PositionComponent with HasGameRef<MyGame> {
-  bool visible = false;
-
-  GameOverText gameOverText;
-  GameOverButton gameOverButton;
-
-  GameOverPanel(Image spriteImage) : super() {
-    gameOverText = GameOverText(spriteImage); // GameOverText is a Component
-    gameOverButton = GameOverButton(spriteImage); // GameOverRestart is a SpriteComponent
-
-    addChild(gameRef, gameOverText);
-    addChild(gameRef, gameOverButton);
-  }
-
-  @override
-  void render(Canvas canvas) {
-    if (visible) {
-      super.render(canvas);
-    } // If not visible none of the children will be rendered
-  }
-}
-```
 
 ## ParallaxComponent
 

--- a/doc/components.md
+++ b/doc/components.md
@@ -49,23 +49,23 @@ Usually if you are going to make your own component you want to extend `Position
 
 It is used by `SpriteBodyComponent` and `BodyComponent` in Forge2D since those components doesn't have their position in relation to the screen, but in relation to the Forge2D world.
 
-## AnimationComponent
+## SpriteAnimation
 
-This component uses an instance of the [Animation](/doc/images.md#Animation) class to represent a Component that has a sprite that runs a single cyclic animation.
+This class is used to represent a Component that has a sprite that runs a single cyclic animation.
 
 This will create a simple three frame animation
 
 ```dart
     List<Sprite> sprites = [0, 1, 2].map((i) => Sprite('player_${i}.png')).toList();
     final size = Vector2.all(64.0);
-    this.player = AnimationComponent(size, new Animation.spriteList(sprites, stepTime: 0.01));
+    this.player = SpriteAnimation(size, new Animation.spriteList(sprites, stepTime: 0.01));
 ```
 
 If you have a sprite sheet, you can use the `sequenced` constructor, identical to the one provided by the `Animation` class (check more details in [the appropriate section](/doc/images.md#Animation)):
 
 ```dart
     final size = Vector2.all(64.0);
-    this.player = AnimationComponent.sequenced(size, 'player.png', 2);
+    this.player = SpriteAnimation.sequenced(size, 'player.png', 2);
 ```
 
 If you are not using `BaseGame`, don't forget this component needs to be update'd even if static, because the animation object needs to be ticked to move the frames.
@@ -263,3 +263,9 @@ The corners are drawn at the same size, the sides are stretched on the side dire
 Using this, you can get a box/rectangle that expands well to any sizes. This is useful for making panels, dialogs, borders.
 
 Check the example app `nine_tile_box` details on how to use it.
+
+## Effects
+
+Flame provides a set of effects that can be applied to a certain type of components, these effects can be used to animate some properties of your components, like position or dimensions. You can check the list of those effects [here](/doc/effects.md).
+
+Examples of the running effects can be found [here](/doc/examples/effects);

--- a/doc/components.md
+++ b/doc/components.md
@@ -1,5 +1,8 @@
 # Components
 
+![Component Diagram](https://i.imgur.com/1mTqcqI.png)
+This diagram might look intimidating, but don't worry, it is not as complex as it looks.
+
 ## Component
 All components inherit from the abstract class `Component`.
 

--- a/doc/examples/gestures/lib/main_overlapping_tapables.dart
+++ b/doc/examples/gestures/lib/main_overlapping_tapables.dart
@@ -1,0 +1,68 @@
+import 'dart:math' as math;
+
+import 'package:flame/anchor.dart';
+import 'package:flame/extensions/vector2.dart';
+import 'package:flame/palette.dart';
+import 'package:flutter/material.dart';
+import 'package:flame/game.dart';
+import 'package:flame/components/position_component.dart';
+import 'package:flame/components/mixins/tapable.dart';
+
+void main() {
+  final game = MyGame();
+
+  final widget = Container(
+    padding: const EdgeInsets.all(50),
+    color: const Color(0xFFA9A9A9),
+    child: game.widget,
+  );
+
+  runApp(widget);
+}
+
+class TapableSquare extends PositionComponent with Tapable {
+  Paint _randomPaint() {
+    final rng = math.Random();
+    final color = Color.fromRGBO(
+        rng.nextInt(256), rng.nextInt(256), rng.nextInt(256), 0.9);
+    return PaletteEntry(color).paint;
+  }
+
+  Paint currentPaint;
+
+  TapableSquare({Vector2 position}) {
+    currentPaint = _randomPaint();
+    size = Vector2.all(100);
+    this.position = position ?? Vector2.all(100);
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    canvas.drawRect(size.toRect(), currentPaint);
+  }
+
+  @override
+  bool onTapUp(TapUpDetails details) {
+    return false;
+  }
+
+  @override
+  bool onTapDown(TapDownDetails details) {
+    angle += 1.0;
+    return false;
+  }
+
+  @override
+  bool onTapCancel() {
+    return false;
+  }
+}
+
+class MyGame extends BaseGame with HasTapableComponents {
+  MyGame() {
+    add(TapableSquare(position: Vector2(100, 100)));
+    add(TapableSquare(position: Vector2(150, 150)));
+    add(TapableSquare(position: Vector2(100, 200)));
+  }
+}

--- a/doc/examples/gestures/lib/main_overlapping_tapables.dart
+++ b/doc/examples/gestures/lib/main_overlapping_tapables.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-import 'package:flame/anchor.dart';
 import 'package:flame/extensions/vector2.dart';
 import 'package:flame/palette.dart';
 import 'package:flutter/material.dart';

--- a/doc/examples/gestures/lib/main_tapables.dart
+++ b/doc/examples/gestures/lib/main_tapables.dart
@@ -1,3 +1,4 @@
+import 'package:flame/anchor.dart';
 import 'package:flame/extensions/vector2.dart';
 import 'package:flutter/material.dart';
 import 'package:flame/game.dart';
@@ -34,24 +35,28 @@ class TapableSquare extends PositionComponent with Tapable {
   }
 
   @override
-  void onTapUp(TapUpDetails details) {
+  bool onTapUp(TapUpDetails details) {
     _beenPressed = false;
+    return true;
   }
 
   @override
-  void onTapDown(TapDownDetails details) {
+  bool onTapDown(TapDownDetails details) {
     _beenPressed = true;
+    angle += 1.0;
+    return true;
   }
 
   @override
-  void onTapCancel() {
+  bool onTapCancel() {
     _beenPressed = false;
+    return true;
   }
 }
 
 class MyGame extends BaseGame with HasTapableComponents {
   MyGame() {
-    add(TapableSquare());
-    add(TapableSquare()..y = 250);
+    add(TapableSquare()..anchor = Anchor.center);
+    add(TapableSquare()..y = 350);
   }
 }

--- a/doc/images.md
+++ b/doc/images.md
@@ -52,7 +52,7 @@ Example:
     final playerSprite = Sprite(image);
 ```
 
-## Game.images
+### Game.images
 
 The `Game` class offers some utility methods for handling images loading too. It bundles an instance of the `Images` class, that can be used to load image assets to be used during the game. The game will automatically free the cache when the game widget is removed from the widget tree.
 

--- a/doc/images.md
+++ b/doc/images.md
@@ -52,7 +52,7 @@ Example:
     final playerSprite = Sprite(image);
 ```
 
-# Game.images
+## Game.images
 
 The `Game` class offers some utility methods for handling images loading too. It bundles an instance of the `Images` class, that can be used to load image assets to be used during the game. The game will automatically free the cache when the game widget is removed from the widget tree.
 

--- a/doc/text.md
+++ b/doc/text.md
@@ -2,7 +2,7 @@
 
 Flame has some dedicated classes to help you render text.
 
-# TextConfig
+## TextConfig
 
 A Text Config contains all typographical information required to render text; i.e., font size and color, family, etc.
 

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -13,9 +13,9 @@ import 'component.dart';
 
 /// This can be extended to represent a basic Component for your game.
 ///
-/// The difference between this and [Component] is that this can have children,
-/// handles effects on your component and can be used to see whether a point is
-/// on your component, which is useful for handling the effect of gestures.
+/// The difference between this and [Component] is that the [BaseComponent] can
+/// have children, handle effects and can be used to see whether a position on
+/// the screen is on your component, which is useful for handling gestures.
 abstract class BaseComponent extends Component {
   final EffectsHandler _effectsHandler = EffectsHandler();
 

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:flame/components/mixins/has_game_ref.dart';
 import 'package:meta/meta.dart';
 import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
@@ -11,6 +10,7 @@ import '../extensions/vector2.dart';
 import '../game.dart';
 import '../text_config.dart';
 import 'component.dart';
+import 'mixins/has_game_ref.dart';
 
 /// This can be extended to represent a basic Component for your game.
 ///

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -113,7 +113,10 @@ abstract class BaseComponent extends Component {
   /// Uses the game passed in, or uses the game from [HasGameRef] otherwise,
   /// to prepare the child component before it is added to the list of children
   void addChild(Component c, {Game gameRef}) {
-    assert(gameRef != null || this is HasGameRef);
+    assert(
+      gameRef != null || this is HasGameRef,
+      "Need gameRef either as an argument or from the HasGameRef mixin",
+    );
     gameRef ??= (this as HasGameRef).gameRef;
     if (gameRef is BaseGame) {
       gameRef.prepare(c);

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -127,8 +127,8 @@ abstract class BaseComponent extends Component {
   }
 
   /// This method first calls the passed handler on the leaves in the tree, the children without any children of their own.
-  /// Then it down the tree to all other children and then finally it passes itself to the handler.
-  /// The propagation continues until a handler returns false, which means "do not continue", or when the handler has been called on the full tree.
+  /// Then it continues through all other children.
+  /// The propagation continues until the handler returns false, which means "do not continue", or when the handler has been called with all children
   ///
   /// This method is important to be used by the engine to propagate actions like rendering, taps, etc,
   /// but you can call it yourself if you need to apply an action to the whole component chain.
@@ -142,13 +142,11 @@ abstract class BaseComponent extends Component {
         shouldContinue = child.propagateToChildren(handler);
         if (shouldContinue) {
           shouldContinue = handler(child);
-        } else {
+        }
+        if (!shouldContinue) {
           break;
         }
       }
-    }
-    if (this is T && shouldContinue) {
-      shouldContinue = handler(this as T);
     }
     return shouldContinue;
   }

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flame/components/mixins/has_game_ref.dart';
 import 'package:meta/meta.dart';
 import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
@@ -109,9 +110,11 @@ abstract class BaseComponent extends Component {
   /// Get a list of non removed effects
   List<ComponentEffect> get effects => _effectsHandler.effects;
 
-  /// Uses the game passed in to prepare the child component before it is added
-  /// to the list of children
-  void addChild(Game gameRef, Component c) {
+  /// Uses the game passed in, or uses the game from [HasGameRef] otherwise,
+  /// to prepare the child component before it is added to the list of children
+  void addChild(Component c, {Game gameRef}) {
+    assert(gameRef != null || this is HasGameRef);
+    gameRef ??= (this as HasGameRef).gameRef;
     if (gameRef is BaseGame) {
       gameRef.prepare(c);
     }

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -1,0 +1,92 @@
+import 'package:meta/meta.dart';
+import 'package:ordered_set/comparing.dart';
+import 'package:ordered_set/ordered_set.dart';
+
+import '../effects/effects.dart';
+import '../effects/effects_handler.dart';
+import '../extensions/vector2.dart';
+import '../game.dart';
+import 'component.dart';
+
+/// This can be extended to represent a basic Component for your game.
+///
+/// The difference between this and [Component] is that this can have children,
+/// handles effects on your component and can be used to see whether a point is
+/// on your component, which is useful for handling the effect of gestures.
+abstract class BaseComponent extends Component {
+  final EffectsHandler _effectsHandler = EffectsHandler();
+
+  final OrderedSet<Component> children =
+      OrderedSet(Comparing.on((c) => c.priority));
+
+  /// This method is called periodically by the game engine to request that your component updates itself.
+  ///
+  /// The time [dt] in seconds (with microseconds precision provided by Flutter) since the last update cycle.
+  /// This time can vary according to hardware capacity, so make sure to update your state considering this.
+  /// All components on [BaseGame] are always updated by the same amount. The time each one takes to update adds up to the next update cycle.
+  @mustCallSuper
+  @override
+  void update(double dt) {
+    _effectsHandler.update(dt);
+  }
+
+  /// Called to check whether the point should be counted as a tap on the component
+  bool checkOverlap(Vector2 point) => false;
+
+  /// Add an effect to the component
+  void addEffect(ComponentEffect effect) {
+    _effectsHandler.add(effect, this);
+  }
+
+  /// Mark an effect for removal on the component
+  void removeEffect(ComponentEffect effect) {
+    _effectsHandler.removeEffect(effect);
+  }
+
+  /// Remove all effects
+  void clearEffects() {
+    _effectsHandler.clearEffects();
+  }
+
+  /// Get a list of non removed effects
+  List<ComponentEffect> get effects => _effectsHandler.effects;
+
+  /// Uses the game passed in to prepare the child component before it is added
+  /// to the list of children
+  void addChild(Game gameRef, Component c) {
+    if (gameRef is BaseGame) {
+      gameRef.prepare(c);
+    }
+    children.add(c);
+  }
+
+  /// This method first calls the passed function on itself and then recursively propagates it to every children
+  /// and grandchildren (and so on) of this component, either until it has propagated through the whole tree or
+  /// if the handler at any point returns false.
+  ///
+  /// This method is important to be used by the engine to propagate actions like rendering, taps, etc,
+  /// but you can call it yourself if you need to apply an action to the whole component chain.
+  /// It will only consider components of type T in the hierarchy, so use T = Component to target everything.
+  bool propagateToChildren<T extends Component>(
+    bool Function(T) handler,
+  ) {
+    bool shouldContinue = true;
+    if (this is T) {
+      shouldContinue = handler(this as T);
+      if (!shouldContinue) {
+        return false;
+      }
+    }
+    for (Component child in children) {
+      if (child is T) {
+        shouldContinue = handler(child);
+        if (shouldContinue && child is BaseComponent) {
+          shouldContinue = child.propagateToChildren(handler);
+        } else {
+          break;
+        }
+      }
+    }
+    return shouldContinue;
+  }
+}

--- a/lib/components/mixins/tapable.dart
+++ b/lib/components/mixins/tapable.dart
@@ -1,73 +1,77 @@
-import 'dart:ui';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
+import '../component.dart';
+import '../../extensions/offset.dart';
 import '../../game/base_game.dart';
-import '../position_component.dart';
 
-mixin Tapable on PositionComponent {
-  void onTapCancel() {}
-  void onTapDown(TapDownDetails details) {}
-  void onTapUp(TapUpDetails details) {}
+mixin Tapable on Component {
+  bool onTapCancel() {
+    return true;
+  }
+
+  bool onTapDown(TapDownDetails details) {
+    return true;
+  }
+
+  bool onTapUp(TapUpDetails details) {
+    return true;
+  }
 
   int _currentPointerId;
 
   bool _checkPointerId(int pointerId) => _currentPointerId == pointerId;
 
-  bool checkTapOverlap(Rect rect, Offset o) => rect.contains(o);
-
-  void handleTapDown(Rect rect, int pointerId, TapDownDetails details) {
-    if (checkTapOverlap(rect, details.localPosition)) {
+  bool handleTapDown(int pointerId, TapDownDetails details) {
+    if (checkOverlap(details.localPosition.toVector2())) {
       _currentPointerId = pointerId;
-      onTapDown(details);
+      return onTapDown(details);
     }
+    return true;
   }
 
-  void handleTapUp(Rect rect, int pointerId, TapUpDetails details) {
+  bool handleTapUp(int pointerId, TapUpDetails details) {
     if (_checkPointerId(pointerId) &&
-        checkTapOverlap(rect, details.localPosition)) {
+        checkOverlap(details.localPosition.toVector2())) {
       _currentPointerId = null;
-      onTapUp(details);
+      return onTapUp(details);
     }
+    return true;
   }
 
-  void handleTapCancel(int pointerId) {
+  bool handleTapCancel(int pointerId) {
     if (_checkPointerId(pointerId)) {
       _currentPointerId = null;
-      onTapCancel();
+      return onTapCancel();
     }
+    return true;
   }
 }
 
 mixin HasTapableComponents on BaseGame {
-  Iterable<PositionComponent> _positionComponents() {
-    return components.whereType<PositionComponent>();
-  }
-
   @mustCallSuper
   void onTapCancel(int pointerId) {
-    _positionComponents().forEach((c) {
+    components.forEach((c) {
       c.propagateToChildren<Tapable>(
-        (child, _) => child.handleTapCancel(pointerId),
+        (child) => child.handleTapCancel(pointerId),
       );
     });
   }
 
   @mustCallSuper
   void onTapDown(int pointerId, TapDownDetails details) {
-    _positionComponents().forEach((c) {
+    components.forEach((c) {
       c.propagateToChildren<Tapable>(
-        (child, rect) => child.handleTapDown(rect, pointerId, details),
+        (child) => child.handleTapDown(pointerId, details),
       );
     });
   }
 
   @mustCallSuper
   void onTapUp(int pointerId, TapUpDetails details) {
-    _positionComponents().forEach((c) {
+    components.forEach((c) {
       c.propagateToChildren<Tapable>(
-        (child, rect) => child.handleTapUp(rect, pointerId, details),
+        (child) => child.handleTapUp(pointerId, details),
       );
     });
   }

--- a/lib/components/mixins/tapable.dart
+++ b/lib/components/mixins/tapable.dart
@@ -1,8 +1,8 @@
-import 'package:flame/components/component.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
 import '../base_component.dart';
+import '../component.dart';
 import '../../extensions/offset.dart';
 import '../../game/base_game.dart';
 

--- a/lib/components/mixins/tapable.dart
+++ b/lib/components/mixins/tapable.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
-import '../component.dart';
+import '../base_component.dart';
 import '../../extensions/offset.dart';
 import '../../game/base_game.dart';
 
-mixin Tapable on Component {
+mixin Tapable on BaseComponent {
   bool onTapCancel() {
     return true;
   }
@@ -52,27 +52,33 @@ mixin HasTapableComponents on BaseGame {
   @mustCallSuper
   void onTapCancel(int pointerId) {
     components.forEach((c) {
-      c.propagateToChildren<Tapable>(
-        (child) => child.handleTapCancel(pointerId),
-      );
+      if (c is BaseComponent) {
+        c.propagateToChildren<Tapable>(
+          (child) => child.handleTapCancel(pointerId),
+        );
+      }
     });
   }
 
   @mustCallSuper
   void onTapDown(int pointerId, TapDownDetails details) {
     components.forEach((c) {
-      c.propagateToChildren<Tapable>(
-        (child) => child.handleTapDown(pointerId, details),
-      );
+      if (c is BaseComponent) {
+        c.propagateToChildren<Tapable>(
+          (child) => child.handleTapDown(pointerId, details),
+        );
+      }
     });
   }
 
   @mustCallSuper
   void onTapUp(int pointerId, TapUpDetails details) {
     components.forEach((c) {
-      c.propagateToChildren<Tapable>(
-        (child) => child.handleTapUp(pointerId, details),
-      );
+      if (c is BaseComponent) {
+        c.propagateToChildren<Tapable>(
+          (child) => child.handleTapUp(pointerId, details),
+        );
+      }
     });
   }
 }

--- a/lib/components/mixins/tapable.dart
+++ b/lib/components/mixins/tapable.dart
@@ -52,7 +52,7 @@ mixin Tapable on BaseComponent {
 mixin HasTapableComponents on BaseGame {
   @mustCallSuper
   void onTapCancel(int pointerId) {
-    for (Component c in components) {
+    for (Component c in components.toList().reversed) {
       bool shouldContinue = true;
       if (c is BaseComponent) {
         shouldContinue = c.propagateToChildren<Tapable>(
@@ -70,7 +70,7 @@ mixin HasTapableComponents on BaseGame {
 
   @mustCallSuper
   void onTapDown(int pointerId, TapDownDetails details) {
-    for (Component c in components) {
+    for (Component c in components.toList().reversed) {
       bool shouldContinue = true;
       if (c is BaseComponent) {
         shouldContinue = c.propagateToChildren<Tapable>(
@@ -88,7 +88,7 @@ mixin HasTapableComponents on BaseGame {
 
   @mustCallSuper
   void onTapUp(int pointerId, TapUpDetails details) {
-    for (Component c in components) {
+    for (Component c in components.toList().reversed) {
       bool shouldContinue = true;
       if (c is BaseComponent) {
         shouldContinue = c.propagateToChildren<Tapable>(

--- a/lib/components/mixins/tapable.dart
+++ b/lib/components/mixins/tapable.dart
@@ -1,3 +1,4 @@
+import 'package:flame/components/component.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
@@ -51,34 +52,55 @@ mixin Tapable on BaseComponent {
 mixin HasTapableComponents on BaseGame {
   @mustCallSuper
   void onTapCancel(int pointerId) {
-    components.forEach((c) {
+    for (Component c in components) {
+      bool shouldContinue = true;
       if (c is BaseComponent) {
-        c.propagateToChildren<Tapable>(
+        shouldContinue = c.propagateToChildren<Tapable>(
           (child) => child.handleTapCancel(pointerId),
         );
       }
-    });
+      if (c is Tapable && shouldContinue) {
+        shouldContinue = c.handleTapCancel(pointerId);
+      }
+      if (!shouldContinue) {
+        break;
+      }
+    }
   }
 
   @mustCallSuper
   void onTapDown(int pointerId, TapDownDetails details) {
-    components.forEach((c) {
+    for (Component c in components) {
+      bool shouldContinue = true;
       if (c is BaseComponent) {
-        c.propagateToChildren<Tapable>(
+        shouldContinue = c.propagateToChildren<Tapable>(
           (child) => child.handleTapDown(pointerId, details),
         );
       }
-    });
+      if (c is Tapable && shouldContinue) {
+        shouldContinue = c.handleTapDown(pointerId, details);
+      }
+      if (!shouldContinue) {
+        break;
+      }
+    }
   }
 
   @mustCallSuper
   void onTapUp(int pointerId, TapUpDetails details) {
-    components.forEach((c) {
+    for (Component c in components) {
+      bool shouldContinue = true;
       if (c is BaseComponent) {
-        c.propagateToChildren<Tapable>(
+        shouldContinue = c.propagateToChildren<Tapable>(
           (child) => child.handleTapUp(pointerId, details),
         );
       }
-    });
+      if (c is Tapable && shouldContinue) {
+        shouldContinue = c.handleTapUp(pointerId, details);
+      }
+      if (!shouldContinue) {
+        break;
+      }
+    }
   }
 }

--- a/lib/components/mixins/tapable.dart
+++ b/lib/components/mixins/tapable.dart
@@ -50,57 +50,33 @@ mixin Tapable on BaseComponent {
 }
 
 mixin HasTapableComponents on BaseGame {
-  @mustCallSuper
-  void onTapCancel(int pointerId) {
+  void _handleTapEvent(bool Function(Tapable child) tapEventHandler) {
     for (Component c in components.toList().reversed) {
       bool shouldContinue = true;
       if (c is BaseComponent) {
-        shouldContinue = c.propagateToChildren<Tapable>(
-          (child) => child.handleTapCancel(pointerId),
-        );
+        shouldContinue = c.propagateToChildren<Tapable>(tapEventHandler);
       }
       if (c is Tapable && shouldContinue) {
-        shouldContinue = c.handleTapCancel(pointerId);
+        shouldContinue = tapEventHandler(c);
       }
       if (!shouldContinue) {
         break;
       }
     }
+  }
+
+  @mustCallSuper
+  void onTapCancel(int pointerId) {
+    _handleTapEvent((Tapable child) => child.handleTapCancel(pointerId));
   }
 
   @mustCallSuper
   void onTapDown(int pointerId, TapDownDetails details) {
-    for (Component c in components.toList().reversed) {
-      bool shouldContinue = true;
-      if (c is BaseComponent) {
-        shouldContinue = c.propagateToChildren<Tapable>(
-          (child) => child.handleTapDown(pointerId, details),
-        );
-      }
-      if (c is Tapable && shouldContinue) {
-        shouldContinue = c.handleTapDown(pointerId, details);
-      }
-      if (!shouldContinue) {
-        break;
-      }
-    }
+    _handleTapEvent((Tapable child) => child.handleTapDown(pointerId, details));
   }
 
   @mustCallSuper
   void onTapUp(int pointerId, TapUpDetails details) {
-    for (Component c in components.toList().reversed) {
-      bool shouldContinue = true;
-      if (c is BaseComponent) {
-        shouldContinue = c.propagateToChildren<Tapable>(
-          (child) => child.handleTapUp(pointerId, details),
-        );
-      }
-      if (c is Tapable && shouldContinue) {
-        shouldContinue = c.handleTapUp(pointerId, details);
-      }
-      if (!shouldContinue) {
-        break;
-      }
-    }
+    _handleTapEvent((Tapable child) => child.handleTapUp(pointerId, details));
   }
 }

--- a/lib/components/particle_component.dart
+++ b/lib/components/particle_component.dart
@@ -7,7 +7,7 @@ import 'component.dart';
 
 /// Base container for [Particle] instances to be attach
 /// to a [Component] tree. Could be added either to [BaseGame]
-/// or an implementation of the [BaseComponent].
+/// or an implementation of [BaseComponent].
 /// Proxies [Component] lifecycle hooks to nested [Particle].
 class ParticleComponent extends Component {
   Particle particle;

--- a/lib/components/particle_component.dart
+++ b/lib/components/particle_component.dart
@@ -7,7 +7,7 @@ import 'component.dart';
 
 /// Base container for [Particle] instances to be attach
 /// to a [Component] tree. Could be added either to [BaseGame]
-/// or [ComposedComponent] as needed.
+/// or an implementation of the [BaseComponent].
 /// Proxies [Component] lifecycle hooks to nested [Particle].
 class ParticleComponent extends Component {
   Particle particle;

--- a/lib/components/particle_component.dart
+++ b/lib/components/particle_component.dart
@@ -3,14 +3,13 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 
 import '../particle.dart';
-import 'base_component.dart';
 import 'component.dart';
 
 /// Base container for [Particle] instances to be attach
 /// to a [Component] tree. Could be added either to [BaseGame]
 /// or [ComposedComponent] as needed.
 /// Proxies [Component] lifecycle hooks to nested [Particle].
-class ParticleComponent extends BaseComponent {
+class ParticleComponent extends Component {
   Particle particle;
 
   ParticleComponent({

--- a/lib/components/particle_component.dart
+++ b/lib/components/particle_component.dart
@@ -3,13 +3,14 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 
 import '../particle.dart';
+import 'base_component.dart';
 import 'component.dart';
 
 /// Base container for [Particle] instances to be attach
 /// to a [Component] tree. Could be added either to [BaseGame]
 /// or [ComposedComponent] as needed.
 /// Proxies [Component] lifecycle hooks to nested [Particle].
-class ParticleComponent extends Component {
+class ParticleComponent extends BaseComponent {
   Particle particle;
 
   ParticleComponent({

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -8,6 +8,7 @@ import '../anchor.dart';
 import '../extensions/offset.dart';
 import '../extensions/vector2.dart';
 import '../text_config.dart';
+import 'base_component.dart';
 import 'component.dart';
 
 /// A [Component] implementation that represents a component that has a
@@ -22,7 +23,7 @@ import 'component.dart';
 /// rendered automatically when this is updated and rendered.
 /// They are translated by this component's (x,y). They do not need to fit
 /// within this component's (width, height).
-abstract class PositionComponent extends Component {
+abstract class PositionComponent extends BaseComponent {
   /// The position of this component on the screen (relative to the anchor).
   Vector2 position = Vector2.zero();
 

--- a/lib/components/position_component.dart
+++ b/lib/components/position_component.dart
@@ -1,13 +1,12 @@
 import 'dart:ui' hide Offset;
+import 'dart:math' as math;
 
+import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
-import 'package:ordered_set/comparing.dart';
-import 'package:ordered_set/ordered_set.dart';
 
 import '../anchor.dart';
 import '../extensions/offset.dart';
 import '../extensions/vector2.dart';
-import '../game.dart';
 import '../text_config.dart';
 import 'component.dart';
 
@@ -47,7 +46,7 @@ abstract class PositionComponent extends Component {
   double get height => size.y;
   set height(double height) => size.y = height;
 
-  /// Get the top left position regardless of the anchor
+  /// Get the top left position regardless of the anchor and angle
   Vector2 get topLeftPosition => anchor.translate(position, size);
 
   /// Set the top left position regardless of the anchor
@@ -72,12 +71,9 @@ abstract class PositionComponent extends Component {
 
   /// This is set by the BaseGame to tell this component to render additional debug information,
   /// like borders, coordinates, etc.
-  /// This is very helpful while debbuging. Set your BaseGame debugMode to true.
+  /// This is very helpful while debugging. Set your BaseGame debugMode to true.
   /// You can also manually override this for certain components in order to identify issues.
   bool debugMode = false;
-
-  final OrderedSet<Component> _children =
-      OrderedSet(Comparing.on((c) => c.priority));
 
   Color get debugColor => const Color(0xFFFF00FF);
 
@@ -97,6 +93,45 @@ abstract class PositionComponent extends Component {
   void setByRect(Rect rect) {
     size.setValues(rect.width, rect.height);
     topLeftPosition = rect.topLeft.toVector2();
+  }
+
+  @override
+  bool checkOverlap(Vector2 point) {
+    final corners = _rotatedCorners();
+    corners.add(corners.first);
+    for (int i = 1; i < corners.length; i++) {
+      final lastCorner = corners[i - 1];
+      final corner = corners[i];
+      final isOutside = (corner.x - lastCorner.x) * (point.y - lastCorner.y) -
+              (point.x - lastCorner.x) * (corner.y - lastCorner.y) >
+          0;
+      if (isOutside) {
+        // Point is outside of convex polygon (only used for rectangles so far)
+        return false;
+      }
+    }
+    return true;
+  }
+
+  List<Vector2> _rotatedCorners() {
+    Vector2 rotateCorner(Vector2 corner) {
+      return Vector2(
+        math.cos(angle) * (corner.x - position.x) -
+            math.sin(angle) * (corner.y - position.y) +
+            position.x,
+        math.sin(angle) * (corner.x - position.x) +
+            math.cos(angle) * (corner.y - position.y) +
+            position.y,
+      );
+    }
+
+    // Counter-clockwise direction
+    return [
+      rotateCorner(topLeftPosition), // Top-left
+      rotateCorner(topLeftPosition + Vector2(0.0, size.y)), // Bottom-left
+      rotateCorner(topLeftPosition + size), // Bottom-right
+      rotateCorner(topLeftPosition + Vector2(size.x, 0.0)), // Top-right
+    ];
   }
 
   double angleTo(PositionComponent c) => position.angleTo(c.position);
@@ -137,36 +172,11 @@ abstract class PositionComponent extends Component {
     }
   }
 
-  /// This function recursively propagates an action to every children and grandchildren (and so on) of this component,
-  /// by keeping track of their positions by composing the positions of their parents.
-  /// For example, if this has a child that itself has a child, this will invoke handler for this (with no translation),
-  /// for the first child translating by this, and for the grand child by translating both this and the first child.
-  /// This is important to be used by the engine to propagate actions like rendering, taps, etc, but you can call it
-  /// yourself if you need to apply an action to the whole component chain.
-  /// It will only consider components of type T in the hierarchy, so use T = PositionComponent to target everything.
-  void propagateToChildren<T extends PositionComponent>(
-    void Function(T, Rect) handler,
-  ) {
-    final rect = toRect();
-    if (this is T) {
-      handler(this as T, rect);
-    }
-    _children.forEach((c) {
-      if (c is PositionComponent) {
-        final newRect = c.toRect().translate(rect.left, rect.top);
-        if (c is T) {
-          handler(this as T, newRect);
-        }
-        c.propagateToChildren(handler);
-      }
-    });
-  }
-
   @mustCallSuper
   @override
   void onGameResize(Vector2 gameSize) {
     super.onGameResize(gameSize);
-    _children.forEach((child) => child.onGameResize(gameSize));
+    children.forEach((child) => child.onGameResize(gameSize));
   }
 
   @mustCallSuper
@@ -179,7 +189,7 @@ abstract class PositionComponent extends Component {
     }
 
     canvas.save();
-    _children.forEach((comp) => _renderChild(canvas, comp));
+    children.forEach((c) => _renderChild(canvas, c));
     canvas.restore();
   }
 
@@ -190,26 +200,5 @@ abstract class PositionComponent extends Component {
     c.render(canvas);
     canvas.restore();
     canvas.save();
-  }
-
-  void addChild(Game gameRef, Component c) {
-    if (gameRef is BaseGame) {
-      gameRef.prepare(c);
-    }
-    _children.add(c);
-  }
-
-  bool removeChild(PositionComponent c) {
-    return _children.remove(c);
-  }
-
-  Iterable<Component> removeChildren(
-    bool Function(Component) test,
-  ) {
-    return _children.removeWhere(test);
-  }
-
-  void clearChildren() {
-    _children.clear();
   }
 }

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import '../components/component.dart';
+import '../components/base_component.dart';
 import '../components/position_component.dart';
 import '../extensions/vector2.dart';
 
@@ -10,7 +10,7 @@ export './rotate_effect.dart';
 export './scale_effect.dart';
 export './sequence_effect.dart';
 
-abstract class ComponentEffect<T extends Component> {
+abstract class ComponentEffect<T extends BaseComponent> {
   T component;
   Function() onComplete;
 

--- a/lib/effects/effects_handler.dart
+++ b/lib/effects/effects_handler.dart
@@ -1,4 +1,4 @@
-import '../components/component.dart';
+import '../components/base_component.dart';
 import 'effects.dart';
 
 export './move_effect.dart';
@@ -24,7 +24,7 @@ class EffectsHandler {
   }
 
   /// Add an effect to the handler
-  void add(ComponentEffect effect, Component component) {
+  void add(ComponentEffect effect, BaseComponent component) {
     _effects.add(effect..initialize(component));
   }
 

--- a/test/base_game_test.dart
+++ b/test/base_game_test.dart
@@ -23,8 +23,9 @@ class MyComponent extends PositionComponent
   int onRemoveCallCounter = 0;
 
   @override
-  void onTapDown(TapDownDetails details) {
+  bool onTapDown(TapDownDetails details) {
     tapped = true;
+    return true;
   }
 
   @override
@@ -40,7 +41,7 @@ class MyComponent extends PositionComponent
   }
 
   @override
-  bool checkTapOverlap(Rect c, Offset o) => true;
+  bool checkOverlap(Vector2 v) => true;
 
   @override
   void onRemove() => ++onRemoveCallCounter;

--- a/test/components/composed_component_test.dart
+++ b/test/components/composed_component_test.dart
@@ -15,12 +15,13 @@ class MyTap extends PositionComponent with Tapable, Resizable {
   bool tapped = false;
 
   @override
-  void onTapDown(TapDownDetails details) {
+  bool onTapDown(TapDownDetails details) {
     tapped = true;
+    return true;
   }
 
   @override
-  bool checkTapOverlap(Rect c, Offset o) => true;
+  bool checkOverlap(Vector2 v) => true;
 }
 
 class MyComposed extends PositionComponent with HasGameRef, Tapable {

--- a/test/components/composed_component_test.dart
+++ b/test/components/composed_component_test.dart
@@ -38,7 +38,7 @@ void main() {
     test('taps and resizes children', () {
       final MyGame game = MyGame();
       final MyTap child = MyTap();
-      final MyComposed wrapper = MyComposed()..addChild(game, child);
+      final MyComposed wrapper = MyComposed()..addChild(child);
 
       game.size = size;
       game.add(wrapper);

--- a/test/components/position_component_test.dart
+++ b/test/components/position_component_test.dart
@@ -1,0 +1,78 @@
+import 'dart:math' as math;
+
+import 'package:flame/anchor.dart';
+import 'package:flame/components/position_component.dart';
+import 'package:flame/extensions/vector2.dart';
+import 'package:test/test.dart';
+
+class MyComponent extends PositionComponent {}
+
+void main() {
+  group('PositionComponent overlap test', () {
+    test('overlap', () {
+      final PositionComponent component = MyComponent();
+      component.position = Vector2(2.0, 2.0);
+      component.size = Vector2(4.0, 4.0);
+      component.angle = 0.0;
+      component.anchor = Anchor.center;
+
+      final point = Vector2(2.0, 2.0);
+      expect(component.checkOverlap(point), true);
+    });
+
+    test('overlap on edge', () {
+      final PositionComponent component = MyComponent();
+      component.position = Vector2(2.0, 2.0);
+      component.size = Vector2(2.0, 2.0);
+      component.angle = 0.0;
+      component.anchor = Anchor.center;
+
+      final point = Vector2(1.0, 1.0);
+      expect(component.checkOverlap(point), true);
+    });
+
+    test('not overlapping with x', () {
+      final PositionComponent component = MyComponent();
+      component.position = Vector2(2.0, 2.0);
+      component.size = Vector2(2.0, 2.0);
+      component.angle = 0.0;
+      component.anchor = Anchor.center;
+
+      final point = Vector2(4.0, 1.0);
+      expect(component.checkOverlap(point), false);
+    });
+
+    test('not overlapping with y', () {
+      final PositionComponent component = MyComponent();
+      component.position = Vector2(2.0, 2.0);
+      component.size = Vector2(2.0, 2.0);
+      component.angle = 0.0;
+      component.anchor = Anchor.center;
+
+      final point = Vector2(1.0, 4.0);
+      expect(component.checkOverlap(point), false);
+    });
+
+    test('overlapping with angle', () {
+      final PositionComponent component = MyComponent();
+      component.position = Vector2(2.0, 2.0);
+      component.size = Vector2(2.0, 2.0);
+      component.angle = math.pi / 4;
+      component.anchor = Anchor.center;
+
+      final point = Vector2(3.1, 2.0);
+      expect(component.checkOverlap(point), true);
+    });
+
+    test('overlapping with angle and topLeft anchor', () {
+      final PositionComponent component = MyComponent();
+      component.position = Vector2(1.0, 1.0);
+      component.size = Vector2(2.0, 2.0);
+      component.angle = math.pi / 4;
+      component.anchor = Anchor.topLeft;
+
+      final point = Vector2(1.0, 3.1);
+      expect(component.checkOverlap(point), true);
+    });
+  });
+}

--- a/test/components/position_component_test.dart
+++ b/test/components/position_component_test.dart
@@ -64,6 +64,17 @@ void main() {
       expect(component.checkOverlap(point), true);
     });
 
+    test('not overlapping with angle', () {
+      final PositionComponent component = MyComponent();
+      component.position = Vector2(2.0, 2.0);
+      component.size = Vector2(2.0, 2.0);
+      component.angle = math.pi / 4;
+      component.anchor = Anchor.center;
+
+      final point = Vector2(1.0, 0.1);
+      expect(component.checkOverlap(point), false);
+    });
+
     test('overlapping with angle and topLeft anchor', () {
       final PositionComponent component = MyComponent();
       component.position = Vector2(1.0, 1.0);


### PR DESCRIPTION
# Description

This is a work in progress and I'm happily taking in comments to improve it, or scrap it.
It changes the way that we propagate to children.

The events (now the different tap functions) return a boolean so that the user can choose if the event should propagate further or not.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `v1.0.0`
- [x] This PR is targeted to merge into `v1.0.0` (not `master` or `develop`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
