### PR TITLE
Effect shouldn't affect non-used properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
  - Rename Dragable -> Draggable
  - Set loop member variable when constructing SpriteAnimationComponent from SpriteAnimationData
+ - Effect shouldn't affect unrelated properties on component
 
 ## 1.0.0-rc3
  - Fix TextBoxComponent rendering

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -168,7 +168,7 @@ abstract class PositionComponentEffect
       if (originalAngle != endAngle) {
         component?.angle = angle;
       }
-      if (originalSize != originalSize) {
+      if (originalSize != endSize) {
         component?.size?.setFrom(size);
       }
     }

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -157,22 +157,31 @@ abstract class PositionComponentEffect
     endSize = component.size.clone();
   }
 
-  @override
-  void setComponentToOriginalState() {
+  /// Only change the parts of the component that is affected by the
+  /// effect, and only set the state if it is the root effect (not part of
+  /// another effect, like children of a CombinedEffect or SequenceEffect).
+  void _setComponentState(Vector2 position, double angle, Vector2 size) {
     if (isRootEffect()) {
-      component?.position?.setFrom(originalPosition);
-      component?.angle = originalAngle;
-      component?.size?.setFrom(endSize);
+      if (originalPosition != endPosition) {
+        component?.position?.setFrom(position);
+      }
+      if (originalAngle != endAngle) {
+        component?.angle = angle;
+      }
+      if (originalSize != originalSize) {
+        component?.size?.setFrom(size);
+      }
     }
   }
 
   @override
+  void setComponentToOriginalState() {
+    _setComponentState(originalPosition, originalAngle, originalSize);
+  }
+
+  @override
   void setComponentToEndState() {
-    if (isRootEffect()) {
-      component?.position?.setFrom(endPosition);
-      component?.angle = endAngle;
-      component?.size?.setFrom(endSize);
-    }
+    _setComponentState(endPosition, endAngle, endSize);
   }
 }
 


### PR DESCRIPTION
# Description

Right now an effect resets all the properties of a position component when it is done, it should only reset the once it has affected.
For example a ScaleEffect will reset the position of the PositionComponent when it is done.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
