### PR TITLE
Add anchor for ShapeComponent constructor

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -18,6 +18,7 @@
  - Refactor TextBoxComponent
  - Fix bugs with TextBoxComponent
  - Improve error message for composed components
+ - Add `anchor` for `ShapeComponent` constructor
 
 
 ## [1.0.0-releasecandidate.11]

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -12,13 +12,13 @@ class ShapeComponent extends PositionComponent {
   ShapeComponent(
     this.shape,
     this.shapePaint, {
-    Anchor? anchor,
+    Anchor anchor = Anchor.center,
     int? priority,
   }) : super(
           position: shape.position,
           size: shape.size,
           angle: shape.angle,
-          anchor: anchor ?? Anchor.center,
+          anchor: anchor,
           priority: priority,
         );
 

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -12,12 +12,13 @@ class ShapeComponent extends PositionComponent {
   ShapeComponent(
     this.shape,
     this.shapePaint, {
+    Anchor? anchor,
     int? priority,
   }) : super(
           position: shape.position,
           size: shape.size,
           angle: shape.angle,
-          anchor: Anchor.center,
+          anchor: anchor ?? Anchor.center,
           priority: priority,
         );
 


### PR DESCRIPTION
# Description

Add `anchor` for `ShapeComponent` constructor, so we can easily set the anchor.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
