### PR TITLE
Fix gesture detection on children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
  - Removing methods `initialDimensions` and `removeGestureRecognizer` to avoid confusion
  - Adding standard for `SpriteComponent` and `SpriteAnimationComponent` constructors
  - Move files to comply with the dart package layout convention
+ - Fix gesture detection bug of children of `PositionComponent`
 
 ## 1.0.0-rc5
  - Option for overlays to be already visible on the GameWidget

--- a/lib/src/components/base_component.dart
+++ b/lib/src/components/base_component.dart
@@ -24,6 +24,11 @@ abstract class BaseComponent extends Component {
   final OrderedSet<Component> _children =
       OrderedSet(Comparing.on((c) => c.priority));
 
+  /// If the component has a parent it will be set here
+  BaseComponent _parent;
+
+  BaseComponent get parent => _parent;
+
   /// The children list shouldn't be modified directly, that is why an
   /// [UnmodifiableListView] is used. If you want to add children use the
   /// [addChild] method, and if you want to propagate something to the children
@@ -134,6 +139,10 @@ abstract class BaseComponent extends Component {
     gameRef ??= (this as HasGameRef).gameRef;
     if (gameRef is BaseGame) {
       gameRef.prepare(child);
+    }
+
+    if (child is BaseComponent) {
+      child._parent = this;
     }
 
     final childOnLoadFuture = child.onLoad();

--- a/lib/src/components/base_component.dart
+++ b/lib/src/components/base_component.dart
@@ -156,13 +156,17 @@ abstract class BaseComponent extends Component {
 
   bool containsChild(Component c) => _children.contains(c);
 
-  /// This method first calls the passed handler on the leaves in the tree, the children without any children of their own.
-  /// Then it continues through all other children.
-  /// The propagation continues until the handler returns false, which means "do not continue", or when the handler has been called with all children
+  /// This method first calls the passed handler on the leaves in the tree,
+  /// the children without any children of their own.
+  /// Then it continues through all other children. The propagation continues
+  /// until the handler returns false, which means "do not continue", or when
+  /// the handler has been called with all children
   ///
-  /// This method is important to be used by the engine to propagate actions like rendering, taps, etc,
-  /// but you can call it yourself if you need to apply an action to the whole component chain.
-  /// It will only consider components of type T in the hierarchy, so use T = Component to target everything.
+  /// This method is important to be used by the engine to propagate actions
+  /// like rendering, taps, etc, but you can call it yourself if you need to
+  /// apply an action to the whole component chain.
+  /// It will only consider components of type T in the hierarchy,
+  /// so use T = Component to target everything.
   bool propagateToChildren<T extends Component>(
     bool Function(T) handler,
   ) {

--- a/lib/src/components/position_component.dart
+++ b/lib/src/components/position_component.dart
@@ -49,8 +49,9 @@ abstract class PositionComponent extends BaseComponent {
 
   /// Get the absolute top left position regardless of whether it is a child or not
   Vector2 get absoluteTopLeftPosition {
-    if(parent is PositionComponent) {
-      return (parent as PositionComponent).absoluteTopLeftPosition + topLeftPosition;
+    if (parent is PositionComponent) {
+      return (parent as PositionComponent).absoluteTopLeftPosition +
+          topLeftPosition;
     } else {
       return topLeftPosition;
     }
@@ -58,7 +59,7 @@ abstract class PositionComponent extends BaseComponent {
 
   /// Get the position that everything in this component is positioned in relation to
   Vector2 get absoluteCanvasPosition {
-    if(parent is PositionComponent) {
+    if (parent is PositionComponent) {
       return (parent as PositionComponent).absoluteTopLeftPosition;
     } else {
       return Vector2.zero();

--- a/lib/src/components/position_component.dart
+++ b/lib/src/components/position_component.dart
@@ -24,8 +24,7 @@ abstract class PositionComponent extends BaseComponent {
   /// The position of this component on the screen (relative to the anchor).
   Vector2 position = Vector2.zero();
 
-  /// If the component has a [PositionComponent] as a parent it will be
-  /// added here
+  /// If the component has a [PositionComponent] as a parent it will be set here
   PositionComponent _positionParent;
 
   /// X position of this component on the screen (relative to the anchor).

--- a/lib/src/components/position_component.dart
+++ b/lib/src/components/position_component.dart
@@ -26,7 +26,7 @@ abstract class PositionComponent extends BaseComponent {
 
   /// If the component has a [PositionComponent] as a parent it will be
   /// added here
-  PositionComponent positionParent;
+  PositionComponent _positionParent;
 
   /// X position of this component on the screen (relative to the anchor).
   double get x => position.x;
@@ -53,7 +53,7 @@ abstract class PositionComponent extends BaseComponent {
 
   /// Get the absolute top left position regardless of whether it is a child or not
   Vector2 get absoluteTopLeftPosition {
-    return (positionParent?.absoluteTopLeftPosition ?? Vector2.zero()) +
+    return (_positionParent?.absoluteTopLeftPosition ?? Vector2.zero()) +
         topLeftPosition;
   }
 
@@ -91,7 +91,7 @@ abstract class PositionComponent extends BaseComponent {
   @override
   bool checkOverlap(Vector2 absolutePoint) {
     final point = absolutePoint -
-        (positionParent?.absoluteTopLeftPosition ?? Vector2.zero());
+        (_positionParent?.absoluteTopLeftPosition ?? Vector2.zero());
     final corners = _rotatedCorners();
     for (int i = 0; i < corners.length; i++) {
       final previousCorner = corners[i];
@@ -173,7 +173,7 @@ abstract class PositionComponent extends BaseComponent {
   Future<void> addChild(Component child, {Game gameRef}) async {
     super.addChild(child, gameRef: gameRef);
     if (child is PositionComponent) {
-      child.positionParent = this;
+      child._positionParent = this;
     }
   }
 }

--- a/test/components/composed_component_test.dart
+++ b/test/components/composed_component_test.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:test/test.dart';
 
 import '../util/mock_canvas.dart';

--- a/test/components/composed_component_test.dart
+++ b/test/components/composed_component_test.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:test/test.dart';
 
 import '../util/mock_canvas.dart';
@@ -12,7 +13,8 @@ class MyGame extends BaseGame with HasTapableComponents {}
 class MyTap extends PositionComponent with Tapable {
   Vector2 gameSize;
 
-  bool tapped = false;
+  int tapTimes = 0;
+  bool get tapped => tapTimes > 0;
   bool updated = false;
   bool rendered = false;
 
@@ -36,12 +38,9 @@ class MyTap extends PositionComponent with Tapable {
 
   @override
   bool onTapDown(TapDownDetails details) {
-    tapped = true;
+    ++tapTimes;
     return true;
   }
-
-  @override
-  bool checkOverlap(Vector2 v) => true;
 }
 
 class MyAsyncChild extends MyTap {
@@ -49,14 +48,9 @@ class MyAsyncChild extends MyTap {
   Future<void> onLoad() => Future.value();
 }
 
-class MyComposed extends PositionComponent with HasGameRef, Tapable {
-  @override
-  Rect toRect() => Rect.zero;
-}
+class MyComposed extends PositionComponent with HasGameRef, Tapable {}
 
-class PositionComponentNoNeedForRect extends PositionComponent with Tapable {}
-
-Vector2 size = Vector2(1.0, 1.0);
+Vector2 size = Vector2.all(300);
 
 void main() {
   group('composable component test', () {
@@ -102,6 +96,26 @@ void main() {
 
       expect(child.gameSize, size);
       expect(child.tapped, true);
+    });
+
+    test('tap on offset children', () {
+      final MyGame game = MyGame();
+      final MyTap child = MyTap()
+        ..position = Vector2.all(100)
+        ..size = Vector2.all(100);
+      final MyComposed wrapper = MyComposed()
+        ..position = Vector2.all(100)
+        ..size = Vector2.all(300);
+
+      game.size.setFrom(size);
+      game.add(wrapper);
+      wrapper.addChild(child);
+      game.update(0.0);
+      game.onTapDown(1, TapDownDetails(globalPosition: const Offset(250, 250)));
+
+      expect(child.gameSize, size);
+      expect(child.tapped, true);
+      expect(child.tapTimes, 1);
     });
 
     test('updates and renders children', () {


### PR DESCRIPTION
# Description

Since the children aren't positioned in an absolute manner their gesture detection was off, this is fixed by taking the parent into account recursively.

Fixes #635 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
