### PR TITLE
Debug mode to be variable on BaseGame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
  - Remove Resizable mixin
  - Use config defaults for TextBoxComponent
  - Fixing Game Render Box for flutter >= 1.25
- - DebudMode to be variable instead of function on BaseGame
+ - DebugMode to be variable instead of function on BaseGame
 
 ## 1.0.0-rc3
  - Fix TextBoxComponent rendering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  - Remove Resizable mixin
  - Use config defaults for TextBoxComponent
  - Fixing Game Render Box for flutter >= 1.25
+ - DebudMode to be variable instead of function on BaseGame
 
 ## 1.0.0-rc3
  - Fix TextBoxComponent rendering

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -13,8 +13,7 @@ class MyGame extends Game with FPS {
 
 ## BaseGame features
 
-Flame provides some features for debugging, these features are enabled when the method `debugMode` from the `BaseGame` class is overridden, and returning `true`. When it's enabled all `PositionComponent`s will be wrapped into a rectangle, and have its position rendered on the screen, so you can visually verify the component boundaries and position.
-
-In addition to the debugMode, you can also ask `BaseGame` to record the fps(the `BaseGame` used the [FPSCounter](fps-counter) mixin). To enable it you have to override the `recordFps` method to return `true`, by doing so, you can access the current fps by using the method `fps`.
+Flame provides some features for debugging, these features are enabled when the `debugMode` from the `BaseGame` class is set to `true` (or overridden to be true).
+When it's enabled all `PositionComponent`s will be wrapped into a rectangle, and have its position rendered on the screen, so you can visually verify the component boundaries and position.
 
 To see a working example of the debugging features of the `BaseGame`, [check this example](/doc/examples/debug).

--- a/doc/examples/composability/lib/main.dart
+++ b/doc/examples/composability/lib/main.dart
@@ -47,7 +47,7 @@ class MyGame extends BaseGame {
   ParentSquare _parent;
 
   @override
-  bool debugMode() => true;
+  bool debugMode = true;
 
   MyGame() {
     _parent = ParentSquare(Vector2.all(200), Vector2.all(300));

--- a/doc/examples/debug/lib/main.dart
+++ b/doc/examples/debug/lib/main.dart
@@ -62,7 +62,7 @@ class MyGame extends BaseGame {
   final fpsTextConfig = TextConfig(color: const Color(0xFFFFFFFF));
 
   @override
-  bool debugMode() => true;
+  bool debugMode = true;
 
   @override
   Future<void> onLoad() async {
@@ -91,7 +91,7 @@ class MyGame extends BaseGame {
   void render(Canvas canvas) {
     super.render(canvas);
 
-    if (debugMode()) {
+    if (debugMode) {
       fpsTextConfig.render(canvas, fps(120).toString(), Vector2(0, 50));
     }
   }

--- a/doc/examples/particles/lib/main.dart
+++ b/doc/examples/particles/lib/main.dart
@@ -498,13 +498,13 @@ class MyGame extends BaseGame {
   }
 
   @override
-  bool debugMode() => true;
+  bool debugMode = true;
 
   @override
   void render(Canvas canvas) {
     super.render(canvas);
 
-    if (debugMode()) {
+    if (debugMode) {
       fpsTextConfig.render(
           canvas, '${fps(120).toStringAsFixed(2)}fps', Vector2(0, size.y - 24));
     }

--- a/lib/game/base_game.dart
+++ b/lib/game/base_game.dart
@@ -48,7 +48,7 @@ class BaseGame extends Game with FPSCounter {
       );
     }
 
-    if (debugMode() && c is PositionComponent) {
+    if (debugMode && c is PositionComponent) {
       c.debugMode = true;
     }
 
@@ -151,9 +151,10 @@ class BaseGame extends Game with FPSCounter {
 
   /// Returns whether this [Game] is in debug mode or not.
   ///
-  /// Returns `false` by default. Override to use the debug mode.
-  /// You can use this value to enable debug behaviors for your game, many components show extra information on screen when on debug mode
-  bool debugMode() => false;
+  /// Returns `false` by default. Override it, or set it to true, to use debug mode.
+  /// You can use this value to enable debug behaviors for your game and many components will
+  /// show extra information on the screen when debug mode is activated
+  bool debugMode = false;
 
   /// Returns the current time in seconds with microseconds precision.
   ///


### PR DESCRIPTION
# Description

Allows for simpler activation mid-game, and also follow the standard we have for `BaseComponent`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
