### PR TITLE
Bump versions and fix lint issues (v0.x)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
         with:
-          channel: 'beta'
+          channel: 'stable'
       - run: flutter --version
       - run: flutter pub get
       - run: ./scripts/lint.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [next]
 
+## 0.29.0
+- Update audioplayers to latest version (now `assets` will not be added to prefixes automatically)
+- Fix lint issues with 0.28.0
+
 ## 0.28.0
 - Fix spriteAsWidget deprecation message
 - Add `lineHeight` property to `TextConfig`

--- a/doc/README.md
+++ b/doc/README.md
@@ -18,7 +18,7 @@ Put the pub package as your dependency by dropping the following in your `pubspe
 
 ```yaml
 dependencies:
-  flame: ^0.28.0
+  flame: ^0.29.0
 ```
 
 And start using it!

--- a/doc/examples/animation_widget/pubspec.yaml
+++ b/doc/examples/animation_widget/pubspec.yaml
@@ -2,6 +2,7 @@ name: animation_widget
 description: A sample Flame project to showcase the animationAsWidget method.
 
 version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"

--- a/doc/examples/animations/pubspec.yaml
+++ b/doc/examples/animations/pubspec.yaml
@@ -2,6 +2,7 @@ name: animations
 description: Flame sample game showcasing animations features
 
 version: 1.0.0+1
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/aseprite/pubspec.yaml
+++ b/doc/examples/aseprite/pubspec.yaml
@@ -2,6 +2,7 @@ name: aseprite
 description: Flame sample for using Aseprite animations
 
 version: 1.0.0+1
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/audiopool/pubspec.yaml
+++ b/doc/examples/audiopool/pubspec.yaml
@@ -1,6 +1,8 @@
 name:  audiopool
 description: Flame example application showcasing the audiopool class
+
 version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"

--- a/doc/examples/box2d/contact_callbacks/pubspec.yaml
+++ b/doc/examples/box2d/contact_callbacks/pubspec.yaml
@@ -1,7 +1,8 @@
 name: box2d_contact_callbacks
 description: Flame sample game showcasing the structure for box2d games
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/box2d/simple/pubspec.yaml
+++ b/doc/examples/box2d/simple/pubspec.yaml
@@ -1,7 +1,8 @@
 name: box2d
 description: Flame sample game showcasing the structure for box2d games
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/debug/pubspec.yaml
+++ b/doc/examples/debug/pubspec.yaml
@@ -1,7 +1,8 @@
 name: debug
 description: Flame sample for using debug features
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/effects/combined_effects/pubspec.yaml
+++ b/doc/examples/effects/combined_effects/pubspec.yaml
@@ -1,7 +1,8 @@
 name: combined_effects
 description: Flame sample game showcasing combined effects
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/effects/infinite_effects/pubspec.yaml
+++ b/doc/examples/effects/infinite_effects/pubspec.yaml
@@ -1,7 +1,8 @@
 name: infinite_effects
 description: Flame sample game showcasing infinite effects
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/effects/sequence_effect/pubspec.yaml
+++ b/doc/examples/effects/sequence_effect/pubspec.yaml
@@ -1,7 +1,8 @@
 name: sequence_effect
 description: Flame sample game showcasing the sequence effect
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/effects/simple/pubspec.yaml
+++ b/doc/examples/effects/simple/pubspec.yaml
@@ -1,7 +1,8 @@
 name: effects
 description: A Flame game showcasing the use of the effects api
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/gestures/pubspec.yaml
+++ b/doc/examples/gestures/pubspec.yaml
@@ -1,7 +1,8 @@
 name: gestures
 description: A flame game showcasing the use of gestures callbacks
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/go_desktop/pubspec.yaml
+++ b/doc/examples/go_desktop/pubspec.yaml
@@ -1,7 +1,8 @@
 name: go_desktop
 description: Flame sample game on using the go flutter desktop framework
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/isometric/pubspec.yaml
+++ b/doc/examples/isometric/pubspec.yaml
@@ -2,6 +2,7 @@ name: isometric
 description: Example of isometric tilemap using Flame
 
 version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/joystick/pubspec.yaml
+++ b/doc/examples/joystick/pubspec.yaml
@@ -1,7 +1,8 @@
 name: joystick
 description: A flame game showcasing the use of joystick
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/keyboard/pubspec.yaml
+++ b/doc/examples/keyboard/pubspec.yaml
@@ -1,7 +1,8 @@
 name: keyboard
 description: Simple Flame project showcasing how to use the Keyboard events
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/layers/pubspec.yaml
+++ b/doc/examples/layers/pubspec.yaml
@@ -1,9 +1,8 @@
 name: layers
 description: Simple project to showcase the layer feature of Flame
 
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/doc/examples/nine_tile_box/pubspec.yaml
+++ b/doc/examples/nine_tile_box/pubspec.yaml
@@ -1,7 +1,8 @@
 name: nine_tile_box
 description: Flame sample for using the nine_tile_box feature
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/parallax/pubspec.yaml
+++ b/doc/examples/parallax/pubspec.yaml
@@ -1,7 +1,8 @@
 name: parallax
 description: Flame sample game showcasing the parallax features
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/particles/pubspec.yaml
+++ b/doc/examples/particles/pubspec.yaml
@@ -1,7 +1,8 @@
 name: particles
 description: Flame sample game showcasing particle effects
 
-version: 1.0.0
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/render_flip/pubspec.yaml
+++ b/doc/examples/render_flip/pubspec.yaml
@@ -1,7 +1,8 @@
 name: render_flip
 description: Flame sample game showcasing animations features
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/sound/pubspec.yaml
+++ b/doc/examples/sound/pubspec.yaml
@@ -1,6 +1,8 @@
 name: sound
 description: Flame example application showcasing the audio features
+
 version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"

--- a/doc/examples/sprite_batch/pubspec.yaml
+++ b/doc/examples/sprite_batch/pubspec.yaml
@@ -1,7 +1,8 @@
 name: sprite_batch
 description: Showcasing SpriteBatch features
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/sprites/pubspec.yaml
+++ b/doc/examples/sprites/pubspec.yaml
@@ -1,7 +1,8 @@
 name: sprites
 description: Flame sample game showcasing rendering 500 sprites
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/spritesheet/pubspec.yaml
+++ b/doc/examples/spritesheet/pubspec.yaml
@@ -1,7 +1,8 @@
 name: spritesheet
 description: Flame sample game showcasing spritesheet features
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/text/pubspec.yaml
+++ b/doc/examples/text/pubspec.yaml
@@ -2,6 +2,7 @@ name: text
 description: A sample Flame project that renders texts.
 
 version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"

--- a/doc/examples/timer/pubspec.yaml
+++ b/doc/examples/timer/pubspec.yaml
@@ -1,7 +1,8 @@
 name: timer
 description: Example app using Timer class
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"

--- a/doc/examples/widgets/pubspec.yaml
+++ b/doc/examples/widgets/pubspec.yaml
@@ -1,7 +1,8 @@
 name: widgets
 description: A Flutter project showcasing Flame's widgets.
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/doc/examples/with_widgets_overlay/pubspec.yaml
+++ b/doc/examples/with_widgets_overlay/pubspec.yaml
@@ -1,7 +1,8 @@
 name: with_widgets_overlay
 description: A Flame game showcasing how to use the WithWidgetsOverlay feature
 
-version: 1.0.0+1
+version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,6 +2,7 @@ name: position_component
 description: A new Flutter project.
 
 version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ">=2.0.0 <3.0.0"

--- a/lib/animation.dart
+++ b/lib/animation.dart
@@ -83,7 +83,7 @@ class Animation {
     this.loop = true,
   }) : assert(amountPerRow == null || amount >= amountPerRow) {
     amountPerRow ??= amount;
-    frames = List<Frame>(amount);
+    frames = List<Frame>.filled(amount, null);
     for (var i = 0; i < amount; i++) {
       final Sprite sprite = Sprite(
         imagePath,
@@ -109,7 +109,7 @@ class Animation {
     this.loop = true,
   }) : assert(amountPerRow == null || amount >= amountPerRow) {
     amountPerRow ??= amount;
-    frames = List<Frame>(amount);
+    frames = List<Frame>.filled(amount, null);
     for (var i = 0; i < amount; i++) {
       final Sprite sprite = Sprite(
         imagePath,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 0.28.0
+version: 0.29.0
 homepage: https://github.com/flame-engine/flame
 
 dependencies:
   flutter:
     sdk: flutter
-  audioplayers: ^0.15.1
-  ordered_set: ^2.0.0
-  path_provider: ^1.6.0
+  audioplayers: ^0.17.1
+  ordered_set: ^2.0.1
+  path_provider: ^1.6.24
   box2d_flame: ^0.4.6
   synchronized: ^2.1.0
   convert: ^2.0.1


### PR DESCRIPTION
This is a new release for our v0 (stable) channel. This:

* updates audioplayers to fix some issues with notifications center
* fixes some lint issues on 0.28.0 that costs us points on pub
* I had to add `publish_to: none` to all our examples, that was being complained about on our local analyze

Remember that v0.x of Flame only works on Flutter stable because there was a Flutter breaking change (use Flame 1.0 for newer flutter channels).