### PR TITLE
Unify multiple render methods on Sprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Update PR template with removal of develop branch
  - Translate README to Russian
  - Split up Component and PositionComponent to BaseComponent
+ - Unify multiple render methods on Sprite
 
 ## 1.0.0-rc2
  - Improve IsometricTileMap and Spritesheet classes

--- a/doc/examples/layers/lib/main.dart
+++ b/doc/examples/layers/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flame/extensions/vector2.dart';
 import 'package:flutter/material.dart' hide Animation;
 import 'package:flame/game.dart';
 import 'package:flame/sprite.dart';
@@ -24,13 +25,15 @@ class GameLayer extends DynamicLayer {
 
   @override
   void drawLayer() {
-    playerSprite.renderRect(
+    playerSprite.render(
       canvas,
-      const Rect.fromLTWH(50, 50, 150, 150),
+      position: Vector2.all(50),
+      size: Vector2.all(150),
     );
-    enemySprite.renderRect(
+    enemySprite.render(
       canvas,
-      const Rect.fromLTWH(250, 150, 100, 50),
+      position: Vector2(250, 150),
+      size: Vector2(100, 50),
     );
   }
 }
@@ -44,9 +47,10 @@ class BackgroundLayer extends PreRenderedLayer {
 
   @override
   void drawLayer() {
-    sprite.renderRect(
+    sprite.render(
       canvas,
-      const Rect.fromLTWH(50, 200, 300, 150),
+      position: Vector2(50, 200),
+      size: Vector2(300, 150),
     );
   }
 }

--- a/doc/examples/sprites/lib/main_base64.dart
+++ b/doc/examples/sprites/lib/main_base64.dart
@@ -1,3 +1,4 @@
+import 'package:flame/extensions/vector2.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flame/sprite.dart';
@@ -25,6 +26,6 @@ class MyGame extends Game {
 
   @override
   void render(Canvas canvas) {
-    _sprite.renderRect(canvas, const Rect.fromLTWH(100, 100, 100, 100));
+    _sprite.render(canvas, position: Vector2.all(100), size: Vector2.all(100));
   }
 }

--- a/doc/util.md
+++ b/doc/util.md
@@ -46,7 +46,7 @@ These two functions help with registering (and de-registering) gesture recognize
 ### Other functions
 
 * `text`: discussed [here](/doc/text.md)
-* `drawWhere`: a very simple function that manually applies an offset to the `Canvas`, render stuff given via a function and then reset the `Canvas`, without using the `Canvas`' built-in `save`/`restore` functionality. This might be useful because `BaseGame` uses the state of the canvas, and you should not mess with it.
+* `renderWhere`: a very simple function that manually applies an offset to the `Canvas`, render stuff given via a function and then reset the `Canvas`, without using the `Canvas`' built-in `save`/`restore` functionality. This might be useful because `BaseGame` uses the state of the canvas, and you should not mess with it.
  
 ## Timer
 

--- a/doc/util.md
+++ b/doc/util.md
@@ -45,8 +45,7 @@ These two functions help with registering (and de-registering) gesture recognize
 
 ### Other functions
 
-* `text`: discussed [here](/doc/text.md)
-* `renderWhere`: a very simple function that manually applies an offset to the `Canvas`, render stuff given via a function and then reset the `Canvas`, without using the `Canvas`' built-in `save`/`restore` functionality. This might be useful because `BaseGame` uses the state of the canvas, and you should not mess with it.
+* `renderWhereAt` and `renderRotated`: if you are directly rendering to the `Canvas`, you can use these functions to easily manipulate coordinates to render things on the correct places. They change the `Canvas` transformation matrix but reset afterwards.
  
 ## Timer
 

--- a/lib/components/isometric_tile_map_component.dart
+++ b/lib/components/isometric_tile_map_component.dart
@@ -49,7 +49,7 @@ class IsometricTileMapComponent extends PositionComponent {
         if (element != -1) {
           final sprite = tileset.getSpriteById(element);
           final p = getBlockPositionInts(j, i);
-          sprite.renderRect(c, p.toPositionedRect(size));
+          sprite.render(c, position: p, size: size);
         }
       }
     }

--- a/lib/components/joystick/joystick_action.dart
+++ b/lib/components/joystick/joystick_action.dart
@@ -10,6 +10,7 @@ import '../../gestures.dart';
 import '../../sprite.dart';
 import 'joystick_component.dart';
 import 'joystick_events.dart';
+import 'joystick_utils.dart';
 
 enum JoystickActionAlign { TOP_LEFT, BOTTOM_LEFT, TOP_RIGHT, BOTTOM_RIGHT }
 
@@ -113,37 +114,17 @@ class JoystickAction {
   }
 
   void render(Canvas c) {
-    if (_rectBackgroundDirection != null && _dragging && enableDirection) {
-      if (spriteBackgroundDirection == null) {
-        final double radiusBackground = _rectBackgroundDirection.width / 2;
-        c.drawCircle(
-          Offset(
-            _rectBackgroundDirection.left + radiusBackground,
-            _rectBackgroundDirection.top + radiusBackground,
-          ),
-          radiusBackground,
-          _paintBackground,
-        );
-      } else {
-        spriteBackgroundDirection.renderRect(c, _rectBackgroundDirection);
-      }
-    }
-
-    if (_spriteAction != null) {
-      if (_rectAction != null) {
-        _spriteAction.renderRect(c, _rectAction);
-      }
-    } else {
-      final double radiusAction = _rectAction.width / 2;
-      c.drawCircle(
-        Offset(
-          _rectAction.left + radiusAction,
-          _rectAction.top + radiusAction,
-        ),
-        radiusAction,
-        isPressed ? _paintActionPressed : _paintAction,
+    if (_dragging && enableDirection) {
+      JoystickUtils.renderControl(
+        c,
+        spriteBackgroundDirection,
+        _rectBackgroundDirection,
+        _paintBackground,
       );
     }
+
+    final actionPaint = isPressed ? _paintActionPressed : _paintAction;
+    JoystickUtils.renderControl(c, _spriteAction, _rectAction, actionPaint);
   }
 
   void update(double dt) {

--- a/lib/components/joystick/joystick_directional.dart
+++ b/lib/components/joystick/joystick_directional.dart
@@ -21,11 +21,11 @@ class JoystickDirectional {
   final double opacityKnob;
 
   Sprite _backgroundSprite;
-  Paint _paintBackground;
+  Paint _backgroundPaint;
   Rect _backgroundRect;
 
   Sprite _knobSprite;
-  Paint _paintKnob;
+  Paint _knobPaint;
   Rect _knobRect;
 
   bool _dragging = false;
@@ -51,14 +51,14 @@ class JoystickDirectional {
     if (spriteBackgroundDirectional != null) {
       _backgroundSprite = spriteBackgroundDirectional;
     } else {
-      _paintBackground = Paint()
+      _backgroundPaint = Paint()
         ..color = color.withOpacity(opacityBackground)
         ..style = PaintingStyle.fill;
     }
     if (spriteKnobDirectional != null) {
       _knobSprite = spriteKnobDirectional;
     } else {
-      _paintKnob = Paint()
+      _knobPaint = Paint()
         ..color = color.withOpacity(opacityKnob)
         ..style = PaintingStyle.fill;
     }
@@ -67,7 +67,7 @@ class JoystickDirectional {
   }
 
   void initialize(Vector2 screenSize, JoystickController joystickController) {
-    _screenSize = _screenSize;
+    _screenSize = screenSize;
     _joystickController = joystickController;
 
     final osBackground = Offset(margin.left, _screenSize.y - margin.bottom);
@@ -84,14 +84,14 @@ class JoystickDirectional {
       canvas,
       _backgroundSprite,
       _backgroundRect,
-      _paintBackground,
+      _backgroundPaint,
     );
 
     JoystickUtils.renderControl(
       canvas,
       _knobSprite,
       _knobRect,
-      _paintKnob,
+      _knobPaint,
     );
   }
 

--- a/lib/components/joystick/joystick_directional.dart
+++ b/lib/components/joystick/joystick_directional.dart
@@ -153,7 +153,8 @@ class JoystickDirectional {
     if (!_dragging && directional.contains(event.initialPosition)) {
       _dragging = true;
       _dragPosition = event.initialPosition;
-      _currentDragEvent = event
+      _currentDragEvent = event;
+      _currentDragEvent
         ..onUpdate = onPanUpdate
         ..onEnd = onPanEnd
         ..onCancel = onPanCancel;

--- a/lib/components/joystick/joystick_directional.dart
+++ b/lib/components/joystick/joystick_directional.dart
@@ -73,8 +73,10 @@ class JoystickDirectional {
     final osBackground = Offset(margin.left, _screenSize.y - margin.bottom);
     _backgroundRect = Rect.fromCircle(center: osBackground, radius: size / 2);
 
-    final osKnob = _backgroundRect.center;
-    _knobRect = Rect.fromCircle(center: osKnob, radius: size / 4);
+    _knobRect = Rect.fromCircle(
+      center: _backgroundRect.center,
+      radius: size / 4,
+    );
 
     _dragPosition = _knobRect.center;
   }
@@ -171,8 +173,10 @@ class JoystickDirectional {
 
     _backgroundRect = Rect.fromCircle(center: position, radius: size / 2);
 
-    final osKnob = _backgroundRect.center;
-    _knobRect = Rect.fromCircle(center: osKnob, radius: size / 4);
+    _knobRect = Rect.fromCircle(
+      center: _backgroundRect.center,
+      radius: size / 4,
+    );
   }
 
   void onPanUpdate(DragUpdateDetails details) {

--- a/lib/components/joystick/joystick_utils.dart
+++ b/lib/components/joystick/joystick_utils.dart
@@ -1,0 +1,28 @@
+import 'dart:ui';
+
+import '../../sprite.dart';
+import '../../extensions/offset.dart';
+import '../../extensions/size.dart';
+
+class JoystickUtils {
+  static void renderControl(Canvas c, Sprite sprite, Rect rect, Paint paint) {
+    if (rect == null) {
+      return;
+    }
+
+    if (sprite == null) {
+      final double radius = rect.width / 2;
+      c.drawCircle(
+        Offset(rect.left + radius, rect.top + radius),
+        radius,
+        paint,
+      );
+    } else {
+      sprite.render(
+        c,
+        position: rect.topLeft.toVector2(),
+        size: rect.size.toVector2(),
+      );
+    }
+  }
+}

--- a/lib/particles/animation_particle.dart
+++ b/lib/particles/animation_particle.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
+import '../anchor.dart';
 import '../extensions/vector2.dart';
 import '../particle.dart';
 import '../sprite_animation.dart';
@@ -34,11 +35,11 @@ class SpriteAnimationParticle extends Particle {
 
   @override
   void render(Canvas canvas) {
-    animation.getSprite().renderCentered(
+    animation.getSprite().render(
           canvas,
-          Vector2.zero(),
-          overridePaint: overridePaint,
           size: size,
+          anchor: Anchor.center,
+          overridePaint: overridePaint,
         );
   }
 

--- a/lib/particles/sprite_particle.dart
+++ b/lib/particles/sprite_particle.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
+import '../anchor.dart';
 import '../particle.dart';
 import '../sprite.dart';
 import '../extensions/vector2.dart';
@@ -22,11 +23,11 @@ class SpriteParticle extends Particle {
 
   @override
   void render(Canvas canvas) {
-    sprite.renderCentered(
+    sprite.render(
       canvas,
-      Vector2.zero(),
-      overridePaint: overridePaint,
       size: size,
+      anchor: Anchor.center,
+      overridePaint: overridePaint,
     );
   }
 }

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'anchor.dart';
 import 'extensions/offset.dart';
 import 'extensions/vector2.dart';
 import 'palette.dart';
@@ -37,67 +38,28 @@ class Sprite {
     src = (position ?? Vector2.zero()).toPositionedRect(srcSize);
   }
 
-  /// Renders this Sprite on the position [p], scaled by the [scale] factor provided.
+  /// Renders this sprite onto the canvas.
   ///
-  /// It renders with src size multiplied by [scale] in both directions.
-  /// Anchor is on top left as default.
-  /// If not loaded, does nothing.
-  void renderScaled(
-    Canvas canvas,
-    Vector2 p, {
-    double scale = 1.0,
-    Paint overridePaint,
-  }) {
-    renderPosition(
-      canvas,
-      p,
-      size: srcSize * scale,
-      overridePaint: overridePaint,
-    );
-  }
-
-  void renderPosition(
-    Canvas canvas,
-    Vector2 p, {
-    Vector2 size,
-    Paint overridePaint,
-  }) {
-    size ??= srcSize;
-    renderRect(canvas, p.toPositionedRect(size), overridePaint: overridePaint);
-  }
-
+  /// * position: x,y coordinates where it will be drawn; default to origin.
+  /// * size: width/height dimensions; it can be bigger or smaller than the original size -- but it defaults to the original texture size.
+  /// * overridePaint: paint to use. You can also change the paint on your Sprite instance. Default is white.
+  /// * anchor: where in the sprite the x/y coordinates refer to; defaults to topLeft.
   void render(
     Canvas canvas, {
+    Vector2 position,
     Vector2 size,
+    Anchor anchor = Anchor.topLeft,
     Paint overridePaint,
   }) {
-    size ??= srcSize;
-    renderRect(canvas, size.toRect(), overridePaint: overridePaint);
-  }
+    final drawPosition = position ?? Vector2.zero();
+    final drawSize = size ?? srcSize;
 
-  /// Renders this sprite centered in the position [p], i.e., on [p] - [size] / 2.
-  ///
-  /// If [size] is not provided, the original size of the src image is used.
-  /// If the asset is not yet loaded, it does nothing.
-  void renderCentered(
-    Canvas canvas,
-    Vector2 p, {
-    Vector2 size,
-    Paint overridePaint,
-  }) {
-    size ??= srcSize;
-    renderRect(
-      canvas,
-      (p - size / 2).toPositionedRect(size),
-      overridePaint: overridePaint,
-    );
-  }
+    final delta = -anchor.relativePosition
+      ..multiply(drawSize);
+    final drawRect = (drawPosition + delta).toPositionedRect(drawSize);
 
-  void renderRect(
-    Canvas canvas,
-    Rect dst, {
-    Paint overridePaint,
-  }) {
-    canvas.drawImageRect(image, src, dst, overridePaint ?? paint);
+    final drawPaint = overridePaint ?? paint;
+
+    canvas.drawImageRect(image, src, drawRect, drawPaint);
   }
 }

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -54,8 +54,7 @@ class Sprite {
     final drawPosition = position ?? Vector2.zero();
     final drawSize = size ?? srcSize;
 
-    final delta = -anchor.relativePosition
-      ..multiply(drawSize);
+    final delta = anchor.relativePosition..multiply(drawSize);
     final drawRect = (drawPosition + delta).toPositionedRect(drawSize);
 
     final drawPaint = overridePaint ?? paint;

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -127,10 +127,30 @@ class Util {
   /// Utility method to render stuff on a specific place.
   ///
   /// Some render methods don't allow to pass a offset.
-  /// This method translate the canvas, draw what you want, and then translate back.
-  void drawWhere(Canvas c, Vector2 p, void Function(Canvas) fn) {
+  /// This method translate the canvas before rendering your block.
+  /// The changes are reset after the block is run.
+  void renderAt(Canvas c, Vector2 p, void Function(Canvas) block) {
+    c.save();
     c.translate(p.x, p.y);
-    fn(c);
-    c.translate(-p.x, -p.y);
+    block(c);
+    c.restore();
+  }
+
+  /// Utility method to render stuff rotated at specific angle.
+  ///
+  /// It rotates the canvas around the center of rotation.
+  /// The changes are reset after the block is run.
+  void renderRotated(
+    Canvas c,
+    double angle,
+    Vector2 rotationCenter,
+    void Function(Canvas) block,
+  ) {
+    c.save();
+    c.translate(-rotationCenter.x, -rotationCenter.y);
+    c.rotate(angle);
+    c.translate(rotationCenter.x, rotationCenter.y);
+    block(c);
+    c.restore();
   }
 }

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -127,30 +127,30 @@ class Util {
   /// Utility method to render stuff on a specific place.
   ///
   /// Some render methods don't allow to pass a offset.
-  /// This method translate the canvas before rendering your block.
-  /// The changes are reset after the block is run.
-  void renderAt(Canvas c, Vector2 p, void Function(Canvas) block) {
+  /// This method translate the canvas before rendering your fn.
+  /// The changes are reset after the fn is run.
+  void renderAt(Canvas c, Vector2 p, void Function(Canvas) fn) {
     c.save();
     c.translate(p.x, p.y);
-    block(c);
+    fn(c);
     c.restore();
   }
 
   /// Utility method to render stuff rotated at specific angle.
   ///
   /// It rotates the canvas around the center of rotation.
-  /// The changes are reset after the block is run.
+  /// The changes are reset after the fn is run.
   void renderRotated(
     Canvas c,
     double angle,
     Vector2 rotationCenter,
-    void Function(Canvas) block,
+    void Function(Canvas) fn,
   ) {
     c.save();
     c.translate(-rotationCenter.x, -rotationCenter.y);
     c.rotate(angle);
     c.translate(rotationCenter.x, rotationCenter.y);
-    block(c);
+    fn(c);
     c.restore();
   }
 }

--- a/lib/widgets/nine_tile_box.dart
+++ b/lib/widgets/nine_tile_box.dart
@@ -41,7 +41,7 @@ class _Painter extends widgets.CustomPainter {
     final verticalHeight = size.height - destTileSize * 2;
 
     void render(Sprite sprite, double x, double y, double w, double h) {
-      sprite.renderRect(canvas, Rect.fromLTWH(x, y, w, h));
+      sprite.render(canvas, position: Vector2(x, y), size: Vector2(w, h));
     }
 
     // Middle

--- a/lib/widgets/sprite_button.dart
+++ b/lib/widgets/sprite_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
+import '../extensions/size.dart';
 import '../sprite.dart';
 
 class SpriteButton extends StatefulWidget {
@@ -69,6 +70,6 @@ class _ButtonPainer extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    _sprite.renderRect(canvas, Rect.fromLTWH(0, 0, size.width, size.height));
+    _sprite.render(canvas, size: size.toVector2());
   }
 }


### PR DESCRIPTION
# Description

We had quite a few methods for rendering Sprites. I unified them all into a single signature with good parameters.
Also made Flame.util methods related to rendering more consistent and useful.
Also some small refactorings on Joystick stuff to use the new render methods more easily.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on `develop`
- [x] This PR is targeted to merge into `develop` (not `develop`)
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
