### PR TITLE
Abstracting text API to enable custom renderers

### DIFF
--- a/doc/text.md
+++ b/doc/text.md
@@ -5,19 +5,25 @@ Flame has some dedicated classes to help you render text.
 ## TextRenderer
 
 `TextRenderer` is the abstract class used by Flame to render text. Flame provides one
-implementation for this called `TextPaint` but anyone can implement this and create
-a custom way to render text.
+implementation for this called `TextPaint` but anyone can implement this abstraction
+and create a custom way to render text.
 
 ## TextPaint
 
 A Text Paint is the built in implementation of text rendering on Flame, it is based on top of
-Flutter's `TextPainter` class (hence the name) and contains all typographical information
-required to render text; i.e., font size and color, family, etc.
+Flutter's `TextPainter` class (hence the name), it can be configured by its config class
+`TextPaingConfig` which contains all typographical information required to render text; i.e., font
+size and color, family, etc.
 
 Example usage:
 
 ```dart
-const TextPaint textPaint = TextPaint(fontSize: 48.0, fontFamily: 'Awesome Font');
+const TextPaint textPaint = TextPaint(
+  config: TextPaintConfig(
+    fontSize: 48.0,
+    fontFamily: 'Awesome Font',
+  ),
+);
 ```
 
  - `fontFamily`: a commonly available font, like Arial (default), or a custom font added in your
@@ -32,7 +38,7 @@ For more information regarding colors and how to create then, see the
 After the creation of the text paint you can use its `render` method to draw some string on a canvas:
 
 ```dart
-textPaint.render(canvas, "Flame is awesome", Position(10, 10));
+textPaint.render(canvas, "Flame is awesome", Vector2(10, 10));
 ```
 
 If you want to set the anchor of the text you can also do that in the render call, with the optional

--- a/doc/text.md
+++ b/doc/text.md
@@ -2,15 +2,22 @@
 
 Flame has some dedicated classes to help you render text.
 
-## TextConfig
+## TextRenderer
 
-A Text Config contains all typographical information required to render text; i.e., font size and
-color, family, etc.
+`TextRenderer` is the abstract class used by Flame to render text. Flame provides one
+implementation for this called `TextPaint` but anyone can implement this and create
+a custom way to render text.
+
+## TextPaint
+
+A Text Paint is the built in implementation of text rendering on Flame, it is based on top of
+Flutter's `TextPainter` class (hence the name) and contains all typographical information
+required to render text; i.e., font size and color, family, etc.
 
 Example usage:
 
 ```dart
-const TextConfig config = TextConfig(fontSize: 48.0, fontFamily: 'Awesome Font');
+const TextPaint textPaint = TextPaint(fontSize: 48.0, fontFamily: 'Awesome Font');
 ```
 
  - `fontFamily`: a commonly available font, like Arial (default), or a custom font added in your
@@ -22,17 +29,17 @@ const TextConfig config = TextConfig(fontSize: 48.0, fontFamily: 'Awesome Font')
 For more information regarding colors and how to create then, see the
 [Colors and the Palette](palette.md) guide.
 
-After the creation of the config you can use its `render` method to draw some string on a canvas:
+After the creation of the text paint you can use its `render` method to draw some string on a canvas:
 
 ```dart
-config.render(canvas, "Flame is awesome", Position(10, 10));
+textPaint.render(canvas, "Flame is awesome", Position(10, 10));
 ```
 
 If you want to set the anchor of the text you can also do that in the render call, with the optional
 `anchor` parameter:
 
 ```dart
-config.render(canvas, 'Flame is awesome', Vector2(10, 10), anchor: Anchor.topCenter);
+textPaint.render(canvas, 'Flame is awesome', Vector2(10, 10), anchor: Anchor.topCenter);
 ```
 
 ## Text Components
@@ -47,12 +54,12 @@ Flame provides two text components that make it even easier to render text in yo
 Example usage:
 
 ```dart
-TextConfig regular = TextConfig(color: BasicPalette.white.color);
+TextPaint regular = TextPaint(color: BasicPalette.white.color);
 
 class MyGame extends BaseGame {
   @override
   Future<void> onLoad() async {
-    add(TextComponent('Hello, Flame', config: regular)
+    add(TextComponent('Hello, Flame', textRenderer: regular)
       ..anchor = Anchor.topCenter
       ..x = size.width / 2 // size is a property from game
       ..y = 32.0);
@@ -74,15 +81,15 @@ Example usage:
 
 ```dart
 class MyTextBox extends TextBoxComponent {
-  MyTextBox(String text) : super(text, config: tiny, boxConfig: TextBoxConfig(timePerChar: 0.05));
+  MyTextBox(String text) : super(text, textRenderer: tiny, boxConfig: TextBoxConfig(timePerChar: 0.05));
 
   @override
   void drawBackground(Canvas c) {
     Rect rect = Rect.fromLTWH(0, 0, width, height);
-    c.drawRect(rect, new Paint()..color = Color(0xFFFF00FF));
+    c.drawRect(rect, Paint()..color = Color(0xFFFF00FF));
     c.drawRect(
         rect.deflate(boxConfig.margin),
-        new Paint()
+        Paint()
           ..color = BasicPalette.black.color
           ..style = PaintingStyle.stroke);
   }

--- a/examples/lib/stories/camera_and_viewport/follow_object.dart
+++ b/examples/lib/stories/camera_and_viewport/follow_object.dart
@@ -14,7 +14,7 @@ final R = Random();
 class MovableSquare extends SquareComponent
     with Hitbox, Collidable, HasGameRef<CameraAndViewportGame> {
   static const double speed = 300;
-  static final TextConfig config = TextConfig(fontSize: 12);
+  static final TextPaint textRenderer = TextPaint(fontSize: 12);
 
   final Vector2 velocity = Vector2.zero();
   late Timer timer;
@@ -41,7 +41,7 @@ class MovableSquare extends SquareComponent
   void render(Canvas c) {
     super.render(c);
     final text = '(${x.toInt()}, ${y.toInt()})';
-    config.render(c, text, size / 2, anchor: Anchor.center);
+    textRenderer.render(c, text, size / 2, anchor: Anchor.center);
   }
 
   @override

--- a/examples/lib/stories/camera_and_viewport/follow_object.dart
+++ b/examples/lib/stories/camera_and_viewport/follow_object.dart
@@ -14,7 +14,11 @@ final R = Random();
 class MovableSquare extends SquareComponent
     with Hitbox, Collidable, HasGameRef<CameraAndViewportGame> {
   static const double speed = 300;
-  static final TextPaint textRenderer = TextPaint(fontSize: 12);
+  static final TextPaint textRenderer = TextPaint(
+    config: const TextPaintConfig(
+      fontSize: 12,
+    ),
+  );
 
   final Vector2 velocity = Vector2.zero();
   late Timer timer;

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -168,7 +168,9 @@ class CollidableSnowman extends MyCollidable {
 class MultipleShapes extends BaseGame
     with HasCollidables, HasDraggableComponents {
   final TextPaint fpsTextPaint = TextPaint(
-    color: BasicPalette.white.color,
+    config: TextPaintConfig(
+      color: BasicPalette.white.color,
+    ),
   );
 
   @override

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -167,7 +167,7 @@ class CollidableSnowman extends MyCollidable {
 
 class MultipleShapes extends BaseGame
     with HasCollidables, HasDraggableComponents {
-  final TextConfig fpsTextConfig = TextConfig(
+  final TextPaint fpsTextPaint = TextPaint(
     color: BasicPalette.white.color,
   );
 
@@ -229,7 +229,7 @@ class MultipleShapes extends BaseGame
   @override
   void render(Canvas canvas) {
     super.render(canvas);
-    fpsTextConfig.render(
+    fpsTextPaint.render(
       canvas,
       '${fps(120).toStringAsFixed(2)}fps',
       Vector2(0, size.y - 24),

--- a/examples/lib/stories/components/debug.dart
+++ b/examples/lib/stories/components/debug.dart
@@ -34,7 +34,11 @@ class LogoCompomnent extends SpriteComponent with HasGameRef<DebugGame> {
 }
 
 class DebugGame extends BaseGame {
-  static final fpsTextPaint = TextPaint(color: const Color(0xFFFFFFFF));
+  static final fpsTextPaint = TextPaint(
+    config: const TextPaintConfig(
+      color: Color(0xFFFFFFFF),
+    ),
+  );
 
   @override
   bool debugMode = true;

--- a/examples/lib/stories/components/debug.dart
+++ b/examples/lib/stories/components/debug.dart
@@ -34,7 +34,7 @@ class LogoCompomnent extends SpriteComponent with HasGameRef<DebugGame> {
 }
 
 class DebugGame extends BaseGame {
-  static final fpsTextConfig = TextConfig(color: const Color(0xFFFFFFFF));
+  static final fpsTextPaint = TextPaint(color: const Color(0xFFFFFFFF));
 
   @override
   bool debugMode = true;
@@ -67,7 +67,7 @@ class DebugGame extends BaseGame {
     super.render(canvas);
 
     if (debugMode) {
-      fpsTextConfig.render(canvas, fps(120).toString(), Vector2(0, 50));
+      fpsTextPaint.render(canvas, fps(120).toString(), Vector2(0, 50));
     }
   }
 }

--- a/examples/lib/stories/rendering/text.dart
+++ b/examples/lib/stories/rendering/text.dart
@@ -5,7 +5,7 @@ import 'package:flame/game.dart';
 import 'package:flame/palette.dart';
 import 'package:flutter/material.dart';
 
-final _regular = TextConfig(color: BasicPalette.white.color);
+final _regular = TextPaint(color: BasicPalette.white.color);
 final _tiny = _regular.withFontSize(12.0);
 
 final _white = Paint()
@@ -16,7 +16,7 @@ class MyTextBox extends TextBoxComponent {
   MyTextBox(String text)
       : super(
           text,
-          config: _tiny,
+          textRenderer: _tiny,
           boxConfig: TextBoxConfig(
             timePerChar: 0.05,
             growingBox: true,
@@ -43,20 +43,20 @@ class TextGame extends BaseGame {
   @override
   Future<void> onLoad() async {
     add(
-      TextComponent('Hello, Flame', config: _regular)
+      TextComponent('Hello, Flame', textRenderer: _regular)
         ..anchor = Anchor.topCenter
         ..x = size.x / 2
         ..y = 32.0,
     );
 
     add(
-      TextComponent('center', config: _tiny)
+      TextComponent('center', textRenderer: _tiny)
         ..anchor = Anchor.center
         ..position.setFrom(size / 2),
     );
 
     add(
-      TextComponent('bottomRight', config: _tiny)
+      TextComponent('bottomRight', textRenderer: _tiny)
         ..anchor = Anchor.bottomRight
         ..position.setFrom(size),
     );

--- a/examples/lib/stories/rendering/text.dart
+++ b/examples/lib/stories/rendering/text.dart
@@ -5,8 +5,9 @@ import 'package:flame/game.dart';
 import 'package:flame/palette.dart';
 import 'package:flutter/material.dart';
 
-final _regular = TextPaint(color: BasicPalette.white.color);
-final _tiny = _regular.withFontSize(12.0);
+final _regularTextConfig = TextPaintConfig(color: BasicPalette.white.color);
+final _regular = TextPaint(config: _regularTextConfig);
+final _tiny = TextPaint(config: _regularTextConfig.withFontSize(12.0));
 
 final _white = Paint()
   ..color = BasicPalette.white.color

--- a/examples/lib/stories/utils/particles.dart
+++ b/examples/lib/stories/utils/particles.dart
@@ -21,7 +21,7 @@ class ParticlesGame extends BaseGame {
   final Random rnd = Random();
   final StepTween steppedTween = StepTween(begin: 0, end: 5);
   final trafficLight = TrafficLightComponent();
-  final TextConfig fpsTextConfig = TextConfig(
+  final TextPaint fpsTextPaint = TextPaint(
     color: const Color(0xFFFFFFFF),
   );
 
@@ -474,7 +474,7 @@ class ParticlesGame extends BaseGame {
     super.render(canvas);
 
     if (debugMode) {
-      fpsTextConfig.render(
+      fpsTextPaint.render(
         canvas,
         '${fps(120).toStringAsFixed(2)}fps',
         Vector2(0, size.y - 24),

--- a/examples/lib/stories/utils/particles.dart
+++ b/examples/lib/stories/utils/particles.dart
@@ -22,7 +22,9 @@ class ParticlesGame extends BaseGame {
   final StepTween steppedTween = StepTween(begin: 0, end: 5);
   final trafficLight = TrafficLightComponent();
   final TextPaint fpsTextPaint = TextPaint(
-    color: const Color(0xFFFFFFFF),
+    config: const TextPaintConfig(
+      color: Color(0xFFFFFFFF),
+    ),
   );
 
   /// Defines the lifespan of all the particles in these examples

--- a/examples/lib/stories/utils/timer.dart
+++ b/examples/lib/stories/utils/timer.dart
@@ -4,7 +4,11 @@ import 'package:flame/timer.dart';
 import 'package:flame/gestures.dart';
 
 class TimerGame extends Game with TapDetector {
-  final TextPaint textConfig = TextPaint(color: const Color(0xFFFFFFFF));
+  final TextPaint textConfig = TextPaint(
+    config: const TextPaintConfig(
+      color: Color(0xFFFFFFFF),
+    ),
+  );
   late Timer countdown;
   late Timer interval;
 

--- a/examples/lib/stories/utils/timer.dart
+++ b/examples/lib/stories/utils/timer.dart
@@ -4,7 +4,7 @@ import 'package:flame/timer.dart';
 import 'package:flame/gestures.dart';
 
 class TimerGame extends Game with TapDetector {
-  final TextConfig textConfig = TextConfig(color: const Color(0xFFFFFFFF));
+  final TextPaint textConfig = TextPaint(color: const Color(0xFFFFFFFF));
   late Timer countdown;
   late Timer interval;
 

--- a/examples/lib/stories/utils/timer_component.dart
+++ b/examples/lib/stories/utils/timer_component.dart
@@ -4,13 +4,13 @@ import 'package:flame/timer.dart';
 import 'package:flame/gestures.dart';
 
 class RenderedTimeComponent extends TimerComponent {
-  final TextConfig textConfig = TextConfig(color: const Color(0xFFFFFFFF));
+  final TextPaint textPaint = TextPaint(color: const Color(0xFFFFFFFF));
 
   RenderedTimeComponent(Timer timer) : super(timer);
 
   @override
   void render(Canvas canvas) {
-    textConfig.render(
+    textPaint.render(
       canvas,
       'Elapsed time: ${timer.current}',
       Vector2(10, 150),

--- a/examples/lib/stories/utils/timer_component.dart
+++ b/examples/lib/stories/utils/timer_component.dart
@@ -4,7 +4,11 @@ import 'package:flame/timer.dart';
 import 'package:flame/gestures.dart';
 
 class RenderedTimeComponent extends TimerComponent {
-  final TextPaint textPaint = TextPaint(color: const Color(0xFFFFFFFF));
+  final TextPaint textPaint = TextPaint(
+    config: const TextPaintConfig(
+      color: Color(0xFFFFFFFF),
+    ),
+  );
 
   RenderedTimeComponent(Timer timer) : super(timer);
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Add a new renderRect method to Sprite
  - Addresses the TODO to change the camera public APIs to take Anchors for relativePositions
  - Adds methods to support moving the camera relative to its current position
+ - Abstracting the text api to allow custom text renderers on the framework
 
 ## [1.0.0-rc9]
  - Fix input bug with other anchors than center

--- a/packages/flame/lib/components.dart
+++ b/packages/flame/lib/components.dart
@@ -21,5 +21,5 @@ export 'src/components/sprite_component.dart';
 export 'src/components/text_box_component.dart';
 export 'src/components/text_component.dart';
 export 'src/extensions/vector2.dart';
-export 'src/text_config.dart';
+export 'src/text.dart';
 export 'src/timer.dart';

--- a/packages/flame/lib/game.dart
+++ b/packages/flame/lib/game.dart
@@ -6,4 +6,4 @@ export 'src/game/game.dart';
 export 'src/game/game_widget/game_widget.dart';
 export 'src/game/projector.dart';
 export 'src/game/viewport.dart';
-export 'src/text_config.dart';
+export 'src/text.dart';

--- a/packages/flame/lib/src/components/base_component.dart
+++ b/packages/flame/lib/src/components/base_component.dart
@@ -50,7 +50,12 @@ abstract class BaseComponent extends Component {
     ..strokeWidth = 1
     ..style = PaintingStyle.stroke;
 
-  TextPaint get debugTextPaint => TextPaint(color: debugColor, fontSize: 12);
+  TextPaint get debugTextPaint => TextPaint(
+        config: TextPaintConfig(
+          color: debugColor,
+          fontSize: 12,
+        ),
+      );
 
   /// This method is called periodically by the game engine to request that your component updates itself.
   ///

--- a/packages/flame/lib/src/components/base_component.dart
+++ b/packages/flame/lib/src/components/base_component.dart
@@ -9,7 +9,7 @@ import '../../game.dart';
 import '../effects/effects.dart';
 import '../effects/effects_handler.dart';
 import '../extensions/vector2.dart';
-import '../text_config.dart';
+import '../text.dart';
 import 'component.dart';
 import 'mixins/has_game_ref.dart';
 
@@ -50,7 +50,7 @@ abstract class BaseComponent extends Component {
     ..strokeWidth = 1
     ..style = PaintingStyle.stroke;
 
-  TextConfig get debugTextConfig => TextConfig(color: debugColor, fontSize: 12);
+  TextPaint get debugTextPaint => TextPaint(color: debugColor, fontSize: 12);
 
   /// This method is called periodically by the game engine to request that your component updates itself.
   ///

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -156,7 +156,7 @@ abstract class PositionComponent extends BaseComponent {
       (this as Hitbox).renderShapes(canvas);
     }
     canvas.drawRect(size.toRect(), debugPaint);
-    debugTextConfig.render(
+    debugTextPaint.render(
       canvas,
       'x: ${x.toStringAsFixed(2)} y:${y.toStringAsFixed(2)}',
       Vector2(-50, -15),
@@ -165,7 +165,7 @@ abstract class PositionComponent extends BaseComponent {
     final rect = toRect();
     final dx = rect.right;
     final dy = rect.bottom;
-    debugTextConfig.render(
+    debugTextPaint.render(
       canvas,
       'x:${dx.toStringAsFixed(2)} y:${dy.toStringAsFixed(2)}',
       Vector2(width - 50, height),

--- a/packages/flame/lib/src/components/text_component.dart
+++ b/packages/flame/lib/src/components/text_component.dart
@@ -4,14 +4,12 @@ import 'package:flutter/painting.dart';
 import 'package:meta/meta.dart';
 
 import '../extensions/vector2.dart';
-import '../text_config.dart';
+import '../text.dart';
 import 'position_component.dart';
 
 class TextComponent extends PositionComponent {
   String _text;
-  TextConfig _config;
-
-  late TextPainter _tp;
+  TextRenderer _textRenderer;
 
   String get text => _text;
 
@@ -22,32 +20,32 @@ class TextComponent extends PositionComponent {
     }
   }
 
-  TextConfig get config => _config;
+  TextRenderer get textRenderer => _textRenderer;
 
-  set config(TextConfig config) {
-    _config = config;
+  set textRenderer(TextRenderer textRenderer) {
+    _textRenderer = textRenderer;
     _updateBox();
   }
 
   TextComponent(
     this._text, {
-    TextConfig? config,
+    TextRenderer? textRenderer,
     Vector2? position,
     Vector2? size,
-  })  : _config = config ?? TextConfig(),
+  })  : _textRenderer = textRenderer ?? TextPaint(),
         super(position: position, size: size) {
     _updateBox();
   }
 
   void _updateBox() {
-    _tp = config.toTextPainter(_text);
-    size.setValues(_tp.width, _tp.height);
+    final size = textRenderer.measureText(_text);
+    size.setValues(size.x, size.y);
   }
 
   @mustCallSuper
   @override
-  void render(Canvas c) {
-    super.render(c);
-    _tp.paint(c, Offset.zero);
+  void render(Canvas canvas) {
+    super.render(canvas);
+    _textRenderer.render(canvas, text, Vector2.zero());
   }
 }

--- a/packages/flame/lib/src/text.dart
+++ b/packages/flame/lib/src/text.dart
@@ -8,6 +8,10 @@ import 'extensions/size.dart';
 import 'extensions/vector2.dart';
 import 'memory_cache.dart';
 
+/// [TextRenderer] is the abstract API that Flame uses for rendering text in its features
+/// this class can be extended to provide an implementation of text rendering in the engine.
+///
+/// See [TextPaint] for the default implementation offered by Flame
 abstract class TextRenderer<T extends BaseTextConfig> {
   final T config;
 

--- a/packages/flame/lib/src/text.dart
+++ b/packages/flame/lib/src/text.dart
@@ -104,9 +104,10 @@ class TextPaintConfig extends BaseTextConfig {
     TextDirection textDirection = TextDirection.rtl,
     double? lineHeight,
   }) : super(
-            fontSize: fontSize,
-            textDirection: textDirection,
-            lineHeight: lineHeight);
+          fontSize: fontSize,
+          textDirection: textDirection,
+          lineHeight: lineHeight,
+        );
 
   /// Creates a new [TextPaintConfig] changing only the [fontSize].
   ///

--- a/packages/flame/lib/src/text.dart
+++ b/packages/flame/lib/src/text.dart
@@ -8,13 +8,45 @@ import 'extensions/size.dart';
 import 'extensions/vector2.dart';
 import 'memory_cache.dart';
 
+abstract class TextRenderer {
+  /// Renders a given [text] in a given position [position] using the provided [canvas] and [anchor].
+  ///
+  /// Renders it in the given position, considering the [anchor] specified.
+  /// For example, if [Anchor.center] is specified, it's going to be drawn centered around [position].
+  ///
+  /// Example usage (Using TextPaint implementation):
+  ///
+  ///     const TextPaint config = TextPaint(fontSize: 48.0, fontFamily: 'Awesome Font');
+  ///     config.render(canvas, Vector2(size.x - 10, size.y - 10, anchor: Anchor.bottomRight);
+  void render(
+    Canvas canvas,
+    String text,
+    Vector2 position, {
+    Anchor anchor = Anchor.topLeft,
+  });
+
+  /// Given a [text] String, returns the width of that [text].
+  double measureTextWidth(String text);
+
+  /// Given a [text] String, returns the height of that [text].
+  double measureTextHeight(String text);
+
+  /// Given a [text] String, returns a Vector2 with the size of that [text] has.
+  Vector2 measureText(String text) {
+    return Vector2(
+      measureTextWidth(text),
+      measureTextHeight(text),
+    );
+  }
+}
+
 /// A Text Config contains all typographical information required to render texts; i.e., font size and color, family, etc.
 ///
 /// It does not hold information regarding the position of the text to be render neither the text itself (the string).
 /// To hold all those information, use the Text component.
 ///
 /// It is used by [TextComponent].
-class TextConfig {
+class TextPaint extends TextRenderer {
   /// The font size to be used, in points.
   final double fontSize;
 
@@ -23,7 +55,7 @@ class TextConfig {
   /// Dart's [Color] class is just a plain wrapper on top of ARGB color (0xAARRGGBB).
   /// For example,
   ///
-  ///     const TextConfig config = TextConfig(color: const Color(0xFF00FF00)); // green
+  ///     const TextPaint config = TextPaint(color: const Color(0xFF00FF00)); // green
   ///
   /// You can also use your Palette class to access colors used in your game.
   final Color color;
@@ -62,10 +94,10 @@ class TextConfig {
   final MemoryCache<String, material.TextPainter> _textPainterCache =
       MemoryCache();
 
-  /// Creates a constant [TextConfig] with sensible defaults.
+  /// Creates a constant [TextPaint] with sensible defaults.
   ///
   /// Every parameter can be specified.
-  TextConfig({
+  TextPaint({
     this.fontSize = 24.0,
     this.color = const Color(0xFF000000),
     this.fontFamily = 'Arial',
@@ -74,15 +106,7 @@ class TextConfig {
     this.lineHeight,
   });
 
-  /// Renders a given [text] in a given position [p] using the provided [canvas] and [anchor].
-  ///
-  /// It creates a [material.TextPainter] instance using the [toTextPainter] method, and renders it in the given position, considering the [anchor] specified.
-  /// For example, if [Anchor.center] is specified, it's going to be drawn centered around [p].
-  ///
-  /// Example usage:
-  ///
-  ///     const TextConfig config = TextConfig(fontSize: 48.0, fontFamily: 'Awesome Font');
-  ///     config.render(c, Offset(size.width - 10, size.height - 10, anchor: Anchor.bottomRight);
+  @override
   void render(
     Canvas canvas,
     String text,
@@ -94,13 +118,23 @@ class TextConfig {
     tp.paint(canvas, translatedPosition.toOffset());
   }
 
+  @override
+  double measureTextWidth(String text) {
+    return toTextPainter(text).width;
+  }
+
+  @override
+  double measureTextHeight(String text) {
+    return toTextPainter(text).height;
+  }
+
   /// Returns a [material.TextPainter] that allows for text rendering and size measuring.
   ///
   /// A [material.TextPainter] has three important properties: paint, width and height (or size).
   ///
   /// Example usage:
   ///
-  ///     const TextConfig config = TextConfig(fontSize: 48.0, fontFamily: 'Awesome Font');
+  ///     const TextPaint config = TextPaint(fontSize: 48.0, fontFamily: 'Awesome Font');
   ///     final tp = config.toTextPainter('Score: $score');
   ///     tp.paint(c, Offset(size.width - p.width - 10, size.height - p.height - 10));
   ///
@@ -130,11 +164,11 @@ class TextConfig {
     return _textPainterCache.getValue(text)!;
   }
 
-  /// Creates a new [TextConfig] changing only the [fontSize].
+  /// Creates a new [TextPaint] changing only the [fontSize].
   ///
   /// This does not change the original (as it's immutable).
-  TextConfig withFontSize(double fontSize) {
-    return TextConfig(
+  TextPaint withFontSize(double fontSize) {
+    return TextPaint(
       fontSize: fontSize,
       color: color,
       fontFamily: fontFamily,
@@ -143,11 +177,11 @@ class TextConfig {
     );
   }
 
-  /// Creates a new [TextConfig] changing only the [color].
+  /// Creates a new [TextPaint] changing only the [color].
   ///
   /// This does not change the original (as it's immutable).
-  TextConfig withColor(Color color) {
-    return TextConfig(
+  TextPaint withColor(Color color) {
+    return TextPaint(
       fontSize: fontSize,
       color: color,
       fontFamily: fontFamily,
@@ -156,11 +190,11 @@ class TextConfig {
     );
   }
 
-  /// Creates a new [TextConfig] changing only the [fontFamily].
+  /// Creates a new [TextPaint] changing only the [fontFamily].
   ///
   /// This does not change the original (as it's immutable).
-  TextConfig withFontFamily(String fontFamily) {
-    return TextConfig(
+  TextPaint withFontFamily(String fontFamily) {
+    return TextPaint(
       fontSize: fontSize,
       color: color,
       fontFamily: fontFamily,
@@ -169,11 +203,11 @@ class TextConfig {
     );
   }
 
-  /// Creates a new [TextConfig] changing only the [textAlign].
+  /// Creates a new [TextPaint] changing only the [textAlign].
   ///
   /// This does not change the original (as it's immutable).
-  TextConfig withTextAlign(TextAlign textAlign) {
-    return TextConfig(
+  TextPaint withTextAlign(TextAlign textAlign) {
+    return TextPaint(
       fontSize: fontSize,
       color: color,
       fontFamily: fontFamily,
@@ -182,11 +216,11 @@ class TextConfig {
     );
   }
 
-  /// Creates a new [TextConfig] changing only the [textDirection].
+  /// Creates a new [TextPaint] changing only the [textDirection].
   ///
   /// This does not change the original (as it's immutable).
-  TextConfig withTextDirection(TextDirection textDirection) {
-    return TextConfig(
+  TextPaint withTextDirection(TextDirection textDirection) {
+    return TextPaint(
       fontSize: fontSize,
       color: color,
       fontFamily: fontFamily,


### PR DESCRIPTION
# Description

This PR does two things:
 - Create an abstraction for text rendering on the framework, with this abstraction we can now easily introduce more ways of rendering text on Flame and we can still use the same components with different methods of text rendering.
 - Rename the `TextConfig` class to `TextPaint`: I always found it a little confusing that our class for rendering text was named `TextConfig` since it is not only a text configuration, but also a text renderer. I choose `TextPaint` for the new name because that implementation is quite tied to the Flutter's `TextPainter` class, that name was also inspired by the Flutter's duo classes `CustomPainter` and `CustomPaint`.
 
The most importante part of this PR is the abstraction, the renaming is a proposal, let me know what you think of the idea.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [ ] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
