### PR TITLE
Adapting SpriteBatchComponent constructors to other components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [next]
  - Moving device related methods (like `fullScreen`) from `util.dart` to `device.dart`
  - Moving render functions from `util.dart` to `extensions/canvas.dart`
- - Adapting SpriteBatchComponent contructors to match the pattern followed on other components
+ - Adapting SpriteBatchComponent constructors to match the pattern used on other components
 
 ## 1.0.0-rc6
  - Use `Offset` type directly in `JoystickAction.update` calculations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
  - Moving device related methods (like `fullScreen`) from `util.dart` to `device.dart`
  - Moving render functions from `util.dart` to `extensions/canvas.dart`
+ - Adapting SpriteBatchComponent contructors to match the pattern followed on other components
 
 ## 1.0.0-rc6
  - Use `Offset` type directly in `JoystickAction.update` calculations

--- a/doc/examples/sprite_batch/lib/main_auto_loading.dart
+++ b/doc/examples/sprite_batch/lib/main_auto_loading.dart
@@ -15,7 +15,8 @@ void main() async {
   );
 }
 
-class MySpriteBatchComponent extends SpriteBatchComponent with HasGameRef<MyGame> {
+class MySpriteBatchComponent extends SpriteBatchComponent
+    with HasGameRef<MyGame> {
   @override
   Future<void> onLoad() async {
     spriteBatch = await gameRef.loadSpriteBatch('boom3.png');
@@ -40,7 +41,8 @@ class MySpriteBatchComponent extends SpriteBatchComponent with HasGameRef<MyGame
       final sx = r.nextInt(8) * 128.0;
       final sy = r.nextInt(8) * 128.0;
       final x = r.nextInt(gameRef.size.x.toInt()).toDouble();
-      final y = r.nextInt(gameRef.size.y ~/ 2).toDouble() + gameRef.size.y / 2.0;
+      final y =
+          r.nextInt(gameRef.size.y ~/ 2).toDouble() + gameRef.size.y / 2.0;
       spriteBatch.add(
         source: Rect.fromLTWH(sx, sy, 128, 128),
         offset: Vector2(x - 64, y - 64),

--- a/doc/examples/sprite_batch/lib/main_auto_loading.dart
+++ b/doc/examples/sprite_batch/lib/main_auto_loading.dart
@@ -1,0 +1,59 @@
+import 'dart:math';
+
+import 'package:flame/sprite_batch.dart';
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart';
+import 'package:flame/game.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final game = MyGame();
+  runApp(
+    GameWidget(
+      game: game,
+    ),
+  );
+}
+
+class MySpriteBatchComponent extends SpriteBatchComponent with HasGameRef<MyGame> {
+  @override
+  Future<void> onLoad() async {
+    spriteBatch = await gameRef.loadSpriteBatch('boom3.png');
+
+    spriteBatch.add(
+      source: const Rect.fromLTWH(128 * 4.0, 128 * 4.0, 64, 128),
+      offset: Vector2.all(200),
+      color: Colors.greenAccent,
+      scale: 2,
+      rotation: pi / 9.0,
+      anchor: Vector2.all(64),
+    );
+
+    spriteBatch.addTransform(
+      source: const Rect.fromLTWH(128 * 4.0, 128 * 4.0, 64, 128),
+      color: Colors.redAccent,
+    );
+
+    const NUM = 100;
+    final r = Random();
+    for (int i = 0; i < NUM; ++i) {
+      final sx = r.nextInt(8) * 128.0;
+      final sy = r.nextInt(8) * 128.0;
+      final x = r.nextInt(gameRef.size.x.toInt()).toDouble();
+      final y = r.nextInt(gameRef.size.y ~/ 2).toDouble() + gameRef.size.y / 2.0;
+      spriteBatch.add(
+        source: Rect.fromLTWH(sx, sy, 128, 128),
+        offset: Vector2(x - 64, y - 64),
+      );
+    }
+  }
+}
+
+class MyGame extends BaseGame {
+  SpriteBatch spriteBatch;
+
+  @override
+  Future<void> onLoad() async {
+    add(MySpriteBatchComponent());
+  }
+}

--- a/doc/images.md
+++ b/doc/images.md
@@ -146,7 +146,7 @@ You render it with a `Canvas` and an optional `Paint`, `BlendMode` and `CullRect
 
 A `SpriteBatchComponent` is also available for your convenience.
 
-See examples [here](https://github.com/flame-engine/flame/tree/master/doc/examples/sprite_batch).
+See the examples [here](https://github.com/flame-engine/flame/tree/master/doc/examples/sprite_batch).
 
 ## Composition
 

--- a/doc/images.md
+++ b/doc/images.md
@@ -146,7 +146,7 @@ You render it with a `Canvas` and an optional `Paint`, `BlendMode` and `CullRect
 
 A `SpriteBatchComponent` is also available for your convenience.
 
-See example [here](https://github.com/flame-engine/flame/tree/master/doc/examples/sprite_batch).
+See examples [here](https://github.com/flame-engine/flame/tree/master/doc/examples/sprite_batch).
 
 ## Composition
 

--- a/lib/src/components/sprite_batch_component.dart
+++ b/lib/src/components/sprite_batch_component.dart
@@ -4,10 +4,13 @@ import '../sprite_batch.dart';
 import 'component.dart';
 
 class SpriteBatchComponent extends Component {
-  final SpriteBatch spriteBatch;
+  SpriteBatch spriteBatch;
   BlendMode blendMode;
   Rect cullRect;
   Paint paint;
+
+  /// Creates a component with an empty sprite batch which can be set later
+  SpriteBatchComponent();
 
   SpriteBatchComponent.fromSpriteBatch(
     this.spriteBatch, {
@@ -18,7 +21,7 @@ class SpriteBatchComponent extends Component {
 
   @override
   void render(Canvas canvas) {
-    spriteBatch.render(
+    spriteBatch?.render(
       canvas,
       blendMode: blendMode,
       cullRect: cullRect,


### PR DESCRIPTION
# Description

Making SpriteBatchComponent constructor be more in the standard followed by SpriteComponent and SpriteAnimationComponent allowing a better use of the onLoad method on the component

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
