### PR TITLE
Fix children render order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
  - Added `toImage` method for the `Sprite` class
  - Uniform use of `dt` instead of `t` in all update methods
  - Add more optional arguments for unified constructors of components
+ - Fix rendering order when a sprite component has children
 
 ## 1.0.0-rc6
  - Use `Offset` type directly in `JoystickAction.update` calculations

--- a/lib/src/components/sprite_component.dart
+++ b/lib/src/components/sprite_component.dart
@@ -41,11 +41,12 @@ class SpriteComponent extends PositionComponent {
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     sprite?.render(
       canvas,
       size: size,
       overridePaint: overridePaint,
     );
+
+    super.render(canvas);
   }
 }


### PR DESCRIPTION
## Description

The children should be rendered after the parent is rendered.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The Flame analyzer (`./scripts/analyze.sh`) does not report any problems on my PR.
- [x] I have added examples for new features in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh`.
- [x] I read and followed the [Flutter Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I am happy with the current version of this PR and it is ready to be reviewed
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

## Related Issues

#678 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
