### PR TITLE
Fix inconsistency on IsometricTileMap

### DIFF
--- a/packages/flame/lib/src/components/isometric_tile_map_component.dart
+++ b/packages/flame/lib/src/components/isometric_tile_map_component.dart
@@ -98,9 +98,9 @@ class IsometricTileMapComponent extends PositionComponent {
 
   /// Return whether the matrix contains a block in its bounds.
   bool containsBlock(Block block) {
-    return block.x >= 0 &&
-        block.x < matrix.length &&
-        block.y >= 0 &&
-        block.y < matrix[block.x].length;
+    return block.y >= 0 &&
+        block.y < matrix.length &&
+        block.x >= 0 &&
+        block.x < matrix[block.y].length;
   }
 }


### PR DESCRIPTION
We decided on a convention as to index the matrix as `matrix[j][i]`; however the `containsBlock` method was using the wrong convention. This fixes it.