### PR TITLE
Add some render box updates

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,6 @@
+macos/
+test/
+
 # Miscellaneous
 *.class
 *.log

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -23,6 +23,7 @@
  - Add `SpriteAnimation` support to parallax
  - Fix `Parallax` alignment for images with different width and height
  - Fix `ImageComposition` image bounds validation
+ - Improved the internal Render object widget performance
 
 ## [1.0.0-releasecandidate.11]
  - Replace deprecated analysis option lines-of-executable-code with source-lines-of-code

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -23,7 +23,7 @@
  - Add `SpriteAnimation` support to parallax
  - Fix `Parallax` alignment for images with different width and height
  - Fix `ImageComposition` image bounds validation
- - Improved the internal Render object widget performance
+ - Improved the internal `RenderObject` widget performance
 
 ## [1.0.0-releasecandidate.11]
  - Replace deprecated analysis option lines-of-executable-code with source-lines-of-code

--- a/packages/flame/lib/src/game/game_loop.dart
+++ b/packages/flame/lib/src/game/game_loop.dart
@@ -28,6 +28,10 @@ class GameLoop {
     _ticker.stop();
   }
 
+  void dispose() {
+    _ticker.dispose();
+  }
+
   void pause() {
     _ticker.muted = true;
     previous = Duration.zero;

--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -13,10 +13,9 @@ import 'game_loop.dart';
 class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   BuildContext buildContext;
   Game game;
-  late GameLoop gameLoop;
+  GameLoop? gameLoop;
 
   GameRenderBox(this.buildContext, this.game) {
-    gameLoop = GameLoop(gameLoopCallback);
     WidgetsBinding.instance!.addTimingsCallback(game.onTimingsCallback);
   }
 
@@ -37,6 +36,8 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
     super.attach(owner);
     game.attach(owner, this);
 
+    final gameLoop = this.gameLoop = GameLoop(gameLoopCallback);
+
     game.pauseEngineFn = gameLoop.pause;
     game.resumeEngineFn = gameLoop.resume;
 
@@ -51,7 +52,8 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   void detach() {
     super.detach();
     game.detach();
-    gameLoop.dispose();
+    gameLoop?.dispose();
+    gameLoop = null;
     _unbindLifecycleListener();
   }
 

--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -24,6 +24,9 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   bool get sizedByParent => true;
 
   @override
+  bool get isRepaintBoundary => true;
+
+  @override
   void performResize() {
     super.performResize();
     game.onResize(constraints.biggest.toVector2());
@@ -48,7 +51,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   void detach() {
     super.detach();
     game.detach();
-    gameLoop.stop();
+    gameLoop.dispose();
     _unbindLifecycleListener();
   }
 
@@ -58,6 +61,11 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
     }
     game.update(dt);
     markNeedsPaint();
+  }
+
+  @override
+  void performLayout() {
+    size = constraints.biggest;
   }
 
   @override

--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -298,6 +298,6 @@ class _GameRenderObjectWidget extends LeafRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, GameRenderBox renderObject) {
-    renderObject..game = game;
+    renderObject.game = game;
   }
 }

--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -293,9 +293,11 @@ class _GameRenderObjectWidget extends LeafRenderObjectWidget {
 
   @override
   RenderBox createRenderObject(BuildContext context) {
-    return RenderConstrainedBox(
-      child: GameRenderBox(context, game),
-      additionalConstraints: const BoxConstraints.expand(),
-    );
+    return GameRenderBox(context, game);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, GameRenderBox renderObject) {
+    renderObject..game = game;
   }
 }


### PR DESCRIPTION
# Description

Some improvements on our render object widget. 


- Made game loop call dispose on the ticker on detach. 
- Made the render object a repaint boundary, avoid an entire screen that contains a GameWidget to repaint every frame.
- Made the render object itself as expanded enabling the removal of that `RenderConstrainedBox`


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
