### PR TITLE
No need to pre-register types in ComponentSet

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Fix issue with `Draggable`s not being removed from `draggables` list
  - Increase Flutter SDK constraint to `>= 2.5.0`.
  - Make the root bundle exposed via `Flame.bundle` actually configurable
+ - It's no longer necessary to call `ComponentSet.register()` before `.query()`
 
 ## [1.0.0-releasecandidate.14]
  - Reset effects after they are done so that they can be repeated

--- a/packages/flame/lib/src/components/component_set.dart
+++ b/packages/flame/lib/src/components/component_set.dart
@@ -138,8 +138,7 @@ class ComponentSet extends QueryableOrderedSet<Component> {
   /// This is equivalent to `List.whereType<C>()`, except the result of this
   /// operation is memoized for each distinct type [C]. The type [C] may be
   /// "registered" in advance using `register<C>()`, or it may not, in which
-  /// case the type will be registered at the time of the first query. There
-  /// is no performance difference between these two approaches.
+  /// case the type will be registered at the time of the first query.
   @override
   List<C> query<C extends Component>() {
     if (!isRegistered<C>()) {

--- a/packages/flame/lib/src/components/component_set.dart
+++ b/packages/flame/lib/src/components/component_set.dart
@@ -133,6 +133,21 @@ class ComponentSet extends QueryableOrderedSet<Component> {
     _removeLater.addAll(this);
   }
 
+  /// Return sublist of all components of type [C].
+  ///
+  /// This is equivalent to `List.whereType<C>()`, except the result of this
+  /// operation is memoized for each distinct type [C]. The type [C] may be
+  /// "registered" in advance using `register<C>()`, or it may not, in which
+  /// case the type will be registered at the time of the first query. There
+  /// is no performance difference between these two approaches.
+  @override
+  List<C> query<C extends Component>() {
+    if (!isRegistered<C>()) {
+      super.register<C>();
+    }
+    return super.query<C>();
+  }
+
   /// Materializes the component list in reversed order.
   Iterable<Component> reversed() {
     return toList().reversed;

--- a/packages/flame/lib/src/components/mixins/has_collidables.dart
+++ b/packages/flame/lib/src/components/mixins/has_collidables.dart
@@ -17,12 +17,6 @@ mixin HasCollidables on FlameGame {
   }
 
   @override
-  Future<void>? onLoad() {
-    children.register<Collidable>();
-    return super.onLoad();
-  }
-
-  @override
   void update(double dt) {
     super.update(dt);
     handleCollidables();

--- a/packages/flame/lib/src/effects/effects.dart
+++ b/packages/flame/lib/src/effects/effects.dart
@@ -129,7 +129,6 @@ abstract class ComponentEffect<T extends Component> extends Component {
   Future<void> onLoad() async {
     super.onLoad();
     affectedParent = _affectedParent(parent);
-    parent?.children.register<ComponentEffect>();
   }
 
   @override

--- a/packages/flame/lib/src/effects/effects.dart
+++ b/packages/flame/lib/src/effects/effects.dart
@@ -129,6 +129,7 @@ abstract class ComponentEffect<T extends Component> extends Component {
   Future<void> onLoad() async {
     super.onLoad();
     affectedParent = _affectedParent(parent);
+    parent?.children.register<ComponentEffect>();
   }
 
   @override

--- a/packages/flame/test/effects/effect_test_utils.dart
+++ b/packages/flame/test/effects/effect_test_utils.dart
@@ -25,7 +25,6 @@ void effectTest(
   double epsilon = 0.01,
   required Random random,
 }) async {
-  component.children.register<ComponentEffect>();
   expectedPosition ??= Vector2.zero();
   expectedSize ??= Vector2.all(100.0);
   expectedScale ??= Vector2.all(1.0);


### PR DESCRIPTION
# Description

It is no longer necessary to call `ComponentSet.register<T>()` before being able to use `ComponentSet.query<T>()`. The list of components matching `T` will be computed on demand. Note that this does not result in performance degradation, since the amount of work needed to construct the filtered list is the same in both cases. In fact, this approach provides a minor performance benefit in case some of the elements are removed from the ComponentSet before querying, or some type gets queried only on a fraction of the ComponentSets.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

