### PR TITLE
BaseComponent removes children marked as shouldRemove during update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+  - BaseComponent removes children marked as shouldRemove during update
 
 ## 1.0.0-rc5
  - Option for overlays to be already visible on the GameWidget

--- a/lib/components/base_component.dart
+++ b/lib/components/base_component.dart
@@ -56,6 +56,7 @@ abstract class BaseComponent extends Component {
   @override
   void update(double dt) {
     _effectsHandler.update(dt);
+    _children.removeWhere((c) => c.shouldRemove).forEach((c) => c.onRemove());
     _children.forEach((c) => c.update(dt));
   }
 


### PR DESCRIPTION
# Description

BaseComponent never actually removes children marked for removal, so calling `child.remove()` has no effect.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
