### PR TITLE
Rename `prepareCanvas` to `preRender`

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Add an empty `postRender` method that will run after each components render method
  - Rename `Tapable` to `Tappable`
  - Rename `HasTapableComponents` to `HasTappableComponents`
+ - Rename `prepareCanvas` to `preRender`
 
 ## [1.0.0-releasecandidate.12]
  - Fix link to code in example stories

--- a/packages/flame/lib/src/components/base_component.dart
+++ b/packages/flame/lib/src/components/base_component.dart
@@ -66,7 +66,7 @@ abstract class BaseComponent extends Component {
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    prepareCanvas(canvas);
+    preRender(canvas);
   }
 
   @mustCallSuper
@@ -86,14 +86,16 @@ abstract class BaseComponent extends Component {
     }
   }
 
+  /// A render cycle callback that runs before the component and its children
+  /// has been rendered.
+  @protected
+  void preRender(Canvas canvas) {}
+
   /// A render cycle callback that runs after the component has been
   /// rendered, but before any children has been rendered.
   void postRender(Canvas canvas) {}
 
   void renderDebugMode(Canvas canvas) {}
-
-  @protected
-  void prepareCanvas(Canvas canvas) {}
 
   @mustCallSuper
   @override

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -178,7 +178,7 @@ abstract class PositionComponent extends BaseComponent {
   }
 
   @override
-  void prepareCanvas(Canvas canvas) {
+  void preRender(Canvas canvas) {
     canvas.translate(x, y);
     canvas.rotate(angle);
     final delta = -anchor.toVector2()

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
  - Update mechanism by which `BodyComponent`'s are disposed to use the `onRemove` method
+ - Rename `prepareCanvas` to `preRender`
 
 ## [0.7.3-releasecandidate.12]
  - Fix prepareCanvas type error

--- a/packages/flame_forge2d/lib/body_component.dart
+++ b/packages/flame_forge2d/lib/body_component.dart
@@ -52,7 +52,7 @@ abstract class BodyComponent<T extends Forge2DGame> extends BaseComponent
   double? _lastAngle;
 
   @override
-  void prepareCanvas(Canvas canvas) {
+  void preRender(Canvas canvas) {
     if (_transform.m14 != body.position.x ||
         _transform.m24 != body.position.y ||
         _lastAngle != angle) {


### PR DESCRIPTION
# Description

Since we now have `postRender` let's follow that standard and rename `prepareCanvas` to `preRender`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
