### PR TITLE
Making SpriteComponent and SpriteAnimationComponent follow the same standard for empty constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  - Adding shortcut for loading Sprites and SpriteAnimation from the global cache
  - Adding loading methods for the different `ParallaxComponent` parts and refactor how the delta velocity works
  - Add tests for `Timer` and fix a bug where `progress` was not reported correctly
+ - Adding standard for SpriteComponent and SpriteAnimationComponent constructors
 
 ## 1.0.0-rc5
  - Option for overlays to be already visible on the GameWidget

--- a/doc/examples/animations/lib/main.dart
+++ b/doc/examples/animations/lib/main.dart
@@ -39,11 +39,13 @@ class MyGame extends BaseGame with TapDetector {
     );
 
     final spriteSize = Vector2.all(100.0);
-    final animationComponent2 = SpriteAnimationComponent(spriteSize, animation);
+    final animationComponent2 =
+        SpriteAnimationComponent.fromSpriteAnimation(spriteSize, animation);
     animationComponent2.x = size.x / 2 - spriteSize.x;
     animationComponent2.y = spriteSize.y;
 
-    final reversedAnimationComponent = SpriteAnimationComponent(
+    final reversedAnimationComponent =
+        SpriteAnimationComponent.fromSpriteAnimation(
       spriteSize,
       animation.reversed(),
     );

--- a/doc/examples/aseprite/lib/main.dart
+++ b/doc/examples/aseprite/lib/main.dart
@@ -22,8 +22,9 @@ class MyGame extends BaseGame {
       jsonData,
     );
     final spriteSize = Vector2.all(200);
-    final animationComponent = SpriteAnimationComponent(spriteSize, animation)
-      ..position = size / 2 - Vector2.all(100);
+    final animationComponent =
+        SpriteAnimationComponent.fromSpriteAnimation(spriteSize, animation)
+          ..position = size / 2 - Vector2.all(100);
 
     add(animationComponent);
   }

--- a/doc/examples/render_flip/lib/main.dart
+++ b/doc/examples/render_flip/lib/main.dart
@@ -36,8 +36,10 @@ class MyGame extends BaseGame {
   }
 
   SpriteAnimationComponent buildAnimationComponent(Image image) {
-    final ac =
-        SpriteAnimationComponent(Vector2.all(100), buildAnimation(image));
+    final ac = SpriteAnimationComponent.fromSpriteAnimation(
+      Vector2.all(100),
+      buildAnimation(image),
+    );
     ac.x = size.x / 2 - ac.x / 2;
     return ac;
   }

--- a/doc/examples/spritesheet/lib/main.dart
+++ b/doc/examples/spritesheet/lib/main.dart
@@ -29,14 +29,15 @@ class MyGame extends BaseGame {
         spriteSheet.createAnimation(row: 1, stepTime: 0.1, to: 7);
     final spriteSize = Vector2(80.0, 90.0);
 
-    final vampireComponent =
-        SpriteAnimationComponent(spriteSize, vampireAnimation)
-          ..x = 150
-          ..y = 100;
-
-    final ghostComponent = SpriteAnimationComponent(spriteSize, ghostAnimation)
+    final vampireComponent = SpriteAnimationComponent.fromSpriteAnimation(
+        spriteSize, vampireAnimation)
       ..x = 150
-      ..y = 220;
+      ..y = 100;
+
+    final ghostComponent =
+        SpriteAnimationComponent.fromSpriteAnimation(spriteSize, ghostAnimation)
+          ..x = 150
+          ..y = 220;
 
     add(vampireComponent);
     add(ghostComponent);

--- a/lib/components/sprite_animation_component.dart
+++ b/lib/components/sprite_animation_component.dart
@@ -11,19 +11,19 @@ class SpriteAnimationComponent extends PositionComponent {
   Paint overridePaint;
   bool removeOnFinish = false;
 
+  /// Creates a component with an empty animation which can be set later
+  SpriteAnimationComponent();
+
   /// Creates an [SpriteAnimationComponent] from an [animation] and a [size]
   ///
   /// Optionally [removeOnFinish] can be set to true to have this component be auto removed from the [BaseGame] when the animation is finished.
-  SpriteAnimationComponent(
+  SpriteAnimationComponent.fromSpriteAnimation(
     Vector2 size,
     this.animation, {
     this.removeOnFinish = false,
   }) : assert(animation != null) {
     super.size.setFrom(size);
   }
-
-  /// Creates a component with an empty animation which can be set later
-  SpriteAnimationComponent.empty();
 
   /// Creates a SpriteAnimationComponent from a [size], an [image] and [data]. Check [SpriteAnimationData] for more info on the available options.
   ///

--- a/lib/components/sprite_component.dart
+++ b/lib/components/sprite_component.dart
@@ -21,6 +21,7 @@ class SpriteComponent extends PositionComponent {
   /// If not provided the default is full white (no tint).
   Paint overridePaint;
 
+  /// Creates a component with an empty sprite which can be set later
   SpriteComponent();
 
   SpriteComponent.fromImage(Vector2 size, Image image)


### PR DESCRIPTION
# Description

SpriteComponent and SpriteAnimationComponent had a similar behavior on allowing an empty initialization, which is very useful because allows the component to load itself using it's `onLoad` method. But they had the constructors using different patterns. This PR simple makes both component follow a similar pattern so it will be easier for the user to use.

After this proposal is accepted I intend on doing a similar thing on all of our components that requires assets, like Parallax, SpriteBatch, etc.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
