### PR TITLE
Fix SpriteAnimationComponent docs

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -132,18 +132,20 @@ class MyGame extends BaseGame {
 
 ## SpriteAnimationComponent
 
-This class is used to represent a Component that has a sprite that runs a single cyclic animation.
+This class is used to represent a Component that has sprites that run in a single cyclic animation.
 
 This will create a simple three frame animation using 3 different images:
 
 ```dart
 final sprites = [0, 1, 2]
-    .map((i) => await Sprite.load('player_$i.png'))
-    .toList();
-final size = Vector2.all(64.0);
+    .map((i) => Sprite.load('player_$i.png'));
+final animation = SpriteAnimation.spriteList(
+    await Future.wait(sprites),
+    stepTime: 0.01,
+);
 this.player = SpriteAnimationComponent(
-  SpriteAnimation.spriteList(sprites, stepTime: 0.01),
-  size: size,
+  animation: animation,
+  size: Vector2.all(64.0),
 );
 ```
 

--- a/doc/components.md
+++ b/doc/components.md
@@ -140,8 +140,8 @@ This will create a simple three frame animation using 3 different images:
 final sprites = [0, 1, 2]
     .map((i) => Sprite.load('player_$i.png'));
 final animation = SpriteAnimation.spriteList(
-    await Future.wait(sprites),
-    stepTime: 0.01,
+  await Future.wait(sprites),
+  stepTime: 0.01,
 );
 this.player = SpriteAnimationComponent(
   animation: animation,

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Fix camera not ending up in the correct position on long jumps
  - Make the `JoystickPlayer` a `PositionComponent`
  - Extract shared logic when handling components set in BaseComponent and BaseGame to ComponentSet.
+ - Fix `SpriteAnimationComponent` docs to use `Future.wait`
 
 ## [1.0.0-releasecandidate.12]
  - Fix link to code in example stories


### PR DESCRIPTION
# Description

The docs for the `SpriteAnimationComponent` tried to pass a list of futures instead of the materialized result.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

https://stackoverflow.com/questions/68265898/the-argument-type-listfuturesprite-cant-be-assigned-to-the-parameter-type/68267088#68267088

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
