### PR TITLE
Generics on components with gameRef

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -15,6 +15,7 @@
  - Rename `Camera.cameraSpeed` to `Camera.speed`
  - Rename `addShape` to `addHitbox` in `Hitbox` mixin
  - Fix bug with Events and Draggables
+ - Add generics to components with HasGameRef so that they can be extended and have another gameRef
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/lib/src/components/input/hud_margin_component.dart
+++ b/packages/flame/lib/src/components/input/hud_margin_component.dart
@@ -3,8 +3,10 @@ import 'package:meta/meta.dart';
 
 import '../../../components.dart';
 import '../../../extensions.dart';
+import '../../../game.dart';
 
-class HudMarginComponent extends PositionComponent with HasGameRef {
+class HudMarginComponent<T extends BaseGame> extends PositionComponent
+    with HasGameRef<T> {
   @override
   bool isHud = true;
 

--- a/packages/flame/lib/src/components/mixins/collidable.dart
+++ b/packages/flame/lib/src/components/mixins/collidable.dart
@@ -21,8 +21,8 @@ mixin Collidable on Hitbox {
   void onCollisionEnd(Collidable other) {}
 }
 
-class ScreenCollidable extends PositionComponent
-    with Hitbox, Collidable, HasGameRef<BaseGame> {
+class ScreenCollidable<T extends BaseGame> extends PositionComponent
+    with Hitbox, Collidable, HasGameRef<T> {
   @override
   CollidableType collidableType = CollidableType.passive;
 

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Next]
  - Added physics tied to widgets example
  - Added basic joint example
+ - Add generics passed to HasGameRef from PositionBodyComponent and SpriteBodyComponent
 
 ## [0.8.0-releasecandidate.13]
  - Update mechanism by which `BodyComponent`'s are disposed to use the `onRemove` method

--- a/packages/flame_forge2d/lib/position_body_component.dart
+++ b/packages/flame_forge2d/lib/position_body_component.dart
@@ -1,8 +1,8 @@
 import 'package:flame/components.dart';
-import 'package:flame_forge2d/forge2d_game.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 import 'body_component.dart';
+import 'forge2d_game.dart';
 
 /// A [PositionBodyComponent] handles a [PositionComponent] on top of a
 /// [BodyComponent]. You have to keep track of the size of the

--- a/packages/flame_forge2d/lib/position_body_component.dart
+++ b/packages/flame_forge2d/lib/position_body_component.dart
@@ -1,4 +1,5 @@
 import 'package:flame/components.dart';
+import 'package:flame_forge2d/forge2d_game.dart';
 import 'package:flutter/cupertino.dart';
 
 import 'body_component.dart';
@@ -6,7 +7,8 @@ import 'body_component.dart';
 /// A [PositionBodyComponent] handles a [PositionComponent] on top of a
 /// [BodyComponent]. You have to keep track of the size of the
 /// [PositionComponent] and it can only have its anchor in the center.
-abstract class PositionBodyComponent extends BodyComponent {
+abstract class PositionBodyComponent<T extends Forge2DGame>
+    extends BodyComponent<T> {
   PositionComponent positionComponent;
   Vector2 size;
 

--- a/packages/flame_forge2d/lib/sprite_body_component.dart
+++ b/packages/flame_forge2d/lib/sprite_body_component.dart
@@ -1,8 +1,10 @@
 import 'package:flame/components.dart';
+import 'package:flame_forge2d/forge2d_game.dart';
 
 import 'position_body_component.dart';
 
-abstract class SpriteBodyComponent extends PositionBodyComponent {
+abstract class SpriteBodyComponent<T extends Forge2DGame>
+    extends PositionBodyComponent<T> {
   /// Make sure that the [size] of the sprite matches the bounding shape of the
   /// body that is create in createBody()
   SpriteBodyComponent(

--- a/packages/flame_forge2d/lib/sprite_body_component.dart
+++ b/packages/flame_forge2d/lib/sprite_body_component.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
-import 'package:flame_forge2d/forge2d_game.dart';
 
+import 'forge2d_game.dart';
 import 'position_body_component.dart';
 
 abstract class SpriteBodyComponent<T extends Forge2DGame>


### PR DESCRIPTION
# Description

Add generics to components with `HasGameRef` so that they can be extended and have another `with HasGameRef` on the top level that uses a more specific game than `BaseGame`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
