### PR TITLE
🚨 Use constructors in classes inherited from `_Asset`

### DIFF
--- a/lib/assets/assets_cache.dart
+++ b/lib/assets/assets_cache.dart
@@ -54,7 +54,7 @@ class AssetsCache {
 
   Future<_StringAsset> _readFile(String fileName) async {
     final string = await rootBundle.loadString('assets/$fileName');
-    return _StringAsset()..value = string;
+    return _StringAsset(string);
   }
 
   Future<_BinaryAsset> _readBinary(String fileName) async {
@@ -62,14 +62,19 @@ class AssetsCache {
     final Uint8List list = Uint8List.view(data.buffer);
 
     final bytes = List<int>.from(list);
-    return _BinaryAsset()..value = bytes;
+    return _BinaryAsset(bytes);
   }
 }
 
 class _Asset<T> {
   T value;
+  _Asset(this.value);
 }
 
-class _StringAsset extends _Asset<String> {}
+class _StringAsset extends _Asset<String> {
+  _StringAsset(String value) : super(value);
+}
 
-class _BinaryAsset extends _Asset<List<int>> {}
+class _BinaryAsset extends _Asset<List<int>> {
+  _BinaryAsset(List<int> value) : super(value);
+}


### PR DESCRIPTION
This simplifies AssetsCache code a bit.

The code is extracted from #549 in an attempt to make the null safety changeset smaller.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [ ] This branch is based on `v1.0.0`
- [ ] This PR is targeted to merge into `v1.0.0` (not `master` or `develop`)
- [ ] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
