### PR TITLE
onCollisionEnd callbacks for Collidable and HitboxShape

### DIFF
--- a/doc/collision_detection.md
+++ b/doc/collision_detection.md
@@ -86,6 +86,15 @@ class MyCollidable extends PositionComponent with Hitbox, Collidable {
       ...
     }
   }
+
+  @override
+  void onCollisionEnd(Collidable other) {
+    if (other is CollidableScreen) {
+      ...
+    } else if (other is YourOtherCollidable) {
+      ...
+    }
+  }
 }
 ```
 
@@ -93,7 +102,8 @@ In this example it can be seen how the Dart `is` keyword is used to check which 
 that your component collided with. The set of points is where the edges of the hitboxes collided.
 Note that the `onCollision` method will be called on both collidable components if they
 have both implemented the `onCollision` method, and also on both shapes if they have that method
-implemented.
+implemented. The same goes for the `onCollisionEnd` method, which is called when two components or
+shapes that were previously colliding no longer colliding with each other.
 
 If you want to check collisions with the screen edges, as we do in the example above, you can use
 the predefined [ScreenCollidable](#ScreenCollidable) class and since that one also is a `Collidable`

--- a/examples/lib/stories/collision_detection/collision_detection.dart
+++ b/examples/lib/stories/collision_detection/collision_detection.dart
@@ -11,7 +11,7 @@ An example with many hitboxes that move around on the screen and during
 collisions they change color depending on what it is that they have collided
 with. 
 
-The snowman, the component built with three circles on top of each other, work
+The snowman, the component built with three circles on top of each other, works
 a little bit differently than the other components to show that you can have
 multiple hitboxes within one component.
 

--- a/examples/lib/stories/collision_detection/collision_detection.dart
+++ b/examples/lib/stories/collision_detection/collision_detection.dart
@@ -6,6 +6,19 @@ import 'circles.dart';
 import 'multiple_shapes.dart';
 import 'only_shapes.dart';
 
+const basicInfo = '''
+An example with many hitboxes that move around on the screen and during
+collisions they change color depending on what it is that they have collided
+with. 
+
+The snowman, the component built with three circles on top of each other, work
+a little bit differently than the other components to show that you can have
+multiple hitboxes within one component.
+
+On this example, you can "throw" the components by dragging them quickly in any
+direction.
+''';
+
 void addCollisionDetectionStories(Dashbook dashbook) {
   dashbook.storiesOf('Collision Detection')
     ..add(
@@ -17,6 +30,7 @@ void addCollisionDetectionStories(Dashbook dashbook) {
       'Multiple shapes',
       (_) => GameWidget(game: MultipleShapes()),
       codeLink: baseLink('collision_detection/multiple_shapes.dart'),
+      info: basicInfo,
     )
     ..add(
       'Shapes without components',

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -75,7 +75,7 @@ abstract class MyCollidable extends PositionComponent
   void onCollision(Set<Vector2> intersectionPoints, Collidable other) {
     final isNew = _activeCollisions.add(other);
     if (isNew) {
-      _activePaint..color = collisionColor(other).withOpacity(0.8);
+      _activePaint.color = collisionColor(other).withOpacity(0.8);
     }
   }
 

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -174,7 +174,7 @@ class SnowmanPart extends HitboxCircle {
       if (other.component is ScreenCollidable) {
         hitPaint..color = startColor;
       } else {
-        hitPaint..color = hitColor.withOpacity(0.8);
+        hitPaint.color = hitColor.withOpacity(0.8);
       }
     };
   }

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -36,7 +36,6 @@ abstract class MyCollidable extends PositionComponent
 
   @override
   Future<void> onLoad() async {
-    await super.onLoad();
     _activePaint = Paint()..color = _defaultColor;
   }
 

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  dart_code_metrics: ^3.1.0
+  dart_code_metrics: ^3.2.2
 
 flutter:
   uses-material-design: true

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Replace deprecated analysis option lines-of-executable-code with source-lines-of-code
  - Fix the anchor of SpriteWidget
  - Add test for re-adding previously removed component
+ - Add onCollisionEnd to make it possible for the user to easily detect when a collision ends
 
 ## [1.0.0-rc10]
  - Updated tutorial documentation to indicate use of new version

--- a/packages/flame/lib/src/components/mixins/collidable.dart
+++ b/packages/flame/lib/src/components/mixins/collidable.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/cupertino.dart';
+
 import '../../../components.dart';
 import '../../../game.dart';
 import '../../components/position_component.dart';
@@ -18,6 +20,7 @@ mixin Collidable on Hitbox {
   CollidableType collidableType = CollidableType.active;
 
   void onCollision(Set<Vector2> intersectionPoints, Collidable other) {}
+  void onCollisionEnd(Collidable other) {}
 }
 
 class ScreenCollidable extends PositionComponent

--- a/packages/flame/lib/src/components/mixins/collidable.dart
+++ b/packages/flame/lib/src/components/mixins/collidable.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/cupertino.dart';
-
 import '../../../components.dart';
 import '../../../game.dart';
 import '../../components/position_component.dart';

--- a/packages/flame/lib/src/components/mixins/hitbox.dart
+++ b/packages/flame/lib/src/components/mixins/hitbox.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:ui';
 
 import '../../../extensions.dart';
 import '../../geometry/shape.dart';
@@ -26,8 +27,8 @@ mixin Hitbox on PositionComponent {
         _shapes.any((shape) => shape.containsPoint(point));
   }
 
-  void renderShapes(Canvas canvas) {
-    _shapes.forEach((shape) => shape.render(canvas, debugPaint));
+  void renderShapes(Canvas canvas, {Paint? paint}) {
+    _shapes.forEach((shape) => shape.render(canvas, paint ?? debugPaint));
   }
 
   /// Since this is a cheaper calculation than checking towards all shapes, this

--- a/packages/flame/lib/src/geometry/collision_detection.dart
+++ b/packages/flame/lib/src/geometry/collision_detection.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import '../../extensions.dart';
 import '../../geometry.dart';
 import '../components/mixins/collidable.dart';
@@ -107,5 +105,5 @@ Set<Vector2> intersections(
 }
 
 int _combinedHash(Object o1, Object o2) {
-  return o1.hashCode < o2.hashCode ? hashValues(o1, o2) : hashValues(o2, o1);
+  return o1.hashCode ^ o2.hashCode;
 }

--- a/packages/flame/lib/src/geometry/collision_detection.dart
+++ b/packages/flame/lib/src/geometry/collision_detection.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import '../../extensions.dart';
 import '../../geometry.dart';
 import '../components/mixins/collidable.dart';
@@ -29,7 +31,7 @@ void collisionDetection(List<Collidable> collidables) {
       if (intersectionPoints.isNotEmpty) {
         collidableX.onCollision(intersectionPoints, collidableY);
         collidableY.onCollision(intersectionPoints, collidableX);
-        final collisionHash = _combineHashCodes(collidableX, collidableY);
+        final collisionHash = hashValues(collidableX, collidableY);
         _collidableHashes.add(collisionHash);
       } else {
         _handleCollisionEnd(collidableX, collidableY);
@@ -40,13 +42,13 @@ void collisionDetection(List<Collidable> collidables) {
 
 bool hasActiveCollision(Collidable collidableA, Collidable collidableB) {
   return _collidableHashes.contains(
-    _combineHashCodes(collidableA, collidableB),
+    hashValues(collidableA, collidableB),
   );
 }
 
 bool hasActiveShapeCollision(HitboxShape shapeA, HitboxShape shapeB) {
   return _shapeHashes.contains(
-    _combineHashCodes(shapeA, shapeB),
+    hashValues(shapeA, shapeB),
   );
 }
 
@@ -54,7 +56,7 @@ void _handleCollisionEnd(Collidable collidableA, Collidable collidableB) {
   if (hasActiveCollision(collidableA, collidableB)) {
     collidableA.onCollisionEnd(collidableB);
     collidableB.onCollisionEnd(collidableA);
-    _collidableHashes.remove(_combineHashCodes(collidableA, collidableB));
+    _collidableHashes.remove(hashValues(collidableA, collidableB));
   }
 }
 
@@ -62,7 +64,7 @@ void _handleShapeCollisionEnd(HitboxShape shapeA, HitboxShape shapeB) {
   if (hasActiveShapeCollision(shapeA, shapeB)) {
     shapeA.onCollisionEnd(shapeB);
     shapeB.onCollisionEnd(shapeA);
-    _shapeHashes.remove(_combineHashCodes(shapeA, shapeB));
+    _shapeHashes.remove(hashValues(shapeA, shapeB));
   }
 }
 
@@ -95,16 +97,11 @@ Set<Vector2> intersections(
         shapeA.onCollision(currentResult, shapeB);
         shapeB.onCollision(currentResult, shapeA);
         currentResult.clear();
-        _shapeHashes.add(_combineHashCodes(shapeA, shapeB));
+        _shapeHashes.add(hashValues(shapeA, shapeB));
       } else {
         _handleShapeCollisionEnd(shapeA, shapeB);
       }
     }
   }
   return result;
-}
-
-// Note that this might result in hash collisions
-int _combineHashCodes(Object o1, Object o2) {
-  return o1.hashCode + o2.hashCode;
 }

--- a/packages/flame/lib/src/geometry/collision_detection.dart
+++ b/packages/flame/lib/src/geometry/collision_detection.dart
@@ -66,7 +66,7 @@ void _handleShapeCollisionEnd(HitboxShape shapeA, HitboxShape shapeB) {
   }
 }
 
-  /// Check what the intersection points of two collidables are
+/// Check what the intersection points of two collidables are
 /// returns an empty list if there are no intersections
 Set<Vector2> intersections(
   Collidable collidableA,

--- a/packages/flame/lib/src/geometry/collision_detection.dart
+++ b/packages/flame/lib/src/geometry/collision_detection.dart
@@ -54,7 +54,7 @@ void _handleCollisionEnd(Collidable collidableA, Collidable collidableB) {
   if (hasActiveCollision(collidableA, collidableB)) {
     collidableA.onCollisionEnd(collidableB);
     collidableB.onCollisionEnd(collidableA);
-    _shapeHashes.remove(_combineHashCodes(collidableA, collidableB));
+    _collidableHashes.remove(_combineHashCodes(collidableA, collidableB));
   }
 }
 

--- a/packages/flame/lib/src/geometry/collision_detection.dart
+++ b/packages/flame/lib/src/geometry/collision_detection.dart
@@ -31,7 +31,7 @@ void collisionDetection(List<Collidable> collidables) {
       if (intersectionPoints.isNotEmpty) {
         collidableX.onCollision(intersectionPoints, collidableY);
         collidableY.onCollision(intersectionPoints, collidableX);
-        final collisionHash = hashValues(collidableX, collidableY);
+        final collisionHash = _combineHashCodes(collidableX, collidableY);
         _collidableHashes.add(collisionHash);
       } else {
         _handleCollisionEnd(collidableX, collidableY);
@@ -42,13 +42,13 @@ void collisionDetection(List<Collidable> collidables) {
 
 bool hasActiveCollision(Collidable collidableA, Collidable collidableB) {
   return _collidableHashes.contains(
-    hashValues(collidableA, collidableB),
+    _combineHashCodes(collidableA, collidableB),
   );
 }
 
 bool hasActiveShapeCollision(HitboxShape shapeA, HitboxShape shapeB) {
   return _shapeHashes.contains(
-    hashValues(shapeA, shapeB),
+    _combineHashCodes(shapeA, shapeB),
   );
 }
 
@@ -56,7 +56,7 @@ void _handleCollisionEnd(Collidable collidableA, Collidable collidableB) {
   if (hasActiveCollision(collidableA, collidableB)) {
     collidableA.onCollisionEnd(collidableB);
     collidableB.onCollisionEnd(collidableA);
-    _collidableHashes.remove(hashValues(collidableA, collidableB));
+    _collidableHashes.remove(_combineHashCodes(collidableA, collidableB));
   }
 }
 
@@ -64,7 +64,7 @@ void _handleShapeCollisionEnd(HitboxShape shapeA, HitboxShape shapeB) {
   if (hasActiveShapeCollision(shapeA, shapeB)) {
     shapeA.onCollisionEnd(shapeB);
     shapeB.onCollisionEnd(shapeA);
-    _shapeHashes.remove(hashValues(shapeA, shapeB));
+    _shapeHashes.remove(_combineHashCodes(shapeA, shapeB));
   }
 }
 
@@ -104,4 +104,8 @@ Set<Vector2> intersections(
     }
   }
   return result;
+}
+
+int _combineHashCodes(Object o1, Object o2) {
+  return o1.hashCode < o2.hashCode ? hashValues(o1, o2) : hashValues(o2, o1);
 }

--- a/packages/flame/lib/src/geometry/collision_detection.dart
+++ b/packages/flame/lib/src/geometry/collision_detection.dart
@@ -31,7 +31,7 @@ void collisionDetection(List<Collidable> collidables) {
       if (intersectionPoints.isNotEmpty) {
         collidableX.onCollision(intersectionPoints, collidableY);
         collidableY.onCollision(intersectionPoints, collidableX);
-        final collisionHash = _combineHashCodes(collidableX, collidableY);
+        final collisionHash = _combinedHash(collidableX, collidableY);
         _collidableHashes.add(collisionHash);
       } else {
         _handleCollisionEnd(collidableX, collidableY);
@@ -42,13 +42,13 @@ void collisionDetection(List<Collidable> collidables) {
 
 bool hasActiveCollision(Collidable collidableA, Collidable collidableB) {
   return _collidableHashes.contains(
-    _combineHashCodes(collidableA, collidableB),
+    _combinedHash(collidableA, collidableB),
   );
 }
 
 bool hasActiveShapeCollision(HitboxShape shapeA, HitboxShape shapeB) {
   return _shapeHashes.contains(
-    _combineHashCodes(shapeA, shapeB),
+    _combinedHash(shapeA, shapeB),
   );
 }
 
@@ -56,7 +56,7 @@ void _handleCollisionEnd(Collidable collidableA, Collidable collidableB) {
   if (hasActiveCollision(collidableA, collidableB)) {
     collidableA.onCollisionEnd(collidableB);
     collidableB.onCollisionEnd(collidableA);
-    _collidableHashes.remove(_combineHashCodes(collidableA, collidableB));
+    _collidableHashes.remove(_combinedHash(collidableA, collidableB));
   }
 }
 
@@ -64,7 +64,7 @@ void _handleShapeCollisionEnd(HitboxShape shapeA, HitboxShape shapeB) {
   if (hasActiveShapeCollision(shapeA, shapeB)) {
     shapeA.onCollisionEnd(shapeB);
     shapeB.onCollisionEnd(shapeA);
-    _shapeHashes.remove(_combineHashCodes(shapeA, shapeB));
+    _shapeHashes.remove(_combinedHash(shapeA, shapeB));
   }
 }
 
@@ -97,7 +97,7 @@ Set<Vector2> intersections(
         shapeA.onCollision(currentResult, shapeB);
         shapeB.onCollision(currentResult, shapeA);
         currentResult.clear();
-        _shapeHashes.add(hashValues(shapeA, shapeB));
+        _shapeHashes.add(_combinedHash(shapeA, shapeB));
       } else {
         _handleShapeCollisionEnd(shapeA, shapeB);
       }
@@ -106,6 +106,6 @@ Set<Vector2> intersections(
   return result;
 }
 
-int _combineHashCodes(Object o1, Object o2) {
+int _combinedHash(Object o1, Object o2) {
   return o1.hashCode < o2.hashCode ? hashValues(o1, o2) : hashValues(o2, o1);
 }

--- a/packages/flame/lib/src/geometry/shape.dart
+++ b/packages/flame/lib/src/geometry/shape.dart
@@ -126,6 +126,10 @@ mixin HitboxShape on Shape {
   /// Assign your own [CollisionCallback] if you want a callback when this
   /// shape collides with another [HitboxShape]
   CollisionCallback onCollision = emptyCollisionCallback;
+
+  /// Assign your own [CollisionEndCallback] if you want a callback when this
+  /// shape stops colliding with another [HitboxShape]
+  CollisionEndCallback onCollisionEnd = emptyCollisionEndCallback;
 }
 
 typedef CollisionCallback = void Function(
@@ -133,7 +137,10 @@ typedef CollisionCallback = void Function(
   HitboxShape other,
 );
 
+typedef CollisionEndCallback = void Function(HitboxShape other);
+
 void emptyCollisionCallback(Set<Vector2> _, HitboxShape __) {}
+void emptyCollisionEndCallback(HitboxShape _) {}
 
 /// Used for caching calculated shapes, the cache is determined to be valid by
 /// comparing a list of values that can be of any type and is compared to the

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.16.0
-  dart_code_metrics: ^3.1.0
+  dart_code_metrics: ^3.2.2
   dartdoc: ^0.42.0
 
 environment:

--- a/packages/flame/test/components/collidable_type_test.dart
+++ b/packages/flame/test/components/collidable_type_test.dart
@@ -12,7 +12,7 @@ class TestGame extends BaseGame with HasCollidables {
 }
 
 class TestBlock extends PositionComponent with Hitbox, Collidable {
-  final Set<Collidable> collisions = {};
+  final List<Collidable> collisions = List.empty(growable: true);
 
   TestBlock(Vector2 position, Vector2 size, CollidableType type)
       : super(
@@ -33,7 +33,9 @@ class TestBlock extends PositionComponent with Hitbox, Collidable {
     List<Collidable> otherCollidables, {
     bool containsSelf = true,
   }) {
-    return collisions.containsAll(otherCollidables..remove(this)) &&
+    return collisions
+            .toSet()
+            .containsAll(otherCollidables.toList()..remove(this)) &&
         collisions.length == otherCollidables.length - (containsSelf ? 1 : 0);
   }
 

--- a/packages/flame/test/components/collidable_type_test.dart
+++ b/packages/flame/test/components/collidable_type_test.dart
@@ -12,7 +12,7 @@ class TestGame extends BaseGame with HasCollidables {
 }
 
 class TestBlock extends PositionComponent with Hitbox, Collidable {
-  final List<Collidable> collisions = List.empty(growable: true);
+  final Set<Collidable> collisions = {};
 
   TestBlock(Vector2 position, Vector2 size, CollidableType type)
       : super(
@@ -33,9 +33,7 @@ class TestBlock extends PositionComponent with Hitbox, Collidable {
     List<Collidable> otherCollidables, {
     bool containsSelf = true,
   }) {
-    return collisions
-            .toSet()
-            .containsAll(otherCollidables.toList()..remove(this)) &&
+    return collisions.containsAll(otherCollidables..remove(this)) &&
         collisions.length == otherCollidables.length - (containsSelf ? 1 : 0);
   }
 

--- a/packages/flame/test/components/collision_callback_test.dart
+++ b/packages/flame/test/components/collision_callback_test.dart
@@ -1,0 +1,129 @@
+import 'package:flame/components.dart';
+import 'package:flame/extensions.dart';
+import 'package:flame/game.dart';
+import 'package:flame/geometry.dart';
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+class TestGame extends BaseGame with HasCollidables {
+  TestGame() {
+    onResize(Vector2.all(200));
+  }
+}
+
+class TestHitbox extends HitboxRectangle {
+  final Set<HitboxShape> collisions = {};
+  int endCounter = 0;
+
+  TestHitbox() {
+    onCollision = (_, shape) => collisions.add(shape);
+    onCollisionEnd = (shape) {
+      endCounter++;
+      collisions.remove(shape);
+    };
+  }
+
+  bool hasCollisionWith(HitboxShape otherShape) {
+    return collisions.contains(otherShape);
+  }
+}
+
+class TestBlock extends PositionComponent with Hitbox, Collidable {
+  final Set<Collidable> collisions = {};
+  final hitbox = TestHitbox();
+  int endCounter = 0;
+
+  TestBlock(Vector2 position, Vector2 size)
+      : super(
+          position: position,
+          size: size,
+        ) {
+    addShape(hitbox);
+  }
+
+  bool hasCollisionWith(Collidable otherCollidable) {
+    return collisions.contains(otherCollidable);
+  }
+
+  @override
+  void onCollision(Set<Vector2> intersectionPoints, Collidable other) {
+    collisions.add(other);
+  }
+
+  @override
+  void onCollisionEnd(Collidable other) {
+    endCounter++;
+    collisions.remove(other);
+  }
+}
+
+void main() {
+  TestGame gameWithCollidables(List<Collidable> collidables) {
+    final game = TestGame();
+    game.addAll(collidables);
+    game.update(0);
+    expect(game.components.isNotEmpty, collidables.isNotEmpty);
+    return game;
+  }
+
+  group(
+    'Collision callbacks are called properly',
+    () {
+      test('collidable callbacks are called', () {
+        final blockA = TestBlock(
+          Vector2.zero(),
+          Vector2.all(10),
+        );
+        final blockB = TestBlock(
+          Vector2.all(1),
+          Vector2.all(10),
+        );
+        final game = gameWithCollidables([blockA, blockB]);
+        expect(blockA.hasCollisionWith(blockB), true);
+        expect(blockB.hasCollisionWith(blockA), true);
+        expect(blockA.collisions.length, 1);
+        expect(blockB.collisions.length, 1);
+        blockB.position = Vector2.all(21);
+        expect(blockA.endCounter, 0);
+        expect(blockB.endCounter, 0);
+        game.update(0);
+        expect(blockA.hasCollisionWith(blockB), false);
+        expect(blockB.hasCollisionWith(blockA), false);
+        expect(blockA.collisions.length, 0);
+        expect(blockB.collisions.length, 0);
+        game.update(0);
+        expect(blockA.endCounter, 1);
+        expect(blockB.endCounter, 1);
+      });
+
+      test('hitbox callbacks are called', () {
+        final blockA = TestBlock(
+          Vector2.zero(),
+          Vector2.all(10),
+        );
+        final blockB = TestBlock(
+          Vector2.all(1),
+          Vector2.all(10),
+        );
+        final hitboxA = blockA.hitbox;
+        final hitboxB = blockB.hitbox;
+        final game = gameWithCollidables([blockA, blockB]);
+        expect(hitboxA.hasCollisionWith(hitboxB), true);
+        expect(hitboxB.hasCollisionWith(hitboxA), true);
+        expect(hitboxA.collisions.length, 1);
+        expect(hitboxB.collisions.length, 1);
+        blockB.position = Vector2.all(21);
+        expect(hitboxA.endCounter, 0);
+        expect(hitboxB.endCounter, 0);
+        game.update(0);
+        expect(hitboxA.hasCollisionWith(hitboxB), false);
+        expect(hitboxB.hasCollisionWith(hitboxA), false);
+        expect(hitboxA.collisions.length, 0);
+        expect(hitboxB.collisions.length, 0);
+        game.update(0);
+        expect(hitboxA.endCounter, 1);
+        expect(hitboxB.endCounter, 1);
+      });
+    },
+  );
+}


### PR DESCRIPTION
# Description

Calls `onCollisionEnd` on `Collidable` and `HitboxShape` once a collision is over.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
