### PR TITLE
Fix scroll detector that did not work before

### DIFF
--- a/packages/flame/lib/src/game/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget.dart
@@ -500,15 +500,15 @@ Widget _applyAdvancedGesturesDetectors(Game game, Widget child) {
 }
 
 Widget _applyMouseDetectors(Game game, Widget child) {
-  return MouseRegion(
-    child: Listener(
+  return Listener(
+    child: MouseRegion(
       child: child,
-      onPointerSignal: (event) =>
-          game is ScrollDetector && event is PointerScrollEvent
-              ? game.onScroll(event)
-              : null,
+      onHover: game is MouseMovementDetector ? game.onMouseMove : null,
     ),
-    onHover: game is MouseMovementDetector ? game.onMouseMove : null,
+    onPointerSignal: (event) =>
+        game is ScrollDetector && event is PointerScrollEvent
+            ? game.onScroll(event)
+            : null,
   );
 }
 


### PR DESCRIPTION
As I mentioned back on the examples migration, the scroll example didn't work. I did some investigating and turns out the bug was incorrect component composition. According to my testing this now works (and also works alongside other detectors like mouse move).