### PR TITLE
Memoizing paint creation on BasicPalette to enable direct use

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
  - Fix input bug with other anchors than center
+ - Memoizing the paint creation on BasicPalette to enable direct use
 
 ## 1.0.0-rc8
  - Migrate to null safety

--- a/packages/flame/lib/src/palette.dart
+++ b/packages/flame/lib/src/palette.dart
@@ -1,11 +1,26 @@
 import 'dart:ui';
 
+class _MemoizedPaint {
+  final Color color;
+  Paint? _paint;
+
+  _MemoizedPaint(this.color);
+
+  Paint get value {
+    _paint ??= Paint()..color;
+    return _paint!;
+  }
+}
+
 class PaletteEntry {
   final Color color;
+  late _MemoizedPaint _paint;
 
-  Paint get paint => Paint()..color = color;
+  Paint get paint => _paint.value;
 
-  const PaletteEntry(this.color);
+  PaletteEntry(this.color) {
+    _paint = _MemoizedPaint(color);
+  }
 
   PaletteEntry withAlpha(int alpha) {
     return PaletteEntry(color.withAlpha(alpha));
@@ -25,6 +40,6 @@ class PaletteEntry {
 }
 
 class BasicPalette {
-  static const PaletteEntry white = PaletteEntry(Color(0xFFFFFFFF));
-  static const PaletteEntry black = PaletteEntry(Color(0xFF000000));
+  static PaletteEntry white = PaletteEntry(Color(0xFFFFFFFF));
+  static PaletteEntry black = PaletteEntry(Color(0xFF000000));
 }

--- a/packages/flame/test/palette_test.dart
+++ b/packages/flame/test/palette_test.dart
@@ -1,0 +1,12 @@
+import 'package:flame/palette.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Palette', () {
+    test('memoizes the paint created', () {
+      final paint = BasicPalette.white.paint;
+      final paint2 = BasicPalette.white.paint;
+      expect(paint, paint2);
+    });
+  });
+}


### PR DESCRIPTION
# Description

The BasicPalette paint field was actually a getter that always created a new Paint, that could bring perfomance issues when the BasicPalette was directly used inside a render function, which seems to me a fair use for that class, because it would create a new paint instance every time. Since the color is final on that class, it makes sense to memoize the paint value, so we don't create unnecessary instances.

I have implemented a very naive memoization function and specific for the paint class as I wasn't sure if it was something worth to be generic to be used elsewhere, but I am open to suggestions.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [ ] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
  - API is still the same, no changes needed
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flutter Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.
