### PR TITLE
👌 Throw exception from `parseAnchor` in `examples/widgets` instead of returning null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+ - Changed `parseAnchor` in `examples/widgets` to throw an exception instead of returning null when it cannot parse an anchor name
  - Code improvements and preparing APIs to null-safety
  - BaseComponent removes children marked as shouldRemove during update
  - Use `find` instead of `globstar` pattern in `scripts/lint.sh` as the later isn't enabled by default in bash

--- a/doc/examples/widgets/lib/main.dart
+++ b/doc/examples/widgets/lib/main.dart
@@ -33,7 +33,7 @@ Anchor parseAnchor(String name) {
       return Anchor.bottomRight;
   }
 
-  return null;
+  throw Exception("Cannot parse anchor name `$name`");
 }
 
 void main() async {
@@ -108,9 +108,8 @@ void main() async {
           child: SpriteWidget(
             sprite: shieldSprite,
             anchor: parseAnchor(
-                  ctx.listProperty('anchor', 'Anchor.center', anchorOptions),
-                ) ??
-                Anchor.topLeft,
+              ctx.listProperty('anchor', 'Anchor.center', anchorOptions),
+            ),
           ),
         ),
       );
@@ -135,9 +134,8 @@ void main() async {
             animation: _animation,
             playing: ctx.boolProperty('playing', true),
             anchor: parseAnchor(
-                  ctx.listProperty('anchor', 'Anchor.center', anchorOptions),
-                ) ??
-                Anchor.topLeft,
+              ctx.listProperty('anchor', 'Anchor.center', anchorOptions),
+            ),
           ),
         ),
       );


### PR DESCRIPTION
# Description

Changed `parseAnchor` in `examples/widgets` to throw an exception instead of returning null when it cannot parse an anchor name

Fixes #607 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
