### PR TITLE
Rename Hitbox mixin to HasHitboxes

### DIFF
--- a/examples/lib/stories/camera_and_viewport/follow_object.dart
+++ b/examples/lib/stories/camera_and_viewport/follow_object.dart
@@ -13,7 +13,7 @@ final R = Random();
 
 class MovableSquare extends SquareComponent
     with
-        Hitbox,
+        HasHitboxes,
         Collidable,
         HasGameRef<CameraAndViewportGame>,
         KeyboardHandler {
@@ -106,7 +106,7 @@ class Map extends Component {
   }
 }
 
-class Rock extends SquareComponent with Hitbox, Collidable, Tappable {
+class Rock extends SquareComponent with HasHitboxes, Collidable, Tappable {
   static final unpressedPaint = Paint()..color = const Color(0xFF2222FF);
   static final pressedPaint = Paint()..color = const Color(0xFF414175);
 

--- a/examples/lib/stories/collision_detection/circles.dart
+++ b/examples/lib/stories/collision_detection/circles.dart
@@ -14,7 +14,7 @@ circle both of them will change color.
 ''';
 
 class MyCollidable extends PositionComponent
-    with HasGameRef<Circles>, Hitbox, Collidable {
+    with HasGameRef<Circles>, HasHitboxes, Collidable {
   late Vector2 velocity;
   final _collisionColor = Colors.amber;
   final _defaultColor = Colors.cyan;

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -25,7 +25,7 @@ direction.
 enum Shapes { circle, rectangle, polygon }
 
 abstract class MyCollidable extends PositionComponent
-    with Draggable, Hitbox, Collidable {
+    with Draggable, HasHitboxes, Collidable {
   double rotationSpeed = 0.0;
   final Vector2 velocity;
   final delta = Vector2.zero();

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Added `StandardEffectController` class
  - Refactored `Effect` class to use `EffectController`, added `Transform2DEffect` class
  - Clarified `TimerComponent` example
+ - Rename `Hitbox` mixin to `HasHitboxes`
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/components/mixins/collidable.dart
+++ b/packages/flame/lib/src/components/mixins/collidable.dart
@@ -16,7 +16,7 @@ enum CollidableType {
   inactive,
 }
 
-mixin Collidable on Hitbox {
+mixin Collidable on HasHitboxes {
   CollidableType collidableType = CollidableType.active;
 
   void onCollision(Set<Vector2> intersectionPoints, Collidable other) {}
@@ -48,7 +48,7 @@ mixin Collidable on Hitbox {
 }
 
 class ScreenCollidable<T extends FlameGame> extends PositionComponent
-    with Hitbox, Collidable, HasGameRef<T> {
+    with HasHitboxes, Collidable, HasGameRef<T> {
   @override
   CollidableType collidableType = CollidableType.passive;
 

--- a/packages/flame/lib/src/components/mixins/hitbox.dart
+++ b/packages/flame/lib/src/components/mixins/hitbox.dart
@@ -5,7 +5,7 @@ import '../../../extensions.dart';
 import '../../geometry/shape.dart';
 import '../position_component.dart';
 
-mixin Hitbox on PositionComponent {
+mixin HasHitboxes on PositionComponent {
   final List<HitboxShape> _hitboxes = <HitboxShape>[];
 
   UnmodifiableListView<HitboxShape> get hitboxes {
@@ -42,7 +42,7 @@ mixin Hitbox on PositionComponent {
   /// Since this is a cheaper calculation than checking towards all shapes, this
   /// check can be done first to see if it even is possible that the shapes can
   /// overlap, since the shapes have to be within the size of the component.
-  bool possiblyOverlapping(Hitbox other) {
+  bool possiblyOverlapping(HasHitboxes other) {
     final maxDistance = other.scaledSize.length + scaledSize.length;
     return other.absoluteCenter.distanceToSquared(absoluteCenter) <=
         maxDistance * maxDistance;

--- a/packages/flame/test/components/collidable_type_test.dart
+++ b/packages/flame/test/components/collidable_type_test.dart
@@ -11,7 +11,7 @@ class TestGame extends FlameGame with HasCollidables {
   }
 }
 
-class TestBlock extends PositionComponent with Hitbox, Collidable {
+class TestBlock extends PositionComponent with HasHitboxes, Collidable {
   final List<Collidable> collisions = List.empty(growable: true);
 
   TestBlock(Vector2 position, Vector2 size, CollidableType type)

--- a/packages/flame/test/components/collision_callback_test.dart
+++ b/packages/flame/test/components/collision_callback_test.dart
@@ -28,7 +28,7 @@ class TestHitbox extends HitboxRectangle {
   }
 }
 
-class TestBlock extends PositionComponent with Hitbox, Collidable {
+class TestBlock extends PositionComponent with HasHitboxes, Collidable {
   final Set<Collidable> collisions = {};
   final hitbox = TestHitbox();
   int endCounter = 0;

--- a/packages/flame/test/components/mixins/has_collidable_test.dart
+++ b/packages/flame/test/components/mixins/has_collidable_test.dart
@@ -3,7 +3,7 @@ import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MyCollidable extends PositionComponent with Hitbox, Collidable {}
+class MyCollidable extends PositionComponent with HasHitboxes, Collidable {}
 
 void main() {
   group('HasCollidables', () {

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -9,7 +9,7 @@ import 'package:flame/geometry.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class MyHitboxComponent extends PositionComponent with Hitbox {}
+class MyHitboxComponent extends PositionComponent with HasHitboxes {}
 
 class MyDebugComponent extends PositionComponent {
   int? precision = 0;
@@ -101,7 +101,7 @@ void main() {
     });
 
     test('component with hitbox contains point', () {
-      final Hitbox component = MyHitboxComponent();
+      final HasHitboxes component = MyHitboxComponent();
       component.position.setValues(1.0, 1.0);
       component.anchor = Anchor.topLeft;
       component.size.setValues(2.0, 2.0);
@@ -118,7 +118,7 @@ void main() {
     });
 
     test('component with anchor topLeft contains point on edge', () {
-      final Hitbox component = MyHitboxComponent();
+      final HasHitboxes component = MyHitboxComponent();
       component.position.setValues(-1, -1);
       component.anchor = Anchor.topLeft;
       component.size.setValues(2.0, 2.0);
@@ -132,7 +132,7 @@ void main() {
     });
 
     test('component with anchor bottomRight contains point on edge', () {
-      final Hitbox component = MyHitboxComponent();
+      final HasHitboxes component = MyHitboxComponent();
       component.position.setValues(1, 1);
       component.anchor = Anchor.bottomRight;
       component.size.setValues(2.0, 2.0);
@@ -146,7 +146,7 @@ void main() {
     });
 
     test('component with anchor topRight does not contain close points', () {
-      final Hitbox component = MyHitboxComponent();
+      final HasHitboxes component = MyHitboxComponent();
       component.position.setValues(1, 1);
       component.anchor = Anchor.topLeft;
       component.size.setValues(2.0, 2.0);
@@ -160,7 +160,7 @@ void main() {
     });
 
     test('component with hitbox does not contains point', () {
-      final Hitbox component = MyHitboxComponent();
+      final HasHitboxes component = MyHitboxComponent();
       component.position.setValues(1.0, 1.0);
       component.anchor = Anchor.topLeft;
       component.size.setValues(2.0, 2.0);

--- a/packages/flame_bloc/example/lib/src/game/components/bullet.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/bullet.dart
@@ -6,7 +6,7 @@ import '../game.dart';
 import 'enemy.dart';
 
 class BulletComponent extends SpriteAnimationComponent
-    with HasGameRef<SpaceShooterGame>, Hitbox, Collidable {
+    with HasGameRef<SpaceShooterGame>, HasHitboxes, Collidable {
   static const bulletSpeed = -500;
 
   bool destroyed = false;

--- a/packages/flame_bloc/example/lib/src/game/components/enemy.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/enemy.dart
@@ -5,7 +5,7 @@ import './explosion.dart';
 import '../game.dart';
 
 class EnemyComponent extends SpriteAnimationComponent
-    with HasGameRef<SpaceShooterGame>, Hitbox, Collidable {
+    with HasGameRef<SpaceShooterGame>, HasHitboxes, Collidable {
   static const enemySpeed = 50;
 
   bool destroyed = false;

--- a/packages/flame_bloc/example/lib/src/game/components/player.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/player.dart
@@ -36,7 +36,7 @@ class PlayerController extends Component
 class PlayerComponent extends SpriteAnimationComponent
     with
         HasGameRef<SpaceShooterGame>,
-        Hitbox,
+        HasHitboxes,
         Collidable,
         KeyboardHandler,
         BlocComponent<InventoryBloc, InventoryState> {


### PR DESCRIPTION
# Description

Since you add hitboxes to a component that has the `Hitbox` mixin, it is a weird name for that mixin.
So therefore I'm renaming it to `HasHitboxes` instead, which is in line with many of our other mixins too.l

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
