### PR TITLE
Add a renderPoint extension method on Canvas

### DIFF
--- a/doc/util.md
+++ b/doc/util.md
@@ -159,6 +159,7 @@ They can all be imported from `package:flame/extensions.dart`
 Methods:
  - `scaleVector`: Just like `canvas scale` method, but takes a `Vector2` as an argument.
  - `translateVector`: Just like `canvas translate` method, but takes a `Vector2` as an argument.
+ - `renderPoint`: renders a single point on the canvas (mostly for debugging purposes).
  - `renderAt` and `renderRotated`: if you are directly rendering to the `Canvas`, you can use these
   functions to easily manipulate coordinates to render things on the correct places. They change the
   `Canvas` transformation matrix but reset afterwards.

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -15,6 +15,7 @@
  - Remove the SpriteAnimationComponent when the animation is really done, not when it is on the last frame
  - Revamp all the docs to be up to date with v1.0.0
  - Make Assets and Images caches have a configurable prefix
+ - Add a renderPoint method to Canvas
 
 ## 1.0.0-rc8
  - Migrate to null safety

--- a/packages/flame/lib/src/extensions/canvas.dart
+++ b/packages/flame/lib/src/extensions/canvas.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import '../../palette.dart';
 import 'vector2.dart';
 
 export 'dart:ui' show Canvas;
@@ -11,6 +12,19 @@ extension CanvasExtension on Canvas {
 
   void translateVector(Vector2 vector) {
     translate(vector.x, vector.y);
+  }
+
+  /// Renders a point as a square of size [size] (default 1 logical pixel) using
+  /// the provided [paint] (default solid magenta).
+  ///
+  /// This is mostly useful for debugging.
+  void renderPoint(
+    Vector2 point, {
+    double size = 1.0,
+    Paint? paint,
+  }) {
+    final rect = (point - Vector2.all(size / 2)) & Vector2.all(size);
+    drawRect(rect, paint ?? BasicPalette.magenta.paint());
   }
 
   /// Utility method to render stuff on a specific place in an isolated way.

--- a/packages/flame/test/extensions/canvas_test.dart
+++ b/packages/flame/test/extensions/canvas_test.dart
@@ -1,0 +1,17 @@
+import 'package:flame/extensions.dart';
+import 'package:test/test.dart';
+
+import '../util/mock_canvas.dart';
+
+void main() {
+  group('Canvas extensions tests', () {
+    test('renderPoint', () {
+      final canvas = MockCanvas();
+      canvas.renderPoint(Vector2.all(10.0), size: 2);
+      expect(
+        canvas.methodCalls,
+        contains('drawRect(9.0, 9.0, 2.0, 2.0)'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

Specially for debugging, it can be useful to render a single point on the canvas. This adds a simple method to our Canvas extension that takes in a Vector2 and a size, and draws a square with length size. You can also customize the color (default magenta).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flutter Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
