### PR TITLE
Default sprite component size to sprite size

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -45,6 +45,7 @@
  - Reviewed the keyboard API with new mixins (`KeyboardHandler` and `HasKeyboardHandlerComponents`)
  - Added `FocusNode` on the game widget and improved keyboard handling in the game.
  - Added ability to have custom mouse cursor on the `GameWidget` region
+ - Change sprite component to default to the Sprite size if not provided
 
 ## [1.0.0-releasecandidate.13]
  - Fix camera not ending up in the correct position on long jumps

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -27,7 +27,11 @@ class SpriteComponent extends PositionComponent with HasPaint {
     int? priority,
     this.sprite,
     Paint? paint,
-  }) : super(position: position, size: size, priority: priority) {
+  }) : super(
+          position: position,
+          size: size ?? sprite?.srcSize,
+          priority: priority,
+        ) {
     if (paint != null) {
       this.paint = paint;
     }

--- a/packages/flame/test/components/sprite_component_test.dart
+++ b/packages/flame/test/components/sprite_component_test.dart
@@ -28,6 +28,13 @@ void main() async {
         srcSize: Vector2(4, 3),
       );
       expect(component4.size, Vector2(40, 30));
+
+      final sprite = Sprite(image, srcSize: Vector2(2, 2));
+      final component5 = SpriteComponent(sprite: sprite, size: Vector2(10, 10));
+      expect(component5.size, Vector2(10, 10));
+
+      final component6 = SpriteComponent(sprite: sprite);
+      expect(component6.size, Vector2(2, 2));
     });
   });
 }


### PR DESCRIPTION
I noticed that for some reason, if we don't provide an explicit `size` for a `SpriteComponent`, it fallbacks to null. I think there is no reason not to fallback to the `Sprite` original size, if present. Thoughts?