### PR TITLE
Function to load all images in prefixed path

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -41,6 +41,7 @@
  - Update `Camera` docs to showcase usage with `Game` class
  - Fixed a bug with `worldBounds` being set to `null` in `Camera`
  - `MockCanvas` is now strongly typed and matches numeric coordinates up to a tolerance
+ - Add `loadAllImages` to `Images`, which loads all images from the prefixed path
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
-import 'dart:convert' show base64;
+import 'dart:convert' show base64, json;
 import 'dart:typed_data';
 import 'dart:ui';
 import 'dart:ui' as ui show decodeImageFromPixels;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 import '../flame.dart';
 
@@ -40,6 +41,16 @@ class Images {
       _loadedFiles[fileName] = _ImageAssetLoader(_fetchToMemory(fileName));
     }
     return _loadedFiles[fileName]!.retrieve();
+  }
+
+  Future<List<Image>> loadAllImages() async {
+    final manifestContent = await rootBundle.loadString('AssetManifest.json');
+    final manifestMap = json.decode(manifestContent) as Map<String, dynamic>;
+    final imagePaths = manifestMap.keys.where((path) {
+      return path.startsWith(prefix) &&
+          path.toLowerCase().contains(RegExp(r'\.(png|jpg|jpeg|svg|gif)$'));
+    }).map((path) => path.replaceFirst(prefix, ''));
+    return loadAll(imagePaths.toList());
   }
 
   /// Convert an array of pixel values into an [Image] object.

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -46,7 +46,7 @@ class Images {
   /// Loads all images from the specified (or default) [prefix] into the cache.
   Future<List<Image>> loadAllImages() async {
     return loadAllFromPattern(RegExp(
-      r'\.(png|jpg|jpeg|svg|gif)$',
+      r'\.(png|jpg|jpeg|svg|gif|webp|bmp|wbmp)$',
       caseSensitive: false,
     ));
   }

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -45,11 +45,19 @@ class Images {
 
   /// Loads all images from the specified (or default) [prefix] into the cache.
   Future<List<Image>> loadAllImages() async {
+    return loadAllFromPattern(RegExp(
+      r'\.(png|jpg|jpeg|svg|gif)$',
+      caseSensitive: false,
+    ));
+  }
+
+  /// Loads all images in the [prefix]ed path that are matching the specified
+  /// pattern.
+  Future<List<Image>> loadAllFromPattern(Pattern pattern) async {
     final manifestContent = await rootBundle.loadString('AssetManifest.json');
     final manifestMap = json.decode(manifestContent) as Map<String, dynamic>;
     final imagePaths = manifestMap.keys.where((path) {
-      return path.startsWith(prefix) &&
-          path.toLowerCase().contains(RegExp(r'\.(png|jpg|jpeg|svg|gif)$'));
+      return path.startsWith(prefix) && path.toLowerCase().contains(pattern);
     }).map((path) => path.replaceFirst(prefix, ''));
     return loadAll(imagePaths.toList());
   }

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -43,6 +43,7 @@ class Images {
     return _loadedFiles[fileName]!.retrieve();
   }
 
+  /// Loads all images from the specified (or default) [prefix] into the cache.
   Future<List<Image>> loadAllImages() async {
     final manifestContent = await rootBundle.loadString('AssetManifest.json');
     final manifestMap = json.decode(manifestContent) as Map<String, dynamic>;

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -15,14 +15,17 @@ class Images {
 
   Images({this.prefix = 'assets/images/'});
 
+  /// Remove the image with the specified [fileName] from the cache.
   void clear(String fileName) {
     _loadedFiles.remove(fileName);
   }
 
+  /// Clear all cached images.
   void clearCache() {
     _loadedFiles.clear();
   }
 
+  /// Gets the specified image with [fileName] from the cache.
   Image fromCache(String fileName) {
     final image = _loadedFiles[fileName];
     assert(
@@ -32,15 +35,17 @@ class Images {
     return image!.loadedImage!;
   }
 
-  Future<List<Image>> loadAll(List<String> fileNames) async {
-    return Future.wait(fileNames.map(load));
-  }
-
+  /// Loads the specified image with [fileName] into the cache.
   Future<Image> load(String fileName) async {
     if (!_loadedFiles.containsKey(fileName)) {
       _loadedFiles[fileName] = _ImageAssetLoader(_fetchToMemory(fileName));
     }
     return _loadedFiles[fileName]!.retrieve();
+  }
+
+  /// Load all images with the specified [fileNames] into the cache.
+  Future<List<Image>> loadAll(List<String> fileNames) async {
+    return Future.wait(fileNames.map(load));
   }
 
   /// Loads all images from the specified (or default) [prefix] into the cache.


### PR DESCRIPTION
# Description

To simplify loading all image assets in the specified (or default) path into the cache.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
