### PR TITLE
Make the anchor class look more like an enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
  - Overhaul the draggables api to fix issues relating to local vs global positions
  - Preventing errors caused by the premature use of size property on game
  - Fix `SpriteAnimationComponent.shouldRemove` use `Component.shouldRemove`
+ - Add utility methods to the Anchor class to make it more "enum like"
 
 ## 1.0.0-rc6
  - Use `Offset` type directly in `JoystickAction.update` calculations

--- a/lib/src/anchor.dart
+++ b/lib/src/anchor.dart
@@ -1,29 +1,61 @@
 import 'extensions/vector2.dart';
 
+/// Represents a relative position inside some 2D object with a rectangular
+/// size or bounding box.
+///
+/// Think of it as the place where you "grab" or "hold" the object.
+/// In Components, the Anchor is where the component position is measured from.
+/// For example, if a component position is (100, 100) the anchor reflects what
+/// exact point of the component that is positioned at (100, 100), as a relative
+/// fraction of the size of the object.
+///
+/// The "default" anchor in most cases is topLeft.
+///
+/// The Anchor is represented by a fraction of the size (in each axis),
+///  where 0 means top/left and 1 means right/bottom.
 class Anchor {
-  static const Anchor topLeft = Anchor(0.0, 0.0);
-  static const Anchor topCenter = Anchor(0.5, 0.0);
-  static const Anchor topRight = Anchor(1.0, 0.0);
-  static const Anchor centerLeft = Anchor(0.0, 0.5);
-  static const Anchor center = Anchor(0.5, 0.5);
-  static const Anchor centerRight = Anchor(1.0, 0.5);
-  static const Anchor bottomLeft = Anchor(0.0, 1.0);
-  static const Anchor bottomCenter = Anchor(0.5, 1.0);
-  static const Anchor bottomRight = Anchor(1.0, 1.0);
+  static const Anchor topLeft = Anchor._(0.0, 0.0);
+  static const Anchor topCenter = Anchor._(0.5, 0.0);
+  static const Anchor topRight = Anchor._(1.0, 0.0);
+  static const Anchor centerLeft = Anchor._(0.0, 0.5);
+  static const Anchor center = Anchor._(0.5, 0.5);
+  static const Anchor centerRight = Anchor._(1.0, 0.5);
+  static const Anchor bottomLeft = Anchor._(0.0, 1.0);
+  static const Anchor bottomCenter = Anchor._(0.5, 1.0);
+  static const Anchor bottomRight = Anchor._(1.0, 1.0);
 
+  /// The relative x position with respect to the object's width;
+  /// 0 means totally to the left (beginning) and 1 means totally to the
+  /// right (end).
   final double x;
+
+  /// The relative y position with respect to the object's height;
+  /// 0 means totally to the top (beginning) and 1 means totally to the
+  /// bottom (end).
   final double y;
 
+  /// Returns [x] and [y] as a Vector2. Note that this is still a relative
+  /// fractional representation.
   Vector2 get toVector2 => Vector2(x, y);
 
-  const Anchor(this.x, this.y);
+  /// Consider Anchor a sealed class (or more specifically an enum).
+  const Anchor._(this.x, this.y);
 
   Vector2 translate(Vector2 p, Vector2 size) {
     return p - (toVector2..multiply(size));
   }
 
+  /// Returns a string representation of this Anchor.
+  ///
+  /// This should only be used for serialization purposes.
+  String get name => _valueNames[this];
+
+  /// Returns a string representation of this Anchor.
+  ///
+  /// This is the same as `name` and should be used only for debugging or
+  /// serialization.
   @override
-  String toString() => _valueNames[this];
+  String toString() => name;
 
   static final Map<Anchor, String> _valueNames = {
     topLeft: 'topLeft',
@@ -37,8 +69,13 @@ class Anchor {
     bottomRight: 'bottomRight',
   };
 
+  /// List of all possible anchor values.
   static final List<Anchor> values = _valueNames.keys.toList();
 
+  /// This should only be used for de-serialization purposes.
+  ///
+  /// If you need to convert anchors to serializable data (like JSON),
+  /// use the `toString()` and `valueOf` methods.
   static Anchor valueOf(String name) {
     return _valueNames.entries.singleWhere((e) => e.value == name).key;
   }

--- a/lib/src/anchor.dart
+++ b/lib/src/anchor.dart
@@ -22,6 +22,9 @@ class Anchor {
     return p - (toVector2..multiply(size));
   }
 
+  @override
+  String toString() => _valueNames[this];
+
   static final Map<Anchor, String> _valueNames = {
     topLeft: 'topLeft',
     topCenter: 'topCenter',
@@ -36,12 +39,7 @@ class Anchor {
 
   static final List<Anchor> values = _valueNames.keys.toList();
 
-  @override
-  String toString() {
-    return _valueNames[this];
-  }
-
-  static Anchor parse(String name) {
+  static Anchor valueOf(String name) {
     return _valueNames.entries.singleWhere((e) => e.value == name).key;
   }
 }

--- a/lib/src/anchor.dart
+++ b/lib/src/anchor.dart
@@ -21,4 +21,27 @@ class Anchor {
   Vector2 translate(Vector2 p, Vector2 size) {
     return p - (toVector2..multiply(size));
   }
+
+  static final Map<Anchor, String> _valueNames = {
+    topLeft: 'topLeft',
+    topCenter: 'topCenter',
+    topRight: 'topRight',
+    centerLeft: 'centerLeft',
+    center: 'center',
+    centerRight: 'centerRight',
+    bottomLeft: 'bottomLeft',
+    bottomCenter: 'bottomCenter',
+    bottomRight: 'bottomRight',
+  };
+
+  static final List<Anchor> values = _valueNames.keys.toList();
+
+  @override
+  String toString() {
+    return _valueNames[this];
+  }
+
+  static Anchor parse(String name) {
+    return _valueNames.entries.singleWhere((e) => e.value == name).key;
+  }
 }

--- a/test/anchor_test.dart
+++ b/test/anchor_test.dart
@@ -1,0 +1,18 @@
+import 'package:flame/src/anchor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Anchor', () {
+    test('can parse to and from string', () async {
+      expect(Anchor.center.toString(), 'center');
+      expect(Anchor.parse('topRight'), Anchor.topRight);
+
+      expect(Anchor.values.length, 9);
+
+      for (final value in Anchor.values) {
+        final thereAndBack = Anchor.parse(value.toString());
+        expect(thereAndBack, value);
+      }
+    });
+  });
+}

--- a/test/anchor_test.dart
+++ b/test/anchor_test.dart
@@ -5,12 +5,12 @@ void main() {
   group('Anchor', () {
     test('can parse to and from string', () async {
       expect(Anchor.center.toString(), 'center');
-      expect(Anchor.parse('topRight'), Anchor.topRight);
+      expect(Anchor.valueOf('topRight'), Anchor.topRight);
 
       expect(Anchor.values.length, 9);
 
       for (final value in Anchor.values) {
-        final thereAndBack = Anchor.parse(value.toString());
+        final thereAndBack = Anchor.valueOf(value.toString());
         expect(thereAndBack, value);
       }
     });


### PR DESCRIPTION
Anchor should really be an enum, but sadly enums in dart are not as sophisticated as java, so we need a class. However dealing with it was not easy because there was no standard way to treat it like a bounded collection of items, so I am adding some common enum helper methods to Anchor to make that integration easier.