### PR TITLE
Add clear function to allow removing all components from base game

### DIFF
--- a/packages/flame/lib/src/game/base_game.dart
+++ b/packages/flame/lib/src/game/base_game.dart
@@ -152,6 +152,11 @@ class BaseGame extends Game with FPSCounter {
     _removeLater.addAll(components);
   }
 
+  /// Marks all existing components to be removed from the components list on the next game tick
+  void clear() {
+    _removeLater.addAll(components);
+  }
+
   /// This implementation of render basically calls [renderComponent] for every component, making sure the canvas is reset for each one.
   ///
   /// You can override it further to add more custom behavior.

--- a/packages/flame/test/game/base_game_test.dart
+++ b/packages/flame/test/game/base_game_test.dart
@@ -6,8 +6,8 @@ import 'package:flame/src/game/game_render_box.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-import 'package:test/test.dart';
 import 'package:flutter_test/flutter_test.dart' as flutter;
+import 'package:test/test.dart';
 
 class MyGame extends BaseGame with HasTapableComponents {}
 
@@ -198,6 +198,22 @@ void main() {
     expect(game.components.length, equals(1));
 
     game.update(0);
+    expect(game.components.isEmpty, equals(true));
+  });
+
+  test('clear removes all components', () {
+    final game = MyGame();
+    final components = List.generate(3, (index) => MyComponent());
+
+    game.onResize(size);
+    game.addAll(components);
+
+    // The components are not added to the component list until an update has been performed
+    game.update(0.0);
+    expect(game.components.length, equals(3));
+
+    game.clear();
+    game.update(0.0);
     expect(game.components.isEmpty, equals(true));
   });
 }


### PR DESCRIPTION
# Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If this is a breaking change, specify explicitly which APIs have been changed*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [ ] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [ ] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [ ] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [ ] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
