### PR TITLE
Possibility to pass in a Camera to FlameGame

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Fix issue with `Draggable`s not being removed from `draggables` list
  - Increase Flutter SDK constraint to `>= 2.5.0`.
  - Make the root bundle exposed via `Flame.bundle` actually configurable
+ - Take in an optional `Camera` as a parameter to `FlameGame`
 
 ## [1.0.0-releasecandidate.14]
  - Reset effects after they are done so that they can be repeated

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -21,8 +21,8 @@ import 'mixins/game.dart';
 /// This is the recommended base class to use for most games made with Flame.
 /// It is based on the Flame Component System (also known as FCS).
 class FlameGame extends Component with Game {
-  FlameGame() {
-    _cameraWrapper = CameraWrapper(Camera(), children);
+  FlameGame({Camera? camera}) {
+    _cameraWrapper = CameraWrapper(camera ?? Camera(), children);
   }
 
   /// The camera translates the coordinate space after the viewport is applied.

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Next]
  - The rendering of `BodyComponent` is now inline with the Flame coordinate system
  - Moved `BodyComponent` base from `BaseComponent` to `Component`
+ - Pass `Forge2DCamera` to super class in `Forge2DGame`
 
 ## [0.8.1-releasecandidate.13]
  - Added physics tied to widgets example

--- a/packages/flame_forge2d/lib/forge2d_game.dart
+++ b/packages/flame_forge2d/lib/forge2d_game.dart
@@ -16,13 +16,11 @@ class Forge2DGame extends FlameGame {
 
   final ContactCallbacks _contactCallbacks = ContactCallbacks();
 
-  @override
-  final Forge2DCamera camera = Forge2DCamera();
-
   Forge2DGame({
     Vector2? gravity,
     double zoom = defaultZoom,
-  }) : world = World(gravity ?? defaultGravity) {
+  })  : world = World(gravity ?? defaultGravity),
+        super(camera: Forge2DCamera()) {
     camera.zoom = zoom;
     world.setContactListener(_contactCallbacks);
   }


### PR DESCRIPTION
# Description

Since Forge2DGame needs to use another camera we need the possibility to pass in another camera than the default one.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
