### PR TITLE
Enable user-defined Anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  - Fix `SpriteAnimationComponent.shouldRemove` use `Component.shouldRemove`
  - Add assertion to make sure Draggables are safe to add
  - Add utility methods to the Anchor class to make it more "enum like"
+ - Enable user-defined anchors
 
 ## 1.0.0-rc6
  - Use `Offset` type directly in `JoystickAction.update` calculations

--- a/lib/src/anchor.dart
+++ b/lib/src/anchor.dart
@@ -12,17 +12,18 @@ import 'extensions/vector2.dart';
 /// The "default" anchor in most cases is topLeft.
 ///
 /// The Anchor is represented by a fraction of the size (in each axis),
-///  where 0 means top/left and 1 means right/bottom.
+/// where 0 in x-axis means left, 0 in y-axis means top, 1 in x-axis means right
+/// and 1 in y-axis means bottom.
 class Anchor {
-  static const Anchor topLeft = Anchor._(0.0, 0.0);
-  static const Anchor topCenter = Anchor._(0.5, 0.0);
-  static const Anchor topRight = Anchor._(1.0, 0.0);
-  static const Anchor centerLeft = Anchor._(0.0, 0.5);
-  static const Anchor center = Anchor._(0.5, 0.5);
-  static const Anchor centerRight = Anchor._(1.0, 0.5);
-  static const Anchor bottomLeft = Anchor._(0.0, 1.0);
-  static const Anchor bottomCenter = Anchor._(0.5, 1.0);
-  static const Anchor bottomRight = Anchor._(1.0, 1.0);
+  static const Anchor topLeft = Anchor(0.0, 0.0);
+  static const Anchor topCenter = Anchor(0.5, 0.0);
+  static const Anchor topRight = Anchor(1.0, 0.0);
+  static const Anchor centerLeft = Anchor(0.0, 0.5);
+  static const Anchor center = Anchor(0.5, 0.5);
+  static const Anchor centerRight = Anchor(1.0, 0.5);
+  static const Anchor bottomLeft = Anchor(0.0, 1.0);
+  static const Anchor bottomCenter = Anchor(0.5, 1.0);
+  static const Anchor bottomRight = Anchor(1.0, 1.0);
 
   /// The relative x position with respect to the object's width;
   /// 0 means totally to the left (beginning) and 1 means totally to the
@@ -38,8 +39,7 @@ class Anchor {
   /// fractional representation.
   Vector2 get toVector2 => Vector2(x, y);
 
-  /// Consider Anchor a sealed class (or more specifically an enum).
-  const Anchor._(this.x, this.y);
+  const Anchor(this.x, this.y);
 
   /// If the position sent in is position for the anchor and the size is the
   /// size of the component (or whatever you are using the Anchor on), the
@@ -51,7 +51,9 @@ class Anchor {
   /// Returns a string representation of this Anchor.
   ///
   /// This should only be used for serialization purposes.
-  String get name => _valueNames[this];
+  String get name {
+    return _valueNames.containsKey(this) ? _valueNames[this] : 'Anchor($x, $y)'; 
+  }
 
   /// Returns a string representation of this Anchor.
   ///
@@ -72,7 +74,7 @@ class Anchor {
     bottomRight: 'bottomRight',
   };
 
-  /// List of all possible anchor values.
+  /// List of all predefined anchor values.
   static final List<Anchor> values = _valueNames.keys.toList();
 
   /// This should only be used for de-serialization purposes.
@@ -80,6 +82,21 @@ class Anchor {
   /// If you need to convert anchors to serializable data (like JSON),
   /// use the `toString()` and `valueOf` methods.
   static Anchor valueOf(String name) {
-    return _valueNames.entries.singleWhere((e) => e.value == name).key;
+    if(_valueNames.containsValue(name)) {
+      return _valueNames.entries.singleWhere((e) => e.value == name).key;
+    } else {
+      final regexp = RegExp(r"^\Anchor\(([^,]+), ([^\)]+)\)");
+      final matches = regexp.allMatches(name).first.group;
+      assert(matches != null, "Bad Anchor format");
+      return Anchor(double.parse(matches(1)), double.parse(matches(2)));
+    }
   }
+  
+  @override
+  bool operator ==(Object other) {
+    return other is Anchor && hashCode == other.hashCode;
+  }
+
+  @override
+  int get hashCode => x.hashCode * 31 + y.hashCode;
 }

--- a/lib/src/anchor.dart
+++ b/lib/src/anchor.dart
@@ -37,15 +37,12 @@ class Anchor {
 
   /// Returns [x] and [y] as a Vector2. Note that this is still a relative
   /// fractional representation.
-  Vector2 get toVector2 => Vector2(x, y);
+  Vector2 toVector2() => Vector2(x, y);
 
   const Anchor(this.x, this.y);
 
-  /// If the position sent in is position for the anchor and the size is the
-  /// size of the component (or whatever you are using the Anchor on), the
-  /// result of [translate] will be the top left position
-  Vector2 translate(Vector2 position, Vector2 size) {
-    return position - (toVector2..multiply(size));
+  Vector2 translate(Vector2 p, Vector2 size) {
+    return p - (toVector2()..multiply(size));
   }
 
   /// Returns a string representation of this Anchor.

--- a/lib/src/anchor.dart
+++ b/lib/src/anchor.dart
@@ -52,7 +52,7 @@ class Anchor {
   ///
   /// This should only be used for serialization purposes.
   String get name {
-    return _valueNames.containsKey(this) ? _valueNames[this] : 'Anchor($x, $y)'; 
+    return _valueNames.containsKey(this) ? _valueNames[this] : 'Anchor($x, $y)';
   }
 
   /// Returns a string representation of this Anchor.
@@ -82,7 +82,7 @@ class Anchor {
   /// If you need to convert anchors to serializable data (like JSON),
   /// use the `toString()` and `valueOf` methods.
   static Anchor valueOf(String name) {
-    if(_valueNames.containsValue(name)) {
+    if (_valueNames.containsValue(name)) {
       return _valueNames.entries.singleWhere((e) => e.value == name).key;
     } else {
       final regexp = RegExp(r"^\Anchor\(([^,]+), ([^\)]+)\)");
@@ -91,7 +91,7 @@ class Anchor {
       return Anchor(double.parse(matches(1)), double.parse(matches(2)));
     }
   }
-  
+
   @override
   bool operator ==(Object other) {
     return other is Anchor && hashCode == other.hashCode;

--- a/lib/src/components/position_component.dart
+++ b/lib/src/components/position_component.dart
@@ -53,7 +53,7 @@ abstract class PositionComponent extends BaseComponent {
 
   /// Set the top left position regardless of the anchor
   set topLeftPosition(Vector2 position) {
-    this.position = position + (anchor.toVector2..multiply(size));
+    this.position = position + (anchor.toVector2()..multiply(size));
   }
 
   /// Get the absolute top left position regardless of whether it is a child or not
@@ -153,7 +153,7 @@ abstract class PositionComponent extends BaseComponent {
   void prepareCanvas(Canvas canvas) {
     canvas.translate(x, y);
     canvas.rotate(angle);
-    final Vector2 delta = -anchor.toVector2
+    final Vector2 delta = -anchor.toVector2()
       ..multiply(size);
     canvas.translate(delta.x, delta.y);
 

--- a/lib/src/sprite.dart
+++ b/lib/src/sprite.dart
@@ -69,7 +69,7 @@ class Sprite {
     final drawPosition = position ?? Vector2.zero();
     final drawSize = size ?? srcSize;
 
-    final delta = anchor.toVector2..multiply(drawSize);
+    final delta = anchor.toVector2()..multiply(drawSize);
     final drawRect = (drawPosition + delta).toPositionedRect(drawSize);
 
     final drawPaint = overridePaint ?? paint;

--- a/lib/src/widgets/sprite_widget.dart
+++ b/lib/src/widgets/sprite_widget.dart
@@ -51,7 +51,7 @@ class _SpritePainter extends CustomPainter {
     final rate = min(widthRate, heightRate);
 
     final paintSize = _sprite.srcSize * rate;
-    final anchorPosition = _anchor.toVector2;
+    final anchorPosition = _anchor.toVector2();
     final anchoredPosition = size.toVector2()..multiply(anchorPosition);
     final delta = (anchoredPosition - paintSize)..multiply(anchorPosition);
 

--- a/test/anchor_test.dart
+++ b/test/anchor_test.dart
@@ -14,5 +14,10 @@ void main() {
         expect(thereAndBack, value);
       }
     });
+
+    test('can parse custom anchor', () async {
+      expect(const Anchor(0.2, 0.2).toString(), 'Anchor(0.2, 0.2)');
+      expect(Anchor.valueOf('Anchor(0.2, 0.2)'), const Anchor(0.2, 0.2));
+    });
   });
 }


### PR DESCRIPTION
# Description

Enables so that the user can define the anchor, not just use our predefined values.

Fixes #674 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

If something is unclear, please submit the PR anyways and ask about what you thought was unclear.

- [x] This branch is based on the latest `master`
- [x] I have added an entry under `[next]` in `CHANGELOG.md`
- [x] I have formatted my code with `flutter format`
- [x] The continuous integration (CI) is passing
