### PR TITLE
Moving mixin assertions to their own prepare method

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -313,10 +313,17 @@ class Component with Loadable {
   @mustCallSuper
   void prepare(Component parent) {
     _parent = parent;
+
     final parentGame = findParent<FlameGame>();
     if (parentGame == null) {
       isPrepared = false;
     } else {
+      assert(
+        parentGame.hasLayout,
+        '"prepare/add" called before the game is ready. '
+        'Did you try to access it on the Game constructor? '
+        'Use the "onLoad" ot "onParentMethod" method instead.',
+      );
       if (parentGame is FlameGame) {
         parentGame.prepareComponent(this);
       }

--- a/packages/flame/lib/src/components/mixins/collidable.dart
+++ b/packages/flame/lib/src/components/mixins/collidable.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../../components.dart';
 import '../../../game.dart';
 import '../../components/position_component.dart';
@@ -27,6 +29,21 @@ mixin Collidable on Hitbox {
       parentGame.collidables.remove(this);
     }
     super.onRemove();
+  }
+
+  @override
+  @mustCallSuper
+  void prepare(Component parent) {
+    super.prepare(parent);
+
+    if (isPrepared) {
+      final parentGame = findParent<FlameGame>();
+      assert(
+        parentGame is HasCollidables,
+        'You can only use the Hitbox/Collidable feature with games that has '
+        'the HasCollidables mixin',
+      );
+    }
   }
 }
 

--- a/packages/flame/lib/src/components/mixins/draggable.dart
+++ b/packages/flame/lib/src/components/mixins/draggable.dart
@@ -60,6 +60,20 @@ mixin Draggable on Component {
     }
     return true;
   }
+
+  @override
+  @mustCallSuper
+  void prepare(Component component) {
+    super.prepare(component);
+    if (isPrepared) {
+      final parentGame = findParent<FlameGame>();
+      assert(
+        parentGame is HasDraggableComponents,
+        'Draggable Components can only be added to a FlameGame with '
+        'HasDraggableComponents',
+      );
+    }
+  }
 }
 
 mixin HasDraggableComponents on FlameGame {

--- a/packages/flame/lib/src/components/mixins/hoverable.dart
+++ b/packages/flame/lib/src/components/mixins/hoverable.dart
@@ -25,6 +25,20 @@ mixin Hoverable on Component {
       }
     }
   }
+
+  @override
+  @mustCallSuper
+  void prepare(Component component) {
+    super.prepare(component);
+    if (isPrepared) {
+      final parentGame = findParent<FlameGame>();
+      assert(
+        parentGame is HasHoverableComponents,
+        'Hoverable Components can only be added to a FlameGame with '
+        'HasHoverableComponents',
+      );
+    }
+  }
 }
 
 mixin HasHoverableComponents on FlameGame {

--- a/packages/flame/lib/src/components/mixins/tappable.dart
+++ b/packages/flame/lib/src/components/mixins/tappable.dart
@@ -45,6 +45,20 @@ mixin Tappable on Component {
     }
     return true;
   }
+
+  @override
+  @mustCallSuper
+  void prepare(Component component) {
+    super.prepare(component);
+    if (isPrepared) {
+      final parentGame = findParent<FlameGame>();
+      assert(
+        parentGame is HasTappableComponents,
+        'Tappable Components can only be added to a FlameGame with '
+        'HasTappableComponents',
+      );
+    }
+  }
 }
 
 mixin HasTappableComponents on FlameGame {

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -3,15 +3,10 @@ import 'dart:ui';
 import 'package:meta/meta.dart';
 
 import '../components/component.dart';
-import '../components/mixins/collidable.dart';
-import '../components/mixins/draggable.dart';
-import '../components/mixins/hoverable.dart';
-import '../components/mixins/tappable.dart';
 import '../extensions/vector2.dart';
 import 'camera/camera.dart';
 import 'camera/camera_wrapper.dart';
 import 'mixins/game.dart';
-import 'mixins/has_collidables.dart';
 
 /// This is a more complete and opinionated implementation of [Game].
 ///
@@ -55,42 +50,6 @@ class FlameGame extends Component with Game {
   /// don't forget to call `super.prepareComponent` when overriding.
   @mustCallSuper
   void prepareComponent(Component c) {
-    assert(
-      hasLayout,
-      '"prepare/add" called before the game is ready. '
-      'Did you try to access it on the Game constructor? '
-      'Use the "onLoad" ot "onParentMethod" method instead.',
-    );
-
-    if (c is Collidable) {
-      assert(
-        this is HasCollidables,
-        'You can only use the Hitbox/Collidable feature with games that has '
-        'the HasCollidables mixin',
-      );
-    }
-    if (c is Tappable) {
-      assert(
-        this is HasTappableComponents,
-        'Tappable Components can only be added to a FlameGame with '
-        'HasTappableComponents',
-      );
-    }
-    if (c is Draggable) {
-      assert(
-        this is HasDraggableComponents,
-        'Draggable Components can only be added to a FlameGame with '
-        'HasDraggableComponents',
-      );
-    }
-    if (c is Hoverable) {
-      assert(
-        this is HasHoverableComponents,
-        'Hoverable Components can only be added to a FlameGame with '
-        'HasHoverableComponents',
-      );
-    }
-
     // First time resize
     c.onGameResize(size);
   }

--- a/packages/flame/test/components/mixins/has_collidable_test.dart
+++ b/packages/flame/test/components/mixins/has_collidable_test.dart
@@ -1,0 +1,23 @@
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class NonCollidableGame extends FlameGame {}
+
+class MyCollidable extends PositionComponent with Hitbox, Collidable {}
+
+void main() {
+  group('HasCollidables', () {
+    flameTest<NonCollidableGame>(
+      "can't add collidables to a game without HasCollidables",
+      createGame: () => NonCollidableGame(),
+      verify: (game) {
+        expect(
+          () => game.add(MyCollidable()),
+          throwsAssertionError,
+        );
+      },
+    );
+  });
+}

--- a/packages/flame/test/game/base_game_test.dart
+++ b/packages/flame/test/game/base_game_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart' as flutter;
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 class MyGame extends FlameGame with HasTappableComponents {}
 
@@ -222,5 +222,15 @@ void main() {
     expect(game.children.length, equals(3));
     game.update(0.0);
     expect(game.children.isEmpty, equals(true));
+  });
+
+  test("can't add a component to a game that don't have layout yet", () {
+    final game = MyGame();
+    final component = MyComponent();
+
+    expect(
+      () => game.add(component),
+      throwsAssertionError,
+    );
   });
 }


### PR DESCRIPTION
# Description

As we noticed on the previous discussions, dart can handle multiple inheritance, so we probably don't need the `prepareComponent` method on the `FlameGame` class.

This PR is a first step for the removal of that method, it moves all the assertions that were done on that method to the mixins that the assertions are related to.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
