### PR TITLE
👌 Use `Offset` type directly in `JoystickAction.update` calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+ - Use `Offset` type directly in `JoystickAction.update` calculations
  - Changed `parseAnchor` in `examples/widgets` to throw an exception instead of returning null when it cannot parse an anchor name
  - Code improvements and preparing APIs to null-safety
  - BaseComponent removes children marked as shouldRemove during update

--- a/lib/components/joystick/joystick_action.dart
+++ b/lib/components/joystick/joystick_action.dart
@@ -136,15 +136,11 @@ class JoystickAction {
       // Calculate the knob position
       final double nextX = dist * cos(_radAngle);
       final double nextY = dist * sin(_radAngle);
-      final Offset nextPoint = Offset(nextX, nextY);
+      final nextPoint = Offset(nextX, nextY);
 
       if (_rectAction != null) {
-        final Offset diff = Offset(
-              _rectBackgroundDirection.center.dx + nextPoint.dx,
-              _rectBackgroundDirection.center.dy + nextPoint.dy,
-            ) -
-            _rectAction.center;
-
+        final diff =
+            _rectBackgroundDirection.center + nextPoint - _rectAction.center;
         _rectAction = _rectAction.shift(diff);
       }
 


### PR DESCRIPTION
# Description

Improved code a bit to utilize `Offset` support for `+` and `-` operators.

Fixes #606 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
- [x] Changelog entry