### PR TITLE
Explicitly set what the effect modifies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Set loop member variable when constructing SpriteAnimationComponent from SpriteAnimationData
  - Effect shouldn't affect unrelated properties on component
  - Fix rendering of children
+ - Explicitly define what fields an effect on PositionComponent modifies
 
 ## 1.0.0-rc3
  - Fix TextBoxComponent rendering

--- a/lib/effects/combined_effect.dart
+++ b/lib/effects/combined_effect.dart
@@ -15,7 +15,14 @@ class CombinedEffect extends PositionComponentEffect {
     bool isInfinite = false,
     bool isAlternating = false,
     void Function() onComplete,
-  }) : super(isInfinite, isAlternating, onComplete: onComplete) {
+  }) : super(
+          isInfinite,
+          isAlternating,
+          modifiesPosition: effects.any((e) => e.modifiesPosition),
+          modifiesAngle: effects.any((e) => e.modifiesAngle),
+          modifiesSize: effects.any((e) => e.modifiesSize),
+          onComplete: onComplete,
+        ) {
     assert(
       effects.every((effect) => effect.component == null),
       'Each effect can only be added once',

--- a/lib/effects/effects.dart
+++ b/lib/effects/effects.dart
@@ -126,11 +126,19 @@ abstract class PositionComponentEffect
   double endAngle;
   Vector2 endSize;
 
+  /// Whether the state of a certain field was modified by the effect
+  final bool modifiesPosition;
+  final bool modifiesAngle;
+  final bool modifiesSize;
+
   PositionComponentEffect(
     bool initialIsInfinite,
     bool initialIsAlternating, {
     bool isRelative = false,
     Curve curve,
+    this.modifiesPosition = false,
+    this.modifiesAngle = false,
+    this.modifiesSize = false,
     void Function() onComplete,
   }) : super(
           initialIsInfinite,
@@ -162,13 +170,13 @@ abstract class PositionComponentEffect
   /// another effect, like children of a CombinedEffect or SequenceEffect).
   void _setComponentState(Vector2 position, double angle, Vector2 size) {
     if (isRootEffect()) {
-      if (originalPosition != endPosition) {
+      if (modifiesPosition) {
         component?.position?.setFrom(position);
       }
-      if (originalAngle != endAngle) {
+      if (modifiesAngle) {
         component?.angle = angle;
       }
-      if (originalSize != endSize) {
+      if (modifiesSize) {
         component?.size?.setFrom(size);
       }
     }
@@ -196,6 +204,9 @@ abstract class SimplePositionComponentEffect extends PositionComponentEffect {
     this.speed,
     Curve curve,
     bool isRelative = false,
+    bool modifiesPosition = false,
+    bool modifiesAngle = false,
+    bool modifiesSize = false,
     void Function() onComplete,
   })  : assert(
           (duration != null) ^ (speed != null),
@@ -206,6 +217,9 @@ abstract class SimplePositionComponentEffect extends PositionComponentEffect {
           initialIsAlternating,
           isRelative: isRelative,
           curve: curve,
+          modifiesPosition: modifiesPosition,
+          modifiesAngle: modifiesAngle,
+          modifiesSize: modifiesSize,
           onComplete: onComplete,
         );
 }

--- a/lib/effects/move_effect.dart
+++ b/lib/effects/move_effect.dart
@@ -45,6 +45,7 @@ class MoveEffect extends SimplePositionComponentEffect {
           speed: speed,
           curve: curve,
           isRelative: isRelative,
+          modifiesPosition: true,
           onComplete: onComplete,
         );
 

--- a/lib/effects/rotate_effect.dart
+++ b/lib/effects/rotate_effect.dart
@@ -29,6 +29,7 @@ class RotateEffect extends SimplePositionComponentEffect {
           speed: speed,
           curve: curve,
           isRelative: isRelative,
+          modifiesAngle: true,
           onComplete: onComplete,
         );
 

--- a/lib/effects/scale_effect.dart
+++ b/lib/effects/scale_effect.dart
@@ -30,6 +30,7 @@ class ScaleEffect extends SimplePositionComponentEffect {
           speed: speed,
           curve: curve,
           isRelative: isRelative,
+          modifiesSize: true,
           onComplete: onComplete,
         );
 

--- a/lib/effects/sequence_effect.dart
+++ b/lib/effects/sequence_effect.dart
@@ -15,7 +15,14 @@ class SequenceEffect extends PositionComponentEffect {
     bool isInfinite = false,
     bool isAlternating = false,
     void Function() onComplete,
-  }) : super(isInfinite, isAlternating, onComplete: onComplete) {
+  }) : super(
+          isInfinite,
+          isAlternating,
+          modifiesPosition: effects.any((e) => e.modifiesPosition),
+          modifiesAngle: effects.any((e) => e.modifiesAngle),
+          modifiesSize: effects.any((e) => e.modifiesSize),
+          onComplete: onComplete,
+        ) {
     assert(
       effects.every((effect) => effect.component == null),
       'Each effect can only be added once',


### PR DESCRIPTION
# Description

Forgot that in the cases where isAlternating = true, endPosition and originalPosition will be the same

Fixes # (issue number, if there is one)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
