### PR TITLE
#895 Fix truncated last frame of SpriteAnimation

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -20,6 +20,7 @@
  - Generalize `paint` usage on components
  - Create `OpacityEffect`
  - Create `ColorEffect`
+ - Fix truncated last frame in non-looping animations
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -244,9 +244,8 @@ class SpriteAnimation {
   /// If [loop] is false, returns whether the animation is done (fixed in the last Sprite).
   ///
   /// Always returns false otherwise.
-  bool done() {
-    return loop ? false : (isLastFrame && clock >= currentFrame.stepTime);
-  }
+  bool _done = false;
+  bool done() => _done;
 
   /// Updates this animation, ticking the lifeTime by an amount [dt] (in seconds).
   void update(double dt) {
@@ -255,19 +254,18 @@ class SpriteAnimation {
     if (isSingleFrame) {
       return;
     }
-    if (!loop && isLastFrame) {
-      onComplete?.call();
-      return;
-    }
-    while (clock > currentFrame.stepTime) {
-      if (!isLastFrame) {
-        clock -= currentFrame.stepTime;
-        currentIndex++;
-      } else if (loop) {
-        clock -= currentFrame.stepTime;
-        currentIndex = 0;
+    while (clock >= currentFrame.stepTime) {
+      clock -= currentFrame.stepTime;
+      if (isLastFrame) {
+        if (loop) {
+          currentIndex = 0;
+        } else {
+          _done = true;
+          onComplete?.call();
+          return;
+        }
       } else {
-        break;
+        currentIndex++;
       }
     }
   }

--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -231,6 +231,7 @@ class SpriteAnimation {
     clock = 0.0;
     elapsed = 0.0;
     currentIndex = 0;
+    _done = false;
   }
 
   /// Gets the current [Sprite] that should be shown.
@@ -251,13 +252,13 @@ class SpriteAnimation {
   void update(double dt) {
     clock += dt;
     elapsed += dt;
-    if (isSingleFrame) {
+    if (isSingleFrame || _done) {
       return;
     }
     while (clock >= currentFrame.stepTime) {
-      clock -= currentFrame.stepTime;
       if (isLastFrame) {
         if (loop) {
+          clock -= currentFrame.stepTime;
           currentIndex = 0;
         } else {
           _done = true;
@@ -265,6 +266,7 @@ class SpriteAnimation {
           return;
         }
       } else {
+        clock -= currentFrame.stepTime;
         currentIndex++;
       }
     }

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -172,8 +172,9 @@ void main() async {
     });
 
     test('Last animation frame is not skipped', () {
-      // See issue #895
+      // See https://github.com/flame-engine/flame/issues/895
       final game = BaseGame();
+      // Non-looping animation, with the expected total duration of 0.500 s
       final animation = SpriteAnimation.spriteList(
         List.filled(5, Sprite(image)),
         stepTime: 0.1,

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -180,9 +180,9 @@ void main() async {
         stepTime: 0.1,
         loop: false,
       );
-      var callbackInvoked = false;
+      var callbackInvoked = 0;
       animation.onComplete = () {
-        callbackInvoked = true;
+        callbackInvoked++;
       };
       final component = SpriteAnimationComponent(animation: animation);
       game.onResize(size);
@@ -199,11 +199,28 @@ void main() async {
       expect(animation.currentIndex, 4);
       expect(animation.clock, closeTo(0.099, 1e-10));
       expect(animation.done(), false);
-      expect(callbackInvoked, false);
+      expect(callbackInvoked, 0);
       // This last tick moves the total clock to 0.5001 s,
       // completing the last animation frame.
       game.update(0.0011);
-      expect(callbackInvoked, true);
+      expect(callbackInvoked, 1);
+      expect(animation.currentIndex, 4);
+      expect(animation.done(), true);
+      // Now move the timer forward again, and verify that the callback won't be
+      // invoked multiple times.
+      for (var i = 0; i < 10; i++) {
+        game.update(1);
+      }
+      expect(callbackInvoked, 1);
+      expect(animation.currentIndex, 4);
+      expect(animation.done(), true);
+      // Lastly, let's reset the animation and see if it still works properly
+      callbackInvoked = 0;
+      animation.reset();
+      expect(animation.currentIndex, 0);
+      expect(animation.done(), false);
+      game.update(100);
+      expect(callbackInvoked, 1);
       expect(animation.currentIndex, 4);
       expect(animation.done(), true);
     });

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 import '../util/mock_image.dart';
 
 void main() async {
-  // Generate a image
+  // Generate an image
   final image = await generateImage();
 
   final size = Vector2(1.0, 1.0);
@@ -170,7 +170,9 @@ void main() async {
       game.update(0.1);
       expect(game.components.length, 1);
     });
+  });
 
+  group('SpriteAnimation timing of animation frames', () {
     test('Last animation frame is not skipped', () {
       // See https://github.com/flame-engine/flame/issues/895
       final game = BaseGame();

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -138,5 +138,41 @@ void main() async {
       game.update(0.1);
       expect(game.components.length, 1);
     });
+
+    test('Last animation frame is not skipped', () {
+      // See issue #895
+      final game = BaseGame();
+      final animation = SpriteAnimation.spriteList(
+        List.filled(5, Sprite(image)),
+        stepTime: 0.1,
+        loop: false,
+      );
+      var callbackInvoked = false;
+      animation.onComplete = () {
+        callbackInvoked = true;
+      };
+      final component = SpriteAnimationComponent(animation: animation);
+      game.onResize(size);
+      game.add(component);
+      game.update(0.01);
+      expect(animation.currentIndex, 0);
+      game.update(0.1);
+      expect(animation.currentIndex, 1);
+      game.update(0.3);
+      expect(animation.currentIndex, 4);
+      game.update(0.089);
+      // At this point we're still on the last frame, which has
+      // almost finished. Total clock time = 0.499 s
+      expect(animation.currentIndex, 4);
+      expect(animation.clock, closeTo(0.099, 1e-10));
+      expect(animation.done(), false);
+      expect(callbackInvoked, false);
+      // This last tick moves the total clock to 0.5001 s,
+      // completing the last animation frame.
+      game.update(0.0011);
+      expect(callbackInvoked, true);
+      expect(animation.currentIndex, 4);
+      expect(animation.done(), true);
+    });
   });
 }


### PR DESCRIPTION
# Description

The code in `SpriteAnimation` used to exit early when it found itself on the last frame with `loop=false`. The new behavior will wait until the last animation frame is ready to roll over to the next frame before deciding to officially stop the animation and call the `onComplete` callback.


## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage.
- [ ] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [ ] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems. <-- I don't think these scripts exist anymore.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

Closes #895

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
