### PR TITLE
Fix coordinate systems and add example

### DIFF
--- a/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
@@ -2,6 +2,7 @@ import 'package:dashbook/dashbook.dart';
 import 'package:flame/game.dart';
 
 import '../../commons/commons.dart';
+import 'coordinate_systems.dart';
 import 'fixed_resolution.dart';
 import 'follow_object.dart';
 import 'zoom.dart';
@@ -21,13 +22,10 @@ void addCameraAndViewportStories(Dashbook dashbook) {
         );
       },
       codeLink: baseLink('camera_and_viewport/follow_object.dart'),
-      /*
-         Text for instructions:
-
-         Move around with W, A, S, D and notice how the camera follows the white square
-         The blue squares can also be clicked to show how the coordinate system respect
-         The camera transformation
-      */
+      info: ''
+          'Move around with W, A, S, D and notice how the camera follows the white square.\n'
+          'If you collide with the blue squares, the camera reference is changed from center to topCenter.\n'
+          'The blue squares can also be clicked to show how the coordinate system respects the camera transformation.',
     )
     ..add(
       'Zoom',
@@ -42,12 +40,9 @@ void addCameraAndViewportStories(Dashbook dashbook) {
         );
       },
       codeLink: baseLink('camera_and_viewport/zoom.dart'),
-      /*
-         Text for instructions:
-
-         On web: use scroll to zoom in and out
-         On mobile: use scale gesture to zoom in and out
-      */
+      info: ''
+          'On web: use scroll to zoom in and out.\n'
+          'On mobile: use scale gesture to zoom in and out.',
     )
     ..add(
       'Fixed Resolution viewport',
@@ -63,10 +58,14 @@ void addCameraAndViewportStories(Dashbook dashbook) {
       },
       codeLink: baseLink('camera_and_viewport/fixed_resolution.dart'),
       info: FixedResolutionGame.info,
-      /*
-         Text for instructions:
-
-         You can change the resolution of the viewport in the right pane.
-      */
+    )
+    ..add(
+      'Coordinate Systems',
+      (context) => CoordinateSystemsWidget(),
+      codeLink: baseLink('camera_and_viewport/coordinate_systems.dart'),
+      info: ''
+          'Displays event data in all 3 coordinte systems (global, widget and game).\n'
+          'Use WASD to move the camera and Q/E to zoom in/out.\n'
+          'Trigger events to see the coordinates on each coordinate space.',
     );
 }

--- a/examples/lib/stories/camera_and_viewport/coordinate_systems.dart
+++ b/examples/lib/stories/camera_and_viewport/coordinate_systems.dart
@@ -1,0 +1,232 @@
+import 'dart:math';
+
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame/input.dart';
+import 'package:flame/palette.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+class CoordinateSystemsWidget extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() {
+    return _CoordinateSystemsState();
+  }
+}
+
+class _CoordinateSystemsState extends State<CoordinateSystemsWidget> {
+  int rowsBefore = 1;
+  int rowsAfter = 1;
+  int colsBefore = 1;
+  int colsAfter = 1;
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ...blocks(
+          rowsBefore,
+          (v) => rowsBefore = v,
+          rotated: false,
+          start: true,
+        ),
+        Expanded(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ...blocks(
+                colsBefore,
+                (v) => colsBefore = v,
+                rotated: true,
+                start: true,
+              ),
+              Expanded(
+                child: GameWidget(game: CoordinateSystemsGame()),
+              ),
+              ...blocks(
+                colsAfter,
+                (v) => colsAfter = v,
+                rotated: true,
+                start: false,
+              ),
+            ],
+          ),
+        ),
+        ...blocks(
+          rowsAfter,
+          (v) => rowsAfter = v,
+          rotated: false,
+          start: false,
+        ),
+      ],
+    );
+  }
+
+  List<Widget> blocks(
+    int variable,
+    void Function(int) setVariable, {
+    required bool rotated,
+    required bool start,
+  }) {
+    final add = Container(
+      child: Center(
+        child: TextButton(
+          child: const Text('+'),
+          onPressed: () => setState(() => setVariable(variable + 1)),
+        ),
+      ),
+      margin: const EdgeInsets.all(32),
+    );
+    return [
+      if (start) add,
+      for (int i = 1; i <= variable; i++)
+        GestureDetector(
+          child: Container(
+            child: Center(
+              child: RotatedBox(
+                quarterTurns: rotated ? 1 : 0,
+                child: Text('Block $i'),
+              ),
+            ),
+            margin: const EdgeInsets.all(32),
+          ),
+          onTap: () => setState(() => setVariable(variable - 1)),
+        ),
+      if (!start) add,
+    ];
+  }
+}
+
+class CoordinateSystemsGame extends BaseGame
+    with
+        MultiTouchTapDetector,
+        MultiTouchDragDetector,
+        ScrollDetector,
+        KeyboardEvents {
+  static final _borderPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 2
+    ..color = BasicPalette.red.color;
+  static final _text = TextPaint(
+    config: TextPaintConfig(
+      color: BasicPalette.red.color,
+      fontSize: 12,
+    ),
+  );
+
+  String? lastEventDesc;
+  Vector2 cameraPosition = Vector2.zero();
+  Vector2 cameraVelocity = Vector2.zero();
+
+  @override
+  Future<void> onLoad() async {
+    camera.followVector2(cameraPosition, relativeOffset: Anchor.topLeft);
+  }
+
+  @override
+  void render(Canvas c) {
+    c.drawRect(canvasSize.toRect(), _borderPaint);
+    _text.render(
+      c,
+      'Camera: WASD to move, QE to zoom',
+      Vector2.all(5.0),
+    );
+    _text.render(
+      c,
+      'Camera: ${camera.position}, zoom: ${camera.zoom}',
+      Vector2(canvasSize.x - 5, 5.0),
+      anchor: Anchor.topRight,
+    );
+    _text.render(
+      c,
+      'This is your Flame game!',
+      canvasSize - Vector2.all(5.0),
+      anchor: Anchor.bottomRight,
+    );
+    final lastEventDesc = this.lastEventDesc;
+    if (lastEventDesc != null) {
+      _text.render(c, lastEventDesc, canvasSize / 2, anchor: Anchor.center);
+    }
+    super.render(c);
+  }
+
+  @override
+  void onTapUp(int pointer, TapUpInfo info) {
+    lastEventDesc = describe('TapUp', info);
+  }
+
+  @override
+  void onTapDown(int pointer, TapDownInfo info) {
+    lastEventDesc = describe('TapDown', info);
+  }
+
+  @override
+  void onDragStart(int pointerId, DragStartInfo info) {
+    lastEventDesc = describe('DragStart', info);
+  }
+
+  @override
+  void onDragUpdate(int pointerId, DragUpdateInfo info) {
+    lastEventDesc = describe('DragUpdate', info);
+  }
+
+  @override
+  void onScroll(PointerScrollInfo info) {
+    lastEventDesc = describe('Scroll', info);
+  }
+
+  static String describe(String name, PositionInfo info) {
+    return [
+      name,
+      'Global: ${info.eventPosition.global}',
+      'Widget: ${info.eventPosition.widget}',
+      'Game: ${info.eventPosition.game}',
+      if (info is DragUpdateInfo) ...[
+        'Delta',
+        'Global: ${info.delta.global}',
+        'Game: ${info.delta.game}',
+      ],
+      if (info is PointerScrollInfo) ...[
+        'Scroll Delta',
+        'Global: ${info.scrollDelta.global}',
+        'Game: ${info.scrollDelta.game}',
+      ],
+    ].join('\n');
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    cameraPosition.add(cameraVelocity * dt * 10);
+    cameraPosition.x = dp(cameraPosition.x, 5);
+    cameraPosition.y = dp(cameraPosition.y, 5);
+  }
+
+  static double dp(double val, int places) {
+    final mod = pow(10.0, places);
+    return (val * mod).round().toDouble() / mod;
+  }
+
+  @override
+  void onKeyEvent(RawKeyEvent e) {
+    final isKeyDown = e is RawKeyDownEvent;
+    if (e.data.keyLabel == 'a') {
+      cameraVelocity.x = isKeyDown ? -1 : 0;
+    } else if (e.data.keyLabel == 'd') {
+      cameraVelocity.x = isKeyDown ? 1 : 0;
+    } else if (e.data.keyLabel == 'w') {
+      cameraVelocity.y = isKeyDown ? -1 : 0;
+    } else if (e.data.keyLabel == 's') {
+      cameraVelocity.y = isKeyDown ? 1 : 0;
+    } else if (isKeyDown) {
+      if (e.data.keyLabel == 'q') {
+        camera.zoom *= 2;
+      } else if (e.data.keyLabel == 'e') {
+        camera.zoom /= 2;
+      }
+    }
+  }
+}

--- a/examples/lib/stories/camera_and_viewport/coordinate_systems.dart.bak
+++ b/examples/lib/stories/camera_and_viewport/coordinate_systems.dart.bak
@@ -199,12 +199,12 @@ class CoordinateSystemsGame extends BaseGame
     super.update(dt);
     cameraPosition.add(cameraVelocity * dt * 10);
     // just make it look pretty
-    cameraPosition.x = _roundDouble(cameraPosition.x, 5);
-    cameraPosition.y = _roundDouble(cameraPosition.y, 5);
+    cameraPosition.x = _dp(cameraPosition.x, 5);
+    cameraPosition.y = _dp(cameraPosition.y, 5);
   }
 
   /// Round [val] up to [places] decimal places.
-  static double _roundDouble(double val, int places) {
+  static double _dp(double val, int places) {
     final mod = pow(10.0, places);
     return (val * mod).round().toDouble() / mod;
   }

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -8,13 +8,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="Flame Example">
+  <meta name="apple-mobile-web-app-title" content="Flame Examples">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>Flame Example</title>
+  <title>Flame Examples</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,6 +11,7 @@
  - Add `NineTileBox.asset`
  - Rename `Camera.cameraSpeed` to `Camera.speed`
  - Rename `addShape` to `addHitbox` in `Hitbox` mixin
+ - Fix bug with Events and Draggables
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/lib/src/game/game.dart
+++ b/packages/flame/lib/src/game/game.dart
@@ -136,26 +136,22 @@ abstract class Game extends Projector {
 
   /// Converts a global coordinate (i.e. w.r.t. the app itself) to a local
   /// coordinate (i.e. w.r.t. he game widget).
-  /// If the widget occupies the whole app ("full screen" games), this operation
-  /// is the identity.
+  /// If the widget occupies the whole app ("full screen" games), or is not
+  /// attached to Flutter, this operation is the identity.
   Vector2 convertGlobalToLocalCoordinate(Vector2 point) {
     if (!isAttached) {
-      throw UnsupportedError(
-        'This method can only be called if the game is attached',
-      );
+      return point.clone();
     }
     return _gameRenderBox!.globalToLocal(point.toOffset()).toVector2();
   }
 
   /// Converts a local coordinate (i.e. w.r.t. the game widget) to a global
   /// coordinate (i.e. w.r.t. the app itself).
-  /// If the widget occupies the whole app ("full screen" games), this operation
-  /// is the identity.
+  /// If the widget occupies the whole app ("full screen" games), or is not
+  /// attached to Flutter, this operation is the identity.
   Vector2 convertLocalToGlobalCoordinate(Vector2 point) {
     if (!isAttached) {
-      throw UnsupportedError(
-        'This method can only be called if the game is attached',
-      );
+      return point.clone();
     }
     return _gameRenderBox!.localToGlobal(point.toOffset()).toVector2();
   }

--- a/packages/flame/test/components/composed_component_test.dart
+++ b/packages/flame/test/components/composed_component_test.dart
@@ -142,7 +142,7 @@ void main() {
         1,
         createTapDownEvent(
           game,
-          position: const Offset(250, 250),
+          globalPosition: const Offset(250, 250),
         ),
       );
 

--- a/packages/flame/test/util/mock_gesture_events.dart
+++ b/packages/flame/test/util/mock_gesture_events.dart
@@ -5,13 +5,13 @@ import 'package:flutter/gestures.dart';
 
 TapDownInfo createTapDownEvent(
   Game game, {
-  Offset? position,
   Offset? globalPosition,
+  Offset? localPosition,
 }) {
   return TapDownInfo.fromDetails(
     game,
     TapDownDetails(
-      localPosition: position ?? Offset.zero,
+      localPosition: localPosition ?? Offset.zero,
       globalPosition: globalPosition ?? Offset.zero,
     ),
   );


### PR DESCRIPTION
# Description

This fixes the Drag events having incorrect coordinates. Allow me to explain the course of operations for the fix, so the PR makes sense:

1. the root issue is that Flutter pulls a short straw on us. I pointed this out as one argument to do our wraps and tried to explain again on the related issue: local coords are not always available for drag events; from the docs:

```
  /// The local position in the coordinate system of the event receiver at
  /// which the pointer contacted the screen.
  ///
  /// Defaults to [globalPosition] if not specified in the constructor.
  final Offset localPosition;
```
note that they always exist for taps. not sure when drags have it or not, but definitely it's a very common issue.
2. I noticed that we are assuming local as src of truth and converting global; should be the opposite. however I noticed that for some reason Global was optional. so here I fixed that making Global mandatory and providing global for all events.
3. now we have both global and local. however there is no clean way to no if the "local" is correct. in general I just decided to distrust local and use global for both, **always** calling the appropriate conversion method.
4. at this point I don't need local anymore, so I just remove it. all raw events provide global coordinates, and we do both transformations.
5. at this point I found an unrelated issue with similar symptoms; we had a `scaleVector` that should be `unscaleVector`. this was actually the issue that @renancaraujo found on Breakout Game. it's not related because that game has no widgets, so local == global. this was an issue when transforming local => game (again, only for Drags).
6. given this, I decided to make a new example to make it very easy to test and understand this stuff. it's a big boy but very simple to understand if you read my comments.
7. as far as I can test, on new and existing examples alike, now everything is 100% :)
8. note as per review checklist: I decided to an example instead of a unit test as I thought that would be easier to understand and more useful

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes https://github.com/flame-engine/flame/issues/774

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
