### PR TITLE
Stop running onRemove during resize

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -8,7 +8,8 @@
  - Take in an optional `Camera` as a parameter to `FlameGame`
  - Make super.onLoad mandatory to avoid memory leaks
  - `QueryableOrderedSet`'s `strictMode` is configurable so it is no longer necessary to call `register` before `query`
-  - Add option to rotate `SpriteWidget`
+ - Add option to rotate `SpriteWidget`
+ - Fix bug where onRemove was called during resizing
 
 ## [1.0.0-releasecandidate.14]
  - Reset effects after they are done so that they can be repeated

--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -48,7 +48,6 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   @override
   void detach() {
     super.detach();
-    game.onRemove();
     game.detach();
     gameLoop?.dispose();
     gameLoop = null;

--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -200,6 +200,7 @@ class _GameWidgetState<T extends Game> extends State<GameWidget<T>> {
   @override
   void dispose() {
     super.dispose();
+    widget.game.onRemove();
     removeOverlaysListener(widget.game);
     // If we received a focus node from the user, they are responsible
     // for disposing it


### PR DESCRIPTION
# Description

Stop running onRemove during onResize (which caused `parent` to be nulled out, causing several issues)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

https://github.com/flame-engine/flame/issues/967
https://github.com/flame-engine/flame/issues/977

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
