### PR TITLE
Same debugMode for children as for parent

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -10,6 +10,7 @@
  - Addresses the TODO to change the camera public APIs to take Anchors for relativePositions
  - Adds methods to support moving the camera relative to its current position
  - Abstracting the text api to allow custom text renderers on the framework
+ - Set the same debug mode for children as for the parent when added
 
 ## [1.0.0-rc9]
  - Fix input bug with other anchors than center

--- a/packages/flame/lib/src/components/base_component.dart
+++ b/packages/flame/lib/src/components/base_component.dart
@@ -158,6 +158,7 @@ abstract class BaseComponent extends Component {
 
     if (child is BaseComponent) {
       child._parent = this;
+      child.debugMode = debugMode;
     }
 
     final childOnLoadFuture = child.onLoad();

--- a/packages/flame/test/components/composed_component_test.dart
+++ b/packages/flame/test/components/composed_component_test.dart
@@ -138,5 +138,21 @@ void main() {
       expect(child.rendered, true);
       expect(child.updated, true);
     });
+
+    test('initially same debugMode as parent', () {
+      final game = MyGame();
+      game.onResize(Vector2.all(100));
+      final child = MyTap();
+      final wrapper = MyComposed();
+      wrapper.debugMode = true;
+
+      wrapper.addChild(child);
+      game.add(wrapper);
+      game.update(0.0);
+
+      expect(child.debugMode, true);
+      wrapper.debugMode = false;
+      expect(child.debugMode, true);
+    });
   });
 }


### PR DESCRIPTION
# Description

The children should have the same debugMode as their parent, at least initially.
This also fixes the composability example.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
