### PR TITLE
Refactor tests to use expectVector2 and expectDouble

### DIFF
--- a/packages/flame/test/components/composed_component_test.dart
+++ b/packages/flame/test/components/composed_component_test.dart
@@ -58,7 +58,7 @@ void main() {
       final wrapper = MyComposed();
       wrapper.addChild(child);
 
-      expect(true, wrapper.containsChild(child));
+      expect(wrapper.containsChild(child), true);
     });
 
     test('removes the child from the component', () {
@@ -68,7 +68,7 @@ void main() {
       expect(true, wrapper.containsChild(child));
 
       wrapper.removeChild(child);
-      expect(false, wrapper.containsChild(child));
+      expect(wrapper.containsChild(child), false);
     });
 
     test(
@@ -78,7 +78,7 @@ void main() {
         final wrapper = MyComposed();
         await wrapper.addChild(child);
 
-        expect(true, wrapper.containsChild(child));
+        expect(wrapper.containsChild(child), true);
       },
     );
 

--- a/packages/flame/test/effects/effect_test_utils.dart
+++ b/packages/flame/test/effects/effect_test_utils.dart
@@ -5,6 +5,9 @@ import 'package:flame/effects.dart';
 import 'package:flame/game.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../util/expect_double.dart';
+import '../util/expect_vector2.dart';
+
 final Random random = Random();
 
 class Callback {
@@ -45,20 +48,19 @@ void effectTest(
   }
 
   if (!shouldComplete) {
-    const floatRange = 0.01;
-    expect(
-      component.position.absoluteError(expectedPosition),
-      closeTo(0.0, floatRange),
+    expectVector2(
+      component.position,
+      expectedPosition,
       reason: 'Position is not correct',
     );
-    expect(
+    expectDouble(
       component.angle,
-      closeTo(expectedAngle, floatRange),
+      expectedAngle,
       reason: 'Angle is not correct',
     );
-    expect(
-      component.size.absoluteError(expectedSize),
-      closeTo(0.0, floatRange),
+    expectVector2(
+      component.size,
+      expectedSize,
       reason: 'Size is not correct',
     );
   } else {
@@ -70,17 +72,17 @@ void effectTest(
       game.update(effect.peakTime - effect.currentTime);
     }
 
-    expect(
+    expectVector2(
       component.position,
       expectedPosition,
       reason: 'Position is not exactly correct',
     );
-    expect(
+    expectDouble(
       component.angle,
       expectedAngle,
       reason: 'Angle is not exactly correct',
     );
-    expect(
+    expectVector2(
       component.size,
       expectedSize,
       reason: 'Size is not exactly correct',

--- a/packages/flame/test/extensions/vector2_test.dart
+++ b/packages/flame/test/extensions/vector2_test.dart
@@ -3,11 +3,8 @@ import 'dart:math' as math;
 import 'package:flame/extensions.dart';
 import 'package:test/test.dart';
 
+import '../util/expect_double.dart';
 import '../util/expect_vector2.dart';
-
-void expectDouble(double d1, double d2) {
-  expect((d1 - d2).abs() <= 0.0001, true);
-}
 
 void main() {
   group('Vector2 test', () {

--- a/packages/flame/test/util/expect_double.dart
+++ b/packages/flame/test/util/expect_double.dart
@@ -1,0 +1,10 @@
+import 'package:test/test.dart';
+
+void expectDouble(
+  double d1,
+  double d2, {
+  double epsilon = 0.0001,
+  String? reason,
+}) {
+  expect((d1 - d2).abs() <= epsilon, true, reason: reason);
+}

--- a/packages/flame/test/util/expect_double.dart
+++ b/packages/flame/test/util/expect_double.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 void expectDouble(
   double d1,
   double d2, {
-  double epsilon = 0.0001,
+  double epsilon = 0.01,
   String? reason,
 }) {
   expect((d1 - d2).abs() <= epsilon, true, reason: reason);

--- a/packages/flame/test/util/expect_vector2.dart
+++ b/packages/flame/test/util/expect_vector2.dart
@@ -1,14 +1,15 @@
 import 'package:flame/extensions.dart';
 import 'package:test/test.dart';
 
-// TODO(luan) refactor other tests to use this
 void expectVector2(
   Vector2 actual,
   Vector2 expected, {
   double epsilon = 0.01,
+  String? reason,
 }) {
   expect(
     actual.absoluteError(expected),
     closeTo(0.0, epsilon),
+    reason: reason,
   );
 }


### PR DESCRIPTION
# Description

Refactor tests to use expectVector2 and expectDouble.

This fixes a TODO

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
