### PR TITLE
Fix issue with draggables not being removed properly

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [Next]
+ - Fix issue with `Draggable`s not being removed from `draggables` list
+
 ## [1.0.0-releasecandidate.14]
  - Reset effects after they are done so that they can be repeated
  - Remove integrated joystick buttons

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -191,6 +191,7 @@ class Component with Loadable {
   @override
   @mustCallSuper
   void onRemove() {
+    super.onRemove();
     children.forEach((child) {
       child.onRemove();
     });

--- a/packages/flame/lib/src/components/mixins/collidable.dart
+++ b/packages/flame/lib/src/components/mixins/collidable.dart
@@ -22,8 +22,11 @@ mixin Collidable on Hitbox {
 
   @override
   void onRemove() {
+    final parentGame = findParent<FlameGame>();
+    if (parentGame is HasCollidables) {
+      parentGame.collidables.remove(this);
+    }
     super.onRemove();
-    findParent<HasCollidables>()?.collidables.remove(this);
   }
 }
 


### PR DESCRIPTION
# Description

Fix issue that was reported on discord with draggables not being removed properly.
It happened since `parent` had already been set to null at the stage where we were supposed to find the parent with `HasDraggables` and remove it from its list.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
