### PR TITLE
Fix aseprite constructor bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
  - Use `find` instead of `globstar` pattern in `scripts/lint.sh` as the later isn't enabled by default in bash
+ - Fixes aseprite constructor bug
  - Improve error handling for the onLoad function
 
 ## 1.0.0-rc5

--- a/lib/sprite_animation.dart
+++ b/lib/sprite_animation.dart
@@ -164,9 +164,9 @@ class SpriteAnimation {
     Image image,
     Map<String, dynamic> jsonData,
   ) {
-    final jsonFrames = jsonData['frames'] as Map<String, Map<String, dynamic>>;
+    final jsonFrames = jsonData['frames'] as Map<String, dynamic>;
 
-    final frames = jsonFrames.values.map((value) {
+    final frames = jsonFrames.values.map((dynamic value) {
       final frameData = value['frame'] as Map<String, dynamic>;
       final int x = frameData['x'] as int;
       final int y = frameData['y'] as int;


### PR DESCRIPTION
While porting the aseprite example to our new [examples repo](https://github.com/flame-engine/flame_example/blob/master/lib/examples/aseprite.dart) I noticed that one wasn't work; this should fix it.