### PR TITLE
Add release site option

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,0 +1,19 @@
+name: docs-site
+
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  publish-site:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: username/my-repo
+          event-type: release-flame
+
+


### PR DESCRIPTION
# Description

Add GH action to dispatch an action on sites repo (check this related PR https://github.com/flame-engine/flame-engine-site/pull/19) on flame releases.


## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

https://github.com/flame-engine/flame-engine-site/pull/19
