### PR TITLE
Flip back the canvas Y-axis after render of BodyComponent

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -140,8 +140,8 @@ This will create a simple three frame animation using 3 different images:
 final sprites = [0, 1, 2]
     .map((i) => Sprite.load('player_$i.png'));
 final animation = SpriteAnimation.spriteList(
-  await Future.wait(sprites),
-  stepTime: 0.01,
+    await Future.wait(sprites),
+    stepTime: 0.01,
 );
 this.player = SpriteAnimationComponent(
   animation: animation,

--- a/doc/components.md
+++ b/doc/components.md
@@ -140,8 +140,8 @@ This will create a simple three frame animation using 3 different images:
 final sprites = [0, 1, 2]
     .map((i) => Sprite.load('player_$i.png'));
 final animation = SpriteAnimation.spriteList(
-    await Future.wait(sprites),
-    stepTime: 0.01,
+  await Future.wait(sprites),
+  stepTime: 0.01,
 );
 this.player = SpriteAnimationComponent(
   animation: animation,

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Add an empty `postRender` method that will run after each components render method
  - Rename `Tapable` to `Tappable`
  - Fix `SpriteAnimationComponent` docs to use `Future.wait`
+ - Add an empty `postRender` method that will run after each components render method
 
 ## [1.0.0-releasecandidate.12]
  - Fix link to code in example stories

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -8,7 +8,7 @@
  - Fix `SpriteAnimationComponent` docs to use `Future.wait`
  - Add an empty `postRender` method that will run after each components render method
  - Rename `Tapable` to `Tappable`
- - Rename `HasTapableComponents` to `HasTappableComponents`
+ - Fix `SpriteAnimationComponent` docs to use `Future.wait`
 
 ## [1.0.0-releasecandidate.12]
  - Fix link to code in example stories

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
-## [next]
+## [Next]
  - Update mechanism by which `BodyComponent`'s are disposed to use the `onRemove` method
+ - Flip y-axis after translation of body position, so that normal flame components can be children
+ - Update to Forge2D 0.8.0
+ - Update to Flame 1.0.0-releasecandidate.13
 
 ## [0.7.3-releasecandidate.12]
  - Fix prepareCanvas type error

--- a/packages/flame_forge2d/example/lib/balls.dart
+++ b/packages/flame_forge2d/example/lib/balls.dart
@@ -1,10 +1,10 @@
 import 'dart:math' as math;
 
-import 'package:forge2d/forge2d.dart';
 import 'package:flame/palette.dart';
 import 'package:flame_forge2d/body_component.dart';
 import 'package:flame_forge2d/contact_callbacks.dart';
 import 'package:flutter/material.dart';
+import 'package:forge2d/forge2d.dart';
 
 import 'boundaries.dart';
 
@@ -63,9 +63,9 @@ class Ball extends BodyComponent {
   }
 
   @override
-  void update(double t) {
-    super.update(t);
-    _timeSinceNudge += t;
+  void update(double dt) {
+    super.update(dt);
+    _timeSinceNudge += dt;
     if (giveNudge) {
       giveNudge = false;
       if (_timeSinceNudge > _minNudgeRest) {

--- a/packages/flame_forge2d/example/lib/composition_sample.dart
+++ b/packages/flame_forge2d/example/lib/composition_sample.dart
@@ -7,7 +7,7 @@ import 'package:forge2d/forge2d.dart';
 import 'balls.dart';
 import 'boundaries.dart';
 
-class CompositionSample extends Forge2DGame with HasTapableComponents {
+class CompositionSample extends Forge2DGame with HasTappableComponents {
   static const info = '''
 This example shows how to compose a `BodyComponent` together with a normal Flame
 component. Click the ball to see the number increment.
@@ -24,7 +24,7 @@ component. Click the ball to see the number increment.
   }
 }
 
-class TapableBall extends Ball with Tapable {
+class TapableBall extends Ball with Tappable {
   late final TextComponent textComponent;
   int counter = 0;
   final TextPaintConfig _textConfig =

--- a/packages/flame_forge2d/example/lib/composition_sample.dart
+++ b/packages/flame_forge2d/example/lib/composition_sample.dart
@@ -1,0 +1,61 @@
+import 'package:flame/components.dart';
+import 'package:flame/palette.dart';
+import 'package:flame_forge2d/flame_forge2d.dart';
+import 'package:flame_forge2d/forge2d_game.dart';
+import 'package:forge2d/forge2d.dart';
+
+import 'balls.dart';
+import 'boundaries.dart';
+
+class CompositionSample extends Forge2DGame with HasTapableComponents {
+  static const info = '''
+This example shows how to compose a `BodyComponent` together with a normal Flame
+component. Click the ball to see the number increment.
+''';
+
+  CompositionSample() : super(zoom: 20, gravity: Vector2(0, -10.0));
+
+  @override
+  Future<void> onLoad() async {
+    final boundaries = createBoundaries(this);
+    boundaries.forEach(add);
+    final center = screenToWorld(viewport.effectiveSize / 2);
+    add(TapableBall(center));
+  }
+}
+
+class TapableBall extends Ball with Tapable {
+  late final TextComponent textComponent;
+  int counter = 0;
+  final TextPaintConfig _textConfig =
+      TextPaintConfig(color: BasicPalette.white.color, fontSize: 4);
+  late final TextPaint _textPaint;
+
+  TapableBall(Vector2 position) : super(position) {
+    originalPaint = BasicPalette.white.paint();
+    paint = originalPaint;
+    _textPaint = TextPaint(config: _textConfig);
+    textComponent = TextComponent(counter.toString(), textRenderer: _textPaint);
+  }
+
+  @override
+  Future<void> onLoad() async {
+    super.onLoad();
+    addChild(textComponent);
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    textComponent.debugMode = false;
+    textComponent.text = counter.toString();
+  }
+
+  @override
+  bool onTapDown(_) {
+    counter++;
+    body.applyLinearImpulse(Vector2.random() * 1000);
+    paint = randomPaint();
+    return false;
+  }
+}

--- a/packages/flame_forge2d/example/lib/composition_sample.dart
+++ b/packages/flame_forge2d/example/lib/composition_sample.dart
@@ -34,19 +34,22 @@ class TapableBall extends Ball with Tappable {
   TapableBall(Vector2 position) : super(position) {
     originalPaint = BasicPalette.white.paint();
     paint = originalPaint;
-    _textPaint = TextPaint(config: _textConfig);
-    textComponent = TextComponent(counter.toString(), textRenderer: _textPaint);
   }
 
   @override
   Future<void> onLoad() async {
     super.onLoad();
+    _textPaint = TextPaint(config: _textConfig);
+    textComponent = TextComponent(counter.toString(), textRenderer: _textPaint);
     addChild(textComponent);
   }
 
   @override
   void update(double dt) {
     super.update(dt);
+    // This is unfortunately needed since [BodyComponent] will set all its
+    // children to `debugMode = true` currently, we should come up with a
+    // nicer solution to this.
     textComponent.debugMode = false;
     textComponent.text = counter.toString();
   }

--- a/packages/flame_forge2d/example/lib/main.dart
+++ b/packages/flame_forge2d/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'blob_sample.dart';
 import 'camera_sample.dart';
 import 'circle_stress_sample.dart';
+import 'composition_sample.dart';
 import 'contact_callbacks_sample.dart';
 import 'domino_sample.dart';
 import 'draggable_sample.dart';
@@ -25,6 +26,12 @@ void main() async {
       'Blob sample',
       (DashbookContext ctx) => GameWidget(game: BlobSample()),
       codeLink: link('blob_sample.dart'),
+    )
+    ..add(
+      'Composition sample',
+      (DashbookContext ctx) => GameWidget(game: CompositionSample()),
+      codeLink: link('composition_sample.dart'),
+      info: CompositionSample.info,
     )
     ..add(
       'Domino sample',

--- a/packages/flame_forge2d/example/lib/position_body_sample.dart
+++ b/packages/flame_forge2d/example/lib/position_body_sample.dart
@@ -1,10 +1,10 @@
 import 'dart:ui';
 
-import 'package:flame_forge2d/position_body_component.dart';
-import 'package:forge2d/forge2d.dart';
 import 'package:flame/components.dart';
 import 'package:flame/gestures.dart';
 import 'package:flame_forge2d/forge2d_game.dart';
+import 'package:flame_forge2d/position_body_component.dart';
+import 'package:forge2d/forge2d.dart';
 
 import 'boundaries.dart';
 

--- a/packages/flame_forge2d/lib/body_component.dart
+++ b/packages/flame_forge2d/lib/body_component.dart
@@ -49,6 +49,7 @@ abstract class BodyComponent<T extends Forge2DGame> extends BaseComponent
 
   /// The matrix used for preparing the canvas
   final Matrix4 _transform = Matrix4.identity();
+  final Matrix4 _flipYTransform = Matrix4.identity()..scale(1.0, -1.0);
   double? _lastAngle;
 
   @override
@@ -66,7 +67,13 @@ abstract class BodyComponent<T extends Forge2DGame> extends BaseComponent
   }
 
   @override
+  void postRender(Canvas canvas) {
+    canvas.transform(_flipYTransform.storage);
+  }
+
+  @override
   void renderDebugMode(Canvas canvas) {
+    canvas.transform(_flipYTransform.storage);
     for (final fixture in body.fixtures) {
       switch (fixture.type) {
         case ShapeType.chain:

--- a/packages/flame_forge2d/lib/forge2d_game.dart
+++ b/packages/flame_forge2d/lib/forge2d_game.dart
@@ -11,10 +11,8 @@ import 'forge2d_camera.dart';
 class Forge2DGame extends BaseGame {
   static final Vector2 defaultGravity = Vector2(0, -10.0);
   static const double defaultZoom = 10.0;
-  final int velocityIterations = 10;
-  final int positionIterations = 10;
 
-  late World world;
+  final World world;
 
   final ContactCallbacks _contactCallbacks = ContactCallbacks();
 
@@ -24,17 +22,15 @@ class Forge2DGame extends BaseGame {
   Forge2DGame({
     Vector2? gravity,
     double zoom = defaultZoom,
-  }) {
-    gravity ??= defaultGravity;
+  }) : world = World(gravity ?? defaultGravity) {
     camera.zoom = zoom;
-    world = World(gravity);
     world.setContactListener(_contactCallbacks);
   }
 
   @override
   void update(double dt) {
     super.update(dt);
-    world.stepDt(dt, velocityIterations, positionIterations);
+    world.stepDt(dt);
   }
 
   @override

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_forge2d
 description: Forge2D (Box2D) support for the Flame game engine. This uses the forge2d package and provides wrappers and components to be used inside Flame.
-version: 0.8.0-releasecandidate.12
+version: 0.7.3-releasecandidate.12
 homepage: https://github.com/flame-engine/flame_forge2d
 publish_to: 'none'
 

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_forge2d
 description: Forge2D (Box2D) support for the Flame game engine. This uses the forge2d package and provides wrappers and components to be used inside Flame.
-version: 0.7.3-releasecandidate.12
+version: 0.8.0-releasecandidate.12
 homepage: https://github.com/flame-engine/flame_forge2d
 publish_to: 'none'
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flame:
     path: ../flame
-  forge2d: ^0.7.2
+  forge2d: ^0.8.0
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
# Description

Since the `BodyComponent` is flipping the y-axis with basically `canvas.scale(1, -1)` in `prepareCanvas` it needs to be flipped back afterwards so that normal Flame components can be added as children.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
