### PR TITLE
Fix order of parent -> children rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
  - Added `toImage` method for the `Sprite` class
  - Uniform use of `dt` instead of `t` in all update methods
  - Add more optional arguments for unified constructors of components
+ - Fix order that parent -> children render in
 
 ## 1.0.0-rc6
  - Use `Offset` type directly in `JoystickAction.update` calculations

--- a/lib/src/components/base_component.dart
+++ b/lib/src/components/base_component.dart
@@ -69,9 +69,6 @@ abstract class BaseComponent extends Component {
   @override
   void render(Canvas canvas) {
     prepareCanvas(canvas);
-    if (debugMode) {
-      renderDebugMode(canvas);
-    }
   }
 
   @mustCallSuper
@@ -82,6 +79,11 @@ abstract class BaseComponent extends Component {
       c.render(canvas);
       canvas.restore();
     });
+
+    // Any debug rendering should be rendered on top of everything
+    if (debugMode) {
+      renderDebugMode(canvas);
+    }
   }
 
   void renderDebugMode(Canvas canvas) {}

--- a/lib/src/components/base_component.dart
+++ b/lib/src/components/base_component.dart
@@ -81,7 +81,7 @@ abstract class BaseComponent extends Component {
       canvas.save();
       c.render(canvas);
       canvas.restore();
-    });   
+    });
   }
 
   void renderDebugMode(Canvas canvas) {}

--- a/lib/src/components/base_component.dart
+++ b/lib/src/components/base_component.dart
@@ -76,7 +76,11 @@ abstract class BaseComponent extends Component {
     render(canvas);
     _children.forEach((c) {
       canvas.save();
-      c.render(canvas);
+      if (c is BaseComponent) {
+        c.renderTree(canvas);
+      } else {
+        c.render(canvas);
+      }
       canvas.restore();
     });
 

--- a/lib/src/components/base_component.dart
+++ b/lib/src/components/base_component.dart
@@ -69,15 +69,19 @@ abstract class BaseComponent extends Component {
   @override
   void render(Canvas canvas) {
     prepareCanvas(canvas);
-
     if (debugMode) {
       renderDebugMode(canvas);
     }
+  }
+
+  @mustCallSuper
+  void renderTree(Canvas canvas) {
+    render(canvas);
     _children.forEach((c) {
       canvas.save();
       c.render(canvas);
       canvas.restore();
-    });
+    });   
   }
 
   void renderDebugMode(Canvas canvas) {}

--- a/lib/src/components/base_component.dart
+++ b/lib/src/components/base_component.dart
@@ -72,15 +72,12 @@ abstract class BaseComponent extends Component {
   }
 
   @mustCallSuper
+  @override
   void renderTree(Canvas canvas) {
     render(canvas);
     _children.forEach((c) {
       canvas.save();
-      if (c is BaseComponent) {
-        c.renderTree(canvas);
-      } else {
-        c.render(canvas);
-      }
+      c.renderTree(canvas);
       canvas.restore();
     });
 

--- a/lib/src/components/component.dart
+++ b/lib/src/components/component.dart
@@ -46,6 +46,10 @@ abstract class Component {
   /// Renders this component on the provided Canvas [c].
   void render(Canvas c) {}
 
+  /// This is used to render this component and potential children on subclasses
+  /// of [Component] on the provided Canvas [c].
+  void renderTree(Canvas c) => render(c);
+
   /// It receives the new game size.
   /// Executed right after the component is attached to a game and right before [onMount] is called
   void onGameResize(Vector2 gameSize) {}

--- a/lib/src/game/base_game.dart
+++ b/lib/src/game/base_game.dart
@@ -1,10 +1,10 @@
 import 'dart:ui';
 
-import 'package:flame/components.dart';
 import 'package:meta/meta.dart';
 import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
 
+import '../../components.dart';
 import '../components/component.dart';
 import '../components/mixins/collidable.dart';
 import '../components/mixins/draggable.dart';
@@ -132,7 +132,7 @@ class BaseGame extends Game with FPSCounter {
     if (!c.isHud) {
       canvas.translate(-camera.x, -camera.y);
     }
-    if(c is BaseComponent) {
+    if (c is BaseComponent) {
       c.renderTree(canvas);
     } else {
       c.render(canvas);

--- a/lib/src/game/base_game.dart
+++ b/lib/src/game/base_game.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flame/components.dart';
 import 'package:meta/meta.dart';
 import 'package:ordered_set/comparing.dart';
 import 'package:ordered_set/ordered_set.dart';
@@ -131,7 +132,11 @@ class BaseGame extends Game with FPSCounter {
     if (!c.isHud) {
       canvas.translate(-camera.x, -camera.y);
     }
-    c.render(canvas);
+    if(c is BaseComponent) {
+      c.renderTree(canvas);
+    } else {
+      c.render(canvas);
+    }
     canvas.restore();
     canvas.save();
   }

--- a/lib/src/game/base_game.dart
+++ b/lib/src/game/base_game.dart
@@ -132,11 +132,7 @@ class BaseGame extends Game with FPSCounter {
     if (!c.isHud) {
       canvas.translate(-camera.x, -camera.y);
     }
-    if (c is BaseComponent) {
-      c.renderTree(canvas);
-    } else {
-      c.render(canvas);
-    }
+    c.renderTree(canvas);
     canvas.restore();
     canvas.save();
   }


### PR DESCRIPTION
## Description

The parent is today rendered after the children, which clearly is not what you want.
This fixes this by handling rendering of `BaseComponent` slightly different.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The Flame analyzer (`./scripts/analyze.sh`) does not report any problems on my PR.
- [x] I have added examples for new features in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh`.
- [x] I read and followed the [Flutter Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I am happy with the current version of this PR and it is ready to be reviewd
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

## Related Issues

#678 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
