### PR TITLE
Fix events + isHud

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -14,6 +14,7 @@
  - Rename `Hitbox` mixin to `HasHitboxes`
  - Added `RemoveEffect` and `SimpleEffectController`
  - Create default implementations of `RectangleComponent`, `CircleComponent` and `PolygonComponent`
+ - Improved interaction between viewport and isHud components
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -165,7 +165,7 @@ class Component with Loadable {
 
   @protected
   Vector2 eventPosition(PositionInfo info) {
-    return isHud ? info.eventPosition.widget : info.eventPosition.game;
+    return isHud ? info.eventPosition.viewportOnly : info.eventPosition.game;
   }
 
   /// Remove the component from its parent in the next tick.

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -7,6 +7,7 @@ import '../extensions/vector2.dart';
 import 'camera/camera.dart';
 import 'camera/camera_wrapper.dart';
 import 'mixins/game.dart';
+import 'projector.dart';
 
 /// This is a more complete and opinionated implementation of [Game].
 ///
@@ -113,22 +114,8 @@ class FlameGame extends Component with Game {
   }
 
   @override
-  Vector2 projectVector(Vector2 vector) {
-    return camera.combinedProjector.projectVector(vector);
-  }
+  Projector viewportProjector() => camera.viewport;
 
   @override
-  Vector2 unprojectVector(Vector2 vector) {
-    return camera.combinedProjector.unprojectVector(vector);
-  }
-
-  @override
-  Vector2 scaleVector(Vector2 vector) {
-    return camera.combinedProjector.scaleVector(vector);
-  }
-
-  @override
-  Vector2 unscaleVector(Vector2 vector) {
-    return camera.combinedProjector.unscaleVector(vector);
-  }
+  Projector projector() => camera.combinedProjector;
 }

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -114,8 +114,8 @@ class FlameGame extends Component with Game {
   }
 
   @override
-  Projector viewportProjector() => camera.viewport;
+  Projector get viewportProjector => camera.viewport;
 
   @override
-  Projector projector() => camera.combinedProjector;
+  Projector get projector => camera.combinedProjector;
 }

--- a/packages/flame/lib/src/game/mixins/game.dart
+++ b/packages/flame/lib/src/game/mixins/game.dart
@@ -24,7 +24,7 @@ import 'loadable.dart';
 /// methods to use it in a `GameWidget`.
 /// Flame will deal with calling these methods properly when the game's widget
 /// is rendered.
-mixin Game on Loadable implements Projector {
+mixin Game on Loadable {
   final images = Images();
   final assets = AssetsCache();
 
@@ -157,17 +157,8 @@ mixin Game on Loadable implements Projector {
     return _gameRenderBox!.localToGlobal(point.toOffset()).toVector2();
   }
 
-  @override
-  Vector2 unprojectVector(Vector2 vector) => vector;
-
-  @override
-  Vector2 projectVector(Vector2 vector) => vector;
-
-  @override
-  Vector2 unscaleVector(Vector2 vector) => vector;
-
-  @override
-  Vector2 scaleVector(Vector2 vector) => vector;
+  Projector projector() => IdentityProjector();
+  Projector viewportProjector() => IdentityProjector();
 
   /// Utility method to load and cache the image for a sprite based on its
   /// options.

--- a/packages/flame/lib/src/game/mixins/game.dart
+++ b/packages/flame/lib/src/game/mixins/game.dart
@@ -157,8 +157,13 @@ mixin Game on Loadable {
     return _gameRenderBox!.localToGlobal(point.toOffset()).toVector2();
   }
 
-  Projector projector() => IdentityProjector();
-  Projector viewportProjector() => IdentityProjector();
+  /// This is the projector used by non-isHUD components.
+  /// This can be overriden on your [Game] implementation.
+  Projector projector = IdentityProjector();
+
+  /// This is the projector used by isHUD components.
+  /// This can be overriden on your [Game] implementation.
+  Projector viewportProjector = IdentityProjector();
 
   /// Utility method to load and cache the image for a sprite based on its
   /// options.

--- a/packages/flame/lib/src/game/projector.dart
+++ b/packages/flame/lib/src/game/projector.dart
@@ -43,6 +43,22 @@ abstract class Projector {
   }
 }
 
+/// A simple Projector implementation that represents the identity operation
+/// (i.e. no-op).
+class IdentityProjector extends Projector {
+  @override
+  Vector2 projectVector(Vector2 v) => v;
+
+  @override
+  Vector2 scaleVector(Vector2 v) => v;
+
+  @override
+  Vector2 unprojectVector(Vector2 v) => v;
+
+  @override
+  Vector2 unscaleVector(Vector2 v) => v;
+}
+
 /// This is a [Projector] implementation that composes a list of projectors,
 /// in the order provided.
 ///

--- a/packages/flame/lib/src/gestures/events.dart
+++ b/packages/flame/lib/src/gestures/events.dart
@@ -18,8 +18,12 @@ class EventPosition {
   /// Coordinates of the event relative to the game widget position/size
   late final Vector2 widget = _game.convertGlobalToLocalCoordinate(global);
 
+  /// Coordinates of the event relative to the game position/size but applying only viewport transformations (not camera).
+  late final Vector2 viewportOnly =
+      _game.viewportProjector().unprojectVector(widget);
+
   /// Coordinates of the event relative to the game position/size and transformations
-  late final Vector2 game = _game.unprojectVector(widget);
+  late final Vector2 game = _game.projector().unprojectVector(widget);
 
   EventPosition(this._game, this._globalPosition);
 }
@@ -35,8 +39,12 @@ class EventDelta {
   /// Raw value relative to the game transformations
   late final Vector2 global = _delta.toVector2();
 
+  /// Scaled value relative to the game viewport only transformations (not camera).
+  late final Vector2 viewportOnly =
+      _game.viewportProjector().unscaleVector(global);
+
   /// Scaled value relative to the game transformations
-  late final Vector2 game = _game.unscaleVector(global);
+  late final Vector2 game = _game.projector().unscaleVector(global);
 
   EventDelta(this._game, this._delta);
 }
@@ -88,7 +96,7 @@ class LongPressStartInfo extends PositionInfo<LongPressStartDetails> {
 
 class LongPressEndInfo extends PositionInfo<LongPressEndDetails> {
   late final Vector2 velocity =
-      _game.unscaleVector(raw.velocity.pixelsPerSecond.toVector2());
+      _game.projector().unscaleVector(raw.velocity.pixelsPerSecond.toVector2());
 
   LongPressEndInfo.fromDetails(
     Game game,
@@ -154,7 +162,7 @@ class DragUpdateInfo extends PositionInfo<DragUpdateDetails> {
 class DragEndInfo extends BaseInfo<DragEndDetails> {
   final Game _game;
   late final Vector2 velocity =
-      _game.unscaleVector(raw.velocity.pixelsPerSecond.toVector2());
+      _game.projector().unscaleVector(raw.velocity.pixelsPerSecond.toVector2());
   double? get primaryVelocity => raw.primaryVelocity;
 
   DragEndInfo.fromDetails(

--- a/packages/flame/lib/src/gestures/events.dart
+++ b/packages/flame/lib/src/gestures/events.dart
@@ -20,10 +20,10 @@ class EventPosition {
 
   /// Coordinates of the event relative to the game position/size but applying only viewport transformations (not camera).
   late final Vector2 viewportOnly =
-      _game.viewportProjector().unprojectVector(widget);
+      _game.viewportProjector.unprojectVector(widget);
 
   /// Coordinates of the event relative to the game position/size and transformations
-  late final Vector2 game = _game.projector().unprojectVector(widget);
+  late final Vector2 game = _game.projector.unprojectVector(widget);
 
   EventPosition(this._game, this._globalPosition);
 }
@@ -41,10 +41,10 @@ class EventDelta {
 
   /// Scaled value relative to the game viewport only transformations (not camera).
   late final Vector2 viewportOnly =
-      _game.viewportProjector().unscaleVector(global);
+      _game.viewportProjector.unscaleVector(global);
 
   /// Scaled value relative to the game transformations
-  late final Vector2 game = _game.projector().unscaleVector(global);
+  late final Vector2 game = _game.projector.unscaleVector(global);
 
   EventDelta(this._game, this._delta);
 }
@@ -96,7 +96,7 @@ class LongPressStartInfo extends PositionInfo<LongPressStartDetails> {
 
 class LongPressEndInfo extends PositionInfo<LongPressEndDetails> {
   late final Vector2 velocity =
-      _game.projector().unscaleVector(raw.velocity.pixelsPerSecond.toVector2());
+      _game.projector.unscaleVector(raw.velocity.pixelsPerSecond.toVector2());
 
   LongPressEndInfo.fromDetails(
     Game game,
@@ -162,7 +162,7 @@ class DragUpdateInfo extends PositionInfo<DragUpdateDetails> {
 class DragEndInfo extends BaseInfo<DragEndDetails> {
   final Game _game;
   late final Vector2 velocity =
-      _game.projector().unscaleVector(raw.velocity.pixelsPerSecond.toVector2());
+      _game.projector.unscaleVector(raw.velocity.pixelsPerSecond.toVector2());
   double? get primaryVelocity => raw.primaryVelocity;
 
   DragEndInfo.fromDetails(

--- a/packages/flame/test/game/projections_test.dart
+++ b/packages/flame/test/game/projections_test.dart
@@ -27,6 +27,23 @@ void main() {
       expect(game.projector().unprojectVector(Vector2(2, 4)), Vector2(1, 2));
       expect(game.projector().scaleVector(Vector2(1, 2)), Vector2(2, 4));
       expect(game.projector().unscaleVector(Vector2(2, 4)), Vector2(1, 2));
+
+      expect(
+        game.viewportProjector().projectVector(Vector2(1, 2)),
+        Vector2(2, 4),
+      );
+      expect(
+        game.viewportProjector().unprojectVector(Vector2(2, 4)),
+        Vector2(1, 2),
+      );
+      expect(
+        game.viewportProjector().scaleVector(Vector2(1, 2)),
+        Vector2(2, 4),
+      );
+      expect(
+        game.viewportProjector().unscaleVector(Vector2(2, 4)),
+        Vector2(1, 2),
+      );
     });
     test('viewport only with translation projection (no camera)', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -89,6 +106,15 @@ void main() {
 
       expect(game.projector().unprojectVector(Vector2.zero()), Vector2.zero());
       expect(game.projector().unprojectVector(Vector2(3, 6)), Vector2(1, 2));
+
+      expect(
+        game.viewportProjector().unprojectVector(Vector2.zero()),
+        Vector2.zero(),
+      );
+      expect(
+        game.viewportProjector().unprojectVector(Vector2(3, 6)),
+        Vector2(3, 6),
+      );
 
       // delta considers the zoom
       expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
@@ -181,6 +207,11 @@ void main() {
       expect(
         game.projector().unprojectVector(Vector2(50, 0)),
         Vector2(10, 100),
+      );
+      // viewport only, top left should be the top left of screen
+      expect(
+        game.viewportProjector().unprojectVector(Vector2(50, 0)),
+        Vector2.zero(),
       );
       // top right of viewport is top left of camera + effective screen width
       expect(

--- a/packages/flame/test/game/projections_test.dart
+++ b/packages/flame/test/game/projections_test.dart
@@ -8,12 +8,12 @@ void main() {
   group('projections', () {
     test('default viewport and camera should no-op projections', () {
       final game = FlameGame(); // default viewport & camera
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
-      expect(game.projector().projectVector(Vector2(1, 2)), Vector2(1, 2));
-      expect(game.projector().unprojectVector(Vector2(1, 2)), Vector2(1, 2));
-      expect(game.projector().scaleVector(Vector2(1, 2)), Vector2(1, 2));
-      expect(game.projector().unscaleVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector.projectVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector.unprojectVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector.scaleVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
     });
     test('viewport only with scale projection (no camera)', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -21,27 +21,27 @@ void main() {
       game.onGameResize(Vector2(200, 200));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2.zero()); // no translation
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
-      expect(game.projector().projectVector(Vector2(1, 2)), Vector2(2, 4));
-      expect(game.projector().unprojectVector(Vector2(2, 4)), Vector2(1, 2));
-      expect(game.projector().scaleVector(Vector2(1, 2)), Vector2(2, 4));
-      expect(game.projector().unscaleVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector.projectVector(Vector2(1, 2)), Vector2(2, 4));
+      expect(game.projector.unprojectVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector.scaleVector(Vector2(1, 2)), Vector2(2, 4));
+      expect(game.projector.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
 
       expect(
-        game.viewportProjector().projectVector(Vector2(1, 2)),
+        game.viewportProjector.projectVector(Vector2(1, 2)),
         Vector2(2, 4),
       );
       expect(
-        game.viewportProjector().unprojectVector(Vector2(2, 4)),
+        game.viewportProjector.unprojectVector(Vector2(2, 4)),
         Vector2(1, 2),
       );
       expect(
-        game.viewportProjector().scaleVector(Vector2(1, 2)),
+        game.viewportProjector.scaleVector(Vector2(1, 2)),
         Vector2(2, 4),
       );
       expect(
-        game.viewportProjector().unscaleVector(Vector2(2, 4)),
+        game.viewportProjector.unscaleVector(Vector2(2, 4)),
         Vector2(1, 2),
       );
     });
@@ -51,31 +51,31 @@ void main() {
       game.onGameResize(Vector2(200, 100));
       expect(viewport.scale, 1); // no scale
       expect(viewport.resizeOffset, Vector2(50, 0)); // y is unchanged
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
       // click on x=0 means -50 in the game coordinates
-      expect(game.projector().unprojectVector(Vector2.zero()), Vector2(-50, 0));
+      expect(game.projector.unprojectVector(Vector2.zero()), Vector2(-50, 0));
       // click on x=50 is right on the edge of the viewport
-      expect(game.projector().unprojectVector(Vector2.all(50)), Vector2(0, 50));
+      expect(game.projector.unprojectVector(Vector2.all(50)), Vector2(0, 50));
       // click on x=150 is on the other edge
       expect(
-        game.projector().unprojectVector(Vector2.all(150)),
+        game.projector.unprojectVector(Vector2.all(150)),
         Vector2(100, 150),
       );
       // 50 past the end
       expect(
-        game.projector().unprojectVector(Vector2(200, 0)),
+        game.projector.unprojectVector(Vector2(200, 0)),
         Vector2(150, 0),
       );
 
       // translations should not affect projecting deltas
-      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().unscaleVector(Vector2.all(50)), Vector2.all(50));
+      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.unscaleVector(Vector2.all(50)), Vector2.all(50));
       expect(
-        game.projector().unscaleVector(Vector2.all(150)),
+        game.projector.unscaleVector(Vector2.all(150)),
         Vector2.all(150),
       );
-      expect(game.projector().unscaleVector(Vector2(200, 0)), Vector2(200, 0));
+      expect(game.projector.unscaleVector(Vector2(200, 0)), Vector2(200, 0));
     });
     test('viewport only with both scale and translation (no camera)', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -83,17 +83,17 @@ void main() {
       game.onGameResize(Vector2(200, 400));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
       // click on y=0 means -100 in the game coordinates
-      expect(game.projector().unprojectVector(Vector2.zero()), Vector2(0, -50));
-      expect(game.projector().unprojectVector(Vector2(0, 100)), Vector2.zero());
+      expect(game.projector.unprojectVector(Vector2.zero()), Vector2(0, -50));
+      expect(game.projector.unprojectVector(Vector2(0, 100)), Vector2.zero());
       expect(
-        game.projector().unprojectVector(Vector2(0, 300)),
+        game.projector.unprojectVector(Vector2(0, 300)),
         Vector2(0, 100),
       );
       expect(
-        game.projector().unprojectVector(Vector2(0, 400)),
+        game.projector.unprojectVector(Vector2(0, 400)),
         Vector2(0, 150),
       );
     });
@@ -102,23 +102,23 @@ void main() {
       game.onGameResize(Vector2.all(1));
 
       game.camera.zoom = 3; // 3x zoom
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
-      expect(game.projector().unprojectVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().unprojectVector(Vector2(3, 6)), Vector2(1, 2));
+      expect(game.projector.unprojectVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.unprojectVector(Vector2(3, 6)), Vector2(1, 2));
 
       expect(
-        game.viewportProjector().unprojectVector(Vector2.zero()),
+        game.viewportProjector.unprojectVector(Vector2.zero()),
         Vector2.zero(),
       );
       expect(
-        game.viewportProjector().unprojectVector(Vector2(3, 6)),
+        game.viewportProjector.unprojectVector(Vector2(3, 6)),
         Vector2(3, 6),
       );
 
       // delta considers the zoom
-      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().unscaleVector(Vector2(3, 6)), Vector2(1, 2));
+      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.unscaleVector(Vector2(3, 6)), Vector2(1, 2));
     });
     test('camera only with translation (default viewport)', () {
       final game = FlameGame(); // default viewport
@@ -126,20 +126,20 @@ void main() {
 
       // top left corner of the screen is (50, 100)
       game.camera.snapTo(Vector2(50, 100));
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
       expect(
-        game.projector().unprojectVector(Vector2.zero()),
+        game.projector.unprojectVector(Vector2.zero()),
         Vector2(50, 100),
       );
       expect(
-        game.projector().unprojectVector(Vector2(-50, 50)),
+        game.projector.unprojectVector(Vector2(-50, 50)),
         Vector2(0, 150),
       );
 
       // delta ignores translations
-      expect(game.projector().scaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().scaleVector(Vector2(-50, 50)), Vector2(-50, 50));
+      expect(game.projector.scaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.scaleVector(Vector2(-50, 50)), Vector2(-50, 50));
     });
     test('camera only with both zoom and translation (default viewport)', () {
       final game = FlameGame(); // default viewport
@@ -151,21 +151,21 @@ void main() {
       game.camera.snapTo(Vector2.all(-100));
       // zoom is 2x, meaning every 1 unit you walk away of (-100, -100)
       game.camera.zoom = 2;
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
       expect(
-        game.projector().unprojectVector(Vector2.zero()),
+        game.projector.unprojectVector(Vector2.zero()),
         Vector2(-100, -100),
       );
       // let's "walk" 10 pixels down on the screen;
       // that means the world walks 5 units
       expect(
-        game.projector().unprojectVector(Vector2(0, 10)),
+        game.projector.unprojectVector(Vector2(0, 10)),
         Vector2(-100, -95),
       );
       // to get to the world 0,0 we need to walk 200 screen units
       expect(
-        game.projector().unprojectVector(Vector2.all(200)),
+        game.projector.unprojectVector(Vector2.all(200)),
         Vector2.zero(),
       );
 
@@ -178,21 +178,21 @@ void main() {
       // meaning the topLeft will be -105, -105 (regardless of zoom)
       // but since the offset is set to center, topLeft will be -102.5, -102.5
       expect(
-        game.projector().unprojectVector(Vector2.zero()),
+        game.projector.unprojectVector(Vector2.zero()),
         Vector2.all(-102.5),
       );
       // and with 2x zoom the center will actually be -100, -100 since the
       // relative offset is set to center.
       expect(
-        game.projector().unprojectVector(Vector2.all(5)),
+        game.projector.unprojectVector(Vector2.all(5)),
         Vector2.all(-100),
       );
       // TODO(luan) we might want to change the behaviour so that the zoom
       // is applied w.r.t. the relativeOffset and not topLeft
 
       // for deltas, we consider only the zoom
-      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().unscaleVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
     test('camera & viewport - two translations', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -201,32 +201,32 @@ void main() {
       game.camera.snapTo(Vector2(10, 100));
       expect(viewport.scale, 1); // no scale
       expect(viewport.resizeOffset, Vector2(50, 0)); // y is unchanged
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
       // top left of viewport should be top left of camera
       expect(
-        game.projector().unprojectVector(Vector2(50, 0)),
+        game.projector.unprojectVector(Vector2(50, 0)),
         Vector2(10, 100),
       );
       // viewport only, top left should be the top left of screen
       expect(
-        game.viewportProjector().unprojectVector(Vector2(50, 0)),
+        game.viewportProjector.unprojectVector(Vector2(50, 0)),
         Vector2.zero(),
       );
       // top right of viewport is top left of camera + effective screen width
       expect(
-        game.projector().unprojectVector(Vector2(150, 0)),
+        game.projector.unprojectVector(Vector2(150, 0)),
         Vector2(110, 100),
       );
       // vertically, only the camera translation is applied
       expect(
-        game.projector().unprojectVector(Vector2(40, 123)),
+        game.projector.unprojectVector(Vector2(40, 123)),
         Vector2(0, 223),
       );
 
       // deltas should not be affected by translations at all
-      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().unscaleVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
     });
     test('camera zoom & viewport translation', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -236,28 +236,28 @@ void main() {
       game.camera.snap();
       expect(viewport.scale, 1); // no scale
       expect(viewport.resizeOffset, Vector2(50, 0)); // y is unchanged
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
       // (50, 0) is the top left corner of the camera
-      expect(game.projector().unprojectVector(Vector2(50, 0)), Vector2.zero());
+      expect(game.projector.unprojectVector(Vector2(50, 0)), Vector2.zero());
       // the top left of the screen is 50 viewport units to the left,
       // but applying the camera zoom on top results in 25 units
       // in the game space
-      expect(game.projector().unprojectVector(Vector2.zero()), Vector2(-25, 0));
+      expect(game.projector.unprojectVector(Vector2.zero()), Vector2(-25, 0));
       // for every two units we walk to right or bottom means one game units
-      expect(game.projector().unprojectVector(Vector2(52, 20)), Vector2(1, 10));
+      expect(game.projector.unprojectVector(Vector2(52, 20)), Vector2(1, 10));
       // the bottom right of the viewport is at (150, 100) on screen coordinates
       // for the viewport that is walking (100, 100) in viewport units
       // for the camera we need to half that so it means walking (50, 50)
       // this is the bottom-right most world pixel that is painted
       expect(
-        game.projector().unprojectVector(Vector2(150, 100)),
+        game.projector.unprojectVector(Vector2(150, 100)),
         Vector2.all(50),
       );
 
       // for deltas, we consider only the 2x zoom of the camera
-      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().unscaleVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
     test('camera translation & viewport scale+translation', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -269,25 +269,25 @@ void main() {
       // the camera should apply a (10, 10) translation on top of the viewport
       game.camera.snapTo(Vector2.all(10));
 
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
       // in the viewport space the top left of the screen would be (0, -100)
       // that means 100 viewport units above the top left of the camera (10, 10)
       // each viewport unit is twice the camera unit, so that is 50 above
       expect(
-        game.projector().unprojectVector(Vector2.zero()),
+        game.projector.unprojectVector(Vector2.zero()),
         Vector2(10, -40),
       );
       // the top left of the camera should be (10, 10) on game space
       // the top left of the camera should be at (0, 100) on the viewport
       expect(
-        game.projector().unprojectVector(Vector2(0, 100)),
+        game.projector.unprojectVector(Vector2(0, 100)),
         Vector2(10, 10),
       );
 
       // for deltas, we consider only 2x scale of the viewport
-      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().unscaleVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
     test('camera & viewport scale/zoom + translation (cancel out scaling)', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -301,41 +301,41 @@ void main() {
       game.camera.zoom = 0.5;
       game.camera.snapTo(Vector2.all(10));
 
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
       // in the viewport space the top left of the screen would be (0, -100)
       // that means 100 screen units above the top left of the camera (10, 10)
       // each viewport unit is exactly one camera unit, because the zoom
       // cancels out the scale
       expect(
-        game.projector().unprojectVector(Vector2.zero()),
+        game.projector.unprojectVector(Vector2.zero()),
         Vector2(10, -90),
       );
       // the top-left most visible pixel on the viewport would be at (0, 100)
       // in screen coordinates. That should be the top left of the camera that
       // is snapped to 10,10 by definition.
       expect(
-        game.projector().unprojectVector(Vector2(0, 100)),
+        game.projector.unprojectVector(Vector2(0, 100)),
         Vector2(10, 10),
       );
       // now each unit we walk in screen space means only 2 units on the
       // viewport space because of the scale. however, since the camera applies
       // a 1/2x zoom, each unit step equals to 1 unit on the game space
       expect(
-        game.projector().unprojectVector(Vector2(1, 100)),
+        game.projector.unprojectVector(Vector2(1, 100)),
         Vector2(11, 10),
       );
       // the last pixel of the viewport is on screen coordinates of (200, 300)
       // for the camera, that should be: top left (10,10) + effective size
       // (100, 100) * zoom (1/2)
       expect(
-        game.projector().unprojectVector(Vector2(200, 300)),
+        game.projector.unprojectVector(Vector2(200, 300)),
         Vector2.all(210),
       );
 
       // for deltas, since the scale and the zoom cancel out, this should no-op
-      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().unscaleVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
     });
     test('camera & viewport scale/zoom + translation', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -349,7 +349,7 @@ void main() {
       game.camera.zoom = 4;
       game.camera.snapTo(Vector2(50, 0));
 
-      _assertIdentityOfProjector(game.projector());
+      _assertIdentityOfProjector(game.projector);
 
       // in the viewport space the top left of the screen would be (0, -100)
       // that means 100 screen units above the top left of the camera (50, 0)
@@ -357,29 +357,29 @@ void main() {
       // each viewport unit is 1/4 of a camera unit
       // so a game unit is 1/8 the screen unit
       expect(
-        game.projector().unprojectVector(Vector2.zero()),
+        game.projector.unprojectVector(Vector2.zero()),
         Vector2(50, -100 / 8),
       );
       // the top left of the camera (50, 0) should be at screen coordinates
       // (0, 100)
-      expect(game.projector().unprojectVector(Vector2(0, 100)), Vector2(50, 0));
+      expect(game.projector.unprojectVector(Vector2(0, 100)), Vector2(50, 0));
       // now each unit we walk on that 200 unit square on screen equals to
       // 1/2 units on the same 100 unit square on the viewport space
       // then, given the 4x camera zoom, each viewport unit becomes 4x a
       // game unit.
-      expect(game.projector().unprojectVector(Vector2(8, 108)), Vector2(51, 1));
+      expect(game.projector.unprojectVector(Vector2(8, 108)), Vector2(51, 1));
       expect(
-        game.projector().unprojectVector(Vector2(16, 104)),
+        game.projector.unprojectVector(Vector2(16, 104)),
         Vector2(52, 0.5),
       );
       expect(
-        game.projector().unprojectVector(Vector2(12, 112)),
+        game.projector.unprojectVector(Vector2(12, 112)),
         Vector2(51.5, 1.5),
       );
 
       // deltas only care about the effective scaling factor, which is 8x
-      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector().unscaleVector(Vector2(8, 16)), Vector2(1, 2));
+      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector.unscaleVector(Vector2(8, 16)), Vector2(1, 2));
     });
   });
 }

--- a/packages/flame/test/game/projections_test.dart
+++ b/packages/flame/test/game/projections_test.dart
@@ -8,12 +8,12 @@ void main() {
   group('projections', () {
     test('default viewport and camera should no-op projections', () {
       final game = FlameGame(); // default viewport & camera
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
-      expect(game.projectVector(Vector2(1, 2)), Vector2(1, 2));
-      expect(game.unprojectVector(Vector2(1, 2)), Vector2(1, 2));
-      expect(game.scaleVector(Vector2(1, 2)), Vector2(1, 2));
-      expect(game.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector().projectVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector().unprojectVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector().scaleVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector().unscaleVector(Vector2(1, 2)), Vector2(1, 2));
     });
     test('viewport only with scale projection (no camera)', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -21,12 +21,12 @@ void main() {
       game.onGameResize(Vector2(200, 200));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2.zero()); // no translation
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
-      expect(game.projectVector(Vector2(1, 2)), Vector2(2, 4));
-      expect(game.unprojectVector(Vector2(2, 4)), Vector2(1, 2));
-      expect(game.scaleVector(Vector2(1, 2)), Vector2(2, 4));
-      expect(game.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector().projectVector(Vector2(1, 2)), Vector2(2, 4));
+      expect(game.projector().unprojectVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector().scaleVector(Vector2(1, 2)), Vector2(2, 4));
+      expect(game.projector().unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
     test('viewport only with translation projection (no camera)', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -34,22 +34,31 @@ void main() {
       game.onGameResize(Vector2(200, 100));
       expect(viewport.scale, 1); // no scale
       expect(viewport.resizeOffset, Vector2(50, 0)); // y is unchanged
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
       // click on x=0 means -50 in the game coordinates
-      expect(game.unprojectVector(Vector2.zero()), Vector2(-50, 0));
+      expect(game.projector().unprojectVector(Vector2.zero()), Vector2(-50, 0));
       // click on x=50 is right on the edge of the viewport
-      expect(game.unprojectVector(Vector2.all(50)), Vector2(0, 50));
+      expect(game.projector().unprojectVector(Vector2.all(50)), Vector2(0, 50));
       // click on x=150 is on the other edge
-      expect(game.unprojectVector(Vector2.all(150)), Vector2(100, 150));
+      expect(
+        game.projector().unprojectVector(Vector2.all(150)),
+        Vector2(100, 150),
+      );
       // 50 past the end
-      expect(game.unprojectVector(Vector2(200, 0)), Vector2(150, 0));
+      expect(
+        game.projector().unprojectVector(Vector2(200, 0)),
+        Vector2(150, 0),
+      );
 
       // translations should not affect projecting deltas
-      expect(game.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.unscaleVector(Vector2.all(50)), Vector2.all(50));
-      expect(game.unscaleVector(Vector2.all(150)), Vector2.all(150));
-      expect(game.unscaleVector(Vector2(200, 0)), Vector2(200, 0));
+      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().unscaleVector(Vector2.all(50)), Vector2.all(50));
+      expect(
+        game.projector().unscaleVector(Vector2.all(150)),
+        Vector2.all(150),
+      );
+      expect(game.projector().unscaleVector(Vector2(200, 0)), Vector2(200, 0));
     });
     test('viewport only with both scale and translation (no camera)', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -57,27 +66,33 @@ void main() {
       game.onGameResize(Vector2(200, 400));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
       // click on y=0 means -100 in the game coordinates
-      expect(game.unprojectVector(Vector2.zero()), Vector2(0, -50));
-      expect(game.unprojectVector(Vector2(0, 100)), Vector2.zero());
-      expect(game.unprojectVector(Vector2(0, 300)), Vector2(0, 100));
-      expect(game.unprojectVector(Vector2(0, 400)), Vector2(0, 150));
+      expect(game.projector().unprojectVector(Vector2.zero()), Vector2(0, -50));
+      expect(game.projector().unprojectVector(Vector2(0, 100)), Vector2.zero());
+      expect(
+        game.projector().unprojectVector(Vector2(0, 300)),
+        Vector2(0, 100),
+      );
+      expect(
+        game.projector().unprojectVector(Vector2(0, 400)),
+        Vector2(0, 150),
+      );
     });
     test('camera only with zoom (default viewport)', () {
       final game = FlameGame(); // default viewport
       game.onGameResize(Vector2.all(1));
 
       game.camera.zoom = 3; // 3x zoom
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
-      expect(game.unprojectVector(Vector2.zero()), Vector2.zero());
-      expect(game.unprojectVector(Vector2(3, 6)), Vector2(1, 2));
+      expect(game.projector().unprojectVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().unprojectVector(Vector2(3, 6)), Vector2(1, 2));
 
       // delta considers the zoom
-      expect(game.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.unscaleVector(Vector2(3, 6)), Vector2(1, 2));
+      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().unscaleVector(Vector2(3, 6)), Vector2(1, 2));
     });
     test('camera only with translation (default viewport)', () {
       final game = FlameGame(); // default viewport
@@ -85,14 +100,20 @@ void main() {
 
       // top left corner of the screen is (50, 100)
       game.camera.snapTo(Vector2(50, 100));
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
-      expect(game.unprojectVector(Vector2.zero()), Vector2(50, 100));
-      expect(game.unprojectVector(Vector2(-50, 50)), Vector2(0, 150));
+      expect(
+        game.projector().unprojectVector(Vector2.zero()),
+        Vector2(50, 100),
+      );
+      expect(
+        game.projector().unprojectVector(Vector2(-50, 50)),
+        Vector2(0, 150),
+      );
 
       // delta ignores translations
-      expect(game.scaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.scaleVector(Vector2(-50, 50)), Vector2(-50, 50));
+      expect(game.projector().scaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().scaleVector(Vector2(-50, 50)), Vector2(-50, 50));
     });
     test('camera only with both zoom and translation (default viewport)', () {
       final game = FlameGame(); // default viewport
@@ -104,14 +125,23 @@ void main() {
       game.camera.snapTo(Vector2.all(-100));
       // zoom is 2x, meaning every 1 unit you walk away of (-100, -100)
       game.camera.zoom = 2;
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
-      expect(game.unprojectVector(Vector2.zero()), Vector2(-100, -100));
+      expect(
+        game.projector().unprojectVector(Vector2.zero()),
+        Vector2(-100, -100),
+      );
       // let's "walk" 10 pixels down on the screen;
       // that means the world walks 5 units
-      expect(game.unprojectVector(Vector2(0, 10)), Vector2(-100, -95));
+      expect(
+        game.projector().unprojectVector(Vector2(0, 10)),
+        Vector2(-100, -95),
+      );
       // to get to the world 0,0 we need to walk 200 screen units
-      expect(game.unprojectVector(Vector2.all(200)), Vector2.zero());
+      expect(
+        game.projector().unprojectVector(Vector2.all(200)),
+        Vector2.zero(),
+      );
 
       // note: in the current implementation, if we change the relative position
       // the zoom is still applied w.r.t. the top left of the screen
@@ -121,16 +151,22 @@ void main() {
       // that means that the center would be -100, -100 if the zoom was 1
       // meaning the topLeft will be -105, -105 (regardless of zoom)
       // but since the offset is set to center, topLeft will be -102.5, -102.5
-      expect(game.unprojectVector(Vector2.zero()), Vector2.all(-102.5));
+      expect(
+        game.projector().unprojectVector(Vector2.zero()),
+        Vector2.all(-102.5),
+      );
       // and with 2x zoom the center will actually be -100, -100 since the
       // relative offset is set to center.
-      expect(game.unprojectVector(Vector2.all(5)), Vector2.all(-100));
+      expect(
+        game.projector().unprojectVector(Vector2.all(5)),
+        Vector2.all(-100),
+      );
       // TODO(luan) we might want to change the behaviour so that the zoom
       // is applied w.r.t. the relativeOffset and not topLeft
 
       // for deltas, we consider only the zoom
-      expect(game.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
     test('camera & viewport - two translations', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -139,18 +175,27 @@ void main() {
       game.camera.snapTo(Vector2(10, 100));
       expect(viewport.scale, 1); // no scale
       expect(viewport.resizeOffset, Vector2(50, 0)); // y is unchanged
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
       // top left of viewport should be top left of camera
-      expect(game.unprojectVector(Vector2(50, 0)), Vector2(10, 100));
+      expect(
+        game.projector().unprojectVector(Vector2(50, 0)),
+        Vector2(10, 100),
+      );
       // top right of viewport is top left of camera + effective screen width
-      expect(game.unprojectVector(Vector2(150, 0)), Vector2(110, 100));
+      expect(
+        game.projector().unprojectVector(Vector2(150, 0)),
+        Vector2(110, 100),
+      );
       // vertically, only the camera translation is applied
-      expect(game.unprojectVector(Vector2(40, 123)), Vector2(0, 223));
+      expect(
+        game.projector().unprojectVector(Vector2(40, 123)),
+        Vector2(0, 223),
+      );
 
       // deltas should not be affected by translations at all
-      expect(game.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().unscaleVector(Vector2(1, 2)), Vector2(1, 2));
     });
     test('camera zoom & viewport translation', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -160,25 +205,28 @@ void main() {
       game.camera.snap();
       expect(viewport.scale, 1); // no scale
       expect(viewport.resizeOffset, Vector2(50, 0)); // y is unchanged
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
       // (50, 0) is the top left corner of the camera
-      expect(game.unprojectVector(Vector2(50, 0)), Vector2.zero());
+      expect(game.projector().unprojectVector(Vector2(50, 0)), Vector2.zero());
       // the top left of the screen is 50 viewport units to the left,
       // but applying the camera zoom on top results in 25 units
       // in the game space
-      expect(game.unprojectVector(Vector2.zero()), Vector2(-25, 0));
+      expect(game.projector().unprojectVector(Vector2.zero()), Vector2(-25, 0));
       // for every two units we walk to right or bottom means one game units
-      expect(game.unprojectVector(Vector2(52, 20)), Vector2(1, 10));
+      expect(game.projector().unprojectVector(Vector2(52, 20)), Vector2(1, 10));
       // the bottom right of the viewport is at (150, 100) on screen coordinates
       // for the viewport that is walking (100, 100) in viewport units
       // for the camera we need to half that so it means walking (50, 50)
       // this is the bottom-right most world pixel that is painted
-      expect(game.unprojectVector(Vector2(150, 100)), Vector2.all(50));
+      expect(
+        game.projector().unprojectVector(Vector2(150, 100)),
+        Vector2.all(50),
+      );
 
       // for deltas, we consider only the 2x zoom of the camera
-      expect(game.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
     test('camera translation & viewport scale+translation', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -190,19 +238,25 @@ void main() {
       // the camera should apply a (10, 10) translation on top of the viewport
       game.camera.snapTo(Vector2.all(10));
 
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
       // in the viewport space the top left of the screen would be (0, -100)
       // that means 100 viewport units above the top left of the camera (10, 10)
       // each viewport unit is twice the camera unit, so that is 50 above
-      expect(game.unprojectVector(Vector2.zero()), Vector2(10, -40));
+      expect(
+        game.projector().unprojectVector(Vector2.zero()),
+        Vector2(10, -40),
+      );
       // the top left of the camera should be (10, 10) on game space
       // the top left of the camera should be at (0, 100) on the viewport
-      expect(game.unprojectVector(Vector2(0, 100)), Vector2(10, 10));
+      expect(
+        game.projector().unprojectVector(Vector2(0, 100)),
+        Vector2(10, 10),
+      );
 
       // for deltas, we consider only 2x scale of the viewport
-      expect(game.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
+      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
     test('camera & viewport scale/zoom + translation (cancel out scaling)', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -216,29 +270,41 @@ void main() {
       game.camera.zoom = 0.5;
       game.camera.snapTo(Vector2.all(10));
 
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
       // in the viewport space the top left of the screen would be (0, -100)
       // that means 100 screen units above the top left of the camera (10, 10)
       // each viewport unit is exactly one camera unit, because the zoom
       // cancels out the scale
-      expect(game.unprojectVector(Vector2.zero()), Vector2(10, -90));
+      expect(
+        game.projector().unprojectVector(Vector2.zero()),
+        Vector2(10, -90),
+      );
       // the top-left most visible pixel on the viewport would be at (0, 100)
       // in screen coordinates. That should be the top left of the camera that
       // is snapped to 10,10 by definition.
-      expect(game.unprojectVector(Vector2(0, 100)), Vector2(10, 10));
+      expect(
+        game.projector().unprojectVector(Vector2(0, 100)),
+        Vector2(10, 10),
+      );
       // now each unit we walk in screen space means only 2 units on the
       // viewport space because of the scale. however, since the camera applies
       // a 1/2x zoom, each unit step equals to 1 unit on the game space
-      expect(game.unprojectVector(Vector2(1, 100)), Vector2(11, 10));
+      expect(
+        game.projector().unprojectVector(Vector2(1, 100)),
+        Vector2(11, 10),
+      );
       // the last pixel of the viewport is on screen coordinates of (200, 300)
       // for the camera, that should be: top left (10,10) + effective size
       // (100, 100) * zoom (1/2)
-      expect(game.unprojectVector(Vector2(200, 300)), Vector2.all(210));
+      expect(
+        game.projector().unprojectVector(Vector2(200, 300)),
+        Vector2.all(210),
+      );
 
       // for deltas, since the scale and the zoom cancel out, this should no-op
-      expect(game.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
+      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().unscaleVector(Vector2(1, 2)), Vector2(1, 2));
     });
     test('camera & viewport scale/zoom + translation', () {
       final viewport = FixedResolutionViewport(Vector2.all(100));
@@ -252,28 +318,37 @@ void main() {
       game.camera.zoom = 4;
       game.camera.snapTo(Vector2(50, 0));
 
-      _assertIdentityOfProjector(game);
+      _assertIdentityOfProjector(game.projector());
 
       // in the viewport space the top left of the screen would be (0, -100)
       // that means 100 screen units above the top left of the camera (50, 0)
       // each screen unit is 1/2 a viewport unit
       // each viewport unit is 1/4 of a camera unit
       // so a game unit is 1/8 the screen unit
-      expect(game.unprojectVector(Vector2.zero()), Vector2(50, -100 / 8));
+      expect(
+        game.projector().unprojectVector(Vector2.zero()),
+        Vector2(50, -100 / 8),
+      );
       // the top left of the camera (50, 0) should be at screen coordinates
       // (0, 100)
-      expect(game.unprojectVector(Vector2(0, 100)), Vector2(50, 0));
+      expect(game.projector().unprojectVector(Vector2(0, 100)), Vector2(50, 0));
       // now each unit we walk on that 200 unit square on screen equals to
       // 1/2 units on the same 100 unit square on the viewport space
       // then, given the 4x camera zoom, each viewport unit becomes 4x a
       // game unit.
-      expect(game.unprojectVector(Vector2(8, 108)), Vector2(51, 1));
-      expect(game.unprojectVector(Vector2(16, 104)), Vector2(52, 0.5));
-      expect(game.unprojectVector(Vector2(12, 112)), Vector2(51.5, 1.5));
+      expect(game.projector().unprojectVector(Vector2(8, 108)), Vector2(51, 1));
+      expect(
+        game.projector().unprojectVector(Vector2(16, 104)),
+        Vector2(52, 0.5),
+      );
+      expect(
+        game.projector().unprojectVector(Vector2(12, 112)),
+        Vector2(51.5, 1.5),
+      );
 
       // deltas only care about the effective scaling factor, which is 8x
-      expect(game.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.unscaleVector(Vector2(8, 16)), Vector2(1, 2));
+      expect(game.projector().unscaleVector(Vector2.zero()), Vector2.zero());
+      expect(game.projector().unscaleVector(Vector2(8, 16)), Vector2(1, 2));
     });
   });
 }

--- a/packages/flame_forge2d/lib/forge2d_game.dart
+++ b/packages/flame_forge2d/lib/forge2d_game.dart
@@ -60,10 +60,10 @@ class Forge2DGame extends FlameGame {
   }
 
   Vector2 worldToScreen(Vector2 position) {
-    return projector().projectVector(position);
+    return projector.projectVector(position);
   }
 
   Vector2 screenToWorld(Vector2 position) {
-    return projector().unprojectVector(position);
+    return projector.unprojectVector(position);
   }
 }

--- a/packages/flame_forge2d/lib/forge2d_game.dart
+++ b/packages/flame_forge2d/lib/forge2d_game.dart
@@ -59,6 +59,11 @@ class Forge2DGame extends FlameGame {
     _contactCallbacks.clear();
   }
 
-  Vector2 worldToScreen(Vector2 position) => projectVector(position);
-  Vector2 screenToWorld(Vector2 position) => unprojectVector(position);
+  Vector2 worldToScreen(Vector2 position) {
+    return projector().projectVector(position);
+  }
+
+  Vector2 screenToWorld(Vector2 position) {
+    return projector().unprojectVector(position);
+  }
 }


### PR DESCRIPTION
I still need to write up an example to showcase this, and maybe some test.

But hopefully this PR is a good starting point for understanding the issue.

Currently we combine both projectos on game (viewport & camera). And say that game `is a Projector`. but for hud elements we ignore that, while we would want to ignore the camera only, and still apply the viewport. So instead I make the game `has` 2 projectors, that way we can use the appropriated one when desired. also change the events to expose both (viewport only, and both). I didn't see any use to expose camera only.