### PR TITLE
Cache and enlarge bounding rectangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Rename points to intersectionPoints for collision detection
  - Added CollidableType to make collision detection more efficient
  - Rename CollidableType.static to passive
+ - Improve collision detection with bounding boxes
 
 ## 1.0.0-rc7
  - Moving device related methods (like `fullScreen`) from `util.dart` to `device.dart`

--- a/lib/src/components/mixins/hitbox.dart
+++ b/lib/src/components/mixins/hitbox.dart
@@ -32,13 +32,18 @@ mixin Hitbox on PositionComponent {
   }
 
   final _cachedBoundingRect = ShapeCache<Rect>();
+
   /// Returns the absolute [Rect] that contains all the corners of the rotated
   /// [toAbsoluteRect] rect.
   Rect toBoundingRect() {
     if (!_cachedBoundingRect.isCacheValid([position, size])) {
-      final maxRadius = size.length/2;
+      final maxRadius = size.length / 2;
       _cachedBoundingRect.updateCache(
-        Rect.fromCenter(center: position.toOffset(), width: maxRadius, height: maxRadius,),
+        Rect.fromCenter(
+          center: position.toOffset(),
+          width: maxRadius,
+          height: maxRadius,
+        ),
         [position.clone(), size.clone()],
       );
     }

--- a/lib/src/components/mixins/hitbox.dart
+++ b/lib/src/components/mixins/hitbox.dart
@@ -31,20 +31,18 @@ mixin Hitbox on PositionComponent {
     _shapes.forEach((shape) => shape.render(canvas, debugPaint));
   }
 
+  final _cachedBoundingRect = ShapeCache<Rect>();
   /// Returns the absolute [Rect] that contains all the corners of the rotated
   /// [toAbsoluteRect] rect.
   Rect toBoundingRect() {
-    final rotatedPoints = toAbsoluteRect().toVertices()
-      ..forEach((v) => v.rotate(
-            angle,
-            center: absolutePosition,
-          ));
-    final minX = rotatedPoints.map<double>((v) => v.x).reduce(min);
-    final minY = rotatedPoints.map<double>((v) => v.y).reduce(min);
-    final maxX = rotatedPoints.map<double>((v) => v.x).reduce(max);
-    final maxY = rotatedPoints.map<double>((v) => v.y).reduce(max);
-
-    return Rect.fromPoints(Offset(minX, minY), Offset(maxX, maxY));
+    if (!_cachedBoundingRect.isCacheValid([position, size])) {
+      final maxRadius = size.length/2;
+      _cachedBoundingRect.updateCache(
+        Rect.fromCenter(center: position.toOffset(), width: maxRadius, height: maxRadius,),
+        [position.clone(), size.clone()],
+      );
+    }
+    return _cachedBoundingRect.value!;
   }
 
   /// Since this is a cheaper calculation than checking towards all shapes, this

--- a/lib/src/geometry/collision_detection.dart
+++ b/lib/src/geometry/collision_detection.dart
@@ -1,22 +1,24 @@
 import '../../extensions.dart';
 import '../components/mixins/collidable.dart';
 
+int _collidableTypeCompare(Collidable a, Collidable b) {
+  return a.collidableType.index - b.collidableType.index;
+}
+
 /// Check whether any [Collidable] in [collidables] collide with each other and
 /// call their onCollision methods accordingly.
 void collisionDetection(List<Collidable> collidables) {
+  collidables.sort(_collidableTypeCompare);
   for (var x = 0; x < collidables.length; x++) {
     final collidableX = collidables[x];
     if (collidableX.collidableType != CollidableType.active) {
-      continue;
+      break;
     }
 
-    for (var y = 0; y < collidables.length; y++) {
+    for (var y = x + 1; y < collidables.length; y++) {
       final collidableY = collidables[y];
-      if ((y <= x && collidableY.collidableType == CollidableType.active) ||
-          collidableY.collidableType == CollidableType.inactive) {
-        // These collidables will already have been checked towards each other
-        // or [collidableY] is inactive
-        continue;
+      if (collidableY.collidableType == CollidableType.inactive) {
+        break;
       }
 
       final intersectionPoints = intersections(collidableX, collidableY);


### PR DESCRIPTION
# Description

The bounding rectangle wasn't cached and it was more expensive to calculate it than necessary. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flutter Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
