### PR TITLE
Rename camera shake amount to duration

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Fix camera not ending up in the correct position on long jumps
  - Make the `JoystickPlayer` a `PositionComponent`
  - Extract shared logic when handling components set in BaseComponent and BaseGame to ComponentSet.
+ - Rename `camera.shake(amount: x)` to `camera.shake(duration: x)`
 
 ## [1.0.0-releasecandidate.12]
  - Fix link to code in example stories

--- a/packages/flame/lib/src/game/camera.dart
+++ b/packages/flame/lib/src/game/camera.dart
@@ -375,11 +375,8 @@ class Camera extends Projector {
   /// Whether the camera is currently shaking or not.
   bool get shaking => _shakeTimer > 0.0;
 
-  /// Keep track how much the [Camera] shook in the last tick.
-  final _lastShake = Vector2.zero();
-
-  /// Keep track how much the [Camera] shook for this shake session.
-  final _totalShakeOffset = Vector2.zero();
+  /// Buffer to re-use for the shake delta.
+  final _shakeBuffer = Vector2.zero();
 
   /// The random number generator to use for shaking
   final _shakeRng = math.Random();
@@ -392,19 +389,11 @@ class Camera extends Projector {
   /// This will be a random number every tick causing a shakiness effect.
   Vector2 _shakeDelta() {
     if (shaking) {
-      _lastShake.setValues(_shakeValue(), _shakeValue());
-      _totalShakeOffset.add(_lastShake);
-      print(_lastShake);
-      return _lastShake;
-    } else if (!_totalShakeOffset.isZero()) {
-      final shakeOffset = _totalShakeOffset.clone()..negate();
-      _totalShakeOffset.setZero();
-      _lastShake.setZero();
-      print(shakeOffset);
-      return shakeOffset;
-    } else {
-      return _lastShake;
+      _shakeBuffer.setValues(_shakeValue(), _shakeValue());
+    } else if (!_shakeBuffer.isZero()) {
+      _shakeBuffer.setZero();
     }
+    return _shakeBuffer;
   }
 
   /// If you need updated on when the position of the camera is updated you

--- a/packages/flame/lib/src/game/camera.dart
+++ b/packages/flame/lib/src/game/camera.dart
@@ -386,7 +386,7 @@ class Camera extends Projector {
   double _shakeValue() => (_shakeRng.nextDouble() - 0.5) * 2 * shakeIntensity;
 
   /// Generates a random [Vector2] of displacement applied to the camera.
-  /// This will be a random number every tick causing a shakiness effect.
+  /// This will be a random [Vector2] every tick causing a shakiness effect.
   Vector2 _shakeDelta() {
     if (shaking) {
       _shakeBuffer.setValues(_shakeValue(), _shakeValue());

--- a/packages/flame/test/game/camera_and_viewport_test.dart
+++ b/packages/flame/test/game/camera_and_viewport_test.dart
@@ -358,6 +358,17 @@ void main() {
       );
       expect(game.camera.position, Vector2.all(-50.0));
     });
+    test('camera shake should return to where it started', () {
+      final game = BaseGame();
+      final camera = game.camera;
+      game.onResize(Vector2.all(200.0));
+      expect(camera.position, Vector2.zero());
+      camera.shake(duration: 9000);
+      game.update(5000);
+      game.update(5000);
+      game.update(5000);
+      expect(camera.position, Vector2.zero());
+    });
   });
   group('viewport & camera', () {
     test('default ratio viewport + camera with world boundaries', () {


### PR DESCRIPTION
# Description

This PR was initially because I thought that the camera didn't return to its original position after a shake (was reported on discord), but it seems that it is. I fixed some small things (so that we don't create new vectors every tick where it is not needed and renamed shake amount to shake duration) and added a test to ensure that the camera does return to its original position.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
