### PR TITLE
Fix flame to be compatible with audioplayers breaking change, also re…

### DIFF
--- a/lib/audio_pool.dart
+++ b/lib/audio_pool.dart
@@ -25,7 +25,7 @@ class AudioPool {
       {this.repeating = false,
       this.maxPlayers = 1,
       this.minPlayers = 1,
-      String prefix = 'audio/sfx/'}) {
+      String prefix = 'assets/audio/sfx/'}) {
     cache = AudioCache(prefix: prefix);
   }
 

--- a/lib/flame_audio.dart
+++ b/lib/flame_audio.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 
 /// Handles flame audio functions
 class FlameAudio {
-  AudioCache audioCache = AudioCache(prefix: 'audio/');
+  AudioCache audioCache = AudioCache(prefix: 'assets/audio/');
 
   /// Plays a single run of the given [file]
   Future<AudioPlayer> play(String file, {volume = 1.0}) {

--- a/lib/game/game_render_box.dart
+++ b/lib/game/game_render_box.dart
@@ -77,11 +77,10 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
     WidgetsBinding.instance.removeObserver(this);
   }
 
-  @override
+  // TODO(luan): this was added to flutter beta but pub is still using an old version to lint
+  // in this state it will work for all flutter channels until stable catches up
+  // ignore: annotate_overrides
   void didChangeAppLifecycleState(AppLifecycleState state) {
     game.lifecycleStateChange(state);
   }
-
-  @override
-  Size computeDryLayout(BoxConstraints constraints) => constraints.biggest;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ dependencies:
     sdk: flutter
   audioplayers: ^0.17.1
   ordered_set: ^2.0.1
-  path_provider: ^1.6.24
   box2d_flame: ^0.4.6
   synchronized: ^2.1.0
   convert: ^2.0.1


### PR DESCRIPTION
This fixes https://github.com/flame-engine/flame/issues/657 for v0.

I will fix the analogous issue on flame_audio once we release rc7 and I can add an example to the new app.

Note: I am also removing path provider so that pub accepts that we support web (as we discussed).

After merging this I will release a next patch version.