### PR TITLE
Remove develop branches from test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - master
-      - develop
       - master-v0.x
-      - develop-v0.x
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
  - Rename retreive -> Retrieve
  - Use internal children set in BaseComponent (fixes issue adding multiple children)
+ - Remove develop branches from github workflow definition
 
 ## 1.0.0-rc4
  - Rename Dragable -> Draggable


### PR DESCRIPTION
# Description

Since the develop branches don't exist anymore, remove the reference to them in the github workflow file.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
