### PR TITLE
SpriteComponent falls back to srcSize instead of image.size

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -22,7 +22,7 @@
  - Create `ColorEffect`
  - Adding ability to pause `SpriteAnimationComponent`
  - Adding `SpriteGroupComponent`
- - Default size of `SpriteComponent` is not `srcSize` instead of spritesheet size
+ - Default size of `SpriteComponent` is `srcSize` instead of spritesheet size
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -22,6 +22,7 @@
  - Create `ColorEffect`
  - Adding ability to pause `SpriteAnimationComponent`
  - Adding `SpriteGroupComponent`
+ - Default size of `SpriteComponent` is not `srcSize` instead of spritesheet size
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -42,7 +42,7 @@ class SpriteComponent extends PositionComponent with HasPaint {
   }) =>
       SpriteComponent(
         position: position,
-        size: size ?? image.size,
+        size: size ?? srcSize ?? image.size,
         sprite: Sprite(
           image,
           srcPosition: srcPosition,

--- a/packages/flame/test/components/sprite_component_test.dart
+++ b/packages/flame/test/components/sprite_component_test.dart
@@ -1,0 +1,28 @@
+import 'package:flame/components.dart';
+import 'package:test/test.dart';
+
+import '../util/mock_image.dart';
+
+void main() async {
+  final image = await generateImage();
+
+  group('SpriteComponent test', () {
+    test('check sizing of SpriteComponent', () {
+      expect(image.width, 1);
+      expect(image.height, 1);
+
+      final component1 = SpriteComponent.fromImage(image);
+      expect(component1.size, Vector2(1, 1));
+
+      final component2 = SpriteComponent.fromImage(image, size: Vector2(5, 10));
+      expect(component2.size, Vector2(5, 10));
+
+      final component3 = SpriteComponent.fromImage(image, srcSize: Vector2(4, 3));
+      expect(component3.size, Vector2(4, 3));
+
+      final component4 =
+          SpriteComponent.fromImage(image, size: Vector2(40, 30), srcSize: Vector2(4, 3));
+      expect(component4.size, Vector2(40, 30));
+    });
+  });
+}

--- a/packages/flame/test/components/sprite_component_test.dart
+++ b/packages/flame/test/components/sprite_component_test.dart
@@ -17,11 +17,17 @@ void main() async {
       final component2 = SpriteComponent.fromImage(image, size: Vector2(5, 10));
       expect(component2.size, Vector2(5, 10));
 
-      final component3 = SpriteComponent.fromImage(image, srcSize: Vector2(4, 3));
+      final component3 = SpriteComponent.fromImage(
+        image,
+        srcSize: Vector2(4, 3),
+      );
       expect(component3.size, Vector2(4, 3));
 
-      final component4 =
-          SpriteComponent.fromImage(image, size: Vector2(40, 30), srcSize: Vector2(4, 3));
+      final component4 = SpriteComponent.fromImage(
+        image,
+        size: Vector2(40, 30),
+        srcSize: Vector2(4, 3),
+      );
       expect(component4.size, Vector2(40, 30));
     });
   });


### PR DESCRIPTION
# Description

When `SpriteComponent` is created without the `size:` parameter, it infers its size from the size of the source image. However, if the source image is a sprite sheet and the user passes `srcSize:`  and `srcPosition:`, then `srcSize` is a much better guess for the sprite's render size.


## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [ ] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
