### PR TITLE
#697 - Add srcPosition and srcSize for SpriteComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Fix example app
  - Rename points to intersectionPoints for collision detection
  - Added CollidableType to make collision detection more efficient
+ - Add srcPosition and srcSize for SpriteComponent
 
 ## 1.0.0-rc7
  - Moving device related methods (like `fullScreen`) from `util.dart` to `device.dart`

--- a/lib/src/components/sprite_component.dart
+++ b/lib/src/components/sprite_component.dart
@@ -36,11 +36,17 @@ class SpriteComponent extends PositionComponent {
     Image image, {
     Vector2? position,
     Vector2? size,
+    Vector2? srcPosition,
+    Vector2? srcSize,
   }) =>
       SpriteComponent(
         position: position,
         size: size ?? image.size,
-        sprite: Sprite(image),
+        sprite: Sprite(
+          image,
+          srcPosition: srcPosition,
+          srcSize: srcSize,
+        ),
       );
 
   @mustCallSuper


### PR DESCRIPTION
# Description

Add `srcPosition` and `srcSize` for `SpriteComponent.fromImage()`, so we can create a `SpriteComponent` with part of an image.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flutter Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

fixes #697 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo