### PR TITLE
Fix TextBoxComponent size computation

### DIFF
--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -100,6 +100,7 @@ class TextBoxComponent<T extends TextRenderer> extends PositionComponent {
     });
     _totalLines = _lines.length;
     _lineHeight = lineHeight ?? 0.0;
+    size = _recomputeSize();
   }
 
   void _updateMaxWidth(double w) {
@@ -132,22 +133,13 @@ class TextBoxComponent<T extends TextRenderer> extends PositionComponent {
     return _lines.length - 1;
   }
 
-  @override
-  Vector2 get size => Vector2(width, height);
-
   double getLineWidth(String line, int charCount) {
     return _textRenderer.measureTextWidth(
       line.substring(0, math.min(charCount, line.length)),
     );
   }
 
-  double? _cachedWidth;
-
-  @override
-  double get width {
-    if (_cachedWidth != null) {
-      return _cachedWidth!;
-    }
+  Vector2 _recomputeSize() {
     if (_boxConfig.growingBox) {
       var i = 0;
       var totalCharCount = 0;
@@ -160,19 +152,15 @@ class TextBoxComponent<T extends TextRenderer> extends PositionComponent {
         i++;
         return getLineWidth(line, charCount);
       }).reduce(math.max);
-      _cachedWidth = textWidth + _boxConfig.margins.horizontal;
+      return Vector2(
+        textWidth + _boxConfig.margins.horizontal,
+        _lineHeight * _lines.length + _boxConfig.margins.vertical,
+      );
     } else {
-      _cachedWidth = _boxConfig.maxWidth + _boxConfig.margins.horizontal;
-    }
-    return _cachedWidth!;
-  }
-
-  @override
-  double get height {
-    if (_boxConfig.growingBox) {
-      return _lineHeight * _lines.length + _boxConfig.margins.vertical;
-    } else {
-      return _lineHeight * _totalLines + _boxConfig.margins.vertical;
+      return Vector2(
+        _boxConfig.maxWidth + _boxConfig.margins.horizontal,
+        _lineHeight * _totalLines + _boxConfig.margins.vertical,
+      );
     }
   }
 
@@ -232,7 +220,7 @@ class TextBoxComponent<T extends TextRenderer> extends PositionComponent {
     super.update(dt);
     _lifeTime += dt;
     if (_previousChar != currentChar) {
-      _cachedWidth = null;
+      size = _recomputeSize();
       redrawLater();
     }
     _previousChar = currentChar;

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -73,12 +73,11 @@ class TextBoxComponent<T extends TextRenderer> extends PositionComponent {
     T? textRenderer,
     TextBoxConfig? boxConfig,
     Vector2? position,
-    Vector2? size,
     int? priority,
   })  : _text = text,
         _boxConfig = boxConfig ?? TextBoxConfig(),
         _textRenderer = textRenderer ?? TextRenderer.createDefault<T>(),
-        super(position: position, size: size, priority: priority) {
+        super(position: position, priority: priority) {
     _lines = [];
     double? lineHeight;
     text.split(' ').forEach((word) {

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -17,7 +17,7 @@ class TextBoxConfig {
   /// word boundaries in as many lines as necessary.
   final double maxWidth;
 
-  /// Margins of the text box w.r.t the [TextBoxComponent.size].
+  /// Margins of the text box w.r.t the [PositionComponent.size].
   final EdgeInsets margins;
 
   /// Defaults to 0. If not zero the characters will appear one by one giving

--- a/packages/flame/test/components/text_box_component_test.dart
+++ b/packages/flame/test/components/text_box_component_test.dart
@@ -1,0 +1,18 @@
+import 'package:flame/components.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('text box component test', () {
+    test('size is properly computed', () async {
+      final c = TextBoxComponent(
+        'The quick brown fox jumps over the lazy dog.',
+        boxConfig: TextBoxConfig(
+          maxWidth: 100.0,
+        ),
+      );
+
+      expect(c.size.x, 100 + 2 * 8);
+      expect(c.size.y, greaterThan(1));
+    });
+  });
+}


### PR DESCRIPTION
# Description

Given the new way we use change notifiers for the `size` property to compute transform matrices, it means that the naive way in which `TextBoxComponent` carelessly overwrote that field broke the integration, meaning that the transformations weren't updated properly. This fixes that by actually setting the size and recomputing when needed. Added a test & tested with the example app.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`. (no need)
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
