### PR TITLE
New linter rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,29 +15,55 @@ linter:
     - always_put_control_body_on_new_line
     - always_require_non_null_named_parameters
     - annotate_overrides
+    - avoid_double_and_int_checks
+    - avoid_dynamic_calls
     - avoid_empty_else
+    - avoid_equals_and_hash_code_on_mutable_classes
+    - avoid_escaping_inner_quotes
     - avoid_field_initializers_in_const_classes
     - avoid_init_to_null
+    - avoid_js_rounded_ints
     - avoid_null_checks_in_equality_operators
+    - avoid_private_typedef_functions
+    - avoid_redundant_argument_values
     - avoid_relative_lib_imports
     - avoid_return_types_on_setters
+    - avoid_shadowing_type_parameters
     - avoid_slow_async_io
+    - avoid_type_to_string
+    - avoid_types_as_parameter_names
+    - avoid_unused_constructor_parameters
     - await_only_futures
+    - camel_case_extensions
     - camel_case_types
     - cancel_subscriptions
+    - cast_nullable_to_non_nullable
+    - close_sinks
+    - comment_references
+    - constant_identifier_names
     - control_flow_in_finally
+    - curly_braces_in_flow_control_structures
+    - directives_ordering
+    - do_not_use_environment
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
+    - exhaustive_cases
+    - file_names
     - hash_and_equals
     - implementation_imports
+    - invariant_booleans
     - iterable_contains_unrelated_type
+    - join_return_with_assignment
     - library_names
     - library_prefixes
     - list_remove_unrelated_type
+    - literal_only_boolean_expressions
+    - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
-    - non_constant_identifier_names
+    - no_runtimeType_toString
+    - omit_local_variable_types
     - package_api_docs
     - package_names
     - package_prefixed_library_names
@@ -78,6 +104,10 @@ linter:
 dart_code_metrics:
   rules:
     - prefer-trailing-comma
+    - prefer-trailing-comma-for-collection
+    - no-equal-then-else
+    - no-object-declaration
+    - potential-null-dereference
   metrics-exclude:
     - test/**
   metrics:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -67,39 +67,70 @@ linter:
     - package_api_docs
     - package_names
     - package_prefixed_library_names
+    - parameter_assignments
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     - prefer_contains
     - prefer_equal_for_default_values
     - prefer_final_fields
+    - prefer_final_in_for_each
     - prefer_final_locals
+    - prefer_for_elements_to_map_fromIterable
     - prefer_foreach
+    - prefer_function_declarations_over_variables
+    - prefer_generic_function_type_aliases
+    - prefer_if_elements_to_conditional_expressions
+    - prefer_if_null_operators
     - prefer_initializing_formals
+    - prefer_inlined_adds
+    - prefer_interpolation_to_compose_strings
     - prefer_is_empty
     - prefer_is_not_empty
+    - prefer_is_not_operator
+    - prefer_iterable_whereType
+    - prefer_mixin
+    - prefer_null_aware_operators
+    - prefer_single_quotes
+    - prefer_spread_collections
     - prefer_relative_imports
     - prefer_typing_uninitialized_variables
+    - prefer_void_to_null
+    - provide_deprecation_message
     - recursive_getters
     - slash_for_doc_comments
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally
+    - type_annotate_public_apis
     - type_init_formals
+    - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
+    - unnecessary_const
     - unnecessary_getters_setters
+    - unnecessary_lambdas
+    - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators
     - unnecessary_overrides
     - unnecessary_parenthesis
+    - unnecessary_raw_strings
+    - unnecessary_statements
+    - unnecessary_string_escapes
+    - unnecessary_string_interpolations
     - unnecessary_this
-    - unrelated_type_equality_checks
+    - use_full_hex_values_for_flutter_colors
+    - use_function_type_syntax_for_parameters
+    - use_is_even_rather_than_modulo
     - use_rethrow_when_possible
-    - unnecessary_new
+    - unrelated_type_equality_checks
+    - unsafe_html
+    - void_checks
 
 dart_code_metrics:
   rules:

--- a/doc/examples/collision_detection/lib/main.dart
+++ b/doc/examples/collision_detection/lib/main.dart
@@ -1,14 +1,12 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:flame/extensions.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
-import 'package:flame/extensions.dart';
 import 'package:flame/geometry.dart';
-
 import 'package:flutter/material.dart' hide Image, Draggable;
-
-import 'dart:ui';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -194,7 +192,7 @@ class MyGame extends BaseGame with HasCollidables, HasDraggableComponents {
     MyCollidable lastToAdd = snowman;
     add(screen);
     add(snowman);
-    int totalAdded = 1;
+    var totalAdded = 1;
     while (totalAdded < 20) {
       lastToAdd = createRandomCollidable(lastToAdd);
       final lastBottomRight =
@@ -219,7 +217,7 @@ class MyGame extends BaseGame with HasCollidables, HasDraggableComponents {
             _distance.x +
             collidableSize.x >
         size.x;
-    Vector2 position = _distance + Vector2(0, lastCollidable.position.y + 200);
+    var position = _distance + Vector2(0, lastCollidable.position.y + 200);
     if (!isXOverflow) {
       position = (lastCollidable.position + _distance)
         ..x += collidableSize.x / 2;

--- a/doc/examples/collision_detection/lib/main_simple.dart
+++ b/doc/examples/collision_detection/lib/main_simple.dart
@@ -1,13 +1,12 @@
+import 'dart:ui';
+
 import 'package:flame/components.dart';
+import 'package:flame/extensions.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
-import 'package:flame/extensions.dart';
 import 'package:flame/geometry.dart';
 import 'package:flame/gestures.dart';
-
 import 'package:flutter/material.dart' hide Image, Draggable;
-
-import 'dart:ui';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/doc/examples/gestures/lib/main_mouse_movement.dart
+++ b/doc/examples/gestures/lib/main_mouse_movement.dart
@@ -1,8 +1,9 @@
+import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
-import 'package:flutter/material.dart';
 import 'package:flame/gestures.dart';
 import 'package:flame/palette.dart';
-import 'package:flame/extensions.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 
 void main() {
   runApp(
@@ -23,7 +24,7 @@ class MyGame extends BaseGame with MouseMovementDetector {
   bool _onTarget = false;
 
   @override
-  void onMouseMove(event) {
+  void onMouseMove(PointerHoverEvent event) {
     target = event.localPosition.toVector2();
   }
 

--- a/doc/examples/gestures/lib/main_mouse_movement.dart
+++ b/doc/examples/gestures/lib/main_mouse_movement.dart
@@ -13,7 +13,7 @@ void main() {
 }
 
 class MyGame extends BaseGame with MouseMovementDetector {
-  static const SPEED = 200;
+  static const speed = 200.0;
 
   Vector2 position = Vector2(0, 0);
   Vector2 target;
@@ -51,7 +51,7 @@ class MyGame extends BaseGame with MouseMovementDetector {
 
       if (!_onTarget) {
         final dir = (target - position).normalized();
-        position += dir * (SPEED * dt);
+        position += dir * speed * dt;
       }
     }
   }

--- a/doc/examples/gestures/lib/main_scroll.dart
+++ b/doc/examples/gestures/lib/main_scroll.dart
@@ -14,7 +14,7 @@ void main() {
 }
 
 class MyGame extends BaseGame with ScrollDetector {
-  static const SPEED = 200;
+  static const speed = 200.0;
 
   Vector2 position = Vector2(0, 0);
   Vector2 target;
@@ -43,7 +43,7 @@ class MyGame extends BaseGame with ScrollDetector {
     super.update(dt);
     if (target != null) {
       final dir = (target - position).normalized();
-      position += dir * (SPEED * dt);
+      position += dir * speed * dt;
     }
   }
 }

--- a/doc/examples/gestures/lib/main_scroll.dart
+++ b/doc/examples/gestures/lib/main_scroll.dart
@@ -1,8 +1,9 @@
-import 'package:flutter/material.dart';
+import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
 import 'package:flame/gestures.dart';
 import 'package:flame/palette.dart';
-import 'package:flame/extensions.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 
 void main() {
   final game = MyGame();
@@ -20,7 +21,7 @@ class MyGame extends BaseGame with ScrollDetector {
   Vector2 target;
 
   @override
-  void onScroll(event) {
+  void onScroll(PointerScrollEvent event) {
     target = position - event.scrollDelta.toVector2();
   }
 

--- a/doc/examples/go_desktop/lib/game.dart
+++ b/doc/examples/go_desktop/lib/game.dart
@@ -20,23 +20,16 @@ class MyGame extends Game {
 
   void _start() {
     RawKeyboard.instance.addListener((RawKeyEvent e) {
-      final bool isKeyDown = e is RawKeyDownEvent;
-
+      final isKeyDown = e is RawKeyDownEvent;
       final keyLabel = e.data.logicalKey.keyLabel;
 
       if (keyLabel == 'a') {
         movingLeft = isKeyDown;
-      }
-
-      if (keyLabel == 'd') {
+      } else if (keyLabel == 'd') {
         movingRight = isKeyDown;
-      }
-
-      if (keyLabel == 'w') {
+      } else if (keyLabel == 'w') {
         movingUp = isKeyDown;
-      }
-
-      if (keyLabel == 's') {
+      } else if (keyLabel == 's') {
         movingDown = isKeyDown;
       }
     });

--- a/doc/examples/go_desktop/lib/game.dart
+++ b/doc/examples/go_desktop/lib/game.dart
@@ -6,10 +6,10 @@ import 'package:flutter/material.dart';
 class MyGame extends Game {
   static final Paint paint = Paint()..color = const Color(0xFFFFFFFF);
 
-  var movingLeft = false;
-  var movingRight = false;
-  var movingUp = false;
-  var movingDown = false;
+  bool movingLeft = false;
+  bool movingRight = false;
+  bool movingUp = false;
+  bool movingDown = false;
 
   double x = 0;
   double y = 0;

--- a/doc/examples/keyboard/lib/main.dart
+++ b/doc/examples/keyboard/lib/main.dart
@@ -31,7 +31,7 @@ class MyGame extends Game with KeyboardEvents {
   }
 
   @override
-  void onKeyEvent(e) {
+  void onKeyEvent(RawKeyEvent e) {
     final isKeyDown = e is RawKeyDownEvent;
     if (e.data.keyLabel == 'a') {
       _dir = isKeyDown ? -1 : 0;

--- a/doc/examples/keyboard/lib/main.dart
+++ b/doc/examples/keyboard/lib/main.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/material.dart';
+import 'dart:ui';
+
 import 'package:flame/game.dart';
 import 'package:flame/keyboard.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
-import 'dart:ui';
 
 void main() => runApp(
       GameWidget(
@@ -32,7 +32,7 @@ class MyGame extends Game with KeyboardEvents {
 
   @override
   void onKeyEvent(e) {
-    final bool isKeyDown = e is RawKeyDownEvent;
+    final isKeyDown = e is RawKeyDownEvent;
     if (e.data.keyLabel == 'a') {
       _dir = isKeyDown ? -1 : 0;
     } else if (e.data.keyLabel == 'd') {

--- a/doc/examples/layers/lib/main.dart
+++ b/doc/examples/layers/lib/main.dart
@@ -1,10 +1,9 @@
-import 'package:flame/components.dart';
-import 'package:flame/game.dart';
-import 'package:flame/flame.dart';
-import 'package:flame/layers.dart';
-
 import 'dart:ui';
 
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flame/game.dart';
+import 'package:flame/layers.dart';
 import 'package:flutter/widgets.dart';
 
 void main() async {

--- a/doc/examples/particles/lib/main.dart
+++ b/doc/examples/particles/lib/main.dart
@@ -178,7 +178,7 @@ class MyGame extends BaseGame {
   }
 
   /// Same example as above, but
-  /// with easing, utilising [CurvedParticle] extension
+  /// with easing, utilizing [CurvedParticle] extension
   Particle easedMovingParticle() {
     return Particle.generate(
       count: 5,
@@ -232,7 +232,7 @@ class MyGame extends BaseGame {
     );
   }
 
-  /// Using [ComputedParticle] to use custom tweening
+  /// Using [ComputedParticle] to provide a custom tween.
   /// In reality, you would like to keep as much of renderer state
   /// defined outside and reused between each call
   Particle steppedComputedParticle() {
@@ -419,7 +419,7 @@ class MyGame extends BaseGame {
       generator: (i) {
         final initialSpeed = randomCellOffset();
         final deceleration = initialSpeed * -1;
-        const gravity = const Offset(0, 40);
+        const gravity = Offset(0, 40);
 
         return AcceleratedParticle(
           speed: initialSpeed,
@@ -524,10 +524,7 @@ class MyGame extends BaseGame {
       columns: columns,
       rows: rows,
     );
-    final sprites = List<Sprite>.generate(
-      frames,
-      (i) => spritesheet.getSpriteById(i),
-    );
+    final sprites = List<Sprite>.generate(frames, spritesheet.getSpriteById);
 
     return SpriteAnimation.spriteList(sprites, stepTime: 0.1);
   }

--- a/doc/examples/particles/lib/main.dart
+++ b/doc/examples/particles/lib/main.dart
@@ -85,8 +85,8 @@ class MyGame extends BaseGame {
     // as per defined grid parameters
     do {
       final particle = particles.removeLast();
-      final double col = particles.length % gridSize;
-      final double row = (particles.length ~/ gridSize).toDouble();
+      final col = particles.length % gridSize;
+      final row = (particles.length ~/ gridSize).toDouble();
       final cellCenter =
           (cellSize.clone()..multiply(Vector2(col, row))) + (cellSize * .5);
 
@@ -193,7 +193,7 @@ class MyGame extends BaseGame {
     );
   }
 
-  /// Same example as above, but using awesome [Inverval]
+  /// Same example as above, but using awesome [Interval]
   /// curve, which "schedules" transition to happen between
   /// certain values of progress. In this example, circles will
   /// move from their initial to their final position
@@ -258,20 +258,19 @@ class MyGame extends BaseGame {
   }
 
   /// Particle which is used in example below
-  Particle reusablePatricle;
+  Particle reusableParticle;
 
   /// A burst of white circles which actually using a single circle
   /// as a form of optimization. Look for reusing parts of particle effects
   /// whenever possible, as there are limits which are relatively easy to reach.
   Particle reuseParticles() {
-    reusablePatricle ??= circle();
+    reusableParticle ??= circle();
 
     return Particle.generate(
-      count: 10,
       generator: (i) => MovingParticle(
         curve: Interval(rnd.nextDouble() * .1, rnd.nextDouble() * .8 + .1),
         to: randomCellOffset() * .5,
-        child: reusablePatricle,
+        child: reusableParticle,
       ),
     );
   }
@@ -326,7 +325,6 @@ class MyGame extends BaseGame {
   /// some non-linearity to something like [MovingParticle]
   Particle acceleratedParticles() {
     return Particle.generate(
-      count: 10,
       generator: (i) => AcceleratedParticle(
         speed:
             Offset(rnd.nextDouble() * 600 - 300, -rnd.nextDouble() * 600) * .2,
@@ -341,12 +339,12 @@ class MyGame extends BaseGame {
   /// Be aware that it's very easy to get *really* bad performance
   /// misusing composites.
   Particle paintParticle() {
-    final List<Color> colors = [
+    final colors = [
       const Color(0xffff0000),
       const Color(0xff00ff00),
       const Color(0xff0000ff),
     ];
-    final List<Offset> positions = [
+    final positions = [
       const Offset(-10, 10),
       const Offset(10, 10),
       const Offset(0, -14),
@@ -404,8 +402,8 @@ class MyGame extends BaseGame {
   /// use of [ComputedParticle] within other particles,
   /// mixing predefined and fully custom behavior.
   Particle fireworkParticle() {
-    // A pallete to paint over the "sky"
-    final List<Paint> paints = [
+    // A palette to paint over the "sky"
+    final paints = [
       Colors.amber,
       Colors.amberAccent,
       Colors.red,
@@ -418,7 +416,6 @@ class MyGame extends BaseGame {
     ].map<Paint>((color) => Paint()..color = color).toList();
 
     return Particle.generate(
-      count: 10,
       generator: (i) {
         final initialSpeed = randomCellOffset();
         final deceleration = initialSpeed * -1;

--- a/doc/examples/render_flip/lib/main.dart
+++ b/doc/examples/render_flip/lib/main.dart
@@ -1,7 +1,8 @@
+import 'dart:ui';
+
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart' hide Image;
-import 'dart:ui';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/doc/examples/sprite_batch/lib/main.dart
+++ b/doc/examples/sprite_batch/lib/main.dart
@@ -36,9 +36,9 @@ class MyGame extends BaseGame {
       color: Colors.redAccent,
     );
 
-    const NUM = 100;
+    const num = 100;
     final r = Random();
-    for (int i = 0; i < NUM; ++i) {
+    for (var i = 0; i < num; ++i) {
       final sx = r.nextInt(8) * 128.0;
       final sy = r.nextInt(8) * 128.0;
       final x = r.nextInt(size.x.toInt()).toDouble();
@@ -49,9 +49,11 @@ class MyGame extends BaseGame {
       );
     }
 
-    add(SpriteBatchComponent.fromSpriteBatch(
-      spriteBatch,
-      blendMode: BlendMode.srcOver,
-    ));
+    add(
+      SpriteBatchComponent.fromSpriteBatch(
+        spriteBatch,
+        blendMode: BlendMode.srcOver,
+      ),
+    );
   }
 }

--- a/doc/examples/sprite_batch/lib/main_auto_loading.dart
+++ b/doc/examples/sprite_batch/lib/main_auto_loading.dart
@@ -35,9 +35,9 @@ class MySpriteBatchComponent extends SpriteBatchComponent
       color: Colors.redAccent,
     );
 
-    const NUM = 100;
+    const num = 100;
     final r = Random();
-    for (int i = 0; i < NUM; ++i) {
+    for (var i = 0; i < num; ++i) {
       final sx = r.nextInt(8) * 128.0;
       final sy = r.nextInt(8) * 128.0;
       final x = r.nextInt(gameRef.size.x.toInt()).toDouble();

--- a/doc/examples/sprites/lib/main_base64.dart
+++ b/doc/examples/sprites/lib/main_base64.dart
@@ -1,8 +1,7 @@
-import 'package:flame/components.dart';
-import 'package:flame/game.dart';
-
 import 'dart:ui';
 
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {

--- a/doc/examples/sprites/lib/main_base64.dart
+++ b/doc/examples/sprites/lib/main_base64.dart
@@ -24,7 +24,7 @@ class MyGame extends Game {
   }
 
   @override
-  void update(dt) {}
+  void update(double dt) {}
 
   @override
   void render(Canvas canvas) {

--- a/doc/examples/text/lib/main.dart
+++ b/doc/examples/text/lib/main.dart
@@ -30,10 +30,10 @@ class MyTextBox extends TextBoxComponent {
 
   @override
   void drawBackground(Canvas c) {
-    final Rect rect = Rect.fromLTWH(0, 0, width, height);
+    final rect = Rect.fromLTWH(0, 0, width, height);
     c.drawRect(rect, Paint()..color = const Color(0xFFFF00FF));
     final margin = boxConfig.margins;
-    final Rect innerRect = Rect.fromLTWH(
+    final innerRect = Rect.fromLTWH(
       margin.left,
       margin.top,
       width - margin.horizontal,

--- a/doc/examples/widgets/lib/main.dart
+++ b/doc/examples/widgets/lib/main.dart
@@ -1,9 +1,9 @@
+import 'package:dashbook/dashbook.dart';
 import 'package:flame/extensions.dart';
-import 'package:flame/widgets.dart';
-import 'package:flutter/material.dart' hide Animation;
 import 'package:flame/flame.dart';
 import 'package:flame/sprite.dart';
-import 'package:dashbook/dashbook.dart';
+import 'package:flame/widgets.dart';
+import 'package:flutter/material.dart' hide Animation;
 
 Anchor parseAnchor(String name) {
   switch (name) {
@@ -118,7 +118,6 @@ void main() async {
     row: 0,
     stepTime: 0.2,
     to: 3,
-    loop: true,
   );
   dashbook.storiesOf('SpriteAnimationWidget').decorator(CenterDecorator()).add(
         'default',

--- a/doc/examples/widgets/lib/main.dart
+++ b/doc/examples/widgets/lib/main.dart
@@ -27,7 +27,7 @@ Anchor parseAnchor(String name) {
       return Anchor.bottomRight;
   }
 
-  throw Exception("Cannot parse anchor name `$name`");
+  throw Exception('Cannot parse anchor name `$name`');
 }
 
 void main() async {
@@ -46,10 +46,10 @@ void main() async {
             tileSize: 16,
             destTileSize: 50,
             child: const Center(
-              child: const Text(
+              child: Text(
                 'Cool label',
-                style: const TextStyle(
-                  color: const Color(0xFFFFFFFF),
+                style: TextStyle(
+                  color: Color(0xFFFFFFFF),
                 ),
               ),
             ),
@@ -72,7 +72,7 @@ void main() async {
             },
             label: const Text(
               'Sprite Button',
-              style: const TextStyle(color: const Color(0xFF5D275D)),
+              style: TextStyle(color: Color(0xFF5D275D)),
             ),
             sprite: _buttons.getSprite(0, 0),
             pressedSprite: _buttons.getSprite(1, 0),

--- a/doc/examples/with_widgets_overlay/lib/main.dart
+++ b/doc/examples/with_widgets_overlay/lib/main.dart
@@ -10,14 +10,14 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       home: MyHomePage(),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key}) : super(key: key);
+  const MyHomePage({Key key}) : super(key: key);
 
   @override
   _MyHomePageState createState() => _MyHomePageState();
@@ -33,7 +33,7 @@ class _MyHomePageState extends State<MyHomePage> {
         height: 100,
         color: const Color(0xFFFF0000),
         child: const Center(
-          child: const Text('Paused'),
+          child: Text('Paused'),
         ),
       ),
     );
@@ -50,12 +50,12 @@ class _MyHomePageState extends State<MyHomePage> {
           : GameWidget<ExampleGame>(
               game: _myGame,
               overlayBuilderMap: {
-                "PauseMenu": pauseMenuBuilder,
+                'PauseMenu': pauseMenuBuilder,
               },
               initialActiveOverlays: const ['PauseMenu'],
             ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => newGame(),
+        onPressed: newGame,
         child: const Icon(Icons.add),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -62,7 +62,7 @@ class MyGame extends BaseGame with DoubleTapDetector, TapDetector {
   }
 
   @override
-  void onTapUp(details) {
+  void onTapUp(TapUpDetails details) {
     final touchArea = Rect.fromCenter(
       center: details.localPosition,
       width: 20,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,8 +21,10 @@ class Palette {
   static const PaletteEntry blue = PaletteEntry(Color(0xFF0000FF));
 }
 
-class Square extends PositionComponent with HasGameRef<MyGame> {
-  static const SPEED = 0.25;
+class Square extends PositionComponent {
+  static const speed = 0.25;
+  static const squareSize = 128.0;
+
   static Paint white = Palette.white.paint;
   static Paint red = Palette.red.paint;
   static Paint blue = Palette.blue.paint;
@@ -36,23 +38,21 @@ class Square extends PositionComponent with HasGameRef<MyGame> {
     c.drawRect(Rect.fromLTWH(width / 2, height / 2, 3, 3), blue);
   }
 
-  @override
   void update(double dt) {
     super.update(dt);
-    angle += SPEED * dt;
+    angle += speed * t;
     angle %= 2 * math.pi;
   }
 
   @override
   void onMount() {
     super.onMount();
-    size = Vector2.all(gameRef.squareSize);
+    size = Vector2.all(squareSize);
     anchor = Anchor.center;
   }
 }
 
 class MyGame extends BaseGame with DoubleTapDetector, TapDetector {
-  final double squareSize = 128;
   bool running = true;
 
   MyGame() {
@@ -69,12 +69,12 @@ class MyGame extends BaseGame with DoubleTapDetector, TapDetector {
       height: 20,
     );
 
-    bool handled = false;
-    components.forEach((c) {
+    final handled = components.any((c) {
       if (c is PositionComponent && c.toRect().overlaps(touchArea)) {
-        handled = true;
         remove(c);
+        return true;
       }
+      return false;
     });
 
     if (!handled) {

--- a/lib/components.dart
+++ b/lib/components.dart
@@ -1,6 +1,21 @@
-export 'src/components/component.dart';
+export 'joystick.dart';
+export 'joystick.dart';
+export 'src/anchor.dart';
 export 'src/components/base_component.dart';
+export 'src/components/component.dart';
 export 'src/components/isometric_tile_map_component.dart';
+export 'src/components/mixins/collidable.dart';
+export 'src/components/mixins/draggable.dart';
+export 'src/components/mixins/draggable.dart';
+export 'src/components/mixins/has_collidables.dart';
+export 'src/components/mixins/has_game_ref.dart';
+export 'src/components/mixins/has_game_ref.dart';
+export 'src/components/mixins/hitbox.dart';
+export 'src/components/mixins/hitbox.dart';
+export 'src/components/mixins/single_child_particle.dart';
+export 'src/components/mixins/single_child_particle.dart';
+export 'src/components/mixins/tapable.dart';
+export 'src/components/mixins/tapable.dart';
 export 'src/components/nine_tile_box_component.dart';
 export 'src/components/parallax_component.dart';
 export 'src/components/particle_component.dart';
@@ -10,18 +25,7 @@ export 'src/components/sprite_batch_component.dart';
 export 'src/components/sprite_component.dart';
 export 'src/components/text_box_component.dart';
 export 'src/components/text_component.dart';
-
-export 'src/timer.dart';
-export 'joystick.dart';
-
-export 'src/components/mixins/collidable.dart';
-export 'src/components/mixins/draggable.dart';
-export 'src/components/mixins/has_collidables.dart';
-export 'src/components/mixins/has_game_ref.dart';
-export 'src/components/mixins/hitbox.dart';
-export 'src/components/mixins/single_child_particle.dart';
-export 'src/components/mixins/tapable.dart';
-
 export 'src/extensions/vector2.dart';
-export 'src/anchor.dart';
 export 'src/text_config.dart';
+export 'src/timer.dart';
+export 'src/timer.dart';

--- a/lib/game.dart
+++ b/lib/game.dart
@@ -1,7 +1,6 @@
+export 'src/extensions/vector2.dart';
+export 'src/fps_counter.dart';
 export 'src/game/base_game.dart';
 export 'src/game/game.dart';
 export 'src/game/game_widget.dart';
-
-export 'src/extensions/vector2.dart';
-export 'src/fps_counter.dart';
 export 'src/text_config.dart';

--- a/lib/geometry.dart
+++ b/lib/geometry.dart
@@ -1,6 +1,6 @@
 export 'src/geometry/circle.dart';
-export 'src/geometry/line_segment.dart';
 export 'src/geometry/line.dart';
+export 'src/geometry/line_segment.dart';
 export 'src/geometry/polygon.dart';
 export 'src/geometry/rectangle.dart';
 export 'src/geometry/shape.dart';

--- a/lib/image_composition.dart
+++ b/lib/image_composition.dart
@@ -69,7 +69,7 @@ class ImageComposition {
   /// gets added to the composition. It will be rotated in a clock-wise direction
   /// around the [anchor].
   ///
-  /// By default the [anchor] will be the [source.width] and [source.height]
+  /// By default the [anchor] will be the [source].width and [source].height
   /// divided by `2`.
   ///
   /// [isAntiAlias] can be used to if the [image] will be anti aliased. Defaults

--- a/lib/particles.dart
+++ b/lib/particles.dart
@@ -1,5 +1,4 @@
-export 'src/particles/particle.dart';
-
+export 'src/anchor.dart';
 export 'src/particles/accelerated_particle.dart';
 export 'src/particles/animation_particle.dart';
 export 'src/particles/circle_particle.dart';
@@ -10,9 +9,8 @@ export 'src/particles/curved_particle.dart';
 export 'src/particles/image_particle.dart';
 export 'src/particles/moving_particle.dart';
 export 'src/particles/paint_particle.dart';
+export 'src/particles/particle.dart';
 export 'src/particles/rotating_particle.dart';
 export 'src/particles/scaled_particle.dart';
 export 'src/particles/sprite_particle.dart';
 export 'src/particles/translated_particle.dart';
-
-export 'src/anchor.dart';

--- a/lib/src/assets/assets_cache.dart
+++ b/lib/src/assets/assets_cache.dart
@@ -48,7 +48,7 @@ class AssetsCache {
   }
 
   Future<Map<String, dynamic>> readJson(String fileName) async {
-    final String content = await readFile(fileName);
+    final content = await readFile(fileName);
     return jsonDecode(content) as Map<String, dynamic>;
   }
 
@@ -59,7 +59,7 @@ class AssetsCache {
 
   Future<_BinaryAsset> _readBinary(String fileName) async {
     final data = await rootBundle.load('assets/$fileName');
-    final Uint8List list = Uint8List.view(data.buffer);
+    final list = Uint8List.view(data.buffer);
 
     final bytes = List<int>.from(list);
     return _BinaryAsset(bytes);

--- a/lib/src/assets/images.dart
+++ b/lib/src/assets/images.dart
@@ -36,7 +36,7 @@ class Images {
     if (!_loadedFiles.containsKey(fileName)) {
       _loadedFiles[fileName] = _ImageAssetLoader(_fetchToMemory(fileName));
     }
-    return await _loadedFiles[fileName].retrieve();
+    return _loadedFiles[fileName].retrieve();
   }
 
   /// Convert an array of pixel values into an [Image] object.
@@ -73,7 +73,7 @@ class Images {
     if (!_loadedFiles.containsKey(fileName)) {
       _loadedFiles[fileName] = _ImageAssetLoader(_fetchFromBase64(base64));
     }
-    return await _loadedFiles[fileName].retrieve();
+    return _loadedFiles[fileName].retrieve();
   }
 
   Future<Image> _fetchFromBase64(String base64Data) async {
@@ -83,14 +83,14 @@ class Images {
   }
 
   Future<Image> _fetchToMemory(String name) async {
-    final data = await Flame.bundle.load('assets/images/' + name);
+    final data = await Flame.bundle.load('assets/images/$name');
     final bytes = Uint8List.view(data.buffer);
     return _loadBytes(bytes);
   }
 
   Future<Image> _loadBytes(Uint8List bytes) {
     final completer = Completer<Image>();
-    decodeImageFromList(bytes, (image) => completer.complete(image));
+    decodeImageFromList(bytes, completer.complete);
     return completer.future;
   }
 

--- a/lib/src/assets/images.dart
+++ b/lib/src/assets/images.dart
@@ -78,18 +78,18 @@ class Images {
 
   Future<Image> _fetchFromBase64(String base64Data) async {
     final data = base64Data.substring(base64Data.indexOf(',') + 1);
-    final Uint8List bytes = base64.decode(data);
+    final bytes = base64.decode(data);
     return _loadBytes(bytes);
   }
 
   Future<Image> _fetchToMemory(String name) async {
-    final ByteData data = await Flame.bundle.load('assets/images/' + name);
-    final Uint8List bytes = Uint8List.view(data.buffer);
+    final data = await Flame.bundle.load('assets/images/' + name);
+    final bytes = Uint8List.view(data.buffer);
     return _loadBytes(bytes);
   }
 
   Future<Image> _loadBytes(Uint8List bytes) {
-    final Completer<Image> completer = Completer();
+    final completer = Completer<Image>();
     decodeImageFromList(bytes, (image) => completer.complete(image));
     return completer.future;
   }

--- a/lib/src/assets/images.dart
+++ b/lib/src/assets/images.dart
@@ -130,8 +130,6 @@ class _ImageAssetLoader {
   Future<Image> future;
 
   Future<Image> retrieve() async {
-    loadedImage ??= await future;
-
-    return loadedImage;
+    return loadedImage ??= await future;
   }
 }

--- a/lib/src/components/base_component.dart
+++ b/lib/src/components/base_component.dart
@@ -107,8 +107,8 @@ abstract class BaseComponent extends Component {
   }
 
   /// Called to check whether the point is to be counted as within the component
-  /// It needs to be overridden to have any effect, like it is in the
-  /// [PositionComponent]
+  /// It needs to be overridden to have any effect, like it is in
+  /// PositionComponent.
   bool containsPoint(Vector2 point) => false;
 
   /// Add an effect to the component
@@ -179,8 +179,8 @@ abstract class BaseComponent extends Component {
   bool propagateToChildren<T extends Component>(
     bool Function(T) handler,
   ) {
-    bool shouldContinue = true;
-    for (Component child in _children) {
+    var shouldContinue = true;
+    for (final child in _children) {
       if (child is BaseComponent) {
         shouldContinue = child.propagateToChildren(handler);
       }

--- a/lib/src/components/component.dart
+++ b/lib/src/components/component.dart
@@ -8,12 +8,12 @@ import '../extensions/vector2.dart';
 /// This represents a Component for your game.
 ///
 /// Components can be bullets flying on the screen, a spaceship or your player's fighter.
-/// Anything that either renders or updates can be added to the list on [BaseGame]. It will deal with calling those methods for you.
+/// Anything that either renders or updates can be added to the list on BaseGame. It will deal with calling those methods for you.
 /// Components also have other methods that can help you out if you want to override them.
 abstract class Component {
   /// Whether this component is HUD object or not.
   ///
-  /// HUD objects ignore the [BaseGame.camera] when rendered (so their position coordinates are considered relative to the device screen).
+  /// HUD objects ignore the BaseGame.camera when rendered (so their position coordinates are considered relative to the device screen).
   bool isHud = false;
 
   bool _isMounted = false;
@@ -31,16 +31,16 @@ abstract class Component {
 
   /// Whether this component should be removed or not.
   ///
-  /// It will be checked once per component per tick, and if it is true, [BaseGame] will remove it.
+  /// It will be checked once per component per tick, and if it is true, BaseGame will remove it.
   bool shouldRemove = false;
 
   Component({this.priority = 0});
 
   /// This method is called periodically by the game engine to request that your component updates itself.
   ///
-  /// The time [t] in seconds (with microseconds precision provided by Flutter) since the last update cycle.
+  /// The time [dt] in seconds (with microseconds precision provided by Flutter) since the last update cycle.
   /// This time can vary according to hardware capacity, so make sure to update your state considering this.
-  /// All components on [BaseGame] are always updated by the same amount. The time each one takes to update adds up to the next update cycle.
+  /// All components on BaseGame are always updated by the same amount. The time each one takes to update adds up to the next update cycle.
   void update(double dt) {}
 
   /// Renders this component on the provided Canvas [c].
@@ -68,13 +68,13 @@ abstract class Component {
     _isMounted = false;
   }
 
-  /// Called before the component is added to the [BaseGame] by the [add] method.
-  /// Whenever this returns something, [BaseGame] will wait for the [Future] to be resolved before adding the component on the list.
+  /// Called before the component is added to the BaseGame by the add method.
+  /// Whenever this returns something, BaseGame will wait for the [Future] to be resolved before adding the component on the list.
   /// If `null` is returned, the component is added right away.
   ///
   /// Has a default implementation which just returns null.
   ///
-  /// This can be overriden this to add custom logic to the component loading
+  /// This can be overriden this to add custom logic to the component loading.
   ///
   /// Example:
   /// ```dart

--- a/lib/src/components/component.dart
+++ b/lib/src/components/component.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
+import 'package:meta/meta.dart';
 
 import '../extensions/vector2.dart';
 
@@ -74,7 +74,7 @@ abstract class Component {
   ///
   /// Has a default implementation which just returns null.
   ///
-  /// This can be overriden this to add custom logic to the component loading.
+  /// This can be overwritten this to add custom logic to the component loading.
   ///
   /// Example:
   /// ```dart

--- a/lib/src/components/isometric_tile_map_component.dart
+++ b/lib/src/components/isometric_tile_map_component.dart
@@ -1,9 +1,8 @@
 import 'dart:ui';
 
-import 'position_component.dart';
-
 import '../extensions/vector2.dart';
 import '../spritesheet.dart';
+import 'position_component.dart';
 
 /// This is just a pair of <int, int>.
 ///

--- a/lib/src/components/isometric_tile_map_component.dart
+++ b/lib/src/components/isometric_tile_map_component.dart
@@ -42,8 +42,8 @@ class IsometricTileMapComponent extends PositionComponent {
     super.render(c);
 
     final size = effectiveTileSize;
-    for (int i = 0; i < matrix.length; i++) {
-      for (int j = 0; j < matrix[i].length; j++) {
+    for (var i = 0; i < matrix.length; i++) {
+      for (var j = 0; j < matrix[i].length; j++) {
         final element = matrix[i][j];
         if (element != -1) {
           final sprite = tileset.getSpriteById(element);

--- a/lib/src/components/joystick/joystick_action.dart
+++ b/lib/src/components/joystick/joystick_action.dart
@@ -16,7 +16,7 @@ import 'joystick_component.dart';
 import 'joystick_events.dart';
 import 'joystick_utils.dart';
 
-enum JoystickActionAlign { TOP_LEFT, BOTTOM_LEFT, TOP_RIGHT, BOTTOM_RIGHT }
+enum JoystickActionAlign { topLeft, bottomLeft, topRight, bottomRight }
 
 class JoystickAction extends BaseComponent with Draggable, HasGameRef {
   final int actionId;
@@ -56,7 +56,7 @@ class JoystickAction extends BaseComponent with Draggable, HasGameRef {
     this.sizeFactorBackgroundDirection = 1.5,
     this.margin = EdgeInsets.zero,
     this.color = Colors.blueGrey,
-    this.align = JoystickActionAlign.BOTTOM_RIGHT,
+    this.align = JoystickActionAlign.bottomRight,
     this.opacityBackground = 0.5,
     this.opacityKnob = 0.8,
   })  : _spriteAction = sprite,
@@ -88,19 +88,19 @@ class JoystickAction extends BaseComponent with Draggable, HasGameRef {
     final double radius = size / 2;
     double dx = 0, dy = 0;
     switch (align) {
-      case JoystickActionAlign.TOP_LEFT:
+      case JoystickActionAlign.topLeft:
         dx = margin.left + radius;
         dy = margin.top + radius;
         break;
-      case JoystickActionAlign.BOTTOM_LEFT:
+      case JoystickActionAlign.bottomLeft:
         dx = margin.left + radius;
         dy = _screenSize.y - (margin.bottom + radius);
         break;
-      case JoystickActionAlign.TOP_RIGHT:
+      case JoystickActionAlign.topRight:
         dx = _screenSize.x - (margin.right + radius);
         dy = margin.top + radius;
         break;
-      case JoystickActionAlign.BOTTOM_RIGHT:
+      case JoystickActionAlign.bottomRight:
         dx = _screenSize.x - (margin.right + radius);
         dy = _screenSize.y - (margin.bottom + radius);
         break;
@@ -164,7 +164,7 @@ class JoystickAction extends BaseComponent with Draggable, HasGameRef {
       joystickController.joystickAction(
         JoystickActionEvent(
           id: actionId,
-          event: ActionEvent.MOVE,
+          event: ActionEvent.move,
           intensity: _intensity,
           radAngle: radAngle,
         ),
@@ -195,7 +195,7 @@ class JoystickAction extends BaseComponent with Draggable, HasGameRef {
     joystickController.joystickAction(
       JoystickActionEvent(
         id: actionId,
-        event: ActionEvent.DOWN,
+        event: ActionEvent.down,
       ),
     );
     tapDown();
@@ -232,7 +232,7 @@ class JoystickAction extends BaseComponent with Draggable, HasGameRef {
     joystickController.joystickAction(
       JoystickActionEvent(
         id: actionId,
-        event: ActionEvent.UP,
+        event: ActionEvent.up,
       ),
     );
     tapUp();
@@ -246,7 +246,7 @@ class JoystickAction extends BaseComponent with Draggable, HasGameRef {
     joystickController.joystickAction(
       JoystickActionEvent(
         id: actionId,
-        event: ActionEvent.CANCEL,
+        event: ActionEvent.cancel,
       ),
     );
     tapUp();

--- a/lib/src/components/joystick/joystick_action.dart
+++ b/lib/src/components/joystick/joystick_action.dart
@@ -85,8 +85,8 @@ class JoystickAction extends BaseComponent with Draggable, HasGameRef {
   }
 
   void initialize(Vector2 _screenSize) {
-    final double radius = size / 2;
-    double dx = 0, dy = 0;
+    final radius = size / 2;
+    var dx = 0.0, dy = 0.0;
     switch (align) {
       case JoystickActionAlign.topLeft:
         dx = margin.left + radius;
@@ -141,12 +141,12 @@ class JoystickAction extends BaseComponent with Draggable, HasGameRef {
 
       // Distance between the center of joystick background & drag position
       final centerPosition = _rectBackgroundDirection.center.toVector2();
-      double dist = centerPosition.distanceTo(_dragPosition);
+      final unboundDist = centerPosition.distanceTo(_dragPosition);
 
       // The maximum distance for the knob position to the edge of
       // the background + half of its own size. The knob can wander in the
       // background image, but not outside.
-      dist = min(dist, _tileSize);
+      final dist = min(unboundDist, _tileSize);
 
       // Calculate the knob position
       final nextX = dist * cos(radAngle);

--- a/lib/src/components/joystick/joystick_directional.dart
+++ b/lib/src/components/joystick/joystick_directional.dart
@@ -133,12 +133,12 @@ class JoystickDirectional extends BaseComponent with Draggable, HasGameRef {
       final diff = _backgroundRect.center + nextPoint - _knobRect.center;
       _knobRect = _knobRect.shift(diff);
 
-      final double _intensity = dist / _tileSize;
+      final _intensity = dist / _tileSize;
 
       JoystickMoveDirectional directional;
 
       if (_intensity == 0) {
-        directional = JoystickMoveDirectional.IDLE;
+        directional = JoystickMoveDirectional.idle;
       } else {
         directional = JoystickDirectionalEvent.calculateDirectionalByDegrees(
           degrees,
@@ -210,9 +210,7 @@ class JoystickDirectional extends BaseComponent with Draggable, HasGameRef {
     _dragging = false;
     _dragPosition = _backgroundRect.center.toVector2();
     joystickController.joystickChangeDirectional(JoystickDirectionalEvent(
-      directional: JoystickMoveDirectional.IDLE,
-      intensity: 0.0,
-      radAngle: 0.0,
+      directional: JoystickMoveDirectional.idle,
     ));
     return true;
   }
@@ -222,9 +220,7 @@ class JoystickDirectional extends BaseComponent with Draggable, HasGameRef {
     _dragging = false;
     _dragPosition = _backgroundRect.center.toVector2();
     joystickController.joystickChangeDirectional(JoystickDirectionalEvent(
-      directional: JoystickMoveDirectional.IDLE,
-      intensity: 0.0,
-      radAngle: 0.0,
+      directional: JoystickMoveDirectional.idle,
     ));
     return true;
   }

--- a/lib/src/components/joystick/joystick_events.dart
+++ b/lib/src/components/joystick/joystick_events.dart
@@ -1,16 +1,16 @@
 enum JoystickMoveDirectional {
-  MOVE_UP,
-  MOVE_UP_LEFT,
-  MOVE_UP_RIGHT,
-  MOVE_RIGHT,
-  MOVE_DOWN,
-  MOVE_DOWN_RIGHT,
-  MOVE_DOWN_LEFT,
-  MOVE_LEFT,
-  IDLE,
+  moveUp,
+  moveUpLeft,
+  moveUpRight,
+  moveRight,
+  moveDown,
+  moveDownRight,
+  moveDownLeft,
+  moveLeft,
+  idle,
 }
 
-enum ActionEvent { DOWN, UP, MOVE, CANCEL }
+enum ActionEvent { down, up, move, cancel }
 
 class JoystickDirectionalEvent {
   final JoystickMoveDirectional directional;
@@ -25,24 +25,24 @@ class JoystickDirectionalEvent {
 
   static JoystickMoveDirectional calculateDirectionalByDegrees(double degrees) {
     if (degrees > -22.5 && degrees <= 22.5) {
-      return JoystickMoveDirectional.MOVE_RIGHT;
+      return JoystickMoveDirectional.moveRight;
     } else if (degrees > 22.5 && degrees <= 67.5) {
-      return JoystickMoveDirectional.MOVE_DOWN_RIGHT;
+      return JoystickMoveDirectional.moveDownRight;
     } else if (degrees > 67.5 && degrees <= 112.5) {
-      return JoystickMoveDirectional.MOVE_DOWN;
+      return JoystickMoveDirectional.moveDown;
     } else if (degrees > 112.5 && degrees <= 157.5) {
-      return JoystickMoveDirectional.MOVE_DOWN_LEFT;
+      return JoystickMoveDirectional.moveDownLeft;
     } else if ((degrees > 157.5 && degrees <= 180) ||
         (degrees >= -180 && degrees <= -157.5)) {
-      return JoystickMoveDirectional.MOVE_LEFT;
+      return JoystickMoveDirectional.moveLeft;
     } else if (degrees > -157.5 && degrees <= -112.5) {
-      return JoystickMoveDirectional.MOVE_UP_LEFT;
+      return JoystickMoveDirectional.moveUpLeft;
     } else if (degrees > -112.5 && degrees <= -67.5) {
-      return JoystickMoveDirectional.MOVE_UP;
+      return JoystickMoveDirectional.moveUp;
     } else if (degrees > -67.5 && degrees <= -22.5) {
-      return JoystickMoveDirectional.MOVE_UP_RIGHT;
+      return JoystickMoveDirectional.moveUpRight;
     } else {
-      return JoystickMoveDirectional.IDLE;
+      return JoystickMoveDirectional.idle;
     }
   }
 

--- a/lib/src/components/joystick/joystick_utils.dart
+++ b/lib/src/components/joystick/joystick_utils.dart
@@ -1,8 +1,8 @@
 import 'dart:ui';
 
-import '../../sprite.dart';
 import '../../extensions/offset.dart';
 import '../../extensions/size.dart';
+import '../../sprite.dart';
 
 class JoystickUtils {
   static void renderControl(Canvas c, Sprite sprite, Rect rect, Paint paint) {
@@ -13,7 +13,7 @@ class JoystickUtils {
     if (sprite == null) {
       assert(paint != null, '`paint` must not be `null` if `sprite` is `null`');
 
-      final double radius = rect.width / 2;
+      final radius = rect.width / 2;
       c.drawCircle(
         Offset(rect.left + radius, rect.top + radius),
         radius,

--- a/lib/src/components/mixins/collidable.dart
+++ b/lib/src/components/mixins/collidable.dart
@@ -1,7 +1,7 @@
-import 'hitbox.dart';
 import '../../components/position_component.dart';
 import '../../extensions/vector2.dart';
 import '../../geometry/rectangle.dart';
+import 'hitbox.dart';
 
 mixin Collidable on Hitbox {
   void onCollision(Set<Vector2> points, Collidable other) {}

--- a/lib/src/components/mixins/draggable.dart
+++ b/lib/src/components/mixins/draggable.dart
@@ -1,11 +1,9 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import '../../../extensions.dart';
 import '../../game/base_game.dart';
 import '../base_component.dart';
-import '../component.dart';
 
 mixin Draggable on BaseComponent {
   bool onDragStart(int pointerId, Vector2 startPosition) {
@@ -81,8 +79,8 @@ mixin HasDraggableComponents on BaseGame {
   }
 
   void _onGenericEventReceived(bool Function(Draggable) handler) {
-    for (Component c in components.toList().reversed) {
-      bool shouldContinue = true;
+    for (final c in components.toList().reversed) {
+      var shouldContinue = true;
       if (c is BaseComponent) {
         shouldContinue = c.propagateToChildren<Draggable>(handler);
       }

--- a/lib/src/components/mixins/has_collidables.dart
+++ b/lib/src/components/mixins/has_collidables.dart
@@ -7,9 +7,7 @@ mixin HasCollidables on BaseGame {
   final List<Collidable> _collidables = [];
 
   void handleCollidables(Set<Component> removeLater, List<Component> addLater) {
-    removeLater.whereType<Collidable>().forEach((c) {
-      _collidables.remove(c);
-    });
+    removeLater.whereType<Collidable>().forEach(_collidables.remove);
     _collidables.addAll(addLater.whereType<Collidable>());
     collisionDetection(_collidables);
   }

--- a/lib/src/components/mixins/hitbox.dart
+++ b/lib/src/components/mixins/hitbox.dart
@@ -1,9 +1,9 @@
 import 'dart:collection';
 import 'dart:math';
 
-import '../position_component.dart';
 import '../../../extensions.dart';
 import '../../geometry/shape.dart';
+import '../position_component.dart';
 
 mixin Hitbox on PositionComponent {
   final List<HitboxShape> _shapes = <HitboxShape>[];

--- a/lib/src/components/mixins/tapable.dart
+++ b/lib/src/components/mixins/tapable.dart
@@ -1,11 +1,10 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:meta/meta.dart';
 
 import '../../../game.dart';
 import '../../extensions/offset.dart';
 import '../../game/base_game.dart';
 import '../base_component.dart';
-import '../component.dart';
 
 mixin Tapable on BaseComponent {
   bool onTapCancel() {
@@ -51,8 +50,8 @@ mixin Tapable on BaseComponent {
 
 mixin HasTapableComponents on BaseGame {
   void _handleTapEvent(bool Function(Tapable child) tapEventHandler) {
-    for (Component c in components.toList().reversed) {
-      bool shouldContinue = true;
+    for (final c in components.toList().reversed) {
+      var shouldContinue = true;
       if (c is BaseComponent) {
         shouldContinue = c.propagateToChildren<Tapable>(tapEventHandler);
       }

--- a/lib/src/components/nine_tile_box_component.dart
+++ b/lib/src/components/nine_tile_box_component.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../extensions/vector2.dart';
 import '../nine_tile_box.dart';

--- a/lib/src/components/parallax_component.dart
+++ b/lib/src/components/parallax_component.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
+import 'package:meta/meta.dart';
 
 import '../assets/images.dart';
 import '../extensions/vector2.dart';
@@ -81,7 +81,7 @@ class ParallaxComponent extends PositionComponent {
   ///
   /// [load] takes a list of paths to all the images and a size that you want to use in the
   /// parallax.
-  /// Optionally arguments for the [baseVelocity] and [layerDelta] can be passed
+  /// Optionally arguments for the [baseVelocity] and [velocityMultiplierDelta] can be passed
   /// in, [baseVelocity] defines what the base velocity of the layers should be
   /// and [velocityMultiplierDelta] defines how the velocity should change the
   /// closer the layer is ([velocityMultiplierDelta ^ n], where n is the

--- a/lib/src/components/particle_component.dart
+++ b/lib/src/components/particle_component.dart
@@ -6,8 +6,8 @@ import '../particles/particle.dart';
 import 'component.dart';
 
 /// Base container for [Particle] instances to be attach
-/// to a [Component] tree. Could be added either to [BaseGame]
-/// or an implementation of [BaseComponent].
+/// to a [Component] tree. Could be added either to BaseGame
+/// or an implementation of BaseComponent.
 /// Proxies [Component] lifecycle hooks to nested [Particle].
 class ParticleComponent extends Component {
   Particle particle;
@@ -16,12 +16,13 @@ class ParticleComponent extends Component {
     @required this.particle,
   });
 
-  /// This [ParticleComponent] will be removed by [BaseGame]
+  /// This [ParticleComponent] will be removed by the BaseGame.
   @override
   bool get shouldRemove => particle.shouldRemove();
 
-  /// Returns progress of the child [Particle]
-  /// so could be used by external code for something
+  /// Returns progress of the child [Particle].
+  ///
+  /// Could be used by external code if needed.
   double get progress => particle.progress;
 
   /// Passes rendering chain down to the inset

--- a/lib/src/components/particle_component.dart
+++ b/lib/src/components/particle_component.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../particles/particle.dart';
 import 'component.dart';

--- a/lib/src/components/position_component.dart
+++ b/lib/src/components/position_component.dart
@@ -1,7 +1,6 @@
 import 'dart:ui' hide Offset;
 
 import '../anchor.dart';
-import '../collision_detection.dart' as collision_detection;
 import '../extensions/offset.dart';
 import '../extensions/rect.dart';
 import '../extensions/vector2.dart';

--- a/lib/src/components/position_component.dart
+++ b/lib/src/components/position_component.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' hide Offset;
 
 import '../anchor.dart';
+import '../collision_detection.dart' as collision_detection;
 import '../extensions/offset.dart';
 import '../extensions/rect.dart';
 import '../extensions/vector2.dart';
@@ -149,7 +150,7 @@ abstract class PositionComponent extends BaseComponent {
       Vector2(-50, -15),
     );
 
-    final Rect rect = toRect();
+    final rect = toRect();
     final dx = rect.right;
     final dy = rect.bottom;
     debugTextConfig.render(
@@ -163,7 +164,7 @@ abstract class PositionComponent extends BaseComponent {
   void prepareCanvas(Canvas canvas) {
     canvas.translate(x, y);
     canvas.rotate(angle);
-    final Vector2 delta = -anchor.toVector2()
+    final delta = -anchor.toVector2()
       ..multiply(size);
     canvas.translate(delta.x, delta.y);
 

--- a/lib/src/components/sprite_animation_component.dart
+++ b/lib/src/components/sprite_animation_component.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../extensions/vector2.dart';
 import '../sprite_animation.dart';

--- a/lib/src/components/sprite_animation_component.dart
+++ b/lib/src/components/sprite_animation_component.dart
@@ -24,7 +24,7 @@ class SpriteAnimationComponent extends PositionComponent {
 
   /// Creates a SpriteAnimationComponent from a [size], an [image] and [data]. Check [SpriteAnimationData] for more info on the available options.
   ///
-  /// Optionally [removeOnFinish] can be set to true to have this component be auto removed from the [BaseGame] when the animation is finished.
+  /// Optionally [removeOnFinish] can be set to true to have this component be auto removed from the BaseGame when the animation is finished.
   SpriteAnimationComponent.fromFrameData(
     Image image,
     SpriteAnimationData data, {
@@ -39,7 +39,6 @@ class SpriteAnimationComponent extends PositionComponent {
   }
 
   /// Component will be removed after loop end and [removeOnFinish] is set.
-  /// [Component.shouldRemove] worked here.
   @override
   bool get shouldRemove =>
       super.shouldRemove ||

--- a/lib/src/components/sprite_component.dart
+++ b/lib/src/components/sprite_component.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../extensions/vector2.dart';
 import '../sprite.dart';

--- a/lib/src/components/text_box_component.dart
+++ b/lib/src/components/text_box_component.dart
@@ -97,9 +97,9 @@ class TextBoxComponent extends PositionComponent {
       : math.min(_lifeTime ~/ _boxConfig.timePerChar, _text.length);
 
   int get currentLine {
-    int totalCharCount = 0;
-    final int _currentChar = currentChar;
-    for (int i = 0; i < _lines.length; i++) {
+    var totalCharCount = 0;
+    final _currentChar = currentChar;
+    for (var i = 0; i < _lines.length; i++) {
       totalCharCount += _lines[i].length;
       if (totalCharCount > _currentChar) {
         return i;
@@ -125,12 +125,12 @@ class TextBoxComponent extends PositionComponent {
       return _cachedWidth;
     }
     if (_boxConfig.growingBox) {
-      int i = 0;
-      int totalCharCount = 0;
-      final int _currentChar = currentChar;
-      final int _currentLine = currentLine;
-      final double textWidth = _lines.sublist(0, _currentLine + 1).map((line) {
-        final int charCount =
+      var i = 0;
+      var totalCharCount = 0;
+      final _currentChar = currentChar;
+      final _currentLine = currentLine;
+      final textWidth = _lines.sublist(0, _currentLine + 1).map((line) {
+        final charCount =
             (i < _currentLine) ? line.length : (_currentChar - totalCharCount);
         totalCharCount += line.length;
         i++;
@@ -168,8 +168,8 @@ class TextBoxComponent extends PositionComponent {
   }
 
   Future<Image> _redrawCache() {
-    final PictureRecorder recorder = PictureRecorder();
-    final Canvas c = Canvas(recorder, _gameSize.toRect());
+    final recorder = PictureRecorder();
+    final c = Canvas(recorder, _gameSize.toRect());
     _fullRender(c);
     return recorder.endRecording().toImage(width.toInt(), height.toInt());
   }
@@ -179,16 +179,15 @@ class TextBoxComponent extends PositionComponent {
   void _fullRender(Canvas c) {
     drawBackground(c);
 
-    final int _currentLine = currentLine;
-    int charCount = 0;
-    double dy = _boxConfig.margins.top;
-    for (int line = 0; line < _currentLine; line++) {
+    final _currentLine = currentLine;
+    var charCount = 0;
+    var dy = _boxConfig.margins.top;
+    for (var line = 0; line < _currentLine; line++) {
       charCount += _lines[line].length;
       _drawLine(c, _lines[line], dy);
       dy += _lineHeight;
     }
-    final int max =
-        math.min(currentChar - charCount, _lines[_currentLine].length);
+    final max = math.min(currentChar - charCount, _lines[_currentLine].length);
     _drawLine(c, _lines[_currentLine].substring(0, max), dy);
   }
 

--- a/lib/src/components/text_box_component.dart
+++ b/lib/src/components/text_box_component.dart
@@ -62,7 +62,7 @@ class TextBoxComponent extends PositionComponent {
     _lines = [];
     double lineHeight;
     text.split(' ').forEach((word) {
-      final possibleLine = _lines.isEmpty ? word : _lines.last + ' ' + word;
+      final possibleLine = _lines.isEmpty ? word : '${_lines.last} $word';
       final painter = _config.toTextPainter(possibleLine);
       lineHeight ??= painter.height;
       if (painter.width <=

--- a/lib/src/components/text_box_component.dart
+++ b/lib/src/components/text_box_component.dart
@@ -4,9 +4,9 @@ import 'dart:ui';
 
 import 'package:flutter/widgets.dart' hide Image;
 
+import '../extensions/vector2.dart';
 import '../palette.dart';
 import '../text_config.dart';
-import '../extensions/vector2.dart';
 import 'position_component.dart';
 
 class TextBoxConfig {

--- a/lib/src/components/text_component.dart
+++ b/lib/src/components/text_component.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
+import 'package:meta/meta.dart';
 
 import '../extensions/vector2.dart';
 import '../text_config.dart';

--- a/lib/src/device.dart
+++ b/lib/src/device.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-/// Provides methods for controlling the device (e.g. setting the screen to fullscreen).
+/// Provides methods for controlling the device (e.g. setting the screen to full-screen).
 ///
-/// To use this class, access it via [Flame.device]
+/// To use this class, access it via Flame.device.
 class Device {
-  /// Sets the app to be fullscreen (no buttons, bar or notifications on top).
+  /// Sets the app to be full-screen (no buttons, bar or notifications on top).
   Future<void> fullScreen() {
     if (kIsWeb) {
       // TODO: We probably could use dart:html and implement this for web as well

--- a/lib/src/effects/effects.dart
+++ b/lib/src/effects/effects.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../components/base_component.dart';
@@ -221,7 +220,7 @@ abstract class SimplePositionComponentEffect extends PositionComponentEffect {
     void Function() onComplete,
   })  : assert(
           (duration != null) ^ (speed != null),
-          "Either speed or duration necessary",
+          'Either speed or duration necessary',
         ),
         super(
           initialIsInfinite,

--- a/lib/src/effects/move_effect.dart
+++ b/lib/src/effects/move_effect.dart
@@ -58,9 +58,9 @@ class MoveEffect extends SimplePositionComponentEffect {
     // to the previous vector in the list, except the first one which is
     // relative to the start position of the component.
     if (isRelative) {
-      Vector2 lastPosition = _startPosition;
+      var lastPosition = _startPosition;
       _movePath = [];
-      for (Vector2 v in path) {
+      for (final v in path) {
         final nextPosition = v + lastPosition;
         _movePath.add(nextPosition);
         lastPosition = nextPosition;
@@ -70,16 +70,16 @@ class MoveEffect extends SimplePositionComponentEffect {
     }
     endPosition = isAlternating ? _startPosition : _movePath.last;
 
-    double pathLength = 0;
-    Vector2 lastPosition = _startPosition;
-    for (Vector2 v in _movePath) {
+    var pathLength = 0.0;
+    var lastPosition = _startPosition;
+    for (final v in _movePath) {
       pathLength += v.distanceTo(lastPosition);
       lastPosition = v;
     }
 
     _percentagePath = <Vector2Percentage>[];
     lastPosition = _startPosition;
-    for (Vector2 v in _movePath) {
+    for (final v in _movePath) {
       final lengthToPrevious = lastPosition.distanceTo(v);
       final lastEndAt =
           _percentagePath.isNotEmpty ? _percentagePath.last.endAt : 0.0;
@@ -94,7 +94,7 @@ class MoveEffect extends SimplePositionComponentEffect {
       );
       lastPosition = v;
     }
-    final double totalPathLength = isAlternating ? pathLength * 2 : pathLength;
+    final totalPathLength = isAlternating ? pathLength * 2 : pathLength;
     speed ??= totalPathLength / duration;
 
     // `duration` is not null when speed is null
@@ -121,8 +121,8 @@ class MoveEffect extends SimplePositionComponentEffect {
       _currentSubPath =
           _percentagePath.firstWhere((v) => v.endAt >= curveProgress);
     }
-    final double lastEndAt = _currentSubPath.startAt;
-    final double localPercentage =
+    final lastEndAt = _currentSubPath.startAt;
+    final localPercentage =
         (curveProgress - lastEndAt) / (_currentSubPath.endAt - lastEndAt);
     component.position = _currentSubPath.previous +
         ((_currentSubPath.v - _currentSubPath.previous) * localPercentage);

--- a/lib/src/effects/move_effect.dart
+++ b/lib/src/effects/move_effect.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/animation.dart';
 import 'package:meta/meta.dart';
 
+import '../../components.dart';
 import '../extensions/vector2.dart';
 import 'effects.dart';
 
@@ -36,7 +37,7 @@ class MoveEffect extends SimplePositionComponentEffect {
     void Function() onComplete,
   })  : assert(
           (duration != null) ^ (speed != null),
-          "Either speed or duration necessary",
+          'Either speed or duration necessary',
         ),
         super(
           isInfinite,
@@ -50,7 +51,7 @@ class MoveEffect extends SimplePositionComponentEffect {
         );
 
   @override
-  void initialize(component) {
+  void initialize(PositionComponent component) {
     super.initialize(component);
     List<Vector2> _movePath;
     _startPosition = component.position.clone();

--- a/lib/src/effects/rotate_effect.dart
+++ b/lib/src/effects/rotate_effect.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/animation.dart';
 import 'package:meta/meta.dart';
 
+import '../../components.dart';
 import 'effects.dart';
 
 class RotateEffect extends SimplePositionComponentEffect {
@@ -20,7 +21,7 @@ class RotateEffect extends SimplePositionComponentEffect {
     void Function() onComplete,
   })  : assert(
           (duration != null) ^ (speed != null),
-          "Either speed or duration necessary",
+          'Either speed or duration necessary',
         ),
         super(
           isInfinite,
@@ -34,7 +35,7 @@ class RotateEffect extends SimplePositionComponentEffect {
         );
 
   @override
-  void initialize(component) {
+  void initialize(PositionComponent component) {
     super.initialize(component);
     _startAngle = component.angle;
     _delta = isRelative ? angle : angle - _startAngle;

--- a/lib/src/effects/scale_effect.dart
+++ b/lib/src/effects/scale_effect.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/animation.dart';
 import 'package:meta/meta.dart';
 
+import '../../components.dart';
 import '../extensions/vector2.dart';
 import 'effects.dart';
 
@@ -21,7 +22,7 @@ class ScaleEffect extends SimplePositionComponentEffect {
     void Function() onComplete,
   })  : assert(
           duration != null || speed != null,
-          "Either speed or duration necessary",
+          'Either speed or duration necessary',
         ),
         super(
           isInfinite,
@@ -35,7 +36,7 @@ class ScaleEffect extends SimplePositionComponentEffect {
         );
 
   @override
-  void initialize(component) {
+  void initialize(PositionComponent component) {
     super.initialize(component);
     _startSize = component.size;
     _delta = isRelative ? size : size - _startSize;

--- a/lib/src/extensions/canvas.dart
+++ b/lib/src/extensions/canvas.dart
@@ -1,6 +1,6 @@
-import 'vector2.dart';
-
 import 'dart:ui';
+
+import 'vector2.dart';
 
 export 'dart:ui' show Canvas;
 

--- a/lib/src/extensions/rect.dart
+++ b/lib/src/extensions/rect.dart
@@ -44,10 +44,10 @@ extension RectExtension on Rect {
 class RectFactory {
   /// Creates bounds in from of a [Rect] from a list of [Vector2]
   static Rect fromBounds(List<Vector2> pts) {
-    final double minX = pts.map((e) => e.x).reduce(min);
-    final double maxX = pts.map((e) => e.x).reduce(max);
-    final double minY = pts.map((e) => e.y).reduce(min);
-    final double maxY = pts.map((e) => e.y).reduce(max);
+    final minX = pts.map((e) => e.x).reduce(min);
+    final maxX = pts.map((e) => e.x).reduce(max);
+    final minY = pts.map((e) => e.y).reduce(min);
+    final maxY = pts.map((e) => e.y).reduce(max);
     return Rect.fromPoints(Offset(minX, minY), Offset(maxX, maxY));
   }
 }

--- a/lib/src/extensions/rect.dart
+++ b/lib/src/extensions/rect.dart
@@ -2,8 +2,8 @@ import 'dart:math';
 import 'dart:ui';
 
 import '../../geometry.dart';
-import 'vector2.dart';
 import 'offset.dart';
+import 'vector2.dart';
 
 export 'dart:ui' show Rect;
 

--- a/lib/src/flame.dart
+++ b/lib/src/flame.dart
@@ -8,7 +8,7 @@ import 'device.dart';
 
 /// This class holds static references to some useful objects to use in your game.
 ///
-/// You can access shared instances of [AssetsCache], [Images] and [Util].
+/// You can access shared instances of [AssetsCache], [Images] and [Device].
 /// Most games should need only one instance of each, and should use this class to manage that reference.
 class Flame {
   // Flame asset bundle, defaults to root

--- a/lib/src/game/base_game.dart
+++ b/lib/src/game/base_game.dart
@@ -26,10 +26,16 @@ class BaseGame extends Game with FPSCounter {
   final OrderedSet<Component> components =
       OrderedSet(Comparing.on((c) => c.priority));
 
-  /// Components added by the [addLater] method
+  /// Components to be added on the next update.
+  ///
+  /// The component list is only changed at the start of each [update] to avoid
+  /// concurrency issues.
   final List<Component> _addLater = [];
 
-  /// Components to be removed on the next update
+  /// Components to be removed on the next update.
+  ///
+  /// The component list is only changed at the start of each [update] to avoid
+  /// concurrency issues.
   final Set<Component> _removeLater = {};
 
   /// Camera position; every non-HUD component is translated so that the camera position is the top-left corner of the screen.
@@ -132,7 +138,8 @@ class BaseGame extends Game with FPSCounter {
 
   /// This implementation of update updates every component in the list.
   ///
-  /// It also actually adds the components that were added by the [addLater] method, and remove those that are marked for destruction via the [Component.shouldRemove] method.
+  /// It also actually adds the components added via [add] since the previous tick,
+  /// and remove those that are marked for destruction via the [Component.shouldRemove] method.
   /// You can override it further to add more custom behavior.
   @override
   @mustCallSuper
@@ -158,7 +165,8 @@ class BaseGame extends Game with FPSCounter {
     components.forEach((c) => c.update(dt));
   }
 
-  /// This implementation of resize passes the resize call along to every component in the list, enabling each one to make their decisions as how to handle the resize.
+  /// This implementation of resize passes the resize call along to every
+  /// component in the list, enabling each one to make their decisions as how to handle the resize.
   ///
   /// It also updates the [size] field of the class to be used by later added components and other methods.
   /// You can override it further to add more custom behavior, but you should seriously consider calling the super implementation as well.

--- a/lib/src/game/base_game.dart
+++ b/lib/src/game/base_game.dart
@@ -85,7 +85,7 @@ class BaseGame extends Game with FPSCounter {
     );
     assert(
       c is Collidable ? this is HasCollidables : true,
-      "You can only use the Hitbox/Collidable feature with games that has the HasCollidables mixin",
+      'You can only use the Hitbox/Collidable feature with games that has the HasCollidables mixin',
     );
     prepare(c);
     final loadFuture = c.onLoad();

--- a/lib/src/game/game.dart
+++ b/lib/src/game/game.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -9,8 +8,8 @@ import 'package:flutter/widgets.dart';
 
 import '../assets/assets_cache.dart';
 import '../assets/images.dart';
-import '../extensions/vector2.dart';
 import '../extensions/offset.dart';
+import '../extensions/vector2.dart';
 import '../keyboard.dart';
 import '../sprite.dart';
 import '../sprite_animation.dart';
@@ -38,7 +37,7 @@ abstract class Game {
   /// Use [size] and [hasLayout] for safe access.
   Vector2 _size;
 
-  /// Current game viewport size, updated every resize via the [resize] method hook
+  /// Current game viewport size, updated every resize via the [onResize] method hook
   Vector2 get size {
     assert(
       hasLayout,
@@ -199,17 +198,17 @@ abstract class Game {
   /// A property that stores an [ActiveOverlaysNotifier]
   ///
   /// This is useful to render widgets above a game, like a pause menu for example.
-  /// Overlays visible or hidden via [overlays.add] or [overlays.remove], respectively.
+  /// Overlays visible or hidden via [overlays].add or [overlays].remove, respectively.
   ///
   /// Ex:
   /// ```
-  /// final pauseOverlayIdentifier = "PauseMenu";
-  /// overlays.add(pauseOverlayIdentifier); // marks "PauseMenu" to be rendered.
-  /// overlays.remove(pauseOverlayIdentifier); // marks "PauseMenu" to not be rendered.
+  /// final pauseOverlayIdentifier = 'PauseMenu';
+  /// overlays.add(pauseOverlayIdentifier); // marks 'PauseMenu' to be rendered.
+  /// overlays.remove(pauseOverlayIdentifier); // marks 'PauseMenu' to not be rendered.
   /// ```
   ///
   /// See also:
-  /// - [new GameWidget]
+  /// - GameWidget
   /// - [Game.overlays]
   final overlays = ActiveOverlaysNotifier();
 }
@@ -224,7 +223,7 @@ class ActiveOverlaysNotifier extends ChangeNotifier {
   /// Mark a, overlay to be rendered.
   ///
   /// See also:
-  /// - [new GameWidget]
+  /// - GameWidget
   /// - [Game.overlays]
   bool add(String overlayName) {
     final setChanged = _activeOverlays.add(overlayName);
@@ -237,7 +236,7 @@ class ActiveOverlaysNotifier extends ChangeNotifier {
   /// Mark a, overlay to not be rendered.
   ///
   /// See also:
-  /// - [new GameWidget]
+  /// - GameWidget
   /// - [Game.overlays]
   bool remove(String overlayName) {
     final hasRemoved = _activeOverlays.remove(overlayName);

--- a/lib/src/game/game.dart
+++ b/lib/src/game/game.dart
@@ -90,10 +90,10 @@ abstract class Game {
   /// Should be called manually.
   void attach(PipelineOwner owner, GameRenderBox gameRenderBox) {
     if (isAttached) {
-      throw UnsupportedError("""
+      throw UnsupportedError('''
       Game attachment error:
       A game instance can only be attached to one widget at a time.
-      """);
+      ''');
     }
     _gameRenderBox = gameRenderBox;
     onAttach();

--- a/lib/src/game/game_loop.dart
+++ b/lib/src/game/game_loop.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/scheduler.dart';
 
 class GameLoop {
-  Function callback;
+  void Function(double dt) callback;
   Duration previous = Duration.zero;
   Ticker _ticker;
 

--- a/lib/src/game/game_loop.dart
+++ b/lib/src/game/game_loop.dart
@@ -10,15 +10,12 @@ class GameLoop {
   }
 
   void _tick(Duration timestamp) {
-    final double dt = _computeDeltaT(timestamp);
+    final dt = _computeDeltaT(timestamp);
     callback(dt);
   }
 
   double _computeDeltaT(Duration now) {
-    Duration delta = now - previous;
-    if (previous == Duration.zero) {
-      delta = Duration.zero;
-    }
+    final delta = previous == Duration.zero ? Duration.zero : now - previous;
     previous = now;
     return delta.inMicroseconds / Duration.microsecondsPerSecond;
   }

--- a/lib/src/game/game_render_box.dart
+++ b/lib/src/game/game_render_box.dart
@@ -9,6 +9,7 @@ import '../extensions/size.dart';
 import 'game.dart';
 import 'game_loop.dart';
 
+// ignore: prefer_mixin
 class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   BuildContext buildContext;
   Game game;

--- a/lib/src/game/game_widget.dart
+++ b/lib/src/game/game_widget.dart
@@ -200,10 +200,10 @@ class _GameWidgetState<T extends Game> extends State<GameWidget<T>> {
 
     assert(
       !(hasBasicDetectors && hasAdvancedDetectors),
-      """
+      '''
         WARNING: Both Advanced and Basic detectors detected.
         Advanced detectors will override basic detectors and the later will not receive events
-      """,
+      ''',
     );
 
     if (hasBasicDetectors) {
@@ -311,7 +311,7 @@ bool _hasMouseDetectors(Game game) =>
 
 Widget _applyBasicGesturesDetectors(Game game, Widget child) {
   return GestureDetector(
-    key: const ObjectKey("BasicGesturesDetector"),
+    key: const ObjectKey('BasicGesturesDetector'),
     behavior: HitTestBehavior.opaque,
 
     // Taps
@@ -515,7 +515,7 @@ Widget _applyMouseDetectors(Game game, Widget child) {
 class _GameRenderObjectWidget extends LeafRenderObjectWidget {
   final Game game;
 
-  _GameRenderObjectWidget(this.game);
+  const _GameRenderObjectWidget(this.game);
 
   @override
   RenderBox createRenderObject(BuildContext context) {
@@ -532,7 +532,7 @@ class _DragEvent extends Drag {
   void Function(DragEndDetails) onEnd;
 
   @override
-  void update(details) {
+  void update(DragUpdateDetails details) {
     onUpdate?.call(details);
   }
 
@@ -542,7 +542,7 @@ class _DragEvent extends Drag {
   }
 
   @override
-  void end(details) {
+  void end(DragEndDetails details) {
     onEnd?.call(details);
   }
 }

--- a/lib/src/game/game_widget.dart
+++ b/lib/src/game/game_widget.dart
@@ -1,14 +1,14 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter/gestures.dart';
 
 import '../../extensions.dart';
-import 'game.dart';
-import '../gestures.dart';
 import '../components/mixins/draggable.dart';
 import '../components/mixins/tapable.dart';
-import '../extensions/size.dart';
 import '../extensions/offset.dart';
+import '../extensions/size.dart';
+import '../gestures.dart';
+import 'game.dart';
 import 'game_render_box.dart';
 
 typedef GameLoadingWidgetBuilder = Widget Function(
@@ -90,14 +90,14 @@ class GameWidget<T extends Game> extends StatefulWidget {
   ///   return GameWidget(
   ///     game: game,
   ///     overlayBuilderMap: {
-  ///       "PauseMenu": (ctx) {
-  ///         return Text("A pause menu");
+  ///       'PauseMenu': (ctx) {
+  ///         return Text('A pause menu');
   ///       },
   ///     },
   ///   )
   /// }
   /// ...
-  /// game.overlays.add("PauseMenu");
+  /// game.overlays.add('PauseMenu');
   /// ```
   const GameWidget({
     Key key,
@@ -112,8 +112,7 @@ class GameWidget<T extends Game> extends StatefulWidget {
 
   /// Renders a [game] in a flutter widget tree alongside widgets overlays.
   ///
-  /// To use overlays, the game subclass has to be mixed with [HasWidgetsOverlay],
-
+  /// To use overlays, the game subclass has to be mixed with HasWidgetsOverlay.
   @override
   _GameWidgetState<T> createState() => _GameWidgetState<T>();
 }
@@ -180,7 +179,7 @@ class _GameWidgetState<T extends Game> extends State<GameWidget<T>> {
     overlays.forEach((overlayKey) {
       assert(
         widget.overlayBuilderMap?.containsKey(overlayKey) ?? false,
-        "A non mapped overlay has been added: $overlayKey",
+        'A non mapped overlay has been added: $overlayKey',
       );
     });
   }
@@ -424,8 +423,8 @@ Widget _applyBasicGesturesDetectors(Game game, Widget child) {
 }
 
 Widget _applyAdvancedGesturesDetectors(Game game, Widget child) {
-  final Map<Type, GestureRecognizerFactory> gestures = {};
-  int lastGeneratedDragId = 0;
+  final gestures = <Type, GestureRecognizerFactory>{};
+  var lastGeneratedDragId = 0;
 
   void addAndConfigureRecognizer<T extends GestureRecognizer>(
     T Function() ts,

--- a/lib/src/geometry/circle.dart
+++ b/lib/src/geometry/circle.dart
@@ -63,35 +63,34 @@ class Circle extends Shape {
   }) {
     double sq(double x) => pow(x, 2).toDouble();
 
-    final double cx = shapeCenter.x;
-    final double cy = shapeCenter.y;
+    final cx = shapeCenter.x;
+    final cy = shapeCenter.y;
 
-    final Vector2 point1 = line.from;
-    final Vector2 point2 = line.to;
+    final point1 = line.from;
+    final point2 = line.to;
 
-    final Vector2 delta = point2 - point1;
+    final delta = point2 - point1;
 
-    final double A = sq(delta.x) + sq(delta.y);
-    final double B =
-        2 * (delta.x * (point1.x - cx) + delta.y * (point1.y - cy));
-    final double C = sq(point1.x - cx) + sq(point1.y - cy) - sq(radius);
+    final A = sq(delta.x) + sq(delta.y);
+    final B = 2 * (delta.x * (point1.x - cx) + delta.y * (point1.y - cy));
+    final C = sq(point1.x - cx) + sq(point1.y - cy) - sq(radius);
 
-    final double det = B * B - 4 * A * C;
+    final det = B * B - 4 * A * C;
     final result = <Vector2>[];
     if (A <= epsilon || det < 0) {
       return [];
     } else if (det == 0) {
-      final double t = -B / (2 * A);
+      final t = -B / (2 * A);
       result.add(Vector2(point1.x + t * delta.x, point1.y + t * delta.y));
     } else {
-      final double t1 = (-B + sqrt(det)) / (2 * A);
-      final Vector2 i1 = Vector2(
+      final t1 = (-B + sqrt(det)) / (2 * A);
+      final i1 = Vector2(
         point1.x + t1 * delta.x,
         point1.y + t1 * delta.y,
       );
 
-      final double t2 = (-B - sqrt(det)) / (2 * A);
-      final Vector2 i2 = Vector2(
+      final t2 = (-B - sqrt(det)) / (2 * A);
+      final i2 = Vector2(
         point1.x + t2 * delta.x,
         point1.y + t2 * delta.y,
       );

--- a/lib/src/geometry/collision_detection.dart
+++ b/lib/src/geometry/collision_detection.dart
@@ -1,14 +1,12 @@
-import 'shape.dart';
-import '../components/mixins/collidable.dart';
 import '../../extensions.dart';
-import '../../geometry.dart';
+import '../components/mixins/collidable.dart';
 
 /// Check whether any [Collidable] in [collidables] collide with each other and
 /// call their onCollision methods accordingly.
 void collisionDetection(List<Collidable> collidables) {
-  for (int x = 0; x < collidables.length; x++) {
+  for (var x = 0; x < collidables.length; x++) {
     final collidableX = collidables[x];
-    for (int y = x + 1; y < collidables.length; y++) {
+    for (var y = x + 1; y < collidables.length; y++) {
       final collidableY = collidables[y];
       final points = intersections(collidableX, collidableY);
       if (points.isNotEmpty) {
@@ -30,16 +28,14 @@ Set<Vector2> intersections(
 
   final result = <Vector2>{};
   final currentResult = <Vector2>{};
-  for (Shape shapeA in collidableA.shapes) {
-    for (Shape shapeB in collidableB.shapes) {
+  for (final shapeA in collidableA.shapes) {
+    for (final shapeB in collidableB.shapes) {
       currentResult.addAll(shapeA.intersections(shapeB));
       if (currentResult.isNotEmpty) {
         result.addAll(currentResult);
         // Do callbacks to the involved shapes
-        final hitboxShapeA = shapeA as HitboxShape;
-        final hitboxShapeB = shapeB as HitboxShape;
-        hitboxShapeA.onCollision(currentResult, hitboxShapeB);
-        hitboxShapeB.onCollision(currentResult, hitboxShapeA);
+        shapeA.onCollision(currentResult, shapeB);
+        shapeB.onCollision(currentResult, shapeA);
         currentResult.clear();
       }
     }

--- a/lib/src/geometry/line.dart
+++ b/lib/src/geometry/line.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 import '../../extensions.dart';
 
 /// This represents a line on the ax + by = c form
-/// If you just want to represent a part of a line, look into [LineSegment].
+/// If you just want to represent a part of a line, look into LineSegment.
 class Line {
   final double a;
   final double b;
@@ -40,8 +40,8 @@ class Line {
 
   @override
   String toString() {
-    final ax = "${a}x";
-    final by = b.isNegative ? "${b}y" : "+${b}y";
-    return "$ax$by=$c";
+    final ax = '${a}x';
+    final by = b.isNegative ? '${b}y' : '+${b}y';
+    return '$ax$by=$c';
   }
 }

--- a/lib/src/geometry/line_segment.dart
+++ b/lib/src/geometry/line_segment.dart
@@ -1,5 +1,5 @@
-import 'line.dart';
 import '../../extensions.dart';
+import 'line.dart';
 
 /// A [LineSegment] represent a segment of an infinitely long line, it is the
 /// segment between the [from] and [to] vectors (inclusive).
@@ -89,6 +89,6 @@ class LineSegment {
 
   @override
   String toString() {
-    return "[$from, $to]";
+    return '[$from, $to]';
   }
 }

--- a/lib/src/geometry/polygon.dart
+++ b/lib/src/geometry/polygon.dart
@@ -120,7 +120,7 @@ class Polygon extends Shape {
     }
 
     final vertices = hitbox();
-    for (int i = 0; i < vertices.length; i++) {
+    for (var i = 0; i < vertices.length; i++) {
       final edge = getEdge(i, vertices: vertices);
       final isOutside = (edge.to.x - edge.from.x) * (point.y - edge.from.y) -
               (point.x - edge.from.x) * (edge.to.y - edge.from.y) >
@@ -136,9 +136,9 @@ class Polygon extends Shape {
   /// Return all vertices as [LineSegment]s that intersect [rect], if [rect]
   /// is null return all vertices as [LineSegment]s.
   List<LineSegment> possibleIntersectionVertices(Rect rect) {
-    final List<LineSegment> rectIntersections = [];
+    final rectIntersections = <LineSegment>[];
     final vertices = hitbox();
-    for (int i = 0; i < vertices.length; i++) {
+    for (var i = 0; i < vertices.length; i++) {
       final edge = getEdge(i, vertices: vertices);
       if (rect?.intersectsSegment(edge.from, edge.to) ?? true) {
         rectIntersections.add(edge);

--- a/lib/src/geometry/rectangle.dart
+++ b/lib/src/geometry/rectangle.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
-import '../../geometry.dart';
 import '../../extensions.dart';
+import '../../geometry.dart';
 import 'shape.dart';
 
 class Rectangle extends Polygon {
@@ -35,7 +35,7 @@ class Rectangle extends Polygon {
   /// of itself. The [position] will therefore be the center of the Rectangle.
   ///
   /// If you want to create the [Rectangle] from a positioned [Rect] instead,
-  /// have a look at [Rectangle.toRect].
+  /// have a look at [Rectangle.fromRect].
   Rectangle.fromDefinition({
     Vector2 relation,
     Vector2 position,

--- a/lib/src/geometry/shape.dart
+++ b/lib/src/geometry/shape.dart
@@ -72,8 +72,12 @@ mixin HitboxShape on Shape {
   CollisionCallback onCollision = emptyCollisionCallback;
 }
 
-typedef CollisionCallback = Function(Set<Vector2> points, HitboxShape other);
-final CollisionCallback emptyCollisionCallback = (_a, _b) {};
+typedef CollisionCallback = void Function(
+  Set<Vector2> points,
+  HitboxShape other,
+);
+
+void emptyCollisionCallback(Set<Vector2> _, HitboxShape __) {}
 
 /// Used for caching calculated shapes, the cache is determined to be valid by
 /// comparing a list of values that can be of any type and is compared to the
@@ -89,7 +93,7 @@ class ShapeCache<T> {
     if (value == null) {
       return false;
     }
-    for (int i = 0; i < _lastValidCacheValues.length; ++i) {
+    for (var i = 0; i < _lastValidCacheValues.length; ++i) {
       if (_lastValidCacheValues[i] != validCacheValues[i]) {
         return false;
       }

--- a/lib/src/geometry/shape_intersections.dart
+++ b/lib/src/geometry/shape_intersections.dart
@@ -3,11 +3,11 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+import '../../extensions.dart';
+import '../../geometry.dart';
 import 'circle.dart';
 import 'polygon.dart';
 import 'shape.dart';
-import '../../extensions.dart';
-import '../../geometry.dart';
 
 abstract class Intersections<T1 extends Shape, T2 extends Shape> {
   Set<Vector2> intersect(T1 shapeA, T2 shapeB);
@@ -45,8 +45,8 @@ class PolygonPolygonIntersections extends Intersections<Polygon, Polygon> {
     final intersectionsB = polygonB.possibleIntersectionVertices(
       overlappingRect,
     );
-    for (LineSegment lineA in intersectionsA) {
-      for (LineSegment lineB in intersectionsB) {
+    for (final lineA in intersectionsA) {
+      for (final lineB in intersectionsB) {
         intersectionPoints.addAll(lineA.intersections(lineB));
       }
     }
@@ -65,7 +65,7 @@ class CirclePolygonIntersections extends Intersections<Circle, Polygon> {
     final possibleVertices = polygon.possibleIntersectionVertices(
       overlappingRect,
     );
-    for (LineSegment line in possibleVertices) {
+    for (final line in possibleVertices) {
       intersectionPoints.addAll(circle.lineSegmentIntersections(line));
     }
     return intersectionPoints;

--- a/lib/src/parallax.dart
+++ b/lib/src/parallax.dart
@@ -4,9 +4,9 @@ import 'dart:ui';
 import 'package:flutter/painting.dart';
 
 import 'assets/images.dart';
+import 'extensions/canvas.dart';
 import 'extensions/rect.dart';
 import 'extensions/vector2.dart';
-import 'extensions/canvas.dart';
 import 'flame.dart';
 import 'game/game.dart';
 
@@ -121,7 +121,7 @@ class ParallaxLayer {
   /// [parallaxImage] is the representation of the image with data of how the
   /// image should behave.
   /// [velocityMultiplier] will be used to determine the velocity of the layer by
-  /// multiplying the [baseVelocity] with the [velocityMultiplier].
+  /// multiplying the [Parallax.baseVelocity] with the [velocityMultiplier].
   ParallaxLayer(
     this.parallaxImage, {
     Vector2 velocityMultiplier,
@@ -152,10 +152,10 @@ class ParallaxLayer {
 
     // Number of images that can fit on the canvas plus one
     // to have something to scroll to without leaving canvas empty
-    final Vector2 count = Vector2.all(1) + (size.clone()..divide(_imageSize));
+    final count = Vector2.all(1) + (size.clone()..divide(_imageSize));
 
     // Percentage of the image size that will overflow
-    final Vector2 overflow = ((_imageSize.clone()..multiply(count)) - size)
+    final overflow = ((_imageSize.clone()..multiply(count)) - size)
       ..divide(_imageSize);
 
     // Align image to correct side of the screen
@@ -165,7 +165,7 @@ class ParallaxLayer {
     _scroll ??= Vector2(marginX, marginY);
 
     // Size of the area to paint the images on
-    final Vector2 paintSize = count..multiply(_imageSize);
+    final paintSize = count..multiply(_imageSize);
     _paintArea = paintSize.toRect();
   }
 
@@ -186,7 +186,7 @@ class ParallaxLayer {
         break;
     }
 
-    final Vector2 scrollPosition = _scroll.clone()..multiply(_imageSize);
+    final scrollPosition = _scroll.clone()..multiply(_imageSize);
     _paintArea = Rect.fromLTWH(
       -scrollPosition.x,
       -scrollPosition.y,
@@ -281,7 +281,7 @@ class Parallax {
   ///
   /// [load] takes a list of paths to all the images that you want to use in the
   /// parallax.
-  /// Optionally arguments for the [baseVelocity] and [layerDelta] can be passed
+  /// Optionally arguments for the [baseVelocity] and [velocityMultiplierDelta] can be passed
   /// in, [baseVelocity] defines what the base velocity of the layers should be
   /// and [velocityMultiplierDelta] defines how the velocity should change the
   /// closer the layer is ([velocityMultiplierDelta ^ n], where n is the
@@ -302,7 +302,7 @@ class Parallax {
     Images images,
   }) async {
     velocityMultiplierDelta ??= Vector2.all(1.0);
-    int depth = 0;
+    var depth = 0;
     final layers = await Future.wait<ParallaxLayer>(
       paths.map((path) async {
         final image = ParallaxImage.load(

--- a/lib/src/particles/accelerated_particle.dart
+++ b/lib/src/particles/accelerated_particle.dart
@@ -1,10 +1,10 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../components/mixins/single_child_particle.dart';
-import 'particle.dart';
 import 'curved_particle.dart';
+import 'particle.dart';
 
 /// A particle serves as a container for basic
 /// acceleration physics.

--- a/lib/src/particles/animation_particle.dart
+++ b/lib/src/particles/animation_particle.dart
@@ -1,11 +1,11 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../anchor.dart';
 import '../extensions/vector2.dart';
-import 'particle.dart';
 import '../sprite_animation.dart';
+import 'particle.dart';
 
 export '../sprite_animation.dart';
 

--- a/lib/src/particles/circle_particle.dart
+++ b/lib/src/particles/circle_particle.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import 'particle.dart';
 

--- a/lib/src/particles/component_particle.dart
+++ b/lib/src/particles/component_particle.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../components/component.dart';
 import '../extensions/vector2.dart';

--- a/lib/src/particles/composed_particle.dart
+++ b/lib/src/particles/composed_particle.dart
@@ -20,14 +20,14 @@ class ComposedParticle extends Particle {
   void setLifespan(double lifespan) {
     super.setLifespan(lifespan);
 
-    for (var child in children) {
+    for (final child in children) {
       child.setLifespan(lifespan);
     }
   }
 
   @override
   void render(Canvas c) {
-    for (var child in children) {
+    for (final child in children) {
       child.render(c);
     }
   }
@@ -36,7 +36,7 @@ class ComposedParticle extends Particle {
   void update(double dt) {
     super.update(dt);
 
-    for (var child in children) {
+    for (final child in children) {
       child.update(dt);
     }
   }

--- a/lib/src/particles/composed_particle.dart
+++ b/lib/src/particles/composed_particle.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import 'particle.dart';
 

--- a/lib/src/particles/computed_particle.dart
+++ b/lib/src/particles/computed_particle.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import 'particle.dart';
 
@@ -9,7 +9,7 @@ import 'particle.dart';
 /// rendering should be stored elsewhere, so that this delegate could use it
 typedef ParticleRenderDelegate = void Function(Canvas c, Particle particle);
 
-/// An abstract [Particle] container which delegates renderign outside
+/// An abstract [Particle] container which delegates rendering outside
 /// Allows to implement very interesting scenarios from scratch.
 class ComputedParticle extends Particle {
   // A delegate function which will be called

--- a/lib/src/particles/image_particle.dart
+++ b/lib/src/particles/image_particle.dart
@@ -1,13 +1,12 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../extensions/vector2.dart';
 import 'particle.dart';
 
-/// A [Particle] which renders given [Image] on a [Canvas]
-/// image is centered. If any other behavior is needed, consider
-/// using [ComputedParticle].
+/// A [Particle] which renders given [Image] on a [Canvas] image is centered.
+/// If any other behavior is needed, consider using ComputedParticle.
 class ImageParticle extends Particle {
   /// dart.ui [Image] to draw
   Image image;

--- a/lib/src/particles/moving_particle.dart
+++ b/lib/src/particles/moving_particle.dart
@@ -1,11 +1,11 @@
 import 'dart:ui';
 
 import 'package:flutter/animation.dart';
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../components/mixins/single_child_particle.dart';
-import 'particle.dart';
 import '../particles/curved_particle.dart';
+import 'particle.dart';
 
 /// Statically offset given child [Particle] by given [Offset]
 /// If you're looking to move the child, consider [MovingParticle]
@@ -30,7 +30,7 @@ class MovingParticle extends CurvedParticle with SingleChildParticle {
   @override
   void render(Canvas c) {
     c.save();
-    final Offset current = Offset.lerp(from, to, progress);
+    final current = Offset.lerp(from, to, progress);
     c.translate(current.dx, current.dy);
     super.render(c);
     c.restore();

--- a/lib/src/particles/paint_particle.dart
+++ b/lib/src/particles/paint_particle.dart
@@ -1,10 +1,10 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../components/mixins/single_child_particle.dart';
-import 'particle.dart';
 import 'curved_particle.dart';
+import 'particle.dart';
 
 /// A particle which renders its child with certain [Paint]
 /// Could be used for applying composite effects.

--- a/lib/src/particles/particle.dart
+++ b/lib/src/particles/particle.dart
@@ -2,17 +2,17 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/animation.dart';
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../components/component.dart';
 import '../components/particle_component.dart';
+import '../timer.dart';
 import 'accelerated_particle.dart';
 import 'composed_particle.dart';
 import 'moving_particle.dart';
 import 'rotating_particle.dart';
 import 'scaled_particle.dart';
 import 'translated_particle.dart';
-import '../timer.dart';
 
 /// A function which returns [Particle] when called
 typedef ParticleGenerator = Particle Function(int);
@@ -68,7 +68,7 @@ abstract class Particle {
 
   /// Getter which should be used by subclasses
   /// to get overall progress. Also allows to substitute
-  /// progres with other values, for example adding easing as in [CurvedParticle].
+  /// progress with other values, for example adding easing as in CurvedParticle.
   double get progress => _timer.progress;
 
   /// Should render this [Particle] to given [Canvas].
@@ -90,7 +90,7 @@ abstract class Particle {
   /// to pass down it's lifespan. Allows to only specify desired lifespan
   /// once, at the very top of the [Particle] tree which
   /// then will be propagated down using this method.
-  /// See [SingleChildParticle] or [ComposedParticle] for details.
+  /// See SingleChildParticle or [ComposedParticle] for details.
   void setLifespan(double lifespan) {
     _lifespan = lifespan;
     _timer?.stop();
@@ -176,7 +176,7 @@ abstract class Particle {
   }
 
   /// Wraps this particle with [ParticleComponent]
-  /// to be used within the [BaseGame] component system.
+  /// to be used within the BaseGame component system.
   Component asComponent() {
     return ParticleComponent(particle: this);
   }

--- a/lib/src/particles/particle.dart
+++ b/lib/src/particles/particle.dart
@@ -94,7 +94,7 @@ abstract class Particle {
   void setLifespan(double lifespan) {
     _lifespan = lifespan;
     _timer?.stop();
-    final void Function() removeCallback = () => _shouldBeRemoved = true;
+    void removeCallback() => _shouldBeRemoved = true;
     _timer = Timer(lifespan, callback: removeCallback);
     _timer.start();
   }

--- a/lib/src/particles/rotating_particle.dart
+++ b/lib/src/particles/rotating_particle.dart
@@ -1,11 +1,11 @@
 import 'dart:math';
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../components/mixins/single_child_particle.dart';
-import 'particle.dart';
 import 'curved_particle.dart';
+import 'particle.dart';
 
 /// A particle which rotates its child over the lifespan
 /// between two given bounds in radians

--- a/lib/src/particles/scaled_particle.dart
+++ b/lib/src/particles/scaled_particle.dart
@@ -1,10 +1,10 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../components/mixins/single_child_particle.dart';
-import 'particle.dart';
 import 'curved_particle.dart';
+import 'particle.dart';
 
 /// A particle which rotates its child over the lifespan
 /// between two given bounds in radians

--- a/lib/src/particles/sprite_particle.dart
+++ b/lib/src/particles/sprite_particle.dart
@@ -1,11 +1,11 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../anchor.dart';
-import 'particle.dart';
-import '../sprite.dart';
 import '../extensions/vector2.dart';
+import '../sprite.dart';
+import 'particle.dart';
 
 export '../sprite.dart';
 

--- a/lib/src/particles/translated_particle.dart
+++ b/lib/src/particles/translated_particle.dart
@@ -1,12 +1,12 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 import '../components/mixins/single_child_particle.dart';
 import 'particle.dart';
 
 /// Statically offset given child [Particle] by given [Offset]
-/// If you're loking to move the child, consider [MovingParticle]
+/// If you're looking to move the child, consider MovingParticle.
 class TranslatedParticle extends Particle with SingleChildParticle {
   @override
   Particle child;

--- a/lib/src/sprite.dart
+++ b/lib/src/sprite.dart
@@ -2,11 +2,11 @@ import 'dart:ui';
 
 import '../image_composition.dart';
 import 'anchor.dart';
+import 'assets/images.dart';
 import 'extensions/offset.dart';
 import 'extensions/vector2.dart';
 import 'flame.dart';
 import 'palette.dart';
-import 'assets/images.dart';
 
 class Sprite {
   Paint paint = BasicPalette.white.paint;

--- a/lib/src/sprite.dart
+++ b/lib/src/sprite.dart
@@ -44,8 +44,9 @@ class Sprite {
   Vector2 get srcSize => Vector2(src.width, src.height);
 
   set srcSize(Vector2 size) {
-    size ??= Vector2Extension.fromInts(image.width, image.height);
-    src = srcPosition.toPositionedRect(size);
+    final actualSize =
+        size ?? Vector2Extension.fromInts(image.width, image.height);
+    src = srcPosition.toPositionedRect(actualSize);
   }
 
   Vector2 get srcPosition => src.topLeft.toVector2();

--- a/lib/src/sprite_animation.dart
+++ b/lib/src/sprite_animation.dart
@@ -1,5 +1,6 @@
-import 'package:meta/meta.dart';
 import 'dart:ui';
+
+import 'package:meta/meta.dart';
 
 import 'assets/images.dart';
 import 'extensions/vector2.dart';
@@ -173,14 +174,14 @@ class SpriteAnimation {
     final frames = jsonFrames.values.map((dynamic value) {
       final map = value as Map;
       final frameData = map['frame'] as Map<String, dynamic>;
-      final int x = frameData['x'] as int;
-      final int y = frameData['y'] as int;
-      final int width = frameData['w'] as int;
-      final int height = frameData['h'] as int;
+      final x = frameData['x'] as int;
+      final y = frameData['y'] as int;
+      final width = frameData['w'] as int;
+      final height = frameData['h'] as int;
 
       final stepTime = (map['duration'] as int) / 1000;
 
-      final Sprite sprite = Sprite(
+      final sprite = Sprite(
         image,
         srcPosition: Vector2Extension.fromInts(x, y),
         srcSize: Vector2Extension.fromInts(width, height),
@@ -217,7 +218,7 @@ class SpriteAnimation {
   /// Sets a different step time to each frame. The sizes of the arrays must match.
   set variableStepTimes(List<double> stepTimes) {
     assert(stepTimes.length == frames.length);
-    for (int i = 0; i < frames.length; i++) {
+    for (var i = 0; i < frames.length; i++) {
       frames[i].stepTime = stepTimes[i];
     }
   }

--- a/lib/src/sprite_animation.dart
+++ b/lib/src/sprite_animation.dart
@@ -171,13 +171,14 @@ class SpriteAnimation {
     final jsonFrames = jsonData['frames'] as Map<String, dynamic>;
 
     final frames = jsonFrames.values.map((dynamic value) {
-      final frameData = value['frame'] as Map<String, dynamic>;
+      final map = value as Map;
+      final frameData = map['frame'] as Map<String, dynamic>;
       final int x = frameData['x'] as int;
       final int y = frameData['y'] as int;
       final int width = frameData['w'] as int;
       final int height = frameData['h'] as int;
 
-      final stepTime = (value['duration'] as int) / 1000;
+      final stepTime = (map['duration'] as int) / 1000;
 
       final Sprite sprite = Sprite(
         image,

--- a/lib/src/sprite_batch.dart
+++ b/lib/src/sprite_batch.dart
@@ -26,7 +26,7 @@ extension SpriteBatchExtension on Game {
   }
 }
 
-/// This is the scale value used in [BatchItem.matrix], we can't determine this from the [Batchitem.transform],
+/// This is the scale value used in [BatchItem.matrix], we can't determine this from the [BatchItem.transform],
 /// but we also don't need to do so because it is already calculated inside the transform values.
 const _defaultScale = 0.0;
 
@@ -82,7 +82,7 @@ class BatchItem {
 /// The SpriteBatch API allows for rendering multiple items at once.
 ///
 /// This class allows for optimization when you want to draw many parts of an
-/// image onto the canvas. It is more efficient than using multiple calls to [drawImageRect]
+/// image onto the canvas. It is more efficient than using multiple calls to [Canvas.drawImageRect]
 /// and provides more functionality by allowing each [BatchItem] to have their own transform
 /// rotation and color.
 ///
@@ -176,10 +176,11 @@ class SpriteBatch {
 
   /// Add a new batch item using a RSTransform.
   ///
-  /// The [source] parameter is the source location on the [atlas]. You can position it
-  /// on the canvas using the [offset] parameter.
+  /// The [source] parameter is the source location on the [atlas].
   ///
-  /// The [color] paramater allows you to render a color behind the batch item, as a background color.
+  /// You can position, rotate and scale it on the canvas using the [transform] parameter.
+  ///
+  /// The [color] parameter allows you to render a color behind the batch item, as a background color.
   ///
   /// The [add] method may be a simpler way to add a batch item to the batch. However,
   /// if there is a way to factor out the computations of the sine and cosine of the
@@ -210,7 +211,7 @@ class SpriteBatch {
   ///
   /// You can transform the sprite from its [offset] using [scale], [rotation] and [anchor].
   ///
-  /// The [color] paramater allows you to render a color behind the batch item, as a background color.
+  /// The [color] parameter allows you to render a color behind the batch item, as a background color.
   ///
   /// This method creates a new [RSTransform] based on the given transform arguments. If many [RSTransform] objects are being
   /// created and there is a way to factor out the computations of the sine and cosine of the rotation

--- a/lib/src/text_config.dart
+++ b/lib/src/text_config.dart
@@ -20,7 +20,7 @@ class TextConfig {
 
   /// The font color to be used.
   ///
-  /// Dart's [Color] class is just a plain wrapper on top of ARGB color (0xFFrrggbb).
+  /// Dart's [Color] class is just a plain wrapper on top of ARGB color (0xAARRGGBB).
   /// For example,
   ///
   ///     const TextConfig config = TextConfig(color: const Color(0xFF00FF00)); // green
@@ -30,13 +30,14 @@ class TextConfig {
 
   /// The font family to be used. You can use available by default fonts for your platform (like Arial), or you can add custom fonts.
   ///
-  /// To add custom fonts, add the following code to your pubspec.yml file:
+  /// To add custom fonts, add the following code to your pubspec.yaml file:
   ///
   ///     flutter:
   ///       fonts:
   ///         - family: 5x5
   ///           fonts:
   ///             - asset: assets/fonts/5x5_pixel.ttf
+  ///
   /// In this example we are adding a font family that's being named '5x5' provided in the specified ttf file.
   /// You must provide the full path of the ttf file (from root); you should put it into your assets folder, and preferably inside a fonts folder.
   /// You don't need to add this together with the other assets on the flutter/assets bit.
@@ -88,8 +89,8 @@ class TextConfig {
     Vector2 p, {
     Anchor anchor = Anchor.topLeft,
   }) {
-    final material.TextPainter tp = toTextPainter(text);
-    final Vector2 translatedPosition = anchor.translate(p, tp.size.toVector2());
+    final tp = toTextPainter(text);
+    final translatedPosition = anchor.translate(p, tp.size.toVector2());
     tp.paint(canvas, translatedPosition.toOffset());
   }
 
@@ -107,17 +108,17 @@ class TextConfig {
   /// That way, you don't need to perform the math for yourself.
   material.TextPainter toTextPainter(String text) {
     if (!_textPainterCache.containsKey(text)) {
-      final material.TextStyle style = material.TextStyle(
+      final style = material.TextStyle(
         color: color,
         fontSize: fontSize,
         fontFamily: fontFamily,
         height: lineHeight,
       );
-      final material.TextSpan span = material.TextSpan(
+      final span = material.TextSpan(
         style: style,
         text: text,
       );
-      final material.TextPainter tp = material.TextPainter(
+      final tp = material.TextPainter(
         text: span,
         textAlign: textAlign,
         textDirection: textDirection,

--- a/lib/src/timer.dart
+++ b/lib/src/timer.dart
@@ -65,7 +65,8 @@ class Timer {
   }
 }
 
-/// Simple component which wraps a [Timer] instance allowing it to be easily used inside a [BaseGame] game.
+/// Simple component which wraps a [Timer] instance allowing it to be easily
+/// used inside a BaseGame game.
 class TimerComponent extends Component {
   Timer timer;
 

--- a/lib/src/widgets/animation_widget.dart
+++ b/lib/src/widgets/animation_widget.dart
@@ -19,7 +19,7 @@ class SpriteAnimationWidget extends StatefulWidget {
   /// Should the [animation] be playing or not
   final bool playing;
 
-  SpriteAnimationWidget({
+  const SpriteAnimationWidget({
     this.animation,
     this.playing = true,
     this.anchor = Anchor.topLeft,
@@ -35,7 +35,7 @@ class _AnimationWidget extends State<SpriteAnimationWidget>
   double _lastUpdated;
 
   @override
-  void didUpdateWidget(oldWidget) {
+  void didUpdateWidget(SpriteAnimationWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.playing) {
       _initAnimation();
@@ -89,7 +89,7 @@ class _AnimationWidget extends State<SpriteAnimationWidget>
   }
 
   @override
-  Widget build(ctx) {
+  Widget build(BuildContext ctx) {
     return SpriteWidget(
       sprite: widget.animation.getSprite(),
       anchor: widget.anchor,

--- a/lib/src/widgets/nine_tile_box.dart
+++ b/lib/src/widgets/nine_tile_box.dart
@@ -1,6 +1,5 @@
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 

--- a/lib/src/widgets/nine_tile_box.dart
+++ b/lib/src/widgets/nine_tile_box.dart
@@ -133,7 +133,7 @@ class NineTileBox extends StatelessWidget {
 
   final EdgeInsetsGeometry padding;
 
-  NineTileBox({
+  const NineTileBox({
     @required this.image,
     @required this.tileSize,
     @required this.destTileSize,

--- a/lib/src/widgets/sprite_button.dart
+++ b/lib/src/widgets/sprite_button.dart
@@ -14,7 +14,7 @@ class SpriteButton extends StatefulWidget {
   final double width;
   final double height;
 
-  SpriteButton({
+  const SpriteButton({
     @required this.onPressed,
     @required this.label,
     @required this.sprite,

--- a/lib/src/widgets/sprite_widget.dart
+++ b/lib/src/widgets/sprite_widget.dart
@@ -20,7 +20,7 @@ class SpriteWidget extends StatelessWidget {
   /// The positioning [Anchor] for the [sprite]
   final Anchor anchor;
 
-  SpriteWidget({
+  const SpriteWidget({
     @required this.sprite,
     this.anchor = Anchor.topLeft,
   });

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -1,6 +1,5 @@
+export 'src/anchor.dart';
 export 'src/widgets/animation_widget.dart';
 export 'src/widgets/nine_tile_box.dart';
 export 'src/widgets/sprite_button.dart';
 export 'src/widgets/sprite_widget.dart';
-
-export 'src/anchor.dart';

--- a/test/base_game_test.dart
+++ b/test/base_game_test.dart
@@ -64,8 +64,8 @@ Vector2 size = Vector2(1.0, 1.0);
 void main() {
   group('BaseGame test', () {
     test('adds the component to the component list', () {
-      final MyGame game = MyGame();
-      final MyComponent component = MyComponent();
+      final game = MyGame();
+      final component = MyComponent();
 
       game.onResize(size);
       game.add(component);
@@ -78,8 +78,8 @@ void main() {
     test(
       'when the component has onLoad function, adds after load completion',
       () async {
-        final MyGame game = MyGame();
-        final MyAsyncComponent component = MyAsyncComponent();
+        final game = MyGame();
+        final component = MyAsyncComponent();
 
         game.onResize(size);
         await game.add(component);
@@ -94,8 +94,8 @@ void main() {
     );
 
     test('prepare adds gameRef and calls onGameResize', () {
-      final MyGame game = MyGame();
-      final MyComponent component = MyComponent();
+      final game = MyGame();
+      final component = MyComponent();
 
       game.onResize(size);
       game.add(component);
@@ -105,21 +105,21 @@ void main() {
     });
 
     test('component can be tapped', () {
-      final MyGame game = MyGame();
-      final MyComponent component = MyComponent();
+      final game = MyGame();
+      final component = MyComponent();
 
       game.onResize(size);
       game.add(component);
       // The component is not added to the component list until an update has been performed
       game.update(0.0);
-      game.onTapDown(1, TapDownDetails(globalPosition: const Offset(0.0, 0.0)));
+      game.onTapDown(1, TapDownDetails());
 
       expect(component.tapped, true);
     });
 
     test('component is added to component list', () {
-      final MyGame game = MyGame();
-      final MyComponent component = MyComponent();
+      final game = MyGame();
+      final component = MyComponent();
 
       game.onResize(size);
       game.add(component);
@@ -132,8 +132,8 @@ void main() {
     flutter.testWidgets(
       'component render and update is called',
       (flutter.WidgetTester tester) async {
-        final MyGame game = MyGame();
-        final MyComponent component = MyComponent();
+        final game = MyGame();
+        final component = MyComponent();
 
         game.onResize(size);
         game.add(component);
@@ -159,8 +159,8 @@ void main() {
     );
 
     test('onRemove is only called once on component', () {
-      final MyGame game = MyGame();
-      final MyComponent component = MyComponent();
+      final game = MyGame();
+      final component = MyComponent();
 
       game.onResize(size);
       game.add(component);

--- a/test/components/collision_detection_test.dart
+++ b/test/components/collision_detection_test.dart
@@ -149,24 +149,24 @@ void main() {
 
   group('Line.intersections tests', () {
     test('Simple line intersection', () {
-      const line1 = const Line(1, -1, 0);
-      const line2 = const Line(1, 1, 0);
+      const line1 = Line(1, -1, 0);
+      const line2 = Line(1, 1, 0);
       final intersection = line1.intersections(line2);
       expect(intersection.isNotEmpty, true, reason: 'Should have intersection');
       expect(intersection.first == Vector2.all(0), true);
     });
 
     test('Lines with c value', () {
-      const line1 = const Line(1, 1, 1);
-      const line2 = const Line(1, -1, 1);
+      const line1 = Line(1, 1, 1);
+      const line2 = Line(1, -1, 1);
       final intersection = line1.intersections(line2);
       expect(intersection.isNotEmpty, true, reason: 'Should have intersection');
       expect(intersection.first == Vector2(1, 0), true);
     });
 
     test('Does not catch parallel lines', () {
-      const line1 = const Line(1, 1, -3);
-      const line2 = const Line(1, 1, 6);
+      const line1 = Line(1, 1, -3);
+      const line2 = Line(1, 1, 6);
       final intersection = line1.intersections(line2);
       expect(
         intersection.isEmpty,
@@ -176,8 +176,8 @@ void main() {
     });
 
     test('Does not catch same line', () {
-      const line1 = const Line(1, 1, 1);
-      const line2 = const Line(1, 1, 1);
+      const line1 = Line(1, 1, 1);
+      const line2 = Line(1, 1, 1);
       final intersection = line1.intersections(line2);
       expect(
         intersection.isEmpty,
@@ -195,7 +195,7 @@ void main() {
       expect(line.c == 0.0, true, reason: 'c value is not correct');
     });
 
-    test('Line not going through origo', () {
+    test('Line not going through origin', () {
       final line = Line.fromPoints(Vector2(-2, 0), Vector2(0, 2));
       expect(line.a == 2.0, true, reason: 'a value is not correct');
       expect(line.b == -2.0, true, reason: 'b value is not correct');
@@ -220,35 +220,35 @@ void main() {
   group('LineSegment.pointsAt tests', () {
     test('Simple pointing', () {
       final segment = LineSegment(Vector2.zero(), Vector2.all(1));
-      const line = const Line(1, 1, 3);
+      const line = Line(1, 1, 3);
       final isPointingAt = segment.pointsAt(line);
       expect(isPointingAt, true, reason: 'Line should be pointed at');
     });
 
     test('Is not pointed at when crossed', () {
       final segment = LineSegment(Vector2.zero(), Vector2.all(3));
-      const line = const Line(1, 1, 3);
+      const line = Line(1, 1, 3);
       final isPointingAt = segment.pointsAt(line);
       expect(isPointingAt, false, reason: 'Line should not be pointed at');
     });
 
     test('Is not pointed at when parallel', () {
       final segment = LineSegment(Vector2.zero(), Vector2(1, -1));
-      const line = const Line(1, 1, 3);
+      const line = Line(1, 1, 3);
       final isPointingAt = segment.pointsAt(line);
       expect(isPointingAt, false, reason: 'Line should not be pointed at');
     });
 
-    test('Horizonal line can be pointed at', () {
+    test('Horizontal line can be pointed at', () {
       final segment = LineSegment(Vector2.zero(), Vector2.all(1));
-      const line = const Line(0, 1, 2);
+      const line = Line(0, 1, 2);
       final isPointingAt = segment.pointsAt(line);
       expect(isPointingAt, true, reason: 'Line should be pointed at');
     });
 
     test('Vertical line can be pointed at', () {
       final segment = LineSegment(Vector2.zero(), Vector2.all(1));
-      const line = const Line(1, 0, 2);
+      const line = Line(1, 0, 2);
       final isPointingAt = segment.pointsAt(line);
       expect(isPointingAt, true, reason: 'Line should be pointed at');
     });

--- a/test/components/composed_component_test.dart
+++ b/test/components/composed_component_test.dart
@@ -54,16 +54,16 @@ Vector2 size = Vector2.all(300);
 void main() {
   group('composable component test', () {
     test('adds the child to the component', () {
-      final MyTap child = MyTap();
-      final MyComposed wrapper = MyComposed();
+      final child = MyTap();
+      final wrapper = MyComposed();
       wrapper.addChild(child);
 
       expect(true, wrapper.containsChild(child));
     });
 
     test('removes the child from the component', () {
-      final MyTap child = MyTap();
-      final MyComposed wrapper = MyComposed();
+      final child = MyTap();
+      final wrapper = MyComposed();
       wrapper.addChild(child);
       expect(true, wrapper.containsChild(child));
 
@@ -74,8 +74,8 @@ void main() {
     test(
       'when child is async loading, adds the child to the component after loading',
       () async {
-        final MyAsyncChild child = MyAsyncChild();
-        final MyComposed wrapper = MyComposed();
+        final child = MyAsyncChild();
+        final wrapper = MyComposed();
         await wrapper.addChild(child);
 
         expect(true, wrapper.containsChild(child));
@@ -83,26 +83,27 @@ void main() {
     );
 
     test('taps and resizes children', () {
-      final MyGame game = MyGame();
-      final MyTap child = MyTap();
-      final MyComposed wrapper = MyComposed();
+      final game = MyGame();
+      final child = MyTap();
+      final wrapper = MyComposed();
+
       game.onResize(size);
       child.size = Vector2.all(1);
       game.add(wrapper);
       wrapper.addChild(child);
       game.update(0.0);
-      game.onTapDown(1, TapDownDetails(globalPosition: const Offset(0.0, 0.0)));
+      game.onTapDown(1, TapDownDetails());
 
       expect(child.gameSize, size);
       expect(child.tapped, true);
     });
 
     test('tap on offset children', () {
-      final MyGame game = MyGame();
-      final MyTap child = MyTap()
+      final game = MyGame();
+      final child = MyTap()
         ..position = Vector2.all(100)
         ..size = Vector2.all(100);
-      final MyComposed wrapper = MyComposed()
+      final wrapper = MyComposed()
         ..position = Vector2.all(100)
         ..size = Vector2.all(300);
 
@@ -118,10 +119,10 @@ void main() {
     });
 
     test('updates and renders children', () {
-      final MyGame game = MyGame();
+      final game = MyGame();
       game.onResize(Vector2.all(100));
-      final MyTap child = MyTap();
-      final MyComposed wrapper = MyComposed();
+      final child = MyTap();
+      final wrapper = MyComposed();
 
       wrapper.addChild(child);
       game.add(wrapper);

--- a/test/components/has_game_ref_test.dart
+++ b/test/components/has_game_ref_test.dart
@@ -18,8 +18,8 @@ class MyComponent extends PositionComponent with HasGameRef<MyGame> {
 void main() {
   group('has game ref test', () {
     test('simple test', () {
-      final MyComponent c = MyComponent();
-      final MyGame game = MyGame();
+      final c = MyComponent();
+      final game = MyGame();
       game.onResize(Vector2.all(200));
       game.add(c);
       c.foo();

--- a/test/components/resizable_test.dart
+++ b/test/components/resizable_test.dart
@@ -24,23 +24,23 @@ Vector2 size = Vector2(1.0, 1.0);
 void main() {
   group('resizable test', () {
     test('game calls resize on add', () {
-      final MyComponent a = MyComponent('a');
-      final MyGame game = MyGame();
+      final a = MyComponent('a');
+      final game = MyGame();
       game.onResize(size);
       game.add(a);
       expect(a.gameSize, size);
     });
     test('game calls resize after added', () {
-      final MyComponent a = MyComponent('a');
-      final MyGame game = MyGame();
+      final a = MyComponent('a');
+      final game = MyGame();
       game.onResize(Vector2.all(10));
       game.add(a);
       game.onResize(size);
       expect(a.gameSize, size);
     });
     test("game calls doesn't change component size", () {
-      final MyComponent a = MyComponent('a');
-      final MyGame game = MyGame();
+      final a = MyComponent('a');
+      final game = MyGame();
       game.onResize(Vector2.all(10));
       game.add(a);
       game.onResize(size);

--- a/test/effects/combined_effect_test.dart
+++ b/test/effects/combined_effect_test.dart
@@ -29,17 +29,17 @@ void main() {
     bool hasAlternatingRotateEffect = false,
     bool hasAlternatingScaleEffect = false,
   }) {
-    final MoveEffect move = MoveEffect(
+    final move = MoveEffect(
       path: path,
       duration: randomDuration(),
       isAlternating: hasAlternatingMoveEffect,
     );
-    final RotateEffect rotate = RotateEffect(
+    final rotate = RotateEffect(
       angle: argumentAngle,
       duration: randomDuration(),
       isAlternating: hasAlternatingRotateEffect,
     );
-    final ScaleEffect scale = ScaleEffect(
+    final scale = ScaleEffect(
       size: argumentSize,
       duration: randomDuration(),
       isAlternating: hasAlternatingScaleEffect,
@@ -149,7 +149,6 @@ void main() {
         expectedPosition: positionComponent.position.clone(),
         expectedAngle: argumentAngle,
         expectedSize: argumentSize,
-        shouldComplete: true,
       );
     },
   );
@@ -165,7 +164,6 @@ void main() {
         expectedPosition: path.last,
         expectedAngle: positionComponent.angle,
         expectedSize: argumentSize,
-        shouldComplete: true,
       );
     },
   );
@@ -181,7 +179,6 @@ void main() {
         expectedPosition: path.last,
         expectedAngle: argumentAngle,
         expectedSize: positionComponent.size.clone(),
-        shouldComplete: true,
       );
     },
   );

--- a/test/effects/combined_effect_test.dart
+++ b/test/effects/combined_effect_test.dart
@@ -7,13 +7,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'effect_test_utils.dart';
 
 void main() {
-  final Random random = Random();
+  final random = Random();
   Vector2 randomVector2() => (Vector2.random(random) * 100)..round();
   double randomAngle() => 1.0 + random.nextInt(5);
   double randomDuration() => 1.0 + random.nextInt(100);
-  final Vector2 argumentSize = randomVector2();
-  final double argumentAngle = randomAngle();
-  final List<Vector2> path = List.generate(3, (i) => randomVector2());
+  final argumentSize = randomVector2();
+  final argumentAngle = randomAngle();
+  final path = List.generate(3, (i) => randomVector2());
   TestComponent component() {
     return TestComponent(
       position: randomVector2(),

--- a/test/effects/effect_test_utils.dart
+++ b/test/effects/effect_test_utils.dart
@@ -25,19 +25,19 @@ void effectTest(
 }) async {
   expectedPosition ??= Vector2.zero();
   expectedSize ??= Vector2.all(100.0);
-  final Callback callback = Callback();
+  final callback = Callback();
   effect.onComplete = callback.call;
-  final BaseGame game = BaseGame();
+  final game = BaseGame();
   game.onResize(Vector2.all(200));
   game.add(component);
   component.addEffect(effect);
-  final double duration = effect.iterationTime;
+  final duration = effect.iterationTime;
   await tester.pumpWidget(GameWidget(
     game: game,
   ));
-  double timeLeft = iterations * duration;
+  var timeLeft = iterations * duration;
   while (timeLeft > 0) {
-    double stepDelta = 50.0 + random.nextInt(50);
+    var stepDelta = 50.0 + random.nextInt(50);
     stepDelta /= 1000;
     stepDelta = stepDelta < timeLeft ? stepDelta : timeLeft;
     game.update(stepDelta);
@@ -45,25 +45,25 @@ void effectTest(
   }
 
   if (!shouldComplete) {
-    const double floatRange = 0.01;
+    const floatRange = 0.01;
     expect(
       component.position.absoluteError(expectedPosition),
       closeTo(0.0, floatRange),
-      reason: "Position is not correct",
+      reason: 'Position is not correct',
     );
     expect(
       component.angle,
       closeTo(expectedAngle, floatRange),
-      reason: "Angle is not correct",
+      reason: 'Angle is not correct',
     );
     expect(
       component.size.absoluteError(expectedSize),
       closeTo(0.0, floatRange),
-      reason: "Size is not correct",
+      reason: 'Size is not correct',
     );
   } else {
     // To account for float number operations making effects not finish
-    const double epsilon = 0.001;
+    const epsilon = 0.001;
     if (effect.percentage < epsilon) {
       game.update(effect.currentTime);
     } else if (1.0 - effect.percentage < epsilon) {
@@ -73,24 +73,24 @@ void effectTest(
     expect(
       component.position,
       expectedPosition,
-      reason: "Position is not exactly correct",
+      reason: 'Position is not exactly correct',
     );
     expect(
       component.angle,
       expectedAngle,
-      reason: "Angle is not exactly correct",
+      reason: 'Angle is not exactly correct',
     );
     expect(
       component.size,
       expectedSize,
-      reason: "Size is not exactly correct",
+      reason: 'Size is not exactly correct',
     );
   }
-  expect(effect.hasCompleted(), shouldComplete, reason: "Effect shouldFinish");
+  expect(effect.hasCompleted(), shouldComplete, reason: 'Effect shouldFinish');
   expect(
     callback.isCalled,
     shouldComplete,
-    reason: "Callback was treated wrong",
+    reason: 'Callback was treated wrong',
   );
   game.update(0.0); // Since effects are removed before they are updated
   expect(component.effects.isEmpty, shouldComplete);

--- a/test/effects/move_effect_test.dart
+++ b/test/effects/move_effect_test.dart
@@ -7,9 +7,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'effect_test_utils.dart';
 
 void main() {
-  final Random random = Random();
+  final random = Random();
   Vector2 randomVector2() => (Vector2.random(random) * 100)..round();
-  final List<Vector2> path = List.generate(3, (i) => randomVector2());
+  final path = List.generate(3, (i) => randomVector2());
   TestComponent component() => TestComponent(position: randomVector2());
 
   MoveEffect effect({bool isInfinite = false, bool isAlternating = false}) {

--- a/test/effects/rotate_effect_test.dart
+++ b/test/effects/rotate_effect_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'effect_test_utils.dart';
 
 void main() {
-  const double angleArgument = 6.0;
+  const angleArgument = 6.0;
   TestComponent component() => TestComponent(angle: 0.5);
 
   RotateEffect effect({bool isInfinite = false, bool isAlternating = false}) {
@@ -59,7 +59,6 @@ void main() {
         positionComponent,
         effect(isInfinite: true, isAlternating: true),
         expectedAngle: positionComponent.angle,
-        iterations: 1.0,
         shouldComplete: false,
       );
     },

--- a/test/effects/scale_effect_test.dart
+++ b/test/effects/scale_effect_test.dart
@@ -7,9 +7,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'effect_test_utils.dart';
 
 void main() {
-  final Random random = Random();
+  final random = Random();
   Vector2 randomVector2() => (Vector2.random(random) * 100)..round();
-  final Vector2 argumentSize = randomVector2();
+  final argumentSize = randomVector2();
   TestComponent component() => TestComponent(size: randomVector2());
 
   ScaleEffect effect({bool isInfinite = false, bool isAlternating = false}) {

--- a/test/effects/sequence_effect_test.dart
+++ b/test/effects/sequence_effect_test.dart
@@ -7,13 +7,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'effect_test_utils.dart';
 
 void main() {
-  final Random random = Random();
+  final random = Random();
   Vector2 randomVector2() => (Vector2.random(random) * 100)..round();
   double randomAngle() => 1.0 + random.nextInt(5);
   double randomDuration() => 1.0 + random.nextInt(100);
-  final Vector2 argumentSize = randomVector2();
-  final double argumentAngle = randomAngle();
-  final List<Vector2> path = List.generate(3, (i) => randomVector2());
+  final argumentSize = randomVector2();
+  final argumentAngle = randomAngle();
+  final path = List.generate(3, (i) => randomVector2());
   TestComponent component() {
     return TestComponent(
       position: randomVector2(),
@@ -29,17 +29,17 @@ void main() {
     bool hasAlternatingRotateEffect = false,
     bool hasAlternatingScaleEffect = false,
   }) {
-    final MoveEffect move = MoveEffect(
+    final move = MoveEffect(
       path: path,
       duration: randomDuration(),
       isAlternating: hasAlternatingMoveEffect,
     );
-    final RotateEffect rotate = RotateEffect(
+    final rotate = RotateEffect(
       angle: argumentAngle,
       duration: randomDuration(),
       isAlternating: hasAlternatingRotateEffect,
     );
-    final ScaleEffect scale = ScaleEffect(
+    final scale = ScaleEffect(
       size: argumentSize,
       duration: randomDuration(),
       isAlternating: hasAlternatingScaleEffect,
@@ -148,7 +148,6 @@ void main() {
         expectedPosition: positionComponent.position.clone(),
         expectedAngle: argumentAngle,
         expectedSize: argumentSize,
-        shouldComplete: true,
       );
     },
   );
@@ -164,7 +163,6 @@ void main() {
         expectedPosition: path.last,
         expectedAngle: positionComponent.angle,
         expectedSize: argumentSize,
-        shouldComplete: true,
       );
     },
   );
@@ -180,7 +178,6 @@ void main() {
         expectedPosition: path.last,
         expectedAngle: argumentAngle,
         expectedSize: positionComponent.size.clone(),
-        shouldComplete: true,
       );
     },
   );

--- a/test/images_test.dart
+++ b/test/images_test.dart
@@ -15,7 +15,13 @@ void main() {
         data[i + 2] = 255;
         data[i + 3] = 255;
       }
-      final image = await Flame.images.decodeImageFromPixels(data, 8, 8);
+      final image = await Flame.images.decodeImageFromPixels(
+        data,
+        8,
+        8,
+        // ignore: avoid_redundant_argument_values
+        runAsWeb: false, // default value is kIsWeb
+      );
 
       expect((await image.toByteData()).buffer.asUint8List(), equals(output));
     });
@@ -32,7 +38,8 @@ void main() {
         data,
         8,
         8,
-        runAsWeb: true,
+        // ignore: avoid_redundant_argument_values
+        runAsWeb: true, // default value is kIsWeb
       );
 
       expect((await image.toByteData()).buffer.asUint8List(), equals(output));

--- a/test/vector2_test.dart
+++ b/test/vector2_test.dart
@@ -1,6 +1,7 @@
+import 'dart:math' as math;
+
 import 'package:flame/extensions.dart';
 import 'package:test/test.dart';
-import 'dart:math' as math;
 
 void expectDouble(double d1, double d2) {
   expect((d1 - d2).abs() <= 0.0001, true);
@@ -9,14 +10,14 @@ void expectDouble(double d1, double d2) {
 void main() {
   group('Vector2 test', () {
     test('test add', () {
-      final Vector2 p = Vector2(0.0, 5.0) + Vector2(5.0, 5.0);
+      final p = Vector2(0.0, 5.0) + Vector2(5.0, 5.0);
       expectDouble(p.x, 5.0);
       expectDouble(p.y, 10.0);
     });
 
     test('test clone', () {
-      final Vector2 p = Vector2(1.0, 0.0);
-      final Vector2 clone = p.clone();
+      final p = Vector2(1.0, 0.0);
+      final clone = p.clone();
 
       clone.scale(2.0);
       expectDouble(p.x, 1.0);
@@ -24,49 +25,49 @@ void main() {
     });
 
     test('test rotate', () {
-      final Vector2 p = Vector2(1.0, 0.0)..rotate(math.pi / 2);
+      final p = Vector2(1.0, 0.0)..rotate(math.pi / 2);
       expectDouble(p.x, 0.0);
       expectDouble(p.y, 1.0);
     });
 
     test('test length', () {
-      final Vector2 p1 = Vector2(3.0, 4.0);
+      final p1 = Vector2(3.0, 4.0);
       expectDouble(p1.length, 5.0);
 
-      final Vector2 p2 = Vector2(2.0, 0.0);
+      final p2 = Vector2(2.0, 0.0);
       expectDouble(p2.length, 2.0);
 
-      final Vector2 p3 = Vector2(0.0, 1.5);
+      final p3 = Vector2(0.0, 1.5);
       expectDouble(p3.length, 1.5);
     });
 
     test('test distance', () {
-      final Vector2 p1 = Vector2(10.0, 20.0);
-      final Vector2 p2 = Vector2(13.0, 24.0);
-      final double result = p1.distanceTo(p2);
+      final p1 = Vector2(10.0, 20.0);
+      final p2 = Vector2(13.0, 24.0);
+      final result = p1.distanceTo(p2);
       expectDouble(result, 5.0);
     });
 
     test('equality', () {
-      final Vector2 p1 = Vector2.zero();
-      final Vector2 p2 = Vector2.zero();
+      final p1 = Vector2.zero();
+      final p2 = Vector2.zero();
       expect(p1 == p2, true);
     });
 
     test('non equality', () {
-      final Vector2 p1 = Vector2.zero();
-      final Vector2 p2 = Vector2(1.0, 0.0);
+      final p1 = Vector2.zero();
+      final p2 = Vector2(1.0, 0.0);
       expect(p1 == p2, false);
     });
 
     test('hashCode', () {
-      final Vector2 p1 = Vector2(2.0, -1.0);
-      final Vector2 p2 = Vector2(1.0, 0.0);
+      final p1 = Vector2(2.0, -1.0);
+      final p2 = Vector2(1.0, 0.0);
       expect(p1.hashCode == p2.hashCode, false);
     });
 
     test('scaleTo', () {
-      final Vector2 p = Vector2(1.0, 0.0)
+      final p = Vector2(1.0, 0.0)
         ..rotate(math.pi / 4)
         ..scaleTo(2.0);
 
@@ -79,18 +80,18 @@ void main() {
     });
 
     test('scaleTo the zero vector', () {
-      final Vector2 p = Vector2.zero();
+      final p = Vector2.zero();
       expect(p.normalized().length, 0.0);
     });
 
     test('limit', () {
-      final Vector2 p1 = Vector2(1.0, 0.0);
+      final p1 = Vector2(1.0, 0.0);
       p1.clampScalar(0, 0.75);
       expect(p1.length, 0.75);
       expect(p1.x, 0.75);
       expect(p1.y, 0.0);
 
-      final Vector2 p2 = Vector2(1.0, 1.0);
+      final p2 = Vector2(1.0, 1.0);
       p2.clampScalar(0, 3.0);
       expectDouble(p2.length, math.sqrt(2));
       expect(p2.x, 1.0);


### PR DESCRIPTION
I've been studying both `dart_code_metrics` and our regular linter (that has many new rules) to see what I can learn.I basically added all rules that made sense and weren't too hard to fix. Some rules have names that make sense but the implementation is too broad to be useful. The ones I pick I think make a lot of sense. Some I want to add but I will do after the examples are removed (for example, forbid print statements).

The major changes are:

* imports ordering the way I specify on styleguide (but sometimes fail to check on PRs) is now a rule \o/
* local variables are never explicitly typed. fields/methods are always explicitly typed. (we had almost that but there were a few cases left).
* Change all constants to camel case as that is the new dart standard.
* Comments referencing: using [foo] on comments actually creates a doc link. But not everything works. I had to remove some that were broken because the referenced class was not in context. However this rule let me fix A LOT of linking errors that were just typos or outdated references. Also I took the liberty to review all comments I passed through and fix unrelated typos and some outdated stuff. In fact since vscode also highlights grammar errors I fixed a lot of typos everywhere I found.
* Ah finally enforced single quotes that I always have to comment on PRs as well.

Note: this **is** a breaking change because of the constants rename.