### PR TITLE
Ensure non-repeating Timer callback fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Fixes aseprite constructor bug
  - Improve error handling for the onLoad function
  - Add test for child removal
+ - Fix bug where `Timer` callback doesn't fire for non-repeating timers, also fixing bug with `Particle` lifespan
 
 ## 1.0.0-rc5
  - Option for overlays to be already visible on the GameWidget

--- a/lib/timer.dart
+++ b/lib/timer.dart
@@ -29,6 +29,7 @@ class Timer {
       if (_current >= limit) {
         if (!repeat) {
           _running = false;
+          callback?.call();
           return;
         }
         // This is used to cover the rare case of _current being more than


### PR DESCRIPTION
# Description

Non-repeating Timers never fire their callback. This is making Particle lifespans (which use a Timer internally) not ever fire their end callback, so Particles with a lifespan never auto-remove.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
