### PR TITLE
Improve error handling for onLoad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+ - Improve error handling for the onLoad function
 
 ## 1.0.0-rc5
  - Option for overlays to be already visible on the GameWidget


### PR DESCRIPTION
I think errors should not be swallowed, that is a really bad practice. I was very against this when we first discussed, but now that I fell ill of the consequence myself (and took me longer than it should to realize what was going on), I have become vehemently against.

onLoad exceptions should be re-thrown.

This is what it looks like with this change:

![image](https://user-images.githubusercontent.com/882703/103448115-d9d43080-4c62-11eb-94b6-609a255017dc.png)

You still get the option to provide an error handler but now the handler is aware of what the error was. If you do not, the exception is re-thrown as anyone would except.

Before if a handler was not provided (and it was optional) the exception was completely swallowed and not logged, seem, expressed anywhere. And you got a black screen from an empty game. Also even if you wanted to add a custom handler you would not know what went wrong, which made the custom error handler practically useless.