### PR TITLE
Adding CustomPainterComponent

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -494,13 +494,13 @@ for details on how to use it.
 
 ## CustomPainterComponent
 
-A `CustomPainter` is a useful Flutter class used with the `CustomPaint` widget to render custom
+A `CustomPainter` is a Flutter class used with the `CustomPaint` widget to render custom
 shapes inside a Flutter application.
 
 Flame provides a component that can render a `CustomPainter` called `CustomPainterComponent`, it
-receives a custom painter and just render it on the game canvas.
+receives a custom painter and renders it on the game canvas.
 
-This can be useful for sharing custom rendering logic between your Flame game, and your Flutter
+This can be used for sharing custom rendering logic between your Flame game, and your Flutter
 widgets.
 
 Check the example app

--- a/doc/components.md
+++ b/doc/components.md
@@ -492,6 +492,21 @@ Check the example app
 [nine_tile_box](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/utils/nine_tile_box.dart)
 for details on how to use it.
 
+## CustomPainterComponent
+
+A `CustomPainter` is a useful Flutter class used with the `CustomPaint` widget to render custom
+shapes inside a Flutter application.
+
+Flame provides a component that can render a `CustomPainter` called `CustomPainterComponent`, it
+receives a custom painter and just render it on the game canvas.
+
+This can be useful for sharing custom rendering logic between your Flame game, and your Flutter
+widgets.
+
+Check the example app
+[custom_painter_component](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/widgets/custom_painter_component.dart)
+for details on how to use it.
+
 ## Effects
 
 Flame provides a set of effects that can be applied to a certain type of components, these effects

--- a/examples/lib/stories/widgets/custom_painter_component.dart
+++ b/examples/lib/stories/widgets/custom_painter_component.dart
@@ -1,0 +1,137 @@
+import 'package:dashbook/dashbook.dart';
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame/input.dart';
+import 'package:flutter/material.dart';
+
+Widget customPainterBuilder(DashbookContext ctx) {
+  return GameWidget(
+    game: CustomPainterGame(),
+    overlayBuilderMap: {
+      'HappyFace': (context, game) {
+        return Center(
+          child: Container(
+            color: Colors.white,
+            width: 200,
+            height: 200,
+            child: Column(
+              children: [
+                const Text(
+                  'Hey, I can be a widget too!',
+                  style: TextStyle(
+                    color: Colors.black,
+                  ),
+                ),
+                const SizedBox(height: 32),
+                SizedBox(
+                  height: 132,
+                  width: 132,
+                  child: CustomPaint(painter: PlayerCustomPainter()),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    },
+  );
+}
+
+class PlayerCustomPainter extends CustomPainter {
+  late final facePaint = Paint()..color = Colors.yellow;
+
+  late final eyesPaint = Paint()..color = Colors.black;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final faceRadius = size.height / 2;
+
+    canvas.drawCircle(
+      Offset(
+        faceRadius,
+        faceRadius,
+      ),
+      faceRadius,
+      facePaint,
+    );
+
+    final eyeSize = faceRadius * 0.15;
+
+    canvas.drawCircle(
+      Offset(
+        faceRadius - (eyeSize * 2),
+        faceRadius - eyeSize,
+      ),
+      eyeSize,
+      eyesPaint,
+    );
+
+    canvas.drawCircle(
+      Offset(
+        faceRadius + (eyeSize * 2),
+        faceRadius - eyeSize,
+      ),
+      eyeSize,
+      eyesPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return false;
+  }
+}
+
+class Player extends CustomPainterComponent with HasGameRef<CustomPainterGame> {
+  static const speed = 150;
+
+  int direction = 1;
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+
+    painter = PlayerCustomPainter();
+    size = Vector2.all(100);
+
+    y = 200;
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+
+    x += speed * direction * dt;
+
+    if ((x + width >= gameRef.size.x && direction > 0) ||
+        (x <= 0 && direction < 0)) {
+      direction *= -1;
+    }
+  }
+}
+
+class CustomPainterGame extends FlameGame with TapDetector {
+  static const info = '''
+      Example demonstration how to use the CustomPainterComponent.
+
+      On the screen you can see a component using a custom painter being
+      rendered on a FlameGame, and if you tap, that same painter is used to
+      show the happy face on a widget overlay.
+  ''';
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+
+    add(Player());
+  }
+
+  @override
+  void onTap() {
+    if (overlays.isActive('HappyFace')) {
+      overlays.remove('HappyFace');
+    } else {
+      overlays.add('HappyFace');
+    }
+  }
+}

--- a/examples/lib/stories/widgets/widgets.dart
+++ b/examples/lib/stories/widgets/widgets.dart
@@ -1,6 +1,7 @@
 import 'package:dashbook/dashbook.dart';
 
 import '../../commons/commons.dart';
+import 'custom_painter_component.dart';
 import 'nine_tile_box.dart';
 import 'overlay.dart';
 import 'sprite_animation_widget.dart';
@@ -40,5 +41,11 @@ void addWidgetsStories(Dashbook dashbook) {
       'Overlay',
       overlayBuilder,
       codeLink: baseLink('widgets/overlay.dart'),
+    )
+    ..add(
+      'CustomPainterComponent',
+      customPainterBuilder,
+      codeLink: baseLink('widgets/custom_painter_component.dart'),
+      info: CustomPainterGame.info,
     );
 }

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Added `StandardEffectController` class
  - Refactored `Effect` class to use `EffectController`, added `Transform2DEffect` class
  - Clarified `TimerComponent` example
+ - Add `CustomPainterComponent`
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/components.dart
+++ b/packages/flame/lib/components.dart
@@ -1,6 +1,7 @@
 export 'src/anchor.dart';
 export 'src/components/component.dart';
 export 'src/components/component_set.dart';
+export 'src/components/custom_painter_component.dart';
 export 'src/components/input/joystick_component.dart';
 export 'src/components/isometric_tile_map_component.dart';
 export 'src/components/mixins/collidable.dart';

--- a/packages/flame/lib/src/components/custom_painter_component.dart
+++ b/packages/flame/lib/src/components/custom_painter_component.dart
@@ -8,15 +8,18 @@ import 'position_component.dart';
 /// angle.
 ///
 /// This component is usefull to [CustomPainter]s between your Flutter UI and Flame game.
+///
+/// Note that given the active rendering nature of a game, `shouldRepaint` is ignored by
+/// this component.
 class CustomPainterComponent extends PositionComponent {
   /// The [CustomPainter] used to render this component
   CustomPainter? painter;
 
   CustomPainterComponent({
+    this.painter,
     Vector2? position,
     Vector2? size,
     int? priority,
-    this.painter,
   }) : super(
           position: position,
           size: size,

--- a/packages/flame/lib/src/components/custom_painter_component.dart
+++ b/packages/flame/lib/src/components/custom_painter_component.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart';
+
+import '../extensions/vector2.dart';
+import 'position_component.dart';
+
+/// A [PositionComponent] that renders a [CustomPainter] at the designated
+/// position, scaled to have the designated size and rotated to the specified
+/// angle.
+///
+/// This component is usefull to [CustomPainter]s between your Flutter UI and Flame game.
+class CustomPainterComponent extends PositionComponent {
+  /// The [CustomPainter] used to render this component
+  CustomPainter? painter;
+
+  CustomPainterComponent({
+    Vector2? position,
+    Vector2? size,
+    int? priority,
+    this.painter,
+  }) : super(
+          position: position,
+          size: size,
+          priority: priority,
+        );
+
+  @override
+  @mustCallSuper
+  void render(Canvas canvas) {
+    super.render(canvas);
+
+    painter?.paint(canvas, size.toSize());
+  }
+}

--- a/packages/flame/test/components/custom_painter_component_test.dart
+++ b/packages/flame/test/components/custom_painter_component_test.dart
@@ -1,0 +1,21 @@
+import 'package:canvas_test/canvas_test.dart';
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockCustomPainter extends Mock implements CustomPainter {}
+
+void main() {
+  test('correctly calls the paint method of the painter', () {
+    final painter = MockCustomPainter();
+    final component = CustomPainterComponent(
+      painter: painter,
+    )..size = Vector2.all(100);
+
+    final canvas = MockCanvas();
+    component.render(canvas);
+
+    verify(() => painter.paint(canvas, const Size(100, 100)));
+  });
+}


### PR DESCRIPTION
# Description

Adds `CustomPainterComponent`, a component which can help sharing custom rendering logic between Flutter widgets and a Flame game.


https://user-images.githubusercontent.com/835641/139759709-b3b252b9-607c-4cb2-919d-9a9fc008d14e.mov



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

Solves: #1028 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
