### PR TITLE
Rename Hitbox -> HasHitboxes in the docs

### DIFF
--- a/doc/collision_detection.md
+++ b/doc/collision_detection.md
@@ -31,27 +31,29 @@ being called with a large delta time (for example if your app is not in the fore
 behaviour is called tunneling, if you want to read more about it.
 
 ## Mixins
-### Hitbox
-The `Hitbox` mixin is mainly used for two things; to make detection of collisions with other
+### HasHitboxes
+The `HasHitboxes` mixin is mainly used for two things; to make detection of collisions with other
 hitboxes and to more accurately recognize gestures on top of your `PositionComponent`s. Say that you
 have a fairly round rock as a `SpriteComponent` for example, then you don't want to register input
 that is in the corner of the image where the rock is not displayed, since an image is always
-rectangular. Then you can use the `Hitbox` mixin to define a more accurate polygon (or another
+rectangular. Then you can use the `HasHitboxes` mixin to define a more accurate polygon (or another
 shape) for which the input should be within for the event to be registered on your component.
 
-You can add new shapes to the `Hitbox` just like they are added in the below `Collidable` example.
+You can add new shapes to the `HasHitboxes` just like they are added in the below `Collidable`
+example.
 
 ### Collidable
-The `Collidable` mixin is added to a `PositionComponent` that has a `HitBox` and it is used for
-detecting collisions with other `Collidable`s. If you do not add a shape to your `Hitbox` component
-it will never collide with anything. If you want the component to have a default rectangular shape
-that fills the size of your component you can simply do `addHitbox(HitboxRectangle())`.
+The `Collidable` mixin is added to a `PositionComponent` that has a `HasHitboxes` and it is used for
+detecting collisions with other `Collidable`s. If you do not add a shape to your `HasHitboxes` 
+component it will never collide with anything. If you want the component to have a default 
+rectangular shape that fills the size of your component you can simply do 
+`addHitbox(HitboxRectangle())`.
 
 To make your component collidable you would start off something like this:
 
 ```dart
-class MyCollidable extends PositionComponent with Hitbox, Collidable {
-  MyCollidable (
+class MyCollidable extends PositionComponent with HasHitboxes, Collidable {
+  MyCollidable() {
     // This could also be done in onLoad instead of in the constructor
     final shape = HitboxPolygon([
       Vector2(0, 1),
@@ -75,7 +77,7 @@ To react to a collision you should override the `collisionCallback` in your comp
 Example:
 
 ```dart
-class MyCollidable extends PositionComponent with Hitbox, Collidable {
+class MyCollidable extends PositionComponent with HasHitboxes, Collidable {
   ...
 
   @override
@@ -139,7 +141,7 @@ to your game so that the game knows that it should keep track of which component
 Example:
 ```dart
 class MyGame extends FlameGame with HasCollidables {
-  ...
+  // ...
 }
 ```
 
@@ -168,8 +170,8 @@ There are currently three shapes: [Polygon](#Polygon), [Rectangle](#Rectangle) a
 A `HitboxShape` is a `Shape` defined from the center position of the component that it is attached
 to and it has the same bounding size and angle as the component. You can set `localPosition` to have
 the position of the shape deviate from the center of the component. A `HitboxShape` is the type of
-shape that you add to your `Hitbox`, or `Collidable`. Usually these types of shapes are the only
-ones that you need to use.
+shape that you add to your `HasHitboxes`, or `Collidable`. Usually these types of shapes are the
+only ones that you need to use.
 
 #### HitboxPolygon
 It should be noted that if you want to use collision detection or `containsPoint` on the `Polygon`,

--- a/doc/gesture-input.md
+++ b/doc/gesture-input.md
@@ -326,14 +326,12 @@ The provided event info is from the mouse move that triggered the action (enteri
 While the mouse movement is kept inside or outside, no events are fired and those mouse move events are
 not propagated. Only when the state is changed the handlers are triggered.
 
-## Hitbox
-The `Hitbox` mixin is used to make detection of gestures on top of your `PositionComponent`s more
-accurate. Say that you have a fairly round rock as a `SpriteComponent` for example, then you don't
-want to register input that is in the corner of the image where the rock is not displayed. Then you
-can use the `Hitbox` mixin to define a more accurate polygon for which the input should be within
-for the event to be counted on your component.
+## HasHitboxes
+The `HasHitboxes` mixin is used to make detection of gestures on top of your `PositionComponent`s 
+more accurate. Say that you have a fairly round rock as a `SpriteComponent` for example, then you 
+don't want to register input that is in the corner of the image where the rock is not displayed. 
+Then you can use the `HasHitboxes` mixin to define a more accurate polygon for which the input 
+should be within for the event to be counted on your component.
 
 An example of you to use it can be seen
 [here](https://github.com/flame-engine/flame/tree/main/examples/lib/stories/).
-
-

--- a/packages/flame/lib/src/components/mixins/collidable.dart
+++ b/packages/flame/lib/src/components/mixins/collidable.dart
@@ -40,8 +40,8 @@ mixin Collidable on HasHitboxes {
       final parentGame = findParent<FlameGame>();
       assert(
         parentGame is HasCollidables,
-        'You can only use the Hitbox/Collidable feature with games that has '
-        'the HasCollidables mixin',
+        'You can only use the HasHitboxes/Collidable feature with games that '
+        'has the HasCollidables mixin',
       );
     }
   }

--- a/packages/flame/test/components/mixins/has_collidable_test.dart
+++ b/packages/flame/test/components/mixins/has_collidable_test.dart
@@ -12,8 +12,8 @@ void main() {
       createGame: () => FlameGame(),
       verify: (game) {
         const message =
-            'You can only use the Hitbox/Collidable feature with games that has '
-            'the HasCollidables mixin';
+            'You can only use the HasHitboxes/Collidable feature with games '
+            'that has the HasCollidables mixin';
         expect(
           () => game.add(MyCollidable()),
           throwsA(


### PR DESCRIPTION
# Description

Following #1060, this PR fixes the remaining cases where the name `Hitbox` was still used in the docs / error messages.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.
