### PR TITLE
Passing SpriteAnimationData.loop out when constructing SpriteAnimationComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+ - Set loop member variable when constructing SpriteAnimationComponent from SpriteAnimationData
 
 ## 1.0.0-rc3
  - Fix TextBoxComponent rendering

--- a/lib/sprite_animation.dart
+++ b/lib/sprite_animation.dart
@@ -47,18 +47,17 @@ class SpriteAnimationData {
         assert(stepTimes != null) {
     amountPerRow ??= amount;
     texturePosition ??= Vector2.zero();
-    frames = List<SpriteAnimationFrameData>(amount);
-    for (int i = 0; i < amount; i++) {
+    frames = List<SpriteAnimationFrameData>.generate(amount, (i) {
       final position = Vector2(
         texturePosition.x + (i % amountPerRow) * textureSize.x,
         texturePosition.y + (i ~/ amountPerRow) * textureSize.y,
       );
-      frames[i] = SpriteAnimationFrameData(
+      return SpriteAnimationFrameData(
         stepTime: stepTimes[i],
         srcPosition: position,
         srcSize: textureSize,
       );
-    }
+    });
   }
 
   /// Works just like [SpriteAnimationData.variable] but uses the same [stepTime] for all frames

--- a/lib/sprite_animation.dart
+++ b/lib/sprite_animation.dart
@@ -153,6 +153,7 @@ class SpriteAnimation {
         frameData.stepTime,
       );
     }).toList();
+    loop = data.loop;
   }
 
   /// Automatically creates an Animation Object using animation data provided by the json file


### PR DESCRIPTION
# Description

When creating SpriteAnimationComponent from SpriteAnimationData, the SpriteAnimationData.loop is not passed out to SpriteAnimationComponent. As a result, if you specify SpriteAnimationData.loop=false, you will still see the animation loops in apps.

Fixes # (issue number, if there is one)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [X] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [X] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [ ] The continuous integration (CI) is passing
