### PR TITLE
Fix issue in BaseComponent where addChild results in a TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
  - Rename retreive -> Retrieve
- - Fix issue where calling addChild on BaseComponent throws a TypeError on the 2nd call
+ - Use internal children set in BaseComponent (fixes issue adding multiple children)
 
 ## 1.0.0-rc4
  - Rename Dragable -> Draggable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
  - Rename retreive -> Retrieve
+ - Fix issue where calling addChild on BaseComponent throws a TypeError on the 2nd call
 
 ## 1.0.0-rc4
  - Rename Dragable -> Draggable

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -24,7 +24,7 @@ abstract class BaseComponent extends Component {
       OrderedSet(Comparing.on((c) => c.priority));
 
   OrderedSet<Component> get children =>
-      OrderedSet<Component>()..addAll(_children);
+      OrderedSet<Component>(Comparing.on((c) => c.priority))..addAll(_children);
 
   /// This is set by the BaseGame to tell this component to render additional debug information,
   /// like borders, coordinates, etc.

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -23,8 +23,7 @@ abstract class BaseComponent extends Component {
   final OrderedSet<Component> _children =
       OrderedSet(Comparing.on((c) => c.priority));
 
-  OrderedSet<Component> get children =>
-      OrderedSet<Component>(Comparing.on((c) => c.priority))..addAll(_children);
+  List<Component> get children => _children.toList(growable: false);
 
   /// This is set by the BaseGame to tell this component to render additional debug information,
   /// like borders, coordinates, etc.
@@ -84,14 +83,14 @@ abstract class BaseComponent extends Component {
   @override
   void onMount() {
     super.onMount();
-    children.forEach((child) => child.onMount());
+    _children.forEach((child) => child.onMount());
   }
 
   @mustCallSuper
   @override
   void onRemove() {
     super.onRemove();
-    children.forEach((child) => child.onRemove());
+    _children.forEach((child) => child.onRemove());
   }
 
   /// Called to check whether the point is to be counted as within the component


### PR DESCRIPTION
# Description

This adds the compare function to the children getter on `BaseComponent` as it throws a TypeError since Components are not themselves comparable without that. I didn't log an issue for it since this is a simple change.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
