### PR TITLE
Fix `HudMarginComponent` `onGameResize` bug

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Refactored `Effect` class to use `EffectController`, added `Transform2DEffect` class
  - Clarified `TimerComponent` example
  - Fix `onGameResize` margin bug in `HudMarginComponent`
+ - `PositionComponent.size` now returns a `NotifyingVector2`
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Added `StandardEffectController` class
  - Refactored `Effect` class to use `EffectController`, added `Transform2DEffect` class
  - Clarified `TimerComponent` example
+ - Fix `onGameResize` margin bug in `HudMarginComponent`
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/components/input/hud_margin_component.dart
+++ b/packages/flame/lib/src/components/input/hud_margin_component.dart
@@ -34,18 +34,8 @@ class HudMarginComponent<T extends FlameGame> extends PositionComponent
   Future<void> onLoad() async {
     super.onLoad();
     final size = gameRef.camera.viewport.effectiveSize;
-    if (margin != null) {
-      final margin = this.margin!;
-      final x = margin.left != 0
-          ? margin.left + scaledSize.x / 2
-          : size.x - margin.right - scaledSize.x / 2;
-      final y = margin.top != 0
-          ? margin.top + scaledSize.y / 2
-          : size.y - margin.bottom - scaledSize.y / 2;
-      position.setValues(x, y);
-      position =
-          Anchor.center.toOtherAnchorPosition(center, anchor, scaledSize);
-    } else {
+    // If margin is not null we will update the position `onGameResize` instead
+    if (margin == null) {
       final topLeft = size -
           anchor.toOtherAnchorPosition(
             position,
@@ -65,5 +55,25 @@ class HudMarginComponent<T extends FlameGame> extends PositionComponent
         bottomRight.y,
       );
     }
+  }
+
+  @override
+  void onGameResize(Vector2 gameSize) {
+    super.onGameResize(gameSize);
+    if (margin != null) {
+      _updateMargins(gameSize);
+    }
+  }
+
+  void _updateMargins(Vector2 gameSize) {
+    final margin = this.margin!;
+    final x = margin.left != 0
+        ? margin.left + scaledSize.x / 2
+        : gameSize.x - margin.right - scaledSize.x / 2;
+    final y = margin.top != 0
+        ? margin.top + scaledSize.y / 2
+        : gameSize.y - margin.bottom - scaledSize.y / 2;
+    position.setValues(x, y);
+    position = Anchor.center.toOtherAnchorPosition(center, anchor, scaledSize);
   }
 }

--- a/packages/flame/lib/src/components/input/hud_margin_component.dart
+++ b/packages/flame/lib/src/components/input/hud_margin_component.dart
@@ -5,6 +5,15 @@ import '../../../components.dart';
 import '../../../extensions.dart';
 import '../../../game.dart';
 
+/// The [HudMarginComponent] positions itself by a margin to the edge of the
+/// screen instead of by an absolute position on the screen or on the game, so
+/// if the game is resized the component will move to keep its margin.
+/// Note that the margin is calculated to the [Anchor], not to the edge of the
+/// component.
+///
+/// If you set the position of the component instead of a margin when
+/// initializing the component, the margin to the edge of the screen from that
+/// position will be used.
 class HudMarginComponent<T extends FlameGame> extends PositionComponent
     with HasGameRef<T> {
   @override
@@ -33,16 +42,16 @@ class HudMarginComponent<T extends FlameGame> extends PositionComponent
   @mustCallSuper
   Future<void> onLoad() async {
     super.onLoad();
-    final size = gameRef.camera.viewport.effectiveSize;
     // If margin is not null we will update the position `onGameResize` instead
     if (margin == null) {
-      final topLeft = size -
+      final screenSize = gameRef.canvasSize;
+      final topLeft = screenSize -
           anchor.toOtherAnchorPosition(
             position,
             Anchor.topLeft,
             scaledSize,
           );
-      final bottomRight = size -
+      final bottomRight = screenSize -
           anchor.toOtherAnchorPosition(
             position,
             Anchor.bottomRight,
@@ -54,26 +63,31 @@ class HudMarginComponent<T extends FlameGame> extends PositionComponent
         bottomRight.x,
         bottomRight.y,
       );
+    } else {
+      size.addListener(_updateMargins);
     }
+    _updateMargins();
   }
 
   @override
   void onGameResize(Vector2 gameSize) {
     super.onGameResize(gameSize);
-    if (margin != null) {
-      _updateMargins(gameSize);
+    if (isMounted) {
+      _updateMargins();
     }
   }
 
-  void _updateMargins(Vector2 gameSize) {
+  void _updateMargins() {
+    final screenSize = gameRef.canvasSize;
     final margin = this.margin!;
     final x = margin.left != 0
         ? margin.left + scaledSize.x / 2
-        : gameSize.x - margin.right - scaledSize.x / 2;
+        : screenSize.x - margin.right - scaledSize.x / 2;
     final y = margin.top != 0
         ? margin.top + scaledSize.y / 2
-        : gameSize.y - margin.bottom - scaledSize.y / 2;
+        : screenSize.y - margin.bottom - scaledSize.y / 2;
     position.setValues(x, y);
-    position = Anchor.center.toOtherAnchorPosition(center, anchor, scaledSize);
+    position =
+        Anchor.center.toOtherAnchorPosition(position, anchor, scaledSize);
   }
 }

--- a/packages/flame/lib/src/components/input/hud_margin_component.dart
+++ b/packages/flame/lib/src/components/input/hud_margin_component.dart
@@ -8,6 +8,7 @@ import '../../../game.dart';
 /// The [HudMarginComponent] positions itself by a margin to the edge of the
 /// screen instead of by an absolute position on the screen or on the game, so
 /// if the game is resized the component will move to keep its margin.
+///
 /// Note that the margin is calculated to the [Anchor], not to the edge of the
 /// component.
 ///

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -144,7 +144,7 @@ class PositionComponent extends Component {
   /// This property can be reassigned at runtime, although this is not
   /// recommended. Instead, in order to make the [PositionComponent] larger
   /// or smaller, change its [scale].
-  Vector2 get size => _size;
+  NotifyingVector2 get size => _size;
   set size(Vector2 size) => _size.setFrom(size);
 
   /// The width of the component in local coordinates. Note that the object

--- a/packages/flame/test/components/hud_margin_component_test.dart
+++ b/packages/flame/test/components/hud_margin_component_test.dart
@@ -1,0 +1,36 @@
+import 'package:flame/game.dart';
+import 'package:flame/input.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  group('HudMarginComponent test', () {
+    flameTest<FlameGame>(
+      'position set from margin should change onGameResize',
+      createGame: () => FlameGame(),
+      verify: (game) async {
+        final marginComponent = HudMarginComponent(
+          margin: const EdgeInsets.only(right: 10, bottom: 20),
+          size: Vector2.all(20),
+        );
+        await game.add(marginComponent);
+        game.update(0);
+        // The position should be (470, 460) since the game size is (500, 500)
+        // and the component has its anchor in the top left corner (which then
+        // is were the margin will be calculated from).
+        // (500, 500) - size(20, 20) - position(10, 20) = (470, 460)
+        expectVector2(marginComponent.position, Vector2(470.0, 460.0));
+        game.onGameResize(Vector2.all(1000));
+        game.update(0);
+        // After resizing the game, the component should still be 30 pixels from
+        // the right edge and 40 pixels from the bottom.
+        expectVector2(marginComponent.position, Vector2(970.0, 960.0));
+        // After the size of the component is changed the position is also
+        // changed.
+        marginComponent.size.add(Vector2.all(10));
+        expectVector2(marginComponent.position, Vector2(960.0, 950.0));
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Description

Before the position was only updated from the margin on creation, so when the window was resized the buttons didn't keep the margin to the right/bottom if they had that set.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
