### PR TITLE
Add `BaseComponent.postRender`

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -132,18 +132,20 @@ class MyGame extends BaseGame {
 
 ## SpriteAnimationComponent
 
-This class is used to represent a Component that has a sprite that runs a single cyclic animation.
+This class is used to represent a Component that has sprites that run in a single cyclic animation.
 
 This will create a simple three frame animation using 3 different images:
 
 ```dart
 final sprites = [0, 1, 2]
-    .map((i) => await Sprite.load('player_$i.png'))
-    .toList();
-final size = Vector2.all(64.0);
+    .map((i) => Sprite.load('player_$i.png'));
+final animation = SpriteAnimation.spriteList(
+    await Future.wait(sprites),
+    stepTime: 0.01,
+);
 this.player = SpriteAnimationComponent(
-  SpriteAnimation.spriteList(sprites, stepTime: 0.01),
-  size: size,
+  animation: animation,
+  size: Vector2.all(64.0),
 );
 ```
 

--- a/doc/components.md
+++ b/doc/components.md
@@ -140,8 +140,8 @@ This will create a simple three frame animation using 3 different images:
 final sprites = [0, 1, 2]
     .map((i) => Sprite.load('player_$i.png'));
 final animation = SpriteAnimation.spriteList(
-    await Future.wait(sprites),
-    stepTime: 0.01,
+  await Future.wait(sprites),
+  stepTime: 0.01,
 );
 this.player = SpriteAnimationComponent(
   animation: animation,

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Fix camera not ending up in the correct position on long jumps
  - Make the `JoystickPlayer` a `PositionComponent`
  - Extract shared logic when handling components set in BaseComponent and BaseGame to ComponentSet.
+ - Fix `SpriteAnimationComponent` docs to use `Future.wait`
 
 ## [1.0.0-releasecandidate.12]
  - Fix link to code in example stories

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Make the `JoystickPlayer` a `PositionComponent`
  - Extract shared logic when handling components set in BaseComponent and BaseGame to ComponentSet.
  - Fix `SpriteAnimationComponent` docs to use `Future.wait`
+ - Add an empty `postRender` method that will run after each components render method
 
 ## [1.0.0-releasecandidate.12]
  - Fix link to code in example stories

--- a/packages/flame/lib/src/components/base_component.dart
+++ b/packages/flame/lib/src/components/base_component.dart
@@ -73,6 +73,7 @@ abstract class BaseComponent extends Component {
   @override
   void renderTree(Canvas canvas) {
     render(canvas);
+    postRender(canvas);
     children.forEach((c) {
       canvas.save();
       c.renderTree(canvas);
@@ -84,6 +85,10 @@ abstract class BaseComponent extends Component {
       renderDebugMode(canvas);
     }
   }
+
+  /// Runs after the component has been rendered, but before any children has
+  /// been rendered.
+  void postRender(Canvas canvas) {}
 
   void renderDebugMode(Canvas canvas) {}
 

--- a/packages/flame/lib/src/components/base_component.dart
+++ b/packages/flame/lib/src/components/base_component.dart
@@ -86,8 +86,8 @@ abstract class BaseComponent extends Component {
     }
   }
 
-  /// A render cycle callback that runs after the component has been rendered, 
-  /// but before any children has been rendered.
+  /// A render cycle callback that runs after the component has been
+  /// rendered, but before any children has been rendered.
   void postRender(Canvas canvas) {}
 
   void renderDebugMode(Canvas canvas) {}

--- a/packages/flame/lib/src/components/base_component.dart
+++ b/packages/flame/lib/src/components/base_component.dart
@@ -86,8 +86,8 @@ abstract class BaseComponent extends Component {
     }
   }
 
-  /// Runs after the component has been rendered, but before any children has
-  /// been rendered.
+  /// A life cycle callback that runs after the component has been rendered, 
+  /// but before any children has been rendered.
   void postRender(Canvas canvas) {}
 
   void renderDebugMode(Canvas canvas) {}

--- a/packages/flame/lib/src/components/base_component.dart
+++ b/packages/flame/lib/src/components/base_component.dart
@@ -86,7 +86,7 @@ abstract class BaseComponent extends Component {
     }
   }
 
-  /// A life cycle callback that runs after the component has been rendered, 
+  /// A render cycle callback that runs after the component has been rendered, 
   /// but before any children has been rendered.
   void postRender(Canvas canvas) {}
 

--- a/packages/flame/lib/src/components/component_set.dart
+++ b/packages/flame/lib/src/components/component_set.dart
@@ -7,13 +7,13 @@ import '../game/base_game.dart';
 /// This is a simple wrapper over [QueryableOrderedSet] to be used by
 /// [BaseGame] and [BaseComponent].
 ///
-/// Instead of immediatly modifying the component list, all insertion
+/// Instead of immediately modifying the component list, all insertion
 /// and removal operations are queued to be performed on the next tick.
 ///
 /// This will avoid any concurrent modification exceptions while the game
 /// iterates through the component list.
 ///
-/// This wrapper also garantueed that prepare, onLoad, onMount and all the
+/// This wrapper also guaranteed that prepare, onLoad, onMount and all the
 /// lifecycle methods are called properly.
 class ComponentSet extends QueryableOrderedSet<Component> {
   /// Components to be added on the next update.


### PR DESCRIPTION
# Description
Since for Forge2D we have to flip the canvas back after the render of a parent is done an empty `postRender` method is added to `BaseComponent` which is overridden by `BodyComponent` in an upcomming PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
