### PR TITLE
Creating a shortcut for Sprite and SpriteAnimation load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Fixes aseprite constructor bug
  - Improve error handling for the onLoad function
  - Add test for child removal
+ - Adding shortcut for loading Sprites and SpriteAnimation from the global cache
 
 ## 1.0.0-rc5
  - Option for overlays to be already visible on the GameWidget

--- a/lib/game/game.dart
+++ b/lib/game/game.dart
@@ -109,19 +109,13 @@ abstract class Game {
     String path, {
     Vector2 srcSize,
     Vector2 srcPosition,
-  }) async {
-    final image = await images.load(path);
-    return Sprite(image, srcSize: srcSize, srcPosition: srcPosition);
-  }
+  }) => Sprite.load(path, srcPosition: srcPosition, srcSize: srcSize, images: images);
 
   /// Utility method to load and cache the image for a sprite animation based on its options
   Future<SpriteAnimation> loadSpriteAnimation(
     String path,
     SpriteAnimationData data,
-  ) async {
-    final image = await images.load(path);
-    return SpriteAnimation.fromFrameData(image, data);
-  }
+  ) => SpriteAnimation.load(path, data, images: images);
 
   /// Flag to tell the game loop if it should start running upon creation
   bool runOnCreation = true;

--- a/lib/game/game.dart
+++ b/lib/game/game.dart
@@ -109,13 +109,16 @@ abstract class Game {
     String path, {
     Vector2 srcSize,
     Vector2 srcPosition,
-  }) => Sprite.load(path, srcPosition: srcPosition, srcSize: srcSize, images: images);
+  }) =>
+      Sprite.load(path,
+          srcPosition: srcPosition, srcSize: srcSize, images: images);
 
   /// Utility method to load and cache the image for a sprite animation based on its options
   Future<SpriteAnimation> loadSpriteAnimation(
     String path,
     SpriteAnimationData data,
-  ) => SpriteAnimation.load(path, data, images: images);
+  ) =>
+      SpriteAnimation.load(path, data, images: images);
 
   /// Flag to tell the game loop if it should start running upon creation
   bool runOnCreation = true;

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-
 import 'anchor.dart';
 import 'extensions/offset.dart';
 import 'extensions/vector2.dart';
@@ -25,10 +24,10 @@ class Sprite {
   /// Takes a path of an image, a [srcPosition] and [srcSize] and loads the sprite animation
   /// When the [images] is omitted, the global [Flame.images] is used
   static Future<Sprite> load(
-      String src, {
-      Vector2 srcPosition,
-      Vector2 srcSize,
-      Images images,
+    String src, {
+    Vector2 srcPosition,
+    Vector2 srcSize,
+    Images images,
   }) async {
     final _images = images ?? Flame.images;
     final image = await _images.load(src);

--- a/lib/sprite.dart
+++ b/lib/sprite.dart
@@ -1,9 +1,12 @@
 import 'dart:ui';
 
+
 import 'anchor.dart';
 import 'extensions/offset.dart';
 import 'extensions/vector2.dart';
+import 'flame.dart';
 import 'palette.dart';
+import 'assets/images.dart';
 
 class Sprite {
   Paint paint = BasicPalette.white.paint;
@@ -17,6 +20,19 @@ class Sprite {
   }) : assert(image != null, "image can't be null") {
     this.srcSize = srcSize;
     this.srcPosition = srcPosition;
+  }
+
+  /// Takes a path of an image, a [srcPosition] and [srcSize] and loads the sprite animation
+  /// When the [images] is omitted, the global [Flame.images] is used
+  static Future<Sprite> load(
+      String src, {
+      Vector2 srcPosition,
+      Vector2 srcSize,
+      Images images,
+  }) async {
+    final _images = images ?? Flame.images;
+    final image = await _images.load(src);
+    return Sprite(image, srcPosition: srcPosition, srcSize: srcSize);
   }
 
   double get _imageWidth => image.width.toDouble();

--- a/lib/sprite_animation.dart
+++ b/lib/sprite_animation.dart
@@ -1,7 +1,9 @@
 import 'package:meta/meta.dart';
 import 'dart:ui';
 
+import 'assets/images.dart';
 import 'extensions/vector2.dart';
+import 'flame.dart';
 import 'sprite.dart';
 
 class SpriteAnimationFrameData {
@@ -186,6 +188,18 @@ class SpriteAnimation {
 
     this.frames = frames.toList();
     loop = true;
+  }
+
+  /// Takes a path of an image, a [SpriteAnimationData] and loads the sprite animation
+  /// When the [images] is omitted, the global [Flame.images] is used
+  static Future<SpriteAnimation> load(
+      String src,
+      SpriteAnimationData data, {
+      Images images,
+  }) async {
+    final _images = images ?? Flame.images;
+    final image = await _images.load(src);
+    return SpriteAnimation.fromFrameData(image, data);
   }
 
   /// The current frame that should be displayed.

--- a/lib/sprite_animation.dart
+++ b/lib/sprite_animation.dart
@@ -193,9 +193,9 @@ class SpriteAnimation {
   /// Takes a path of an image, a [SpriteAnimationData] and loads the sprite animation
   /// When the [images] is omitted, the global [Flame.images] is used
   static Future<SpriteAnimation> load(
-      String src,
-      SpriteAnimationData data, {
-      Images images,
+    String src,
+    SpriteAnimationData data, {
+    Images images,
   }) async {
     final _images = images ?? Flame.images;
     final image = await _images.load(src);


### PR DESCRIPTION
# Description

Adds a shortcut for Sprite and SpriteAnimation loading using the global cache.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
