### PR TITLE
Fix parallax fullscreen bug when game is resized

### DIFF
--- a/examples/lib/stories/parallax/component.dart
+++ b/examples/lib/stories/parallax/component.dart
@@ -9,8 +9,7 @@ class ComponentParallaxGame extends BaseGame {
   }
 }
 
-class MyParallaxComponent extends ParallaxComponent
-    with HasGameRef<ComponentParallaxGame> {
+class MyParallaxComponent extends ParallaxComponent<ComponentParallaxGame> {
   @override
   Future<void> onLoad() async {
     parallax = await gameRef.loadParallax(

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -15,6 +15,7 @@
  - Rename `Camera.cameraSpeed` to `Camera.speed`
  - Rename `addShape` to `addHitbox` in `Hitbox` mixin
  - Fix bug with Events and Draggables
+ - Fix parallax fullscreen bug when game is resized
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -16,6 +16,7 @@
  - Rename `addShape` to `addHitbox` in `Hitbox` mixin
  - Fix bug with Events and Draggables
  - Fix parallax fullscreen bug when game is resized
+ - Test
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -16,7 +16,6 @@
  - Rename `addShape` to `addHitbox` in `Hitbox` mixin
  - Fix bug with Events and Draggables
  - Fix parallax fullscreen bug when game is resized
- - Test
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/lib/src/components/parallax_component.dart
+++ b/packages/flame/lib/src/components/parallax_component.dart
@@ -78,6 +78,7 @@ class ParallaxComponent<T extends BaseGame> extends PositionComponent
     )..parallax = parallax;
   }
 
+  @mustCallSuper
   @override
   void onGameResize(Vector2 size) {
     super.onGameResize(size);

--- a/packages/flame/lib/src/components/parallax_component.dart
+++ b/packages/flame/lib/src/components/parallax_component.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:flame/components.dart';
 import 'package:flutter/painting.dart';
 import 'package:meta/meta.dart';
 
+import '../../game.dart';
 import '../assets/images.dart';
 import '../extensions/vector2.dart';
 import '../game/game.dart';
@@ -39,7 +41,10 @@ extension ParallaxComponentExtension on Game {
 
 /// A full parallax, several layers of images drawn out on the screen and each
 /// layer moves with different velocities to give an effect of depth.
-class ParallaxComponent extends PositionComponent {
+class ParallaxComponent<T extends BaseGame> extends PositionComponent
+    with HasGameRef<T> {
+  @override
+  bool isHud = true;
   bool isFullscreen = true;
   Parallax? _parallax;
 
@@ -73,14 +78,15 @@ class ParallaxComponent extends PositionComponent {
     )..parallax = parallax;
   }
 
-  @mustCallSuper
   @override
   void onGameResize(Vector2 size) {
     super.onGameResize(size);
-    if (isFullscreen) {
-      this.size.setFrom(size);
-      parallax?.resize(size);
+    if (!isFullscreen) {
+      return;
     }
+    final newSize = gameRef.viewport.effectiveSize;
+    this.size.setFrom(newSize);
+    parallax?.resize(newSize);
   }
 
   @override

--- a/packages/flame/lib/src/components/parallax_component.dart
+++ b/packages/flame/lib/src/components/parallax_component.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flame/components.dart';
 import 'package:flutter/painting.dart';
 import 'package:meta/meta.dart';
 
+import '../../components.dart';
 import '../../game.dart';
 import '../assets/images.dart';
 import '../extensions/vector2.dart';


### PR DESCRIPTION
# Description

Fix parallax fullscreen bug when game is resized. Before if the game was zoomed out the parallax would be minimized when the game was resized.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [xj] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
