### PR TITLE
Improved testing API

### DIFF
--- a/packages/flame/test/components/hoverable_test.dart
+++ b/packages/flame/test/components/hoverable_test.dart
@@ -10,7 +10,11 @@ import 'package:test/test.dart';
 
 class _GameWithHoverables extends FlameGame with HasHoverableComponents {}
 
+final withHoverables = FlameTester(() => _GameWithHoverables());
+
 class _GameWithoutHoverables extends FlameGame {}
+
+final withoutHoverables = FlameTester(() => _GameWithoutHoverables());
 
 class HoverableComponent extends PositionComponent with Hoverable {
   int enterCount = 0;
@@ -45,10 +49,9 @@ class NonPropagatingComponent extends HoverableComponent {
 
 void main() {
   group('hoverable test', () {
-    flameTest<_GameWithHoverables>(
+    withHoverables.test(
       'make sure they cannot be added to invalid games',
-      createGame: () => _GameWithHoverables(),
-      verify: (game) async {
+      (game) async {
         // should be ok
         await game.add(HoverableComponent());
 
@@ -70,10 +73,9 @@ void main() {
       },
     );
 
-    flameTest<_GameWithHoverables>(
+    withHoverables.test(
       'single component',
-      createGame: () => _GameWithHoverables(),
-      verify: (game) async {
+      (game) async {
         final c = HoverableComponent()
           ..position = Vector2(10, 20)
           ..size = Vector2(3, 3);
@@ -116,10 +118,9 @@ void main() {
       },
     );
 
-    flameTest<_GameWithHoverables>(
+    withHoverables.test(
       'camera is respected',
-      createGame: () => _GameWithHoverables(),
-      verify: (game) async {
+      (game) async {
         final c = HoverableComponent()
           ..position = Vector2(10, 20)
           ..size = Vector2(3, 3);
@@ -140,10 +141,9 @@ void main() {
       },
     );
 
-    flameTest<_GameWithHoverables>(
+    withHoverables.test(
       'multiple components',
-      createGame: () => _GameWithHoverables(),
-      verify: (game) async {
+      (game) async {
         final a = HoverableComponent()
           ..position = Vector2(10, 0)
           ..size = Vector2(2, 20);
@@ -180,10 +180,9 @@ void main() {
       },
     );
 
-    flameTest<_GameWithHoverables>(
+    withHoverables.test(
       'composed components',
-      createGame: () => _GameWithHoverables(),
-      verify: (game) async {
+      (game) async {
         final parent = HoverableComponent()
           ..position = Vector2.all(10)
           ..size = Vector2.all(10);

--- a/packages/flame/test/components/hud_margin_component_test.dart
+++ b/packages/flame/test/components/hud_margin_component_test.dart
@@ -6,10 +6,9 @@ import 'package:test/test.dart';
 
 void main() async {
   group('HudMarginComponent test', () {
-    flameTest<FlameGame>(
+    flameGame.test(
       'position set from margin should change onGameResize',
-      createGame: () => FlameGame(),
-      verify: (game) async {
+      (game) async {
         final marginComponent = HudMarginComponent(
           margin: const EdgeInsets.only(right: 10, bottom: 20),
           size: Vector2.all(20),

--- a/packages/flame/test/components/joystick_component_test.dart
+++ b/packages/flame/test/components/joystick_component_test.dart
@@ -8,6 +8,8 @@ import 'package:test/test.dart';
 
 class TestGame extends FlameGame with HasDraggableComponents {}
 
+final testGame = FlameTester(() => TestGame());
+
 void main() {
   group('JoystickDirection tests', () {
     test('Can convert angle to JoystickDirection', () {
@@ -41,10 +43,9 @@ void main() {
   });
 
   group('Joystick input tests', () {
-    flameTest<TestGame>(
-      'Knob should stay on correct side when the total delta is larger than the size and then the knob is moved slightly back again',
-      createGame: () => TestGame(),
-      verify: (game) async {
+    testGame.test(
+      'knob should stay on correct side when the total delta is larger than the size and then the knob is moved slightly back again',
+      (game) async {
         final joystick = JoystickComponent(
           knob: Circle(radius: 5.0).toComponent(),
           size: 20,

--- a/packages/flame/test/components/mixins/has_collidable_test.dart
+++ b/packages/flame/test/components/mixins/has_collidable_test.dart
@@ -1,5 +1,4 @@
 import 'package:flame/components.dart';
-import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -7,10 +6,9 @@ class MyCollidable extends PositionComponent with HasHitboxes, Collidable {}
 
 void main() {
   group('HasCollidables', () {
-    flameTest<FlameGame>(
+    flameGame.test(
       "can't add collidables to a game without HasCollidables",
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         const message =
             'You can only use the HasHitboxes/Collidable feature with games '
             'that has the HasCollidables mixin';

--- a/packages/flame/test/components/priority_test.dart
+++ b/packages/flame/test/components/priority_test.dart
@@ -1,5 +1,4 @@
 import 'package:flame/components.dart';
-import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
@@ -31,10 +30,9 @@ class ParentWithReorderSpy extends Component {
 
 void main() {
   group('priority test', () {
-    flameTest<FlameGame>(
+    flameGame.test(
       'components with different priorities are sorted in the list',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i));
         priorityComponents.shuffle();
@@ -44,10 +42,9 @@ void main() {
       },
     );
 
-    flameTest<FlameGame>(
+    flameGame.test(
       'changing priority should reorder component list',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final firstCompopnent = PriorityComponent(-1);
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i))
@@ -64,10 +61,9 @@ void main() {
       },
     );
 
-    flameTest<FlameGame>(
+    flameGame.test(
       'changing priorities should reorder component list',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i));
         priorityComponents.shuffle();
@@ -87,10 +83,9 @@ void main() {
       },
     );
 
-    flameTest<FlameGame>(
+    flameGame.test(
       'changing child priority should reorder component list',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final parentComponent = PriorityComponent(0);
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i));
@@ -108,10 +103,9 @@ void main() {
       },
     );
 
-    flameTest<FlameGame>(
+    flameGame.test(
       'changing child priorities should reorder component list',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final parentComponent = PriorityComponent(0);
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i));
@@ -133,10 +127,9 @@ void main() {
       },
     );
 
-    flameTest<FlameGame>(
+    flameGame.test(
       'changing grand child priority should reorder component list',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final grandParentComponent = PriorityComponent(0);
         final parentComponent = PriorityComponent(0);
         final priorityComponents =
@@ -156,10 +149,9 @@ void main() {
       },
     );
 
-    flameTest<FlameGame>(
+    flameGame.test(
       '#reorderChildren is only called once per parent per tick',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final a = ParentWithReorderSpy(1);
         final a1 = PriorityComponent(1);
         final a2 = PriorityComponent(2);

--- a/packages/flame/test/effects2/effect_test.dart
+++ b/packages/flame/test/effects2/effect_test.dart
@@ -2,7 +2,6 @@ import 'package:flame/src/components/component.dart';
 import 'package:flame/src/effects2/effect.dart';
 import 'package:flame/src/effects2/effect_controller.dart';
 import 'package:flame/src/effects2/standard_effect_controller.dart';
-import 'package:flame/src/game/flame_game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -79,10 +78,9 @@ void main() {
       expect(effect.x, closeTo(1, 1e-15));
     });
 
-    flameTest<FlameGame>(
+    flameGame.test(
       'removeOnFinish = true',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final obj = Component();
         game.add(obj);
         final effect = MyEffect(StandardEffectController(duration: 1));
@@ -101,10 +99,9 @@ void main() {
       },
     );
 
-    flameTest<FlameGame>(
+    flameGame.test(
       'removeOnFinish = false',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final obj = Component();
         game.add(obj);
         final effect = MyEffect(StandardEffectController(duration: 1));

--- a/packages/flame/test/effects2/transform2d_effect_test.dart
+++ b/packages/flame/test/effects2/transform2d_effect_test.dart
@@ -2,7 +2,6 @@ import 'package:flame/src/components/position_component.dart';
 import 'package:flame/src/effects2/effect_controller.dart';
 import 'package:flame/src/effects2/standard_effect_controller.dart';
 import 'package:flame/src/effects2/transform2d_effect.dart';
-import 'package:flame/src/game/flame_game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -12,10 +11,9 @@ class MyEffect extends Transform2DEffect {
 
 void main() {
   group('Transform2DEffect', () {
-    flameTest<FlameGame>(
+    flameGame.test(
       'onMount',
-      createGame: () => FlameGame(),
-      verify: (game) {
+      (game) {
         final obj = PositionComponent();
         game.add(obj);
         game.update(0);

--- a/packages/flame/test/game/game_widget/game_widget_drag_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_drag_test.dart
@@ -18,6 +18,8 @@ class HorizontalDragGame extends FlameGame with HorizontalDragDetector {
   }
 }
 
+final horizontalGame = FlameTester(() => HorizontalDragGame());
+
 class VerticalDragGame extends FlameGame with VerticalDragDetector {
   bool verticalDragStarted = false;
   bool verticalDragEnded = false;
@@ -32,6 +34,8 @@ class VerticalDragGame extends FlameGame with VerticalDragDetector {
     verticalDragEnded = true;
   }
 }
+
+final verticalGame = FlameTester(() => VerticalDragGame());
 
 class PanGame extends FlameGame with PanDetector {
   bool panStarted = false;
@@ -48,12 +52,13 @@ class PanGame extends FlameGame with PanDetector {
   }
 }
 
+final panGame = FlameTester(() => PanGame());
+
 void main() {
   group('GameWidget - HorizontalDragDetector', () {
-    flameWidgetTest<HorizontalDragGame>(
+    horizontalGame.widgetTest(
       'register drags',
-      createGame: () => HorizontalDragGame(),
-      verify: (game, tester) async {
+      (game, tester) async {
         await tester.drag(
           find.byGame<HorizontalDragGame>(),
           const Offset(50, 0),
@@ -65,10 +70,9 @@ void main() {
     );
   });
   group('GameWidget - VerticallDragDetector', () {
-    flameWidgetTest<VerticalDragGame>(
+    verticalGame.widgetTest(
       'register drags',
-      createGame: () => VerticalDragGame(),
-      verify: (game, tester) async {
+      (game, tester) async {
         await tester.drag(
           find.byGame<VerticalDragGame>(),
           const Offset(50, 0),
@@ -80,10 +84,9 @@ void main() {
     );
   });
   group('GameWidget - PanDetector', () {
-    flameWidgetTest<PanGame>(
+    panGame.widgetTest(
       'register drags',
-      createGame: () => PanGame(),
-      verify: (game, tester) async {
+      (game, tester) async {
         await tester.drag(
           find.byGame<PanGame>(),
           const Offset(50, 0),

--- a/packages/flame/test/game/game_widget/game_widget_pause_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_pause_test.dart
@@ -61,15 +61,17 @@ class MyGame extends FlameGame {
   }
 }
 
-final myGame = FlameTester(
-  () => MyGame(),
-  pumpWidget: (gameWidget, tester) async {
-    await tester.pumpWidget(_Wrapper(child: gameWidget));
-  },
-);
+FlameTester<MyGame> myGame({bool paused = false}) {
+  return FlameTester(
+    () => MyGame()..paused = paused,
+    pumpWidget: (gameWidget, tester) async {
+      await tester.pumpWidget(_Wrapper(child: gameWidget));
+    },
+  );
+}
 
 void main() {
-  myGame.widgetTest(
+  myGame().widgetTest(
     'can pause the engine',
     (game, tester) async {
       // Run two frames
@@ -85,7 +87,7 @@ void main() {
     },
   );
 
-  myGame.widgetTest(
+  myGame().widgetTest(
     'can resume the engine',
     (game, tester) async {
       // Run two frames
@@ -104,7 +106,7 @@ void main() {
     },
   );
 
-  myGame.widgetTest(
+  myGame().widgetTest(
     "when paused, don't auto start after a rebuild",
     (game, tester) async {
       // Run two frames
@@ -120,8 +122,8 @@ void main() {
     },
   );
 
-  myGame.widgetTest(
-    'can started paused',
+  myGame(paused: true).widgetTest(
+    'can start paused',
     (game, tester) async {
       // Run two frames
       await tester.pump();
@@ -131,8 +133,8 @@ void main() {
     },
   );
 
-  myGame.widgetTest(
-    'can started paused and resumed later',
+  myGame(paused: true).widgetTest(
+    'can start paused and resumed later',
     (game, tester) async {
       // Run two frames
       await tester.pump();

--- a/packages/flame/test/game/game_widget/game_widget_pause_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_pause_test.dart
@@ -61,14 +61,17 @@ class MyGame extends FlameGame {
   }
 }
 
+final myGame = FlameTester(
+  () => MyGame(),
+  pumpWidget: (gameWidget, tester) async {
+    await tester.pumpWidget(_Wrapper(child: gameWidget));
+  },
+);
+
 void main() {
-  flameWidgetTest<MyGame>(
+  myGame.widgetTest(
     'can pause the engine',
-    createGame: () => MyGame(),
-    pumpWidget: (gameWidget, tester) async {
-      await tester.pumpWidget(_Wrapper(child: gameWidget));
-    },
-    verify: (game, tester) async {
+    (game, tester) async {
       // Run two frames
       await tester.pump();
       await tester.pump();
@@ -82,13 +85,9 @@ void main() {
     },
   );
 
-  flameWidgetTest<MyGame>(
+  myGame.widgetTest(
     'can resume the engine',
-    createGame: () => MyGame(),
-    pumpWidget: (gameWidget, tester) async {
-      await tester.pumpWidget(_Wrapper(child: gameWidget));
-    },
-    verify: (game, tester) async {
+    (game, tester) async {
       // Run two frames
       await tester.pump();
       await tester.pump();
@@ -105,13 +104,9 @@ void main() {
     },
   );
 
-  flameWidgetTest<MyGame>(
+  myGame.widgetTest(
     "when paused, don't auto start after a rebuild",
-    createGame: () => MyGame(),
-    pumpWidget: (gameWidget, tester) async {
-      await tester.pumpWidget(_Wrapper(child: gameWidget));
-    },
-    verify: (game, tester) async {
+    (game, tester) async {
       // Run two frames
       await tester.pump();
       await tester.pump();
@@ -125,13 +120,9 @@ void main() {
     },
   );
 
-  flameWidgetTest<MyGame>(
+  myGame.widgetTest(
     'can started paused',
-    createGame: () => MyGame()..paused = true,
-    pumpWidget: (gameWidget, tester) async {
-      await tester.pumpWidget(_Wrapper(child: gameWidget));
-    },
-    verify: (game, tester) async {
+    (game, tester) async {
       // Run two frames
       await tester.pump();
       await tester.pump();
@@ -140,13 +131,9 @@ void main() {
     },
   );
 
-  flameWidgetTest<MyGame>(
+  myGame.widgetTest(
     'can started paused and resumed later',
-    createGame: () => MyGame()..paused = true,
-    pumpWidget: (gameWidget, tester) async {
-      await tester.pumpWidget(_Wrapper(child: gameWidget));
-    },
-    verify: (game, tester) async {
+    (game, tester) async {
       // Run two frames
       await tester.pump();
       await tester.pump();

--- a/packages/flame/test/game/game_widget/game_widget_tap_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_tap_test.dart
@@ -28,21 +28,22 @@ class DoubleTapGame extends FlameGame with DoubleTapDetector {
   }
 }
 
+final tapGame = FlameTester(() => TapGame());
+final doubleTapGame = FlameTester(() => DoubleTapGame());
+
 void main() {
   group('GameWidget - TapDetectors', () {
-    flameWidgetTest<TapGame>(
+    tapGame.widgetTest(
       'can receive taps',
-      createGame: () => TapGame(),
-      verify: (game, tester) async {
+      (game, tester) async {
         await tester.tapAt(const Offset(10, 10));
         expect(game.tapRegistered, isTrue);
       },
     );
 
-    flameWidgetTest<DoubleTapGame>(
+    doubleTapGame.widgetTest(
       'can receive double taps',
-      createGame: () => DoubleTapGame(),
-      verify: (game, tester) async {
+      (game, tester) async {
         const tapPosition = Offset(10, 10);
         await tester.tapAt(tapPosition);
         await Future<void>.delayed(const Duration(milliseconds: 50));

--- a/packages/flame/test/game/game_widget/game_widget_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_test.dart
@@ -65,14 +65,19 @@ class MyGame extends FlameGame {
   }
 }
 
-void main() {
-  flameWidgetTest<MyGame>(
-    'calls onAttach when it enters the tree and onDetach and it leaves',
-    createGame: () => MyGame(),
+FlameTester<MyGame> myGame({required bool open}) {
+  return FlameTester(
+    () => MyGame(),
     pumpWidget: (gameWidget, tester) async {
-      await tester.pumpWidget(_Wrapper(child: gameWidget));
+      await tester.pumpWidget(_Wrapper(child: gameWidget, open: open));
     },
-    verify: (game, tester) async {
+  );
+}
+
+void main() {
+  myGame(open: false).widgetTest(
+    'calls onAttach when it enters the tree and onDetach and it leaves',
+    (game, tester) async {
       expect(game.onAttachCalled, isFalse);
 
       await tester.tap(find.text('Toggle'));
@@ -90,18 +95,9 @@ void main() {
       expect(game.onDettachCalled, isTrue);
     },
   );
-  flameWidgetTest<MyGame>(
+  myGame(open: true).widgetTest(
     'size is kept on game after a detach',
-    createGame: () => MyGame(),
-    pumpWidget: (gameWidget, tester) async {
-      await tester.pumpWidget(
-        _Wrapper(
-          child: gameWidget,
-          open: true,
-        ),
-      );
-    },
-    verify: (game, tester) async {
+    (game, tester) async {
       expect(game.hasLayout, isTrue);
 
       await tester.tap(find.text('Toggle'));

--- a/packages/flame_bloc/test/flame_bloc_game_test.dart
+++ b/packages/flame_bloc/test/flame_bloc_game_test.dart
@@ -1,6 +1,5 @@
 import 'package:bloc/bloc.dart';
 import 'package:flame/components.dart';
-import 'package:flame/game.dart';
 import 'package:flame_bloc/flame_bloc.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -40,41 +39,37 @@ void main() {
       cubit = InventoryCubit();
     });
 
-    Future<void> _pumpWidget(
-      GameWidget<MyBlocGame> gameWidget,
-      WidgetTester tester,
-    ) async {
-      await tester.pumpWidget(
-        BlocProvider<InventoryCubit>.value(
-          value: cubit,
-          child: gameWidget,
-        ),
-      );
-    }
+    final blocGame = FlameTester<MyBlocGame>(
+      () => MyBlocGame(),
+      pumpWidget: (gameWidget, tester) async {
+        await tester.pumpWidget(
+          BlocProvider<InventoryCubit>.value(
+            value: cubit,
+            child: gameWidget,
+          ),
+        );
+      },
+    );
 
-    flameWidgetTest<MyBlocGame>(
+    blocGame.widgetTest(
       'can emit states',
-      createGame: () => MyBlocGame(),
-      pumpWidget: _pumpWidget,
-      verify: (game, tester) async {
+      (game, tester) async {
         game.read<InventoryCubit>().selectBow();
 
         expect(cubit.state, equals(InventoryState.bow));
       },
     );
 
-    flameTest<MyBlocGame>(
+    blocGame.test(
       'read throws exection when game is not attached yet',
-      createGame: () => MyBlocGame(),
-      verify: (game) {
+      (game) {
         expect(() => game.read<InventoryCubit>(), throwsException);
       },
     );
 
-    flameTest<MyBlocGame>(
+    blocGame.test(
       'adds component to queue when is not attached',
-      createGame: () => MyBlocGame(),
-      verify: (game) {
+      (game) {
         game.add(InventoryComponent());
         game.update(0);
 
@@ -82,10 +77,9 @@ void main() {
       },
     );
 
-    flameTest<MyBlocGame>(
+    blocGame.test(
       'runs the queue when game is attached',
-      createGame: () => MyBlocGame(),
-      verify: (game) {
+      (game) {
         final component = MockInventoryComponent();
 
         game.prepareComponent(component);
@@ -96,23 +90,19 @@ void main() {
       },
     );
 
-    flameWidgetTest<MyBlocGame>(
+    blocGame.widgetTest(
       'init components with the initial state',
-      createGame: () => MyBlocGame(),
-      pumpWidget: _pumpWidget,
-      verify: (game, tester) async {
+      (game, tester) async {
         final component = InventoryComponent();
         game.add(component);
 
-        expect(component.state, equals(InventoryState.sword));
+        expect(component.state, equals(InventoryState.bow));
       },
     );
 
-    flameWidgetTest<MyBlocGame>(
+    blocGame.widgetTest(
       'components listen to changes',
-      createGame: () => MyBlocGame(),
-      pumpWidget: _pumpWidget,
-      verify: (game, tester) async {
+      (game, tester) async {
         final component = InventoryComponent();
         game.add(component);
         game.read<InventoryCubit>().selectBow();

--- a/packages/flame_bloc/test/flame_bloc_game_test.dart
+++ b/packages/flame_bloc/test/flame_bloc_game_test.dart
@@ -96,7 +96,7 @@ void main() {
         final component = InventoryComponent();
         game.add(component);
 
-        expect(component.state, equals(InventoryState.bow));
+        expect(component.state, equals(InventoryState.sword));
       },
     );
 

--- a/packages/flame_test/example/test/flame_test_test.dart
+++ b/packages/flame_test/example/test/flame_test_test.dart
@@ -2,22 +2,21 @@ import 'package:example/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+final myGame = FlameTester(() => MyGame());
 void main() {
   group('flameTest', () {
     TestWidgetsFlutterBinding.ensureInitialized();
 
-    flameTest<MyGame>(
+    myGame.test(
       'can load the game',
-      createGame: () => MyGame(),
-      verify: (game) {
+      (game) {
         expect(game.children.length, 1);
       },
     );
 
-    flameWidgetTest(
+    myGame.widgetTest(
       'render the game widget',
-      createGame: () => MyGame(),
-      verify: (game, tester) async {
+      (game, tester) async {
         expect(
           find.byGame<MyGame>(),
           findsOneWidget,

--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -1,5 +1,6 @@
 import 'package:flame/game.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart' as flutter_test show test;
+import 'package:flutter_test/flutter_test.dart' hide test;
 import 'package:meta/meta.dart';
 
 extension FlameFinds on CommonFinders {
@@ -13,38 +14,6 @@ extension FlameFinds on CommonFinders {
 typedef GameCreateFunction<T extends Game> = T Function();
 typedef VerifyFunction<T extends Game> = void Function(T);
 
-FlameGame _defaultCreate() => FlameGame();
-
-/// Creates a [Game] specific test case with given [description].
-///
-/// Use [createGame] to create your game instance.
-///
-/// Use [verify] closure to make verifications/assertions.
-@isTest
-void flameTest<T extends Game>(
-  String description, {
-  GameCreateFunction<T>? createGame,
-  VerifyFunction<T>? verify,
-  Vector2? gameSize,
-}) {
-  test(description, () async {
-    final game = (createGame ?? _defaultCreate)();
-    if (game is! T) {
-      fail('createGame provider must be of type T');
-    }
-
-    final size = gameSize ?? Vector2.all(500);
-    game.onGameResize(size);
-
-    await game.onLoad();
-    game.update(0);
-
-    if (verify != null) {
-      verify(game);
-    }
-  });
-}
-
 typedef GameWidgetCreateFunction<T extends Game> = GameWidget<T> Function(
   T game,
 );
@@ -57,44 +26,96 @@ typedef PumpWidgetFunction<T extends Game> = Future<void> Function(
   WidgetTester tester,
 );
 
-/// Creates a [Game] specific test case with given [description]
-/// which runs inside the Flutter test environment.
-///
-/// Use [createGame] to create your game instance.
-///
-/// Use [createGameWidget] to create the [GameWidget], if omitted
-/// the game instance returned by [createGame] will be wrapped into
-/// an empty [GameWidget] instance.
-///
-/// Use [pumpWidget] to define your own function to pump widgets into
-/// the Flutter test environment. When omitted, [flameWidgetTest] simply
-/// will pass the created game widget instance to the test.
-///
-/// Use [verify] closure to make verifications/assertions.
-@isTest
-void flameWidgetTest<T extends Game>(
-  String description, {
-  required GameCreateFunction<T> createGame,
-  GameWidgetCreateFunction<T>? createGameWidget,
-  PumpWidgetFunction<T>? pumpWidget,
-  WidgetVerifyFunction<T>? verify,
-}) {
-  testWidgets(description, (tester) async {
-    final game = createGame();
+/// Customize this class with your specific Game type [T] and a custom
+/// provider `() -> T`, plus some additional configurations including a game
+/// widget builder [createGameWidget], a custom [pumpWidget] function and a custom [gameSize].
+class FlameTester<T extends Game> {
+  /// Use [createGame] to create your game instance.
+  final GameCreateFunction<T> createGame;
 
-    await tester.runAsync(() async {
-      final gameWidget = createGameWidget?.call(game) ?? GameWidget(game: game);
+  /// Use [createGameWidget] to create the [GameWidget]. If omitted,
+  /// the game instance returned by [createGame] will be wrapped into
+  /// an empty [GameWidget] instance.
+  final GameWidgetCreateFunction<T>? createGameWidget;
 
-      final _pump = pumpWidget ??
-          (GameWidget<T> _gameWidget, WidgetTester _tester) =>
-              _tester.pumpWidget(_gameWidget);
+  /// Use [pumpWidget] to define your own function to pump widgets into
+  /// the Flutter test environment. When omitted, [widgetTest] simply
+  /// will pass the created game widget instance to the test.
+  final PumpWidgetFunction<T>? pumpWidget;
 
-      await _pump(gameWidget, tester);
-      await tester.pump();
+  /// Override the game size to be provided during `onGameResize`.
+  /// By default it will be a 500x500 square.
+  final Vector2? gameSize;
 
-      if (verify != null) {
-        await verify(game, tester);
-      }
-    });
+  FlameTester(
+    this.createGame, {
+    this.gameSize,
+    this.createGameWidget,
+    this.pumpWidget,
   });
+
+  /// Creates a [Game] specific test case with given [description].
+  ///
+  /// Use [verify] closure to make verifications/assertions.
+  @isTest
+  void test(
+    String description,
+    VerifyFunction<T> verify,
+  ) {
+    flutter_test.test(description, () async {
+      final game = createGame();
+
+      final size = gameSize ?? Vector2.all(500);
+      game.onGameResize(size);
+
+      await game.onLoad();
+      game.update(0);
+
+      verify(game);
+    });
+  }
+
+  /// Creates a [Game] specific test case with given [description]
+  /// which runs inside the Flutter test environment.
+  ///
+  /// Use [verify] closure to make verifications/assertions.
+  @isTest
+  void widgetTest(
+    String description,
+    WidgetVerifyFunction<T>? verify,
+  ) {
+    testWidgets(description, (tester) async {
+      final game = createGame();
+
+      await tester.runAsync(() async {
+        final gameWidget =
+            createGameWidget?.call(game) ?? GameWidget(game: game);
+
+        final _pump = pumpWidget ??
+            (GameWidget<T> _gameWidget, WidgetTester _tester) =>
+                _tester.pumpWidget(_gameWidget);
+
+        await _pump(gameWidget, tester);
+        await tester.pump();
+
+        if (verify != null) {
+          await verify(game, tester);
+        }
+      });
+    });
+  }
+
+  FlameTester<T> configure({
+    GameCreateFunction<T>? createGame,
+    Vector2? gameSize,
+    GameWidgetCreateFunction<T>? createGameWidget,
+    PumpWidgetFunction<T>? pumpWidget,
+  }) {
+    return FlameTester<T>(
+      createGame ?? this.createGame,
+      gameSize: gameSize ?? this.gameSize,
+      createGameWidget: createGameWidget ?? this.createGameWidget,
+      pumpWidget: pumpWidget ?? this.pumpWidget,
+    );
+  }
 }

--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -119,3 +119,7 @@ class FlameTester<T extends Game> {
     );
   }
 }
+
+/// Default instance of Flame Tester to be used when you don't care about
+/// changing any configuration.
+final flameGame = FlameTester<FlameGame>(() => FlameGame());

--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -13,6 +13,8 @@ extension FlameFinds on CommonFinders {
 typedef GameCreateFunction<T extends Game> = T Function();
 typedef VerifyFunction<T extends Game> = void Function(T);
 
+FlameGame _defaultCreate() => FlameGame();
+
 /// Creates a [Game] specific test case with given [description].
 ///
 /// Use [createGame] to create your game instance.
@@ -21,12 +23,15 @@ typedef VerifyFunction<T extends Game> = void Function(T);
 @isTest
 void flameTest<T extends Game>(
   String description, {
-  required GameCreateFunction<T> createGame,
+  GameCreateFunction<T>? createGame,
   VerifyFunction<T>? verify,
   Vector2? gameSize,
 }) {
   test(description, () async {
-    final game = createGame();
+    final game = (createGame ?? _defaultCreate)();
+    if (game is! T) {
+      fail('createGame provider must be of type T');
+    }
 
     final size = gameSize ?? Vector2.all(500);
     game.onGameResize(size);


### PR DESCRIPTION
# Description

<details>
<summary> ~~first proposal~~ </summary>
Proposal: make the createGame provider for the `flameTest` optional.
Advantages: cleaner, simpler for most use cases.
Disadvantages: not as type safe because if converts a compile error to a runtime error if T != Game (and dart doesn't have overloading).
Other option would be to create a new method where T===FlameGame and it calls this one (but would need to have a different name).
</details>

### Second Proposal

So I came up with a better idea. It came to me that from all the parameters required to run a test, there are two types:

* name and actually test -> these are of course always unique per test. can't have a test with duped name or code
* everything else -> these most commonly have a single value, if not for the entire application, at least for a set of tests

So the proposal is to split this into two steps. the common parameters are provided via the constructor and the test functions only take two parameters. now, when you do wanna change something, I provide a copy constructor. I considered optional parameters on the two test functions but I choose the copy constructor for two reasons: (1) promotes reuse of code between tests even when there are variations and (2, most importantly) the test functions signature now is identical to the test/widgetTest functions from the platform, so it looks more natural

Thoughts?

Note: just a proposal yet, I will (try) to add tests later (tests that test tests are hard haha)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [ ] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [ ] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [ ] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [ ] I read and followed the [Flame Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [ ] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [ ] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
