### PR TITLE
Fix camera when not following component

### DIFF
--- a/packages/flame/lib/src/game/camera.dart
+++ b/packages/flame/lib/src/game/camera.dart
@@ -222,10 +222,10 @@ class Camera {
   }
 
   Vector2 _target() {
-    if (follow == null) {
-      return Vector2.zero();
-    }
     final screenDelta = gameRef.size.clone()..multiply(_currentRelativeOffset);
+    if (follow == null) {
+      return -screenDelta;
+    }
     final attemptedTarget = follow! - screenDelta;
 
     final bounds = worldBounds;

--- a/packages/flame/lib/src/game/camera.dart
+++ b/packages/flame/lib/src/game/camera.dart
@@ -151,13 +151,11 @@ class Camera {
     final ds = cameraSpeed * dt;
     final shake = Vector2(_shakeDelta(), _shakeDelta());
 
+    _moveToTarget(_currentRelativeOffset, _targetRelativeOffset, ds);
     if (_targetCameraDelta != null && _currentCameraDelta != null) {
       _moveToTarget(_currentCameraDelta!, _targetCameraDelta!, ds);
-      _position = _currentCameraDelta! + shake;
-    } else {
-      _moveToTarget(_currentRelativeOffset, _targetRelativeOffset, ds);
-      _position = _target() + shake;
     }
+    _position = _target() + shake;
 
     if (shaking) {
       _shakeTimer -= dt;
@@ -175,6 +173,7 @@ class Camera {
       _currentCameraDelta!.setFrom(_targetCameraDelta!);
     }
     _currentRelativeOffset.setFrom(_targetRelativeOffset);
+    update(0);
   }
 
   /// Converts a vector in the screen space to the world space.
@@ -221,12 +220,13 @@ class Camera {
     _targetRelativeOffset.setFrom(newRelativeOffset);
   }
 
+  Vector2 _screenDelta() {
+    return gameRef.size.clone()..multiply(_currentRelativeOffset);
+  }
+
   Vector2 _target() {
-    final screenDelta = gameRef.size.clone()..multiply(_currentRelativeOffset);
-    if (follow == null) {
-      return -screenDelta;
-    }
-    final attemptedTarget = follow! - screenDelta;
+    final target = _currentCameraDelta ?? follow ?? Vector2.zero();
+    final attemptedTarget = target - _screenDelta();
 
     final bounds = worldBounds;
     if (bounds != null) {
@@ -267,7 +267,7 @@ class Camera {
   /// The camera will be smoothly transitioned to this position.
   /// This will replace any previous targets.
   void moveTo(Vector2 position) {
-    _currentCameraDelta = _position;
+    _currentCameraDelta = _position + _screenDelta();
     _targetCameraDelta = position.clone();
   }
 

--- a/packages/flame/test/game/camera_and_viewport_test.dart
+++ b/packages/flame/test/game/camera_and_viewport_test.dart
@@ -149,6 +149,7 @@ void main() {
       game.camera.moveTo(Vector2.all(4.0));
       game.camera.snap();
       // the component will now be at 10 - 4 = (6, 6)
+      expect(game.camera.position, Vector2.all(4.0));
 
       final canvas = MockCanvas();
       game.render(canvas);

--- a/packages/flame/test/game/camera_and_viewport_test.dart
+++ b/packages/flame/test/game/camera_and_viewport_test.dart
@@ -41,7 +41,7 @@ void main() {
       expect(game.size, Vector2.all(50.00));
 
       final viewport = game.viewport as FixedResolutionViewport;
-      expect(viewport.resizeOffset, Vector2(0, 0));
+      expect(viewport.resizeOffset, Vector2.zero());
       expect(viewport.scaledSize, Vector2(200.0, 200.0));
       expect(viewport.scale, 4.0);
 
@@ -290,6 +290,18 @@ void main() {
       p.position.setValues(-10.0, -20.0);
       game.update(0);
       expect(game.camera.position, Vector2(50, 50));
+    });
+    test('camera relative offset without follow', () {
+      final game = BaseGame();
+      game.onResize(Vector2.all(200.0));
+
+      game.camera.setRelativeOffset(Anchor.center.toVector2());
+
+      game.update(0);
+      expect(game.camera.position, Vector2.zero());
+
+      game.update(10000);
+      expect(game.camera.position, Vector2.all(-100.0));
     });
   });
   group('viewport & camera', () {


### PR DESCRIPTION
Found this bug on camera where if it's not following a component it doesn't respect relative offset, and therefore move doesn't work.