### PR TITLE
Possibility to manually remove `TimerComponent`

### DIFF
--- a/examples/lib/stories/utils/timer_component.dart
+++ b/examples/lib/stories/utils/timer_component.dart
@@ -12,7 +12,11 @@ class RenderedTimeComponent extends TimerComponent {
 
   final double yOffset;
 
-  RenderedTimeComponent(Timer timer, {this.yOffset = 150}) : super(timer);
+  RenderedTimeComponent(Timer timer, {this.yOffset = 150})
+      : super(
+          timer,
+          removeOnFinish: true,
+        );
 
   @override
   void render(Canvas canvas) {

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Added `StandardEffectController` class
  - Refactored `Effect` class to use `EffectController`, added `Transform2DEffect` class
  - Clarified `TimerComponent` example
+ - Possibility to manually remove `TimerComponent`
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/timer.dart
+++ b/packages/flame/lib/src/timer.dart
@@ -46,24 +46,29 @@ class Timer {
     }
   }
 
+  /// Start the timer from 0.
   void start() {
     reset();
     resume();
   }
 
+  /// Stop and reset the timer.
   void stop() {
     reset();
     pause();
   }
 
+  /// Reset the timer to 0, but continue running if it currently is running.
   void reset() {
     _current = 0;
   }
 
+  ///  Pause the timer (no-op if it is already paused).
   void pause() {
     _running = false;
   }
 
+  /// Resume a paused timer (no-op if it is already running).
   void resume() {
     _running = true;
   }

--- a/packages/flame/lib/src/timer.dart
+++ b/packages/flame/lib/src/timer.dart
@@ -47,13 +47,17 @@ class Timer {
   }
 
   void start() {
-    _current = 0;
-    _running = true;
+    reset();
+    resume();
   }
 
   void stop() {
+    reset();
+    pause();
+  }
+
+  void reset() {
     _current = 0;
-    _running = false;
   }
 
   void pause() {
@@ -69,15 +73,16 @@ class Timer {
 /// used inside a FlameGame game.
 class TimerComponent extends Component {
   Timer timer;
+  final bool removeOnFinish;
 
-  TimerComponent(this.timer);
+  TimerComponent(this.timer, {this.removeOnFinish = false});
 
   @override
   void update(double dt) {
     super.update(dt);
     timer.update(dt);
+    if (removeOnFinish && timer.finished) {
+      removeFromParent();
+    }
   }
-
-  @override
-  bool get shouldRemove => timer.finished;
 }


### PR DESCRIPTION
# Description

Since `shouldRemove` was overridden it wasn't possible to manually remove the component.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [xj] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [ ] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
