### PR TITLE
Added Color and Image extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
  - Adapting SpriteBatchComponent constructors to match the pattern used on other components
  - Renamed `Composition` to `ImageComposition` to prevent confusion with the composition component
  - Added `rotation` and `anchor` arguments to `ImageComposition.add`
+ - Added `Image` extensions
+ - Added `Color` extensions
 
 ## 1.0.0-rc6
  - Use `Offset` type directly in `JoystickAction.update` calculations

--- a/lib/extensions.dart
+++ b/lib/extensions.dart
@@ -1,4 +1,6 @@
 export 'src/extensions/canvas.dart';
+export 'src/extensions/color.dart';
+export 'src/extensions/image.dart';
 export 'src/extensions/offset.dart';
 export 'src/extensions/rect.dart';
 export 'src/extensions/size.dart';

--- a/lib/image_composition.dart
+++ b/lib/image_composition.dart
@@ -86,26 +86,19 @@ class ImageComposition {
   }) {
     assert(image != null, 'Image is required to add to the Atlas');
     assert(position != null, 'Position is required');
-    assert(
-      source == null ||
-          source.width <= image.width &&
-              source.height <= image.height &&
-              source.top + source.height <= image.height &&
-              source.top >= 0 &&
-              source.left + source.width <= image.width &&
-              source.left >= 0,
-      'Source rect should fit within in the image constraints',
-    );
-    assert(angle != null, 'rotation can not be null');
+    assert(angle != null, 'angle can not be null');
+
+    final imageRect = image.getBoundingRect();
+    source ??= imageRect;
+    anchor ??= source.toVector2() / 2;
     blendMode ??= defaultBlendMode;
     isAntiAlias ??= defaultAntiAlias;
-    source ??= Rect.fromLTWH(
-      0,
-      0,
-      image.width.toDouble(),
-      image.height.toDouble(),
+
+    assert(
+      imageRect.contains(source.topLeft) &&
+          imageRect.contains(source.bottomRight),
+      'Source rect should fit within in the image constraints',
     );
-    anchor ??= source.toVector2() / 2;
 
     _composes.add(_Composed(
         image, position, source, angle, anchor, isAntiAlias, blendMode));

--- a/lib/src/extensions/color.dart
+++ b/lib/src/extensions/color.dart
@@ -1,0 +1,38 @@
+import 'dart:ui';
+
+export 'dart:ui' show Color;
+
+extension ColorExtension on Color {
+  /// Darken the shade of the color by the [amount].
+  ///
+  /// [amount] is a double between 0 and 1.
+  ///
+  /// Based on: https://stackoverflow.com/a/60191441.
+  Color darken(double amount) {
+    assert(amount >= 0 && amount <= 1);
+
+    final f = 1 - amount;
+    return Color.fromARGB(
+      alpha,
+      (red * f).round(),
+      (green * f).round(),
+      (blue * f).round(),
+    );
+  }
+
+  /// Brighten the shade of the color by the [amount].
+  ///
+  /// [amount] is a double between 0 and 1.
+  ///
+  /// Based on: https://stackoverflow.com/a/60191441.
+  Color brighten(double amount) {
+    assert(amount >= 0 && amount <= 1);
+
+    return Color.fromARGB(
+      alpha,
+      red + ((255 - red) * amount).round(),
+      green + ((255 - green) * amount).round(),
+      blue + ((255 - blue) * amount).round(),
+    );
+  }
+}

--- a/lib/src/extensions/image.dart
+++ b/lib/src/extensions/image.dart
@@ -1,0 +1,73 @@
+import 'dart:typed_data';
+import 'dart:ui';
+
+import '../flame.dart';
+import 'color.dart';
+
+export 'dart:ui' show Image;
+
+extension ImageExtension on Image {
+  /// Helper method for retrieve the pixel data in a Uint8 format.
+  ///
+  /// Pixel order used the [ImageByteFormat.rawRgba] meaning it is: R G B A.
+  Future<Uint8List> pixelsInUint8() async {
+    return (await toByteData()).buffer.asUint8List();
+  }
+
+  /// Returns the bounding [Rect] of the image.
+  Rect getBoundingRect() {
+    return Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble());
+  }
+
+  /// Change each pixel's color to be darker and return a new [Image].
+  ///
+  /// The [amount] is a double value between 0 and 1.
+  Future<Image> darken(double amount) async {
+    assert(amount >= 0 && amount <= 1);
+
+    final pixelData = await pixelsInUint8();
+    final newPixelData = Uint8List(pixelData.length);
+
+    for (var i = 0; i < pixelData.length; i += 4) {
+      final color = Color.fromARGB(
+        pixelData[i + 3],
+        pixelData[i + 0],
+        pixelData[i + 1],
+        pixelData[i + 2],
+      ).darken(amount);
+
+      newPixelData[i] = color.red;
+      newPixelData[i + 1] = color.green;
+      newPixelData[i + 2] = color.blue;
+      newPixelData[i + 3] = color.alpha;
+    }
+
+    return Flame.images.decodeImageFromPixels(newPixelData, width, height);
+  }
+
+  /// Change each pixel's color to be brighter and return a new [Image].
+  ///
+  /// The [amount] is a double value between 0 and 1.
+  Future<Image> brighten(double amount) async {
+    assert(amount >= 0 && amount <= 1);
+
+    final pixelData = await pixelsInUint8();
+    final newPixelData = Uint8List(pixelData.length);
+
+    for (var i = 0; i < pixelData.length; i += 4) {
+      final color = Color.fromARGB(
+        pixelData[i + 3],
+        pixelData[i + 0],
+        pixelData[i + 1],
+        pixelData[i + 2],
+      ).brighten(amount);
+
+      newPixelData[i] = color.red;
+      newPixelData[i + 1] = color.green;
+      newPixelData[i + 2] = color.blue;
+      newPixelData[i + 3] = color.alpha;
+    }
+
+    return Flame.images.decodeImageFromPixels(newPixelData, width, height);
+  }
+}


### PR DESCRIPTION
# Description

Follow up PR from https://github.com/flame-engine/flame/pull/646#discussion_r569535816, introducing an image extension and color extension.

I also added a few methods that I personally use, so if any of those are deemed unnecessary in the context of Flame then I am okay with removing them.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
