### PR TITLE
Adjust styles of highlighted text in docs

### DIFF
--- a/doc/_sphinx/styles/custom.css
+++ b/doc/_sphinx/styles/custom.css
@@ -151,15 +151,17 @@ main.bd-content #main-content .prev-next-bottom .right-next .prevnext-label, mai
 /* Search-related elements */
 
 form.bd-search #search-input {
-    border-bottom-color: #a99a2f;
+    border-bottom-color: #ffe689;
+    color: #ffe689;
+    opacity: 0.3;
 }
 
 form.bd-search #search-input:focus {
-    color: white;
     background: none;
     border-bottom: none;
-    box-shadow: 0 0 4px 0px #ffffff88;
-    border-radius: 4px;
+    border-radius: 6px;
+    box-shadow: 0 0 5px 1px #ffe689;
+    opacity: 1.0;
 }
 
 form.bd-search i.icon.fa-search {


### PR DESCRIPTION
# Description

In the documentation, when performing a text search, the keywords found on the page will now be highlighted properly.
Also adjusted the style of the search form itself, making it less jarring.

<img width="1176" alt="Screen Shot 2021-10-15 at 8 46 24 AM" src="https://user-images.githubusercontent.com/4231472/137515972-ec074a11-e557-4ef4-953d-35c791787d06.png">


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [ ] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [ ] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related issues

https://discord.com/channels/509714518008528896/516639688581316629/897734341881384990