### PR TITLE
Add GameRenderBox.computeDryLayout implementation.

### DIFF
--- a/lib/game/game_render_box.dart
+++ b/lib/game/game_render_box.dart
@@ -81,4 +81,9 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     game.lifecycleStateChange(state);
   }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    return constraints.biggest;
+  }
 }


### PR DESCRIPTION
# Description

This fixes error in flutter (Channel dev, 1.25.0-4.0.pre, on Mac OS X 10.15.4) Running on OSX

Exception:

════════ Exception caught by rendering library ═════════════════════════════════════════════════════
The following assertion was thrown during performResize():
The GameRenderBox class does not implement "computeDryLayout".

If you are not writing your own RenderBox subclass, then this is not
your fault.

Fixes # (issue number, if there is one)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [ ] This branch is based on `v1.0.0`
- [ ] This PR is targeted to merge into `v1.0.0` (not `master` or `develop`)
- [ ] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
