### PR TITLE
increase flutter environment constraint to be at least 2.5.0

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Next]
  - Fix issue with `Draggable`s not being removed from `draggables` list
+ - Increase Flutter SDK constraint to ">= 2.5.0".
 
 ## [1.0.0-releasecandidate.14]
  - Reset effects after they are done so that they can be repeated

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Next]
  - Fix issue with `Draggable`s not being removed from `draggables` list
- - Increase Flutter SDK constraint to ">= 2.5.0".
+ - Increase Flutter SDK constraint to `>= 2.5.0`.
 
 ## [1.0.0-releasecandidate.14]
  - Reset effects after they are done so that they can be repeated

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.24.0"
+  flutter: ">=2.5.0"
 
 flutter:
   uses-material-design: false


### PR DESCRIPTION
Users in discord chat (https://discord.com/channels/509714518008528896/516639688581316629/889504224159862834) are reporting compilation errors using older versions of the Flutter SDK. Constrain the Flutter SDK version in the pubspec so that users can clearly see they need to use at least Flutter 2.5.x (which is currently stable).