### PR TITLE
Remove deprecated analysis option

### DIFF
--- a/examples/analysis_options.yaml
+++ b/examples/analysis_options.yaml
@@ -144,7 +144,4 @@ dart_code_metrics:
   metrics:
     number-of-arguments: 8
     number-of-methods: 32
-    lines-of-executable-code: 200
     cyclomatic-complexity: 36
-
-

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [Next]
+ - Remove deprecated analysis option lines-of-executable-code
+ 
 ## [1.0.0-rc10]
  - Updated tutorial documentation to indicate use of new version
  - Fix bounding box check in collision detection

--- a/packages/flame/analysis_options.yaml
+++ b/packages/flame/analysis_options.yaml
@@ -144,7 +144,4 @@ dart_code_metrics:
   metrics:
     number-of-parameters: 8
     number-of-methods: 32
-    lines-of-executable-code: 200
     cyclomatic-complexity: 36
-
-


### PR DESCRIPTION
# Description

https://github.com/dart-code-checker/dart-code-metrics/pull/291
Can't seem to find any more info about it, but our pipeline is complaining due to it now.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
