### PR TITLE
Adding playing attribute to animation component

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -20,6 +20,7 @@
  - Generalize `paint` usage on components
  - Create `OpacityEffect`
  - Create `ColorEffect`
+ - Adding ability to pause `SpriteAnimationComponent`
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -12,6 +12,7 @@ export '../sprite_animation.dart';
 class SpriteAnimationComponent extends PositionComponent with HasPaint {
   SpriteAnimation? animation;
   bool removeOnFinish = false;
+  bool playing;
 
   /// Creates a component with an empty animation which can be set later
   SpriteAnimationComponent({
@@ -21,6 +22,7 @@ class SpriteAnimationComponent extends PositionComponent with HasPaint {
     this.animation,
     Paint? paint,
     this.removeOnFinish = false,
+    this.playing = true,
   }) : super(position: position, size: size, priority: priority) {
     if (paint != null) {
       this.paint = paint;
@@ -38,6 +40,7 @@ class SpriteAnimationComponent extends PositionComponent with HasPaint {
     int? priority,
     Paint? paint,
     this.removeOnFinish = false,
+    this.playing = true,
   }) : super(position: position, size: size, priority: priority) {
     animation = SpriteAnimation.fromFrameData(image, data);
 
@@ -67,6 +70,8 @@ class SpriteAnimationComponent extends PositionComponent with HasPaint {
   @override
   void update(double dt) {
     super.update(dt);
-    animation?.update(dt);
+    if (playing) {
+      animation?.update(dt);
+    }
   }
 }

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -138,5 +138,37 @@ void main() async {
       game.update(0.1);
       expect(game.components.length, 1);
     });
+
+    test("component isn't removed if it is not playing", () {
+      final game = BaseGame();
+      final animation = SpriteAnimation.spriteList(
+        [
+          Sprite(image),
+          Sprite(image),
+        ],
+        stepTime: 1,
+        loop: false,
+      );
+      final component = SpriteAnimationComponent(
+        animation: animation,
+        removeOnFinish: true,
+        playing: false
+      );
+
+      game.onResize(size);
+      game.add(component);
+
+      // runs a cycle to add the component
+      game.update(0.1);
+      expect(component.shouldRemove, false);
+      expect(game.components.length, 1);
+
+      game.update(2);
+      expect(component.shouldRemove, false);
+
+      // runs a cycle to remove the component
+      game.update(0.1);
+      expect(game.components.length, 1);
+    });
   });
 }

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -166,7 +166,7 @@ void main() async {
       game.update(2);
       expect(component.shouldRemove, false);
 
-      // runs a cycle to remove the component
+      // runs a cycle to potentially remove the component
       game.update(0.1);
       expect(game.components.length, 1);
     });

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -152,7 +152,7 @@ void main() async {
       final component = SpriteAnimationComponent(
         animation: animation,
         removeOnFinish: true,
-        playing: false
+        playing: false,
       );
 
       game.onResize(size);


### PR DESCRIPTION
# Description

Adds a simple attribute to pause the animation component

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [ ] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
