### PR TITLE
Add flame_tiled contributors before package moved

### DIFF
--- a/packages/flame_tiled/README.md
+++ b/packages/flame_tiled/README.md
@@ -9,3 +9,12 @@ Package to bridge the `tiled` library into easy-to-use Flame components.
 </p>
 
 More [here](https://docs.flame-engine.org/main/tiled.html).
+
+## Contributors (before the package moved in to the monorepo)
+ - [erickzanardo](https://github.com/erickzanardo)
+ - [Schnurber](https://github.com/schnurber)
+ - [Akida31](https://github.com/akida31)
+ - [pgainullin](https://github.com/pgainullin)
+ - [wolfenrain](https://github.com/wolfenrain)
+ - [rc-davis](https://github.com/rc-davis)
+ - [luanpotter](https://github.com/luanpotter)


### PR DESCRIPTION
# Description

To give recognition to the people that made contributions before `flame_tiled` was moved in to the monorepo.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
