### PR TITLE
BaseComponent should return immutable chlidren iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  - Rename retreive -> Retrieve
  - Use internal children set in BaseComponent (fixes issue adding multiple children)
  - Remove develop branches from github workflow definition
- - BaseComponent should use internal children set
+ - BaseComponent to return UnmodifiableListView for children
 
 ## 1.0.0-rc4
  - Rename Dragable -> Draggable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Rename retreive -> Retrieve
  - Use internal children set in BaseComponent (fixes issue adding multiple children)
  - Remove develop branches from github workflow definition
+ - BaseComponent should use internal children set
 
 ## 1.0.0-rc4
  - Rename Dragable -> Draggable

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -23,7 +23,7 @@ abstract class BaseComponent extends Component {
   final OrderedSet<Component> _children =
       OrderedSet(Comparing.on((c) => c.priority));
 
-  Iterator<Component> get children => _children.iterator;
+  List<Component> get children => _children.toList(growable: false);
 
   /// This is set by the BaseGame to tell this component to render additional debug information,
   /// like borders, coordinates, etc.

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:ui';
 
 import 'package:meta/meta.dart';
@@ -23,7 +24,13 @@ abstract class BaseComponent extends Component {
   final OrderedSet<Component> _children =
       OrderedSet(Comparing.on((c) => c.priority));
 
-  List<Component> get children => _children.toList(growable: false);
+  /// The children list shouldn't be modified directly, that is why an
+  /// [UnmodifiableListView] is used. If you want to add children use the
+  /// addChild method, and if you want to propagate something to the children
+  /// use the propagateToChildren method.
+  UnmodifiableListView<Component> get children {
+    return UnmodifiableListView(_children);
+  }
 
   /// This is set by the BaseGame to tell this component to render additional debug information,
   /// like borders, coordinates, etc.

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -23,7 +23,7 @@ abstract class BaseComponent extends Component {
   final OrderedSet<Component> _children =
       OrderedSet(Comparing.on((c) => c.priority));
 
-  List<Component> get children => _children.toList(growable: false);
+  Iterator<Component> get children => _children.iterator;
 
   /// This is set by the BaseGame to tell this component to render additional debug information,
   /// like borders, coordinates, etc.

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -29,7 +29,7 @@ abstract class BaseComponent extends Component {
   /// addChild method, and if you want to propagate something to the children
   /// use the propagateToChildren method.
   UnmodifiableListView<Component> get children {
-    return UnmodifiableListView(_children);
+    return UnmodifiableListView<Component>(_children);
   }
 
   /// This is set by the BaseGame to tell this component to render additional debug information,

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -26,8 +26,8 @@ abstract class BaseComponent extends Component {
 
   /// The children list shouldn't be modified directly, that is why an
   /// [UnmodifiableListView] is used. If you want to add children use the
-  /// addChild method, and if you want to propagate something to the children
-  /// use the propagateToChildren method.
+  /// [addChild] method, and if you want to propagate something to the children
+  /// use the [propagateToChildren] method.
   UnmodifiableListView<Component> get children {
     return UnmodifiableListView<Component>(_children);
   }


### PR DESCRIPTION
# Description

The BaseComponent children getter should return an immutable data structure.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
