### PR TITLE
Fix default hitbox with other anchor than center

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [next]
+ - Fix input bug with other anchors than center
 
 ## 1.0.0-rc8
  - Migrate to null safety

--- a/packages/flame/lib/src/anchor.dart
+++ b/packages/flame/lib/src/anchor.dart
@@ -48,6 +48,18 @@ class Anchor {
     return p - (toVector2()..multiply(size));
   }
 
+  /// Take your position [position] that is on this anchor and give back what that
+  /// position it would be on in anchor [otherAnchor] with a size of [size].
+  Vector2 toOtherAnchorPosition(
+    Vector2 position,
+    Anchor otherAnchor,
+    Vector2 size,
+  ) {
+    return position +
+        ((otherAnchor.toVector2() - toVector2())
+          ..multiply(size));
+  }
+
   /// Returns a string representation of this Anchor.
   ///
   /// This should only be used for serialization purposes.

--- a/packages/flame/lib/src/anchor.dart
+++ b/packages/flame/lib/src/anchor.dart
@@ -55,9 +55,7 @@ class Anchor {
     Anchor otherAnchor,
     Vector2 size,
   ) {
-    return position +
-        ((otherAnchor.toVector2() - toVector2())
-          ..multiply(size));
+    return position + ((otherAnchor.toVector2() - toVector2())..multiply(size));
   }
 
   /// Returns a string representation of this Anchor.

--- a/packages/flame/lib/src/components/mixins/hitbox.dart
+++ b/packages/flame/lib/src/components/mixins/hitbox.dart
@@ -37,10 +37,10 @@ mixin Hitbox on PositionComponent {
   /// [toAbsoluteRect] rect.
   Rect toBoundingRect() {
     if (!_cachedBoundingRect.isCacheValid([position, size])) {
-      final maxRadius = size.length / 2;
+      final maxRadius = size.length;
       _cachedBoundingRect.updateCache(
         Rect.fromCenter(
-          center: position.toOffset(),
+          center: absoluteCenter.toOffset(),
           width: maxRadius,
           height: maxRadius,
         ),

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -139,12 +139,6 @@ abstract class PositionComponent extends BaseComponent {
   bool containsPoint(Vector2 point) {
     final rectangle = Rectangle.fromRect(toAbsoluteRect(), angle: angle)
       ..anchorPosition = absolutePosition;
-    final rect = toAbsoluteRect();
-    print(rect.topLeft);
-    print(rect.center);
-    print(rect.width);
-    print(rect.height);
-    print(rectangle.hitbox());
     return rectangle.containsPoint(point);
   }
 

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -49,7 +49,13 @@ abstract class PositionComponent extends BaseComponent {
   Vector2 get absolutePosition => absoluteParentPosition + position;
 
   /// Get the relative top left position regardless of the anchor and angle
-  Vector2 get topLeftPosition => anchor.translate(position, size);
+  Vector2 get topLeftPosition {
+    return anchor.toOtherAnchorPosition(
+      position,
+      Anchor.topLeft,
+      size,
+    );
+  }
 
   /// Set the top left position regardless of the anchor
   set topLeftPosition(Vector2 position) {
@@ -80,7 +86,9 @@ abstract class PositionComponent extends BaseComponent {
 
   /// Get the position of the center of the component's bounding rectangle without rotation
   Vector2 get center {
-    return anchor == Anchor.center ? position : topLeftPosition + (size / 2);
+    return anchor == Anchor.center
+        ? position
+        : anchor.toOtherAnchorPosition(position, Anchor.center, size);
   }
 
   /// Get the absolute center of the component without rotation
@@ -131,6 +139,12 @@ abstract class PositionComponent extends BaseComponent {
   bool containsPoint(Vector2 point) {
     final rectangle = Rectangle.fromRect(toAbsoluteRect(), angle: angle)
       ..anchorPosition = absolutePosition;
+    final rect = toAbsoluteRect();
+    print(rect.topLeft);
+    print(rect.center);
+    print(rect.width);
+    print(rect.height);
+    print(rectangle.hitbox());
     return rectangle.containsPoint(point);
   }
 

--- a/packages/flame/lib/src/geometry/polygon.dart
+++ b/packages/flame/lib/src/geometry/polygon.dart
@@ -103,7 +103,7 @@ class Polygon extends Shape {
             .map((point) =>
                 (point + shapeCenter)..rotate(angle, center: anchorPosition))
             .toList(growable: false),
-        [shapeCenter, size!.clone(), angle],
+        [position.clone(), size!.clone(), angle],
       );
     }
     return _cachedHitbox.value!;

--- a/packages/flame/lib/src/geometry/shape.dart
+++ b/packages/flame/lib/src/geometry/shape.dart
@@ -61,9 +61,7 @@ mixin HitboxShape on Shape {
   /// The shapes center, before rotation
   @override
   Vector2 get shapeCenter {
-    return component.absoluteCenter +
-        position +
-        ((size / 2)..multiply(relativePosition))
+    return (component.absoluteCenter + position)
       ..rotate(angle, center: anchorPosition);
   }
 

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -16,6 +16,7 @@ void main() {
       component.size = Vector2(4.0, 4.0);
       component.angle = 0.0;
       component.anchor = Anchor.center;
+      print(component.topLeftPosition);
 
       final point = Vector2(2.0, 2.0);
       expect(component.containsPoint(point), true);
@@ -103,6 +104,36 @@ void main() {
 
       final point = component.position + component.size / 4;
       expect(component.containsPoint(point), true);
+    });
+
+    test('component with anchor topLeft contains point on edge', () {
+      final size = Vector2(2.0, 2.0);
+      final Hitbox component = MyHitboxComponent();
+      component.position = Vector2(-1, -1);
+      component.anchor = Anchor.topLeft;
+      component.size = size;
+      final hitbox = HitboxRectangle();
+      component.addShape(hitbox);
+
+      expect(component.containsPoint(Vector2(1, 1)), true);
+      expect(component.containsPoint(Vector2(1, -1)), true);
+      expect(component.containsPoint(Vector2(-1, -1)), true);
+      expect(component.containsPoint(Vector2(-1, 1)), true);
+    });
+
+    test('component with anchor bottomRight contains point on edge', () {
+      final size = Vector2(2.0, 2.0);
+      final Hitbox component = MyHitboxComponent();
+      component.position = Vector2(1, -1);
+      component.anchor = Anchor.bottomRight;
+      component.size = size;
+      final hitbox = HitboxRectangle();
+      component.addShape(hitbox);
+
+      expect(component.containsPoint(Vector2(1, 1)), true);
+      expect(component.containsPoint(Vector2(1, -1)), true);
+      expect(component.containsPoint(Vector2(-1, -1)), true);
+      expect(component.containsPoint(Vector2(-1, 1)), true);
     });
 
     test('component with hitbox does not contains point', () {

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -16,7 +16,6 @@ void main() {
       component.size = Vector2(4.0, 4.0);
       component.angle = 0.0;
       component.anchor = Anchor.center;
-      print(component.topLeftPosition);
 
       final point = Vector2(2.0, 2.0);
       expect(component.containsPoint(point), true);

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -135,6 +135,21 @@ void main() {
       expect(component.containsPoint(Vector2(-1, 1)), true);
     });
 
+    test('component with anchor topRight does not contain close points', () {
+      final size = Vector2(2.0, 2.0);
+      final Hitbox component = MyHitboxComponent();
+      component.position = Vector2(1, 1);
+      component.anchor = Anchor.topLeft;
+      component.size = size;
+      final hitbox = HitboxRectangle();
+      component.addShape(hitbox);
+
+      expect(component.containsPoint(Vector2(0.0, 0.0)), false);
+      expect(component.containsPoint(Vector2(0.9, 0.9)), false);
+      expect(component.containsPoint(Vector2(3.1, 3.1)), false);
+      expect(component.containsPoint(Vector2(1.1, 3.1)), false);
+    });
+
     test('component with hitbox does not contains point', () {
       final size = Vector2(2.0, 2.0);
       final Hitbox component = MyHitboxComponent();

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -123,7 +123,7 @@ void main() {
     test('component with anchor bottomRight contains point on edge', () {
       final size = Vector2(2.0, 2.0);
       final Hitbox component = MyHitboxComponent();
-      component.position = Vector2(1, -1);
+      component.position = Vector2(1, 1);
       component.anchor = Anchor.bottomRight;
       component.size = size;
       final hitbox = HitboxRectangle();


### PR DESCRIPTION
# Description

The default hitbox had a degradation where the input rectangle was off if the anchor wasn't centered

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flutter Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

## Related Issues

#705

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
