### PR TITLE
clarified TimerComponent example

### DIFF
--- a/examples/lib/stories/utils/timer_component.dart
+++ b/examples/lib/stories/utils/timer_component.dart
@@ -10,27 +10,29 @@ class RenderedTimeComponent extends TimerComponent {
     ),
   );
 
-  RenderedTimeComponent(Timer timer) : super(timer);
+  final double yOffset;
+
+  RenderedTimeComponent(Timer timer, {this.yOffset = 150}) : super(timer);
 
   @override
   void render(Canvas canvas) {
     super.render(canvas);
     textPaint.render(
       canvas,
-      'Elapsed time: ${timer.current}',
-      Vector2(10, 150),
+      'Elapsed time: ${timer.current.toStringAsFixed(3)}',
+      Vector2(10, yOffset),
     );
   }
 }
 
 class TimerComponentGame extends FlameGame with TapDetector, DoubleTapDetector {
   @override
-  void onTapDown(_) {
+  void onTap() {
     add(RenderedTimeComponent(Timer(1)..start()));
   }
 
   @override
   void onDoubleTap() {
-    add(RenderedTimeComponent(Timer(5)..start()));
+    add(RenderedTimeComponent(Timer(5)..start(), yOffset: 180));
   }
 }

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
  - Added `StandardEffectController` class
+ - Clarified `TimerComponent` example
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration


### PR DESCRIPTION
# Description

Clarified `TimerComponent` such that the timers are not rendered on top of each other on double tap.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
