### PR TITLE
Fixing Game Render Box for flutter >= 1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Explicitly define what fields an effect on PositionComponent modifies
  - Properly propagate onMount and onRemove to children
  - Adding Canvas extensions
+ - Fixing Game Render Box for flutter >= 1.25
 
 ## 1.0.0-rc3
  - Fix TextBoxComponent rendering

--- a/lib/game/game_render_box.dart
+++ b/lib/game/game_render_box.dart
@@ -79,4 +79,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     game.lifecycleStateChange(state);
   }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => constraints.biggest;
 }


### PR DESCRIPTION
# Description

Flutter 1.25+ added a new method on RenderBox that needs to be implemented, this PR adds the method.

Flutter stable still don't have that new method, but since it was a method addition, flutter stable will continue to work fine, we just may get some lint warning when this version leave a pre release.

Either way, this change was tested on both stable and beta channel

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
