### PR TITLE
Migrate RaisedButton -> ElevatedButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Enabling direct import of Sprite and SpriteAnimation
  - Renamed `Composition` to `ImageComposition` to prevent confusion with the composition component
  - Added `rotation` and `anchor` arguments to `ImageComposition.add`
+ - Change RaisedButton to ElevatedButton in timer example
 
 ## 1.0.0-rc6
  - Use `Offset` type directly in `JoystickAction.update` calculations

--- a/doc/examples/timer/lib/main.dart
+++ b/doc/examples/timer/lib/main.dart
@@ -12,12 +12,12 @@ class MyGameApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(routes: {
       '/': (BuildContext context) => Column(children: [
-            RaisedButton(
+            ElevatedButton(
                 child: const Text('Game'),
                 onPressed: () {
                   Navigator.of(context).pushNamed('/game');
                 }),
-            RaisedButton(
+            ElevatedButton(
                 child: const Text('BaseGame'),
                 onPressed: () {
                   Navigator.of(context).pushNamed('/base_game');


### PR DESCRIPTION
# Description

Flutter has deprecated RaisedButton, so this PR just changes our timer example to use the ElevatedButton instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] I have made corresponding changes to the documentation
- [x] I have added examples for new features in `doc/examples`
- [x] The continuous integration (CI) is passing
