### PR TITLE
`ShapeComponent` and `Hitbox` to take transform of parents full ancestor tree into consideration

### DIFF
--- a/doc/collision_detection.md
+++ b/doc/collision_detection.md
@@ -30,6 +30,9 @@ that overshoot each other into account, this could happen when they either move 
 being called with a large delta time (for example if your app is not in the foreground). This
 behaviour is called tunneling, if you want to read more about it.
 
+Also note that the collision detection system doesn't work properly if you scale ancestors of the
+component that is `Collidable`.
+
 ## Mixins
 ### HasHitboxes
 The `HasHitboxes` mixin is mainly used for two things; to make detection of collisions with other

--- a/doc/components.md
+++ b/doc/components.md
@@ -442,7 +442,7 @@ final circle = CircleComponent(radius: 200.0, position: Vector2(100, 200), paint
 
 ### RectangleComponent
 A `RectangleComponent` can be created in two ways, depending on if it is a square or not.
-To create a `RectangleComponent` that is 300px wide and 200px in height you can do the following:
+To create a `RectangleComponent` that is 300 in width and 200 in height you can do the following:
 
 Example:
 ```dart
@@ -456,7 +456,7 @@ final rectangle = RectangleComponent(
 
 To create a square you can instead use the slightly simpler named constructor
 `RectangleComponent.square`. This is an example of how to create a red square with width and height
-200px:
+200:
 
 ```dart
 final paint = BasicPalette.red.paint()..style = PaintingStyle.stroke;

--- a/doc/components.md
+++ b/doc/components.md
@@ -431,7 +431,7 @@ the shape of the specific component, it also takes all the arguments that can be
 `PositionComponent`.
 
 ### CircleComponent
-A `CircleComponent` can be created only defining it's `radius`, but you most likely want to pass it
+A `CircleComponent` can be created only by defining its `radius`, but you most likely want to pass it
 a `position` and maybe `paint` (the default is white) too.
 
 Example:

--- a/doc/components.md
+++ b/doc/components.md
@@ -424,7 +424,7 @@ Three example implementations can be found in the
 
 ## ShapeComponents
 
-There exists three basic components which can be used if you want to draw geometrical shapes as
+There exist three basic components that can be used if you want to draw geometrical shapes as
 components on the screen. Since the `ShapeComponent`s are `PositionComponent`s you can use effects
 on them. All `ShapeComponent`s take a `Paint` as an argument and then arguments to define
 the shape of the specific component, it also takes all the arguments that can be passed to the

--- a/doc/components.md
+++ b/doc/components.md
@@ -441,7 +441,7 @@ final circle = CircleComponent(radius: 200.0, position: Vector2(100, 200), paint
 ```
 
 ### RectangleComponent
-A `RectangleComponent` can be created in two ways, depending on if it is a square or not.
+A `RectangleComponent` can be created in two ways, depending on if it's a square or not.
 To create a `RectangleComponent` that is 300 in width and 200 in height you can do the following:
 
 Example:

--- a/doc/components.md
+++ b/doc/components.md
@@ -422,6 +422,99 @@ It is also possible to create custom renderers by extending the `ParallaxRendere
 Three example implementations can be found in the
 [examples directory](https://github.com/flame-engine/flame/tree/main/examples/lib/stories/parallax).
 
+## ShapeComponents
+
+There exists three basic components which can be used if you want to draw geometrical shapes as
+components on the screen. Since the `ShapeComponent`s are `PositionComponent`s you can use effects
+on them. All `ShapeComponent`s take a `Paint` as an argument and then arguments to define
+the shape of the specific component, it also takes all the arguments that can be passed to the
+`PositionComponent`.
+
+### CircleComponent
+A `CircleComponent` can be created only defining it's `radius`, but you most likely want to pass it
+a `position` and maybe `paint` (the default is white) too.
+
+Example:
+```dart
+final paint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
+final circle = CircleComponent(radius: 200.0, position: Vector2(100, 200), paint: paint);
+```
+
+### RectangleComponent
+A `RectangleComponent` can be created in two ways, depending on if it is a square or not.
+To create a `RectangleComponent` that is 300px wide and 200px in height you can do the following:
+
+Example:
+```dart
+final paint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
+final rectangle = RectangleComponent(
+  size: Vector2(300.0, 200.0),
+  position: Vector2(100, 200),
+  paint: paint,
+);
+```
+
+To create a square you can instead use the slightly simpler named constructor
+`RectangleComponent.square`. This is an example of how to create a red square with width and height
+200px:
+
+```dart
+final paint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
+final square = RectangleComponent.square(
+  size: 200.0,
+  position: Vector2(100, 200),
+  paint: paint,
+);
+```
+
+### PolygonComponent
+The `PolygonComponent` is the most complicated of the `ShapeComponent`s since you'll have to define
+all the "corners" of your polygon. You can create the `PolygonComponent` in two different ways,
+either you use the default constructor which takes a list of `Vector2` where each of them should be
+between -1.0 and 1.0 that describes the ration of the length from the center to the edge of the size
+of the component. So
+`[Vector2(1.0, 1.0), Vector2(1.0, -1.0), Vector2(-1.0, -1.0), Vector2(-1.0, 1.0)]`
+would describe a rectangle that fills the full size of the component. Remember to define the list in
+a counter clockwise manner (if you think in the screen coordinate system where the y-axis is
+flipped, otherwise it is clockwise).
+
+So to create a diamond shaped `PolygonComponent` which is slightly smaller than the defined size you
+would do this:
+
+```dart
+final vertices = ([
+  Vector2(0.0, 0.9),  // Middle of top wall
+  Vector2(-0.9, 0.0), // Middle of left wall
+  Vector2(0.0, -0.9), // Middle of bottom wall
+  Vector2(0.9, 0.0),  // Middle of right wall
+]);
+
+final diamond = PolygonComponent(
+  normalizedVertices: vertices,
+  size: Vector2(200, 300),
+  position: Vector2.all(500),
+)
+```
+
+If you instead want to define your polygon from absolute points you can do that too with the
+`PolygonComponent.fromPoints` factory. When using that one you don't have to define a `size` or a
+`position` either since it will be calculated for you, but if you decide to add those arguments
+anyways they will override what has been calculated from your list of vertices.
+
+Example (diamond shape again):
+
+```dart
+final vertices = ([
+  Vector2(100, 100),  // Middle of top wall
+  Vector2(50, 150), // Middle of left wall
+  Vector2(100, 200), // Middle of bottom wall
+  Vector2(200, 150),  // Middle of right wall
+]);
+
+final diamond = PolygonComponent.fromPoints(vertices);
+)
+```
+
 ## SpriteBodyComponent
 
 See [SpriteBodyComponent](forge2d.md#SpriteBodyComponent) in the Forge2D documentation.

--- a/doc/components.md
+++ b/doc/components.md
@@ -423,12 +423,13 @@ Three example implementations can be found in the
 [examples directory](https://github.com/flame-engine/flame/tree/main/examples/lib/stories/parallax).
 
 ## ShapeComponents
-
-There exist three basic components that can be used if you want to draw geometrical shapes as
-components on the screen. Since the `ShapeComponent`s are `PositionComponent`s you can use effects
-on them. All `ShapeComponent`s take a `Paint` as an argument and then arguments to define
+The `ShapeComponent` is a basic component that can be used if you want to draw geometrical shapes as
+components on the screen.  Since the `ShapeComponent` is a `PositionComponent`s you can use effects
+on it. All `ShapeComponent`s take a `Paint` as an argument and then arguments to define
 the shape of the specific component, it also takes all the arguments that can be passed to the
 `PositionComponent`.
+
+There are three implementations of `ShapeComponent`, which are the following:
 
 ### CircleComponent
 A `CircleComponent` can be created only by defining its `radius`, but you most likely want to pass it

--- a/doc/text.md
+++ b/doc/text.md
@@ -10,45 +10,32 @@ and create a custom way to render text.
 
 ## TextPaint
 
-A `TextPaint` is the built in implementation of text rendering in Flame, it is based on top of
-Flutter's `TextPainter` class (hence the name), it can be configured by the style class `TextStyle`
-which contains all typographical information required to render text; i.e., font size and color,
-font family, etc.
+A Text Paint is the built in implementation of text rendering on Flame, it is based on top of
+Flutter's `TextPainter` class (hence the name), it can be configured by its config class
+`TextPaintConfig` which contains all typographical information required to render text; i.e., font
+size and color, family, etc.
 
 Example usage:
 
 ```dart
 const TextPaint textPaint = TextPaint(
-  style: TextStyle(
+  config: TextPaintConfig(
     fontSize: 48.0,
     fontFamily: 'Awesome Font',
   ),
 );
 ```
 
-Note: there are several packages that contain the class `TextStyle`, make sure that you import
-either `package:flutter/material.dart` or `package:flutter/painting.dart` and if you also need to
-import `dart:ui` you need to import it like this (since that contains another class that is also
-named `TextStyle`):
-
-```dart
-import 'dart:ui' hide TextStyle;
-```
-
-Some common properties of `TextStyle` are the following (here is the
-[full list](https://api.flutter.dev/flutter/painting/TextStyle-class.html)):
-
  - `fontFamily`: a commonly available font, like Arial (default), or a custom font added in your
  pubspec (see [here](https://flutter.io/custom-fonts/) how to do it).
  - `fontSize`: font size, in pts (default `24.0`).
- - `height`: height of text line, as a multiple of font size (default `null`).
- - `color`: the color, as a `ui.Color` (default white).
+ - `lineHeight`: height of text line, as a multiple of font size (default `null`).
+ - `color`: the color, as a `ui.Color` (default black).
 
 For more information regarding colors and how to create then, see the
 [Colors and the Palette](palette.md) guide.
 
-After the creation of the `TextPaint` object you can use its `render` method to draw some string on
-a canvas:
+After the creation of the text paint you can use its `render` method to draw some string on a canvas:
 
 ```dart
 textPaint.render(canvas, "Flame is awesome", Vector2(10, 10));
@@ -73,8 +60,7 @@ Flame provides two text components that make it even easier to render text in yo
 Example usage:
 
 ```dart
-TextStyle style = TextStyle(color: BasicPalette.white.color);
-TextPaint regular = TextPaint(style: style);
+TextPaint regular = TextPaint(color: BasicPalette.white.color);
 
 class MyGame extends FlameGame {
   @override

--- a/doc/text.md
+++ b/doc/text.md
@@ -10,32 +10,45 @@ and create a custom way to render text.
 
 ## TextPaint
 
-A Text Paint is the built in implementation of text rendering on Flame, it is based on top of
-Flutter's `TextPainter` class (hence the name), it can be configured by its config class
-`TextPaintConfig` which contains all typographical information required to render text; i.e., font
-size and color, family, etc.
+A `TextPaint` is the built in implementation of text rendering in Flame, it is based on top of
+Flutter's `TextPainter` class (hence the name), it can be configured by the style class `TextStyle`
+which contains all typographical information required to render text; i.e., font size and color,
+font family, etc.
 
 Example usage:
 
 ```dart
 const TextPaint textPaint = TextPaint(
-  config: TextPaintConfig(
+  style: TextStyle(
     fontSize: 48.0,
     fontFamily: 'Awesome Font',
   ),
 );
 ```
 
+Note: there are several packages that contain the class `TextStyle`, make sure that you import
+either `package:flutter/material.dart` or `package:flutter/painting.dart` and if you also need to
+import `dart:ui` you need to import it like this (since that contains another class that is also
+named `TextStyle`):
+
+```dart
+import 'dart:ui' hide TextStyle;
+```
+
+Some common properties of `TextStyle` are the following (here is the
+[full list](https://api.flutter.dev/flutter/painting/TextStyle-class.html)):
+
  - `fontFamily`: a commonly available font, like Arial (default), or a custom font added in your
  pubspec (see [here](https://flutter.io/custom-fonts/) how to do it).
  - `fontSize`: font size, in pts (default `24.0`).
- - `lineHeight`: height of text line, as a multiple of font size (default `null`).
- - `color`: the color, as a `ui.Color` (default black).
+ - `height`: height of text line, as a multiple of font size (default `null`).
+ - `color`: the color, as a `ui.Color` (default white).
 
 For more information regarding colors and how to create then, see the
 [Colors and the Palette](palette.md) guide.
 
-After the creation of the text paint you can use its `render` method to draw some string on a canvas:
+After the creation of the `TextPaint` object you can use its `render` method to draw some string on
+a canvas:
 
 ```dart
 textPaint.render(canvas, "Flame is awesome", Vector2(10, 10));
@@ -60,7 +73,8 @@ Flame provides two text components that make it even easier to render text in yo
 Example usage:
 
 ```dart
-TextPaint regular = TextPaint(color: BasicPalette.white.color);
+TextStyle style = TextStyle(color: BasicPalette.white.color);
+TextPaint regular = TextPaint(style: style);
 
 class MyGame extends FlameGame {
   @override

--- a/examples/lib/commons/square_component.dart
+++ b/examples/lib/commons/square_component.dart
@@ -10,8 +10,8 @@ class SquareComponent extends RectangleComponent with EffectsHelper {
     Paint? paint,
     int priority = 0,
   }) : super(
-          size: Vector2.all(size),
           position: position,
+          size: Vector2.all(size),
           paint: paint,
           priority: priority,
         );

--- a/examples/lib/commons/square_component.dart
+++ b/examples/lib/commons/square_component.dart
@@ -10,7 +10,7 @@ class SquareComponent extends RectangleComponent with EffectsHelper {
     Paint? paint,
     int priority = 0,
   }) : super(
-          Vector2.all(size),
+          size: Vector2.all(size),
           position: position,
           paint: paint,
           priority: priority,

--- a/examples/lib/stories/camera_and_viewport/follow_object.dart
+++ b/examples/lib/stories/camera_and_viewport/follow_object.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
-import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -12,11 +11,7 @@ import '../../commons/square_component.dart';
 final R = Random();
 
 class MovableSquare extends SquareComponent
-    with
-        HasHitboxes,
-        Collidable,
-        HasGameRef<CameraAndViewportGame>,
-        KeyboardHandler {
+    with Collidable, HasGameRef<CameraAndViewportGame>, KeyboardHandler {
   static const double speed = 300;
   static final TextPaint textRenderer = TextPaint(
     config: const TextPaintConfig(
@@ -27,8 +22,11 @@ class MovableSquare extends SquareComponent
   final Vector2 velocity = Vector2.zero();
   late Timer timer;
 
-  MovableSquare() : super(priority: 1) {
-    addHitbox(HitboxRectangle());
+  MovableSquare() : super(priority: 1);
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
     timer = Timer(3.0)
       ..stop()
       ..callback = () {
@@ -104,7 +102,7 @@ class Map extends Component {
   }
 }
 
-class Rock extends SquareComponent with HasHitboxes, Collidable, Tappable {
+class Rock extends SquareComponent with Collidable, Tappable {
   static final unpressedPaint = Paint()..color = const Color(0xFF2222FF);
   static final pressedPaint = Paint()..color = const Color(0xFF414175);
 
@@ -114,9 +112,7 @@ class Rock extends SquareComponent with HasHitboxes, Collidable, Tappable {
           size: 50,
           priority: 2,
           paint: unpressedPaint,
-        ) {
-    addHitbox(HitboxRectangle());
-  }
+        );
 
   @override
   bool onTapDown(_) {

--- a/examples/lib/stories/collision_detection/circles.dart
+++ b/examples/lib/stories/collision_detection/circles.dart
@@ -7,12 +7,6 @@ import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
 import 'package:flutter/material.dart' hide Image, Draggable;
 
-const circlesInfo = '''
-This example will create a circle every time you tap on the screen. It will have
-the initial velocity towards the center of the screen and if it touches another
-circle both of them will change color.
-''';
-
 class MyCollidable extends PositionComponent
     with HasGameRef<Circles>, HasHitboxes, Collidable {
   late Vector2 velocity;
@@ -65,6 +59,12 @@ class MyCollidable extends PositionComponent
 }
 
 class Circles extends FlameGame with HasCollidables, TapDetector {
+  static const description = '''
+    This example will create a circle every time you tap on the screen. It will
+    have the initial velocity towards the center of the screen and if it touches
+    another circle both of them will change color.
+  ''';
+
   @override
   Future<void> onLoad() async {
     super.onLoad();

--- a/examples/lib/stories/collision_detection/circles.dart
+++ b/examples/lib/stories/collision_detection/circles.dart
@@ -7,6 +7,25 @@ import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
 import 'package:flutter/material.dart' hide Image, Draggable;
 
+class Circles extends FlameGame with HasCollidables, TapDetector {
+  static const description = '''
+    This example will create a circle every time you tap on the screen. It will
+    have the initial velocity towards the center of the screen and if it touches
+    another circle both of them will change color.
+  ''';
+
+  @override
+  Future<void> onLoad() async {
+    super.onLoad();
+    add(ScreenCollidable());
+  }
+
+  @override
+  void onTapDown(TapDownInfo info) {
+    add(MyCollidable(info.eventPosition.game));
+  }
+}
+
 class MyCollidable extends PositionComponent
     with HasGameRef<Circles>, HasHitboxes, Collidable {
   late Vector2 velocity;
@@ -55,24 +74,5 @@ class MyCollidable extends PositionComponent
       return;
     }
     _isCollision = true;
-  }
-}
-
-class Circles extends FlameGame with HasCollidables, TapDetector {
-  static const description = '''
-    This example will create a circle every time you tap on the screen. It will
-    have the initial velocity towards the center of the screen and if it touches
-    another circle both of them will change color.
-  ''';
-
-  @override
-  Future<void> onLoad() async {
-    super.onLoad();
-    add(ScreenCollidable());
-  }
-
-  @override
-  void onTapDown(TapDownInfo info) {
-    add(MyCollidable(info.eventPosition.game));
   }
 }

--- a/examples/lib/stories/collision_detection/circles.dart
+++ b/examples/lib/stories/collision_detection/circles.dart
@@ -7,7 +7,7 @@ import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
 import 'package:flutter/material.dart' hide Image, Draggable;
 
-class Circles extends FlameGame with HasCollidables, TapDetector {
+class CirclesExample extends FlameGame with HasCollidables, TapDetector {
   static const description = '''
     This example will create a circle every time you tap on the screen. It will
     have the initial velocity towards the center of the screen and if it touches
@@ -27,7 +27,7 @@ class Circles extends FlameGame with HasCollidables, TapDetector {
 }
 
 class MyCollidable extends PositionComponent
-    with HasGameRef<Circles>, HasHitboxes, Collidable {
+    with HasGameRef<CirclesExample>, HasHitboxes, Collidable {
   late Vector2 velocity;
   final _collisionColor = Colors.amber;
   final _defaultColor = Colors.cyan;

--- a/examples/lib/stories/collision_detection/collidable_animation.dart
+++ b/examples/lib/stories/collision_detection/collidable_animation.dart
@@ -9,6 +9,41 @@ import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
 import 'package:flame/palette.dart';
 
+class CollidableAnimationGame extends FlameGame with HasCollidables {
+  static const description = '''
+    In this example you can see four animated birds which are flying straight
+    along the same route until they hit either another bird or the wall, which
+    makes them turn. The birds have PolygonHitboxes which are marked with the
+    green lines and dots.
+  ''';
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+    add(ScreenCollidable());
+    // Top left component
+    add(AnimatedComponent(Vector2.all(200), Vector2.all(100))
+      ..flipVertically());
+    // Bottom right component
+    add(AnimatedComponent(
+      Vector2(-100, -100),
+      size.clone()..sub(Vector2.all(200)),
+    ));
+    // Bottom left component
+    add(AnimatedComponent(
+      Vector2(100, -100),
+      Vector2(100, size.y - 100),
+      angle: pi / 4,
+    ));
+    // Top right component
+    add(AnimatedComponent(
+      Vector2(-300, 300),
+      Vector2(size.x - 100, 100),
+      angle: pi / 4,
+    )..flipVertically());
+  }
+}
+
 class AnimatedComponent extends SpriteAnimationComponent
     with HasHitboxes, Collidable, HasGameRef {
   final Vector2 velocity;
@@ -77,40 +112,5 @@ class AnimatedComponent extends SpriteAnimationComponent
   @override
   void onCollisionEnd(Collidable other) {
     activeCollisions.remove(other);
-  }
-}
-
-class CollidableAnimationGame extends FlameGame with HasCollidables {
-  static const description = '''
-    In this example you can see four animated birds which are flying straight
-    along the same route until they hit either another bird or the wall, which
-    makes them turn. The birds have PolygonHitboxes which are marked with the
-    green lines and dots.
-  ''';
-
-  @override
-  Future<void> onLoad() async {
-    await super.onLoad();
-    add(ScreenCollidable());
-    // Top left component
-    add(AnimatedComponent(Vector2.all(200), Vector2.all(100))
-      ..flipVertically());
-    // Bottom right component
-    add(AnimatedComponent(
-      Vector2(-100, -100),
-      size.clone()..sub(Vector2.all(200)),
-    ));
-    // Bottom left component
-    add(AnimatedComponent(
-      Vector2(100, -100),
-      Vector2(100, size.y - 100),
-      angle: pi / 4,
-    ));
-    // Top right component
-    add(AnimatedComponent(
-      Vector2(-300, 300),
-      Vector2(size.x - 100, 100),
-      angle: pi / 4,
-    )..flipVertically());
   }
 }

--- a/examples/lib/stories/collision_detection/collidable_animation.dart
+++ b/examples/lib/stories/collision_detection/collidable_animation.dart
@@ -22,25 +22,32 @@ class CollidableAnimationExample extends FlameGame with HasCollidables {
     await super.onLoad();
     add(ScreenCollidable());
     // Top left component
-    add(AnimatedComponent(Vector2.all(200), Vector2.all(100))
-      ..flipVertically());
+    add(
+      AnimatedComponent(Vector2.all(200), Vector2.all(100))..flipVertically(),
+    );
     // Bottom right component
-    add(AnimatedComponent(
-      Vector2(-100, -100),
-      size.clone()..sub(Vector2.all(200)),
-    ));
+    add(
+      AnimatedComponent(
+        Vector2(-100, -100),
+        size.clone()..sub(Vector2.all(200)),
+      ),
+    );
     // Bottom left component
-    add(AnimatedComponent(
-      Vector2(100, -100),
-      Vector2(100, size.y - 100),
-      angle: pi / 4,
-    ));
+    add(
+      AnimatedComponent(
+        Vector2(100, -100),
+        Vector2(100, size.y - 100),
+        angle: pi / 4,
+      ),
+    );
     // Top right component
-    add(AnimatedComponent(
-      Vector2(-300, 300),
-      Vector2(size.x - 100, 100),
-      angle: pi / 4,
-    )..flipVertically());
+    add(
+      AnimatedComponent(
+        Vector2(-300, 300),
+        Vector2(size.x - 100, 100),
+        angle: pi / 4,
+      )..flipVertically(),
+    );
   }
 }
 

--- a/examples/lib/stories/collision_detection/collidable_animation.dart
+++ b/examples/lib/stories/collision_detection/collidable_animation.dart
@@ -57,12 +57,12 @@ class AnimatedComponent extends SpriteAnimationComponent
 
   @override
   void render(Canvas canvas) {
-    // This is just to clearly see the vertices in the hitboxes
-    hitbox
-        .globalVertices()
-        .forEach((p) => canvas.drawCircle(p.toOffset(), 4, dotPaint));
     super.render(canvas);
+    // This is just to clearly see the vertices in the hitboxes
     hitbox.render(canvas, hitboxPaint);
+    hitbox
+        .localVertices()
+        .forEach((p) => canvas.drawCircle(p.toOffset(), 4, dotPaint));
   }
 
   @override

--- a/examples/lib/stories/collision_detection/collidable_animation.dart
+++ b/examples/lib/stories/collision_detection/collidable_animation.dart
@@ -9,7 +9,7 @@ import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
 import 'package:flame/palette.dart';
 
-class CollidableAnimationGame extends FlameGame with HasCollidables {
+class CollidableAnimationExample extends FlameGame with HasCollidables {
   static const description = '''
     In this example you can see four animated birds which are flying straight
     along the same route until they hit either another bird or the wall, which

--- a/examples/lib/stories/collision_detection/collidable_animation.dart
+++ b/examples/lib/stories/collision_detection/collidable_animation.dart
@@ -53,13 +53,14 @@ class AnimatedComponent extends SpriteAnimationComponent
 
   final Paint hitboxPaint = BasicPalette.green.paint()
     ..style = PaintingStyle.stroke;
+  final Paint dotPaint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
 
   @override
   void render(Canvas canvas) {
     // This is just to clearly see the vertices in the hitboxes
     hitbox
         .globalVertices()
-        .forEach((p) => canvas.drawCircle(p.toOffset(), 2, hitboxPaint));
+        .forEach((p) => canvas.drawCircle(p.toOffset(), 4, dotPaint));
     super.render(canvas);
     hitbox.render(canvas, hitboxPaint);
   }

--- a/examples/lib/stories/collision_detection/collidable_animation.dart
+++ b/examples/lib/stories/collision_detection/collidable_animation.dart
@@ -1,0 +1,115 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
+import 'package:flame/extensions.dart';
+import 'package:flame/game.dart';
+import 'package:flame/geometry.dart';
+import 'package:flame/input.dart';
+import 'package:flame/palette.dart';
+
+class AnimatedComponent extends SpriteAnimationComponent
+    with HasHitboxes, Collidable, HasGameRef {
+  final Vector2 velocity;
+  final List<Collidable> activeCollisions = [];
+
+  AnimatedComponent(this.velocity, Vector2 position, {double angle = -pi / 4})
+      : super(
+          position: position,
+          size: Vector2(150, 100),
+          angle: angle,
+          anchor: Anchor.center,
+        );
+
+  late HitboxPolygon hitbox;
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+    animation = await gameRef.loadSpriteAnimation(
+      'bomb_ptero.png',
+      SpriteAnimationData.sequenced(
+        amount: 4,
+        stepTime: 0.2,
+        textureSize: Vector2.all(48),
+      ),
+    );
+    hitbox = HitboxPolygon([
+      Vector2(0.0, -1.0),
+      Vector2(-1.0, -0.1),
+      Vector2(-0.2, 0.4),
+      Vector2(0.2, 0.4),
+      Vector2(1.0, -0.1),
+    ]);
+    addHitbox(hitbox);
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    position += velocity * dt;
+  }
+
+  final Paint hitboxPaint = BasicPalette.green.paint()
+    ..style = PaintingStyle.stroke;
+
+  @override
+  void render(Canvas canvas) {
+    // This is just to clearly see the vertices in the hitboxes
+    hitbox
+        .globalVertices()
+        .forEach((p) => canvas.drawCircle(p.toOffset(), 2, hitboxPaint));
+    super.render(canvas);
+    hitbox.render(canvas, hitboxPaint);
+  }
+
+  @override
+  void onCollision(Set<Vector2> intersectionPoints, Collidable other) {
+    if (!activeCollisions.contains(other)) {
+      velocity.negate();
+      flipVertically();
+      activeCollisions.add(other);
+    }
+  }
+
+  @override
+  void onCollisionEnd(Collidable other) {
+    activeCollisions.remove(other);
+  }
+}
+
+class CollidableAnimationGame extends FlameGame with HasCollidables {
+  static const description = '''
+    In this example you can see four animated birds which are flying straight
+    along the same route until they hit either another bird or the wall, which
+    makes them turn. The birds have PolygonHitboxes which are marked with the
+    green lines and dots.
+  ''';
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+    add(ScreenCollidable());
+    // Top left component
+    add(AnimatedComponent(Vector2.all(200), Vector2.all(100))
+      ..flipVertically());
+    // Bottom right component
+    add(AnimatedComponent(
+      Vector2(-100, -100),
+      size.clone()..sub(Vector2.all(200)),
+    ));
+    // Bottom left component
+    add(AnimatedComponent(
+      Vector2(100, -100),
+      Vector2(100, size.y - 100),
+      angle: pi / 4,
+    ));
+    // Top right component
+    add(AnimatedComponent(
+      Vector2(-300, 300),
+      Vector2(size.x - 100, 100),
+      angle: pi / 4,
+    )..flipVertically());
+  }
+}

--- a/examples/lib/stories/collision_detection/collision_detection.dart
+++ b/examples/lib/stories/collision_detection/collision_detection.dart
@@ -11,26 +11,26 @@ void addCollisionDetectionStories(Dashbook dashbook) {
   dashbook.storiesOf('Collision Detection')
     ..add(
       'Collidable AnimationComponent',
-      (_) => GameWidget(game: CollidableAnimationGame()),
+      (_) => GameWidget(game: CollidableAnimationExample()),
       codeLink: baseLink('collision_detection/collidable_animation.dart'),
-      info: CollidableAnimationGame.description,
+      info: CollidableAnimationExample.description,
     )
     ..add(
       'Circles',
-      (_) => GameWidget(game: Circles()),
+      (_) => GameWidget(game: CirclesExample()),
       codeLink: baseLink('collision_detection/circles.dart'),
-      info: Circles.description,
+      info: CirclesExample.description,
     )
     ..add(
       'Multiple shapes',
-      (_) => GameWidget(game: MultipleShapes()),
+      (_) => GameWidget(game: MultipleShapesExample()),
       codeLink: baseLink('collision_detection/multiple_shapes.dart'),
-      info: MultipleShapes.description,
+      info: MultipleShapesExample.description,
     )
     ..add(
       'Simple Shapes',
-      (_) => GameWidget(game: SimpleShapes()),
+      (_) => GameWidget(game: SimpleShapesExample()),
       codeLink: baseLink('collision_detection/simple_shapes.dart'),
-      info: SimpleShapes.description,
+      info: SimpleShapesExample.description,
     );
 }

--- a/examples/lib/stories/collision_detection/collision_detection.dart
+++ b/examples/lib/stories/collision_detection/collision_detection.dart
@@ -4,7 +4,7 @@ import 'package:flame/game.dart';
 import '../../commons/commons.dart';
 import 'circles.dart';
 import 'multiple_shapes.dart';
-import 'only_shapes.dart';
+import 'simple_shapes.dart';
 
 void addCollisionDetectionStories(Dashbook dashbook) {
   dashbook.storiesOf('Collision Detection')
@@ -22,8 +22,8 @@ void addCollisionDetectionStories(Dashbook dashbook) {
     )
     ..add(
       'Simple Shapes',
-      (_) => GameWidget(game: OnlyShapes()),
-      codeLink: baseLink('collision_detection/only_shapes.dart'),
+      (_) => GameWidget(game: SimpleShapes()),
+      codeLink: baseLink('collision_detection/simple_shapes.dart'),
       info: onlyShapesInfo,
     );
 }

--- a/examples/lib/stories/collision_detection/collision_detection.dart
+++ b/examples/lib/stories/collision_detection/collision_detection.dart
@@ -3,11 +3,18 @@ import 'package:flame/game.dart';
 
 import '../../commons/commons.dart';
 import 'circles.dart';
+import 'collidable_animation.dart';
 import 'multiple_shapes.dart';
 import 'simple_shapes.dart';
 
 void addCollisionDetectionStories(Dashbook dashbook) {
   dashbook.storiesOf('Collision Detection')
+    ..add(
+      'Collidable AnimationComponent',
+      (_) => GameWidget(game: CollidableAnimationGame()),
+      codeLink: baseLink('collision_detection/collidable_animation.dart'),
+      info: CollidableAnimationGame.description,
+    )
     ..add(
       'Circles',
       (_) => GameWidget(game: Circles()),

--- a/examples/lib/stories/collision_detection/collision_detection.dart
+++ b/examples/lib/stories/collision_detection/collision_detection.dart
@@ -19,18 +19,18 @@ void addCollisionDetectionStories(Dashbook dashbook) {
       'Circles',
       (_) => GameWidget(game: Circles()),
       codeLink: baseLink('collision_detection/circles.dart'),
-      info: circlesInfo,
+      info: Circles.description,
     )
     ..add(
       'Multiple shapes',
       (_) => GameWidget(game: MultipleShapes()),
       codeLink: baseLink('collision_detection/multiple_shapes.dart'),
-      info: multipleShapesInfo,
+      info: MultipleShapes.description,
     )
     ..add(
       'Simple Shapes',
       (_) => GameWidget(game: SimpleShapes()),
       codeLink: baseLink('collision_detection/simple_shapes.dart'),
-      info: onlyShapesInfo,
+      info: SimpleShapes.description,
     );
 }

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -41,11 +41,7 @@ abstract class MyCollidable extends PositionComponent
     Vector2 size,
     this.velocity,
     this.screenCollidable,
-  ) {
-    this.position = position;
-    this.size = size;
-    anchor = Anchor.center;
-  }
+  ) : super(position: position, size: size, anchor: Anchor.center);
 
   @override
   Future<void> onLoad() async {
@@ -287,7 +283,7 @@ class MultipleShapes extends FlameGame
     MyCollidable lastCollidable,
     ScreenCollidable screenCollidable,
   ) {
-    final collidableSize = Vector2.all(50); // + Vector2.random(_rng) * 100;
+    final collidableSize = Vector2.all(50) + Vector2.random(_rng) * 100;
     final isXOverflow = lastCollidable.position.x +
             lastCollidable.size.x / 2 +
             _distance.x +

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart' hide Image, Draggable;
 
 enum Shapes { circle, rectangle, polygon }
 
-class MultipleShapes extends FlameGame
+class MultipleShapesExample extends FlameGame
     with HasCollidables, HasDraggableComponents, FPSCounter {
   static const description = '''
     An example with many hitboxes that move around on the screen and during

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -137,7 +137,7 @@ class CollidablePolygon extends MyCollidable {
     Vector2 velocity,
     ScreenCollidable screenCollidable,
   ) : super(position, size, velocity, screenCollidable) {
-    final shape = HitboxPolygon([
+    final hitbox = HitboxPolygon([
       Vector2(-1.0, 0.0),
       Vector2(-0.8, 0.6),
       Vector2(0.0, 1.0),
@@ -147,7 +147,7 @@ class CollidablePolygon extends MyCollidable {
       Vector2(0, -1.0),
       Vector2(-0.8, -0.8),
     ]);
-    addHitbox(shape);
+    addHitbox(hitbox);
   }
 }
 
@@ -169,8 +169,7 @@ class CollidableCircle extends MyCollidable {
     Vector2 velocity,
     ScreenCollidable screenCollidable,
   ) : super(position, size, velocity, screenCollidable) {
-    final shape = HitboxCircle();
-    addHitbox(shape);
+    addHitbox(HitboxCircle());
   }
 }
 
@@ -179,7 +178,7 @@ class SnowmanPart extends HitboxCircle {
   final hitPaint = Paint();
 
   SnowmanPart(double definition, Vector2 relativeOffset, Color hitColor)
-      : super(definition: definition) {
+      : super(normalizedRadius: definition) {
     this.relativeOffset.setFrom(relativeOffset);
     hitPaint..color = startColor;
     onCollision = (Set<Vector2> intersectionPoints, HitboxShape other) {
@@ -288,7 +287,7 @@ class MultipleShapes extends FlameGame
     MyCollidable lastCollidable,
     ScreenCollidable screenCollidable,
   ) {
-    final collidableSize = Vector2.all(50) + Vector2.random(_rng) * 100;
+    final collidableSize = Vector2.all(50); // + Vector2.random(_rng) * 100;
     final isXOverflow = lastCollidable.position.x +
             lastCollidable.size.x / 2 +
             _distance.x +

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -9,19 +9,6 @@ import 'package:flame/input.dart';
 import 'package:flame/palette.dart';
 import 'package:flutter/material.dart' hide Image, Draggable;
 
-const multipleShapesInfo = '''
-An example with many hitboxes that move around on the screen and during
-collisions they change color depending on what it is that they have collided
-with. 
-
-The snowman, the component built with three circles on top of each other, works
-a little bit differently than the other components to show that you can have
-multiple hitboxes within one component.
-
-On this example, you can "throw" the components by dragging them quickly in any
-direction.
-''';
-
 enum Shapes { circle, rectangle, polygon }
 
 abstract class MyCollidable extends PositionComponent
@@ -243,6 +230,19 @@ MyCollidable randomCollidable(
 
 class MultipleShapes extends FlameGame
     with HasCollidables, HasDraggableComponents, FPSCounter {
+  static const description = '''
+    An example with many hitboxes that move around on the screen and during
+    collisions they change color depending on what it is that they have collided
+    with. 
+    
+    The snowman, the component built with three circles on top of each other, 
+    works a little bit differently than the other components to show that you
+    can have multiple hitboxes within one component.
+    
+    On this example, you can "throw" the components by dragging them quickly in
+    any direction.
+  ''';
+
   final TextPaint fpsTextPaint = TextPaint(
     config: TextPaintConfig(
       color: BasicPalette.white.color,

--- a/examples/lib/stories/collision_detection/only_shapes.dart
+++ b/examples/lib/stories/collision_detection/only_shapes.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
 import 'package:flame/geometry.dart';
@@ -20,6 +21,12 @@ enum Shapes { circle, rectangle, polygon }
 class OnlyShapes extends FlameGame with HasTappableComponents {
   final shapePaint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
   final _rng = Random();
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+    camera.zoom = 2;
+  }
 
   Shape randomShape(Vector2 position) {
     final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
@@ -55,6 +62,18 @@ class OnlyShapes extends FlameGame with HasTappableComponents {
     final tapDownPoint = info.eventPosition.game;
     final component = MyShapeComponent(randomShape(tapDownPoint), shapePaint);
     add(component);
+    component.add(MoveEffect(
+      path: [size / 2],
+      speed: 30,
+      isAlternating: true,
+      isInfinite: true,
+    ));
+    component.add(RotateEffect(
+      angle: 3,
+      speed: 0.4,
+      isAlternating: true,
+      isInfinite: true,
+    ));
   }
 }
 
@@ -63,7 +82,7 @@ class MyShapeComponent extends ShapeComponent with Tappable {
       : super(shape, paint: shapePaint);
 
   @override
-  bool onTapDown(TapDownInfo info) {
+  bool onTapDown(TapDownInfo _) {
     removeFromParent();
     return true;
   }

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -25,15 +25,15 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
   Future<void> onLoad() async {
     await super.onLoad();
     camera.zoom = 2;
-    debugMode = true;
+    //debugMode = true;
   }
 
   MyShapeComponent randomShape(Vector2 position) {
-    final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
+    //final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
+    final shapeType = Shapes.rectangle;
     final shapeSize =
         Vector2.all(25) + Vector2.all(50.0).scaled(_rng.nextDouble());
-    //final shapeAngle = _rng.nextDouble() * 6;
-    final shapeAngle = 0.0;
+    final shapeAngle = _rng.nextDouble() * 6;
     switch (shapeType) {
       case Shapes.circle:
         return MyShapeComponent(
@@ -77,12 +77,12 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
     //  isAlternating: true,
     //  isInfinite: true,
     //));
-    //component.add(RotateEffect(
-    //  angle: 3,
-    //  speed: 0.4,
-    //  isAlternating: true,
-    //  isInfinite: true,
-    //));
+    component.add(RotateEffect(
+      angle: 3,
+      speed: 0.4,
+      isAlternating: true,
+      isInfinite: true,
+    ));
   }
 }
 

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -61,18 +61,22 @@ class SimpleShapesExample extends FlameGame with HasTappableComponents {
     final tapPosition = info.eventPosition.game;
     final component = randomShape(tapPosition);
     add(component);
-    component.add(MoveEffect(
-      path: [size / 2],
-      speed: 30,
-      isAlternating: true,
-      isInfinite: true,
-    ));
-    component.add(RotateEffect(
-      angle: 3,
-      speed: 0.4,
-      isAlternating: true,
-      isInfinite: true,
-    ));
+    component.add(
+      MoveEffect(
+        path: [size / 2],
+        speed: 30,
+        isAlternating: true,
+        isInfinite: true,
+      ),
+    );
+    component.add(
+      RotateEffect(
+        angle: 3,
+        speed: 0.4,
+        isAlternating: true,
+        isInfinite: true,
+      ),
+    );
   }
 }
 

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -21,18 +21,10 @@ enum Shapes { circle, rectangle, polygon }
 class SimpleShapes extends FlameGame with HasTappableComponents {
   final _rng = Random();
 
-  @override
-  Future<void> onLoad() async {
-    await super.onLoad();
-    camera.zoom = 2;
-    //debugMode = true;
-  }
-
   MyShapeComponent randomShape(Vector2 position) {
-    //final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
-    final shapeType = Shapes.rectangle;
+    final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
     final shapeSize =
-        Vector2.all(25) + Vector2.all(50.0).scaled(_rng.nextDouble());
+        Vector2.all(50) + Vector2.all(50.0).scaled(_rng.nextDouble());
     final shapeAngle = _rng.nextDouble() * 6;
     switch (shapeType) {
       case Shapes.circle:
@@ -71,12 +63,12 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
     final tapPosition = info.eventPosition.game;
     final component = randomShape(tapPosition);
     add(component);
-    //component.add(MoveEffect(
-    //  path: [size / 2],
-    //  speed: 30,
-    //  isAlternating: true,
-    //  isInfinite: true,
-    //));
+    component.add(MoveEffect(
+      path: [size / 2],
+      speed: 30,
+      isAlternating: true,
+      isInfinite: true,
+    ));
     component.add(RotateEffect(
       angle: 3,
       speed: 0.4,

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -25,13 +25,15 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
   Future<void> onLoad() async {
     await super.onLoad();
     camera.zoom = 2;
+    debugMode = true;
   }
 
   MyShapeComponent randomShape(Vector2 position) {
     final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
     final shapeSize =
         Vector2.all(25) + Vector2.all(50.0).scaled(_rng.nextDouble());
-    final shapeAngle = _rng.nextDouble() * 6;
+    //final shapeAngle = _rng.nextDouble() * 6;
+    final shapeAngle = 0.0;
     switch (shapeType) {
       case Shapes.circle:
         return MyShapeComponent(
@@ -66,8 +68,8 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
   @override
   void onTapDown(int pointerId, TapDownInfo info) {
     super.onTapDown(pointerId, info);
-    final tapDownPoint = info.eventPosition.game;
-    final component = randomShape(tapDownPoint);
+    final tapPosition = info.eventPosition.game;
+    final component = randomShape(tapPosition);
     add(component);
     //component.add(MoveEffect(
     //  path: [size / 2],
@@ -75,12 +77,12 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
     //  isAlternating: true,
     //  isInfinite: true,
     //));
-    component.add(RotateEffect(
-      angle: 3,
-      speed: 0.4,
-      isAlternating: true,
-      isInfinite: true,
-    ));
+    //component.add(RotateEffect(
+    //  angle: 3,
+    //  speed: 0.4,
+    //  isAlternating: true,
+    //  isInfinite: true,
+    //));
   }
 }
 

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
@@ -6,16 +7,16 @@ import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
 import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
-
-const onlyShapesInfo = '''
-An example which adds random shapes on the screen when you tap it, if you tap on
-an already existing shape it will remove that shape and replace it with a new
-one.
-''';
+import 'package:flame/palette.dart';
 
 enum Shapes { circle, rectangle, polygon }
 
 class SimpleShapes extends FlameGame with HasTappableComponents {
+  static const description = '''
+    An example which adds random shapes on the screen when you tap it, if you
+    tap on an already existing shape it will remove that shape and replace it
+    with a new one.
+  ''';
   final _rng = Random();
 
   MyShapeComponent randomShape(Vector2 position) {
@@ -77,7 +78,7 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
 
 class MyShapeComponent extends ShapeComponent with Tappable {
   @override
-  //final Paint paint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
+  final Paint paint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
 
   MyShapeComponent(
     HitboxShape shape, {
@@ -89,6 +90,7 @@ class MyShapeComponent extends ShapeComponent with Tappable {
           position: position,
           size: size,
           angle: angle,
+          anchor: Anchor.center,
         );
 
   @override

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -18,8 +18,7 @@ one.
 
 enum Shapes { circle, rectangle, polygon }
 
-class OnlyShapes extends FlameGame with HasTappableComponents {
-  final shapePaint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
+class SimpleShapes extends FlameGame with HasTappableComponents {
   final _rng = Random();
 
   @override
@@ -28,17 +27,25 @@ class OnlyShapes extends FlameGame with HasTappableComponents {
     camera.zoom = 2;
   }
 
-  Shape randomShape(Vector2 position) {
+  MyShapeComponent randomShape(Vector2 position) {
     final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
-    const size = 50.0;
+    final shapeSize =
+        Vector2.all(25) + Vector2.all(50.0).scaled(_rng.nextDouble());
+    final shapeAngle = _rng.nextDouble() * 6;
     switch (shapeType) {
       case Shapes.circle:
-        return Circle(radius: size / 2, position: position);
-      case Shapes.rectangle:
-        return Rectangle(
+        return MyShapeComponent(
+          HitboxCircle(),
           position: position,
-          size: Vector2.all(size),
-          angle: _rng.nextDouble() * 6,
+          size: shapeSize,
+          angle: shapeAngle,
+        );
+      case Shapes.rectangle:
+        return MyShapeComponent(
+          HitboxRectangle(),
+          position: position,
+          size: shapeSize,
+          angle: shapeAngle,
         );
       case Shapes.polygon:
         final points = [
@@ -47,11 +54,11 @@ class OnlyShapes extends FlameGame with HasTappableComponents {
           -Vector2.random(_rng),
           Vector2.random(_rng)..x *= -1,
         ];
-        return Polygon.fromDefinition(
-          points,
+        return MyShapeComponent(
+          HitboxPolygon(points),
           position: position,
-          size: Vector2.all(size),
-          angle: _rng.nextDouble() * 6,
+          size: shapeSize,
+          angle: shapeAngle,
         );
     }
   }
@@ -60,14 +67,14 @@ class OnlyShapes extends FlameGame with HasTappableComponents {
   void onTapDown(int pointerId, TapDownInfo info) {
     super.onTapDown(pointerId, info);
     final tapDownPoint = info.eventPosition.game;
-    final component = MyShapeComponent(randomShape(tapDownPoint), shapePaint);
+    final component = randomShape(tapDownPoint);
     add(component);
-    component.add(MoveEffect(
-      path: [size / 2],
-      speed: 30,
-      isAlternating: true,
-      isInfinite: true,
-    ));
+    //component.add(MoveEffect(
+    //  path: [size / 2],
+    //  speed: 30,
+    //  isAlternating: true,
+    //  isInfinite: true,
+    //));
     component.add(RotateEffect(
       angle: 3,
       speed: 0.4,
@@ -78,8 +85,20 @@ class OnlyShapes extends FlameGame with HasTappableComponents {
 }
 
 class MyShapeComponent extends ShapeComponent with Tappable {
-  MyShapeComponent(Shape shape, Paint shapePaint)
-      : super(shape, paint: shapePaint);
+  @override
+  final Paint paint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
+
+  MyShapeComponent(
+    HitboxShape shape, {
+    Vector2? position,
+    Vector2? size,
+    double? angle,
+  }) : super(
+          shape,
+          position: position,
+          size: size,
+          angle: angle,
+        );
 
   @override
   bool onTapDown(TapDownInfo _) {

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
@@ -7,8 +6,6 @@ import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
 import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
-import 'package:flame/palette.dart';
-import 'package:flutter/material.dart' hide Image, Draggable;
 
 const onlyShapesInfo = '''
 An example which adds random shapes on the screen when you tap it, if you tap on
@@ -20,8 +17,6 @@ enum Shapes { circle, rectangle, polygon }
 
 class SimpleShapes extends FlameGame with HasTappableComponents {
   final _rng = Random();
-  @override
-  bool debugMode = true;
 
   MyShapeComponent randomShape(Vector2 position) {
     final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
@@ -55,7 +50,7 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
           position: position,
           size: shapeSize,
           angle: shapeAngle,
-        )..flipHorizontallyAroundCenter();
+        );
     }
   }
 
@@ -65,24 +60,24 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
     final tapPosition = info.eventPosition.game;
     final component = randomShape(tapPosition);
     add(component);
-    //component.add(MoveEffect(
-    //  path: [size / 2],
-    //  speed: 30,
-    //  isAlternating: true,
-    //  isInfinite: true,
-    //));
-    //component.add(RotateEffect(
-    //  angle: 3,
-    //  speed: 0.4,
-    //  isAlternating: true,
-    //  isInfinite: true,
-    //));
+    component.add(MoveEffect(
+      path: [size / 2],
+      speed: 30,
+      isAlternating: true,
+      isInfinite: true,
+    ));
+    component.add(RotateEffect(
+      angle: 3,
+      speed: 0.4,
+      isAlternating: true,
+      isInfinite: true,
+    ));
   }
 }
 
 class MyShapeComponent extends ShapeComponent with Tappable {
   @override
-  final Paint paint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
+  //final Paint paint = BasicPalette.red.paint()..style = PaintingStyle.stroke;
 
   MyShapeComponent(
     HitboxShape shape, {

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -20,11 +20,13 @@ enum Shapes { circle, rectangle, polygon }
 
 class SimpleShapes extends FlameGame with HasTappableComponents {
   final _rng = Random();
+  @override
+  bool debugMode = true;
 
   MyShapeComponent randomShape(Vector2 position) {
     final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
     final shapeSize =
-        Vector2.all(50) + Vector2.all(50.0).scaled(_rng.nextDouble());
+        Vector2.all(100) + Vector2.all(50.0).scaled(_rng.nextDouble());
     final shapeAngle = _rng.nextDouble() * 6;
     switch (shapeType) {
       case Shapes.circle:
@@ -53,7 +55,7 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
           position: position,
           size: shapeSize,
           angle: shapeAngle,
-        );
+        )..flipHorizontallyAroundCenter();
     }
   }
 
@@ -63,18 +65,18 @@ class SimpleShapes extends FlameGame with HasTappableComponents {
     final tapPosition = info.eventPosition.game;
     final component = randomShape(tapPosition);
     add(component);
-    component.add(MoveEffect(
-      path: [size / 2],
-      speed: 30,
-      isAlternating: true,
-      isInfinite: true,
-    ));
-    component.add(RotateEffect(
-      angle: 3,
-      speed: 0.4,
-      isAlternating: true,
-      isInfinite: true,
-    ));
+    //component.add(MoveEffect(
+    //  path: [size / 2],
+    //  speed: 30,
+    //  isAlternating: true,
+    //  isInfinite: true,
+    //));
+    //component.add(RotateEffect(
+    //  angle: 3,
+    //  speed: 0.4,
+    //  isAlternating: true,
+    //  isInfinite: true,
+    //));
   }
 }
 

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -11,7 +11,7 @@ import 'package:flame/palette.dart';
 
 enum Shapes { circle, rectangle, polygon }
 
-class SimpleShapes extends FlameGame with HasTappableComponents {
+class SimpleShapesExample extends FlameGame with HasTappableComponents {
   static const description = '''
     An example which adds random shapes on the screen when you tap it, if you
     tap on an already existing shape it will remove that shape and replace it

--- a/examples/lib/stories/effects/move_effect.dart
+++ b/examples/lib/stories/effects/move_effect.dart
@@ -22,7 +22,8 @@ class MoveEffectGame extends FlameGame with TapDetector {
     await super.onLoad();
     square = SquareComponent(size: 50, position: Vector2(200, 150));
     add(square);
-    final pathMarkers = path.map((p) => CircleComponent(3, position: p));
+    final pathMarkers =
+        path.map((p) => CircleComponent(radius: 3, position: p));
     addAll(pathMarkers);
   }
 

--- a/examples/lib/stories/effects/move_effect_example.dart
+++ b/examples/lib/stories/effects/move_effect_example.dart
@@ -84,7 +84,7 @@ class MoveEffectExample extends FlameGame {
     }
     for (var i = 0; i < 40; i++) {
       add(
-        CircleComponent(5)
+        CircleComponent(radius: 5)
           ..add(
             MoveEffect.along(
               path1,

--- a/examples/lib/stories/effects/remove_effect_example.dart
+++ b/examples/lib/stories/effects/remove_effect_example.dart
@@ -25,7 +25,7 @@ class RemoveEffectExample extends FlameGame with HasTappableComponents {
 
 class _RandomCircle extends CircleComponent with Tappable {
   _RandomCircle(double radius, {Vector2? position, Paint? paint})
-      : super(radius, position: position, paint: paint);
+      : super(radius: radius, position: position, paint: paint);
 
   factory _RandomCircle.random(Random rng) {
     final radius = rng.nextDouble() * 30 + 10;

--- a/examples/lib/stories/input/joystick.dart
+++ b/examples/lib/stories/input/joystick.dart
@@ -1,6 +1,5 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
-import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
 import 'package:flame/palette.dart';
 import 'package:flutter/painting.dart';
@@ -17,8 +16,8 @@ class JoystickGame extends FlameGame with HasDraggableComponents {
     final knobPaint = BasicPalette.blue.withAlpha(200).paint();
     final backgroundPaint = BasicPalette.blue.withAlpha(100).paint();
     joystick = JoystickComponent(
-      knob: Circle(radius: 30).toComponent(paint: knobPaint),
-      background: Circle(radius: 100).toComponent(paint: backgroundPaint),
+      knob: CircleComponent(radius: 30, paint: knobPaint),
+      background: CircleComponent(radius: 100, paint: backgroundPaint),
       margin: const EdgeInsets.only(left: 40, bottom: 40),
     );
     player = JoystickPlayer(joystick);

--- a/examples/lib/stories/input/joystick_advanced.dart
+++ b/examples/lib/stories/input/joystick_advanced.dart
@@ -4,7 +4,6 @@ import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
-import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
 import 'package:flame/palette.dart';
 import 'package:flame/sprite.dart';
@@ -89,9 +88,11 @@ class JoystickAdvancedGame extends FlameGame
     // A button, created from a shape, that adds a rotation effect to the player
     // when it is pressed.
     final shapeButton = HudButtonComponent(
-      button: Circle(radius: 35).toComponent(paint: BasicPalette.white.paint()),
-      buttonDown: Rectangle(size: buttonSize)
-          .toComponent(paint: BasicPalette.blue.paint()),
+      button: CircleComponent(radius: 35),
+      buttonDown: RectangleComponent(
+        size: buttonSize,
+        paint: BasicPalette.blue.paint(),
+      ),
       margin: const EdgeInsets.only(
         right: 85,
         bottom: 150,

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -22,6 +22,7 @@
  - Components that manipulate canvas state are now responsible for saving/restoring that state
  - Remove `super.render` calls that are no longer needed
  - Fixed typo in error message
+ - Underlying `Shape`s in `ShapeComponent` transform with components position, size and angle
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -23,6 +23,7 @@
  - Remove `super.render` calls that are no longer needed
  - Fixed typo in error message
  - Underlying `Shape`s in `ShapeComponent` transform with components position, size and angle
+ - `HitboxShape` takes parents ancestors transformations into consideration (not scaling)
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -176,6 +176,20 @@ class Component with Loadable {
     nextParent = component;
   }
 
+  final List<Component> _ancestors = [];
+
+  /// A list containing the current parent and its parent, and so on, until it
+  /// reaches a component without a parent.
+  List<Component> ancestors() {
+    _ancestors.clear();
+    for (var currentParent = parent;
+        currentParent != null;
+        currentParent = currentParent.parent) {
+      _ancestors.add(currentParent);
+    }
+    return _ancestors;
+  }
+
   /// It receives the new game size.
   /// Executed right after the component is attached to a game and right before
   /// [onLoad] is called.

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -335,7 +335,7 @@ class Component with Loadable {
         parentGame.hasLayout,
         '"prepare/add" called before the game is ready. '
         'Did you try to access it on the Game constructor? '
-        'Use the "onLoad" or "onParentMethod" method instead.',
+        'Use the "onLoad" or "onMount" method instead.',
       );
       if (parentGame is FlameGame) {
         parentGame.prepareComponent(this);

--- a/packages/flame/lib/src/components/mixins/hitbox.dart
+++ b/packages/flame/lib/src/components/mixins/hitbox.dart
@@ -53,7 +53,6 @@ mixin HasHitboxes on PositionComponent {
   /// contain the point, since the shapes have to be within the size of the
   /// component.
   bool possiblyContainsPoint(Vector2 point) {
-    return absoluteCenter.distanceToSquared(point) <=
-        absoluteScaledSize.scaled(0.5).length2;
+    return absoluteCenter.distanceToSquared(point) <= scaledSize.length2;
   }
 }

--- a/packages/flame/lib/src/components/mixins/hitbox.dart
+++ b/packages/flame/lib/src/components/mixins/hitbox.dart
@@ -53,6 +53,7 @@ mixin HasHitboxes on PositionComponent {
   /// contain the point, since the shapes have to be within the size of the
   /// component.
   bool possiblyContainsPoint(Vector2 point) {
-    return absoluteCenter.distanceToSquared(point) <= scaledSize.length2;
+    return absoluteCenter.distanceToSquared(point) <=
+        absoluteScaledSize.scaled(0.5).length2;
   }
 }

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -163,24 +163,9 @@ class PositionComponent extends Component {
   /// component as seen from the parent's perspective, and it is equal to
   /// [size] * [scale]. This is a computed property and cannot be
   /// modified by the user.
-  Vector2 get scaledSize =>
-      Vector2(width * scale.x.abs(), height * scale.y.abs());
-
-  final _totalScale = Vector2.zero();
-
-  /// The resulting scale after all the ancestors and the components own scale
-  /// has been applied.
-  Vector2 get absoluteScale {
-    _totalScale.setValues(scale.x, scale.y);
-    ancestors().whereType<PositionComponent>().forEach((c) {
-      _totalScale.multiply(c.scale);
-    });
-    return _totalScale;
+  Vector2 get scaledSize {
+    return Vector2(width * scale.x.abs(), height * scale.y.abs());
   }
-
-  /// The size of the component after all ancestors and the components own
-  /// scale has been multiplied with its [size].
-  Vector2 get absoluteScaledSize => absoluteScale..multiply(size);
 
   /// The resulting angle after all the ancestors and the components own angle
   /// has been applied.

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -166,6 +166,31 @@ class PositionComponent extends Component {
   Vector2 get scaledSize =>
       Vector2(width * scale.x.abs(), height * scale.y.abs());
 
+  final _totalScale = Vector2.zero();
+
+  /// The resulting scale after all the ancestors and the components own scale
+  /// has been applied.
+  Vector2 get absoluteScale {
+    _totalScale.setValues(scale.x.abs(), scale.y.abs());
+    ancestors().whereType<PositionComponent>().forEach((c) {
+      _totalScale..x *= c.scale.x.abs();
+      _totalScale..y *= c.scale.y.abs();
+    });
+    return _totalScale;
+  }
+
+  /// The size of the component after all ancestors and the components own
+  /// scale has been multiplied with its [size].
+  Vector2 get absoluteScaledSize => absoluteScale..multiply(size);
+
+  /// The resulting angle after all the ancestors and the components own angle
+  /// has been applied.
+  double get absoluteAngle {
+    return ancestors()
+        .whereType<PositionComponent>()
+        .fold<double>(angle, (totalAngle, c) => totalAngle + c.angle);
+  }
+
   /// Measure the distance (in parent's coordinate space) between this
   /// component's anchor and the [other] component's anchor.
   double distance(PositionComponent other) =>

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -171,10 +171,9 @@ class PositionComponent extends Component {
   /// The resulting scale after all the ancestors and the components own scale
   /// has been applied.
   Vector2 get absoluteScale {
-    _totalScale.setValues(scale.x.abs(), scale.y.abs());
+    _totalScale.setValues(scale.x, scale.y);
     ancestors().whereType<PositionComponent>().forEach((c) {
-      _totalScale..x *= c.scale.x.abs();
-      _totalScale..y *= c.scale.y.abs();
+      _totalScale.multiply(c.scale);
     });
     return _totalScale;
   }

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -100,8 +100,8 @@ class RectangleComponent extends ShapeComponent {
 
 class PolygonComponent extends ShapeComponent {
   /// The [normalizedVertices] should be a list of points that range between
-  /// [0.0, 1.0] which defines the relation of the polygon to the size of the
-  /// component.
+  /// [-1.0, 1.0] which defines the relation of the vertices in the polygon
+  /// from the center of the component to the size of the component.
   PolygonComponent({
     required List<Vector2> normalizedVertices,
     Paint? paint,

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -11,6 +11,9 @@ import '../extensions/vector2.dart';
 /// A [ShapeComponent] is a [Shape] wrapped in a [PositionComponent] so that it
 /// can be added to a component tree and take the camera and viewport into
 /// consideration when rendering.
+///
+/// Once you have added a shape in the [ShapeComponent] you should only edit
+/// [position], [size] and [angle] of the [ShapeComponent], not of the [Shape].
 class ShapeComponent extends PositionComponent {
   final Shape shape;
   Paint paint;

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -11,9 +11,6 @@ import '../extensions/vector2.dart';
 /// A [ShapeComponent] is a [Shape] wrapped in a [PositionComponent] so that it
 /// can be added to a component tree and take the camera and viewport into
 /// consideration when rendering.
-///
-/// Once you have added a shape in the [ShapeComponent] you should only edit
-/// [position], [size] and [angle] of the [ShapeComponent], not of the [Shape].
 class ShapeComponent extends PositionComponent with HasHitboxes {
   final HitboxShape shape;
   Paint paint;

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -25,8 +25,7 @@ class ShapeComponent extends PositionComponent {
 
   @override
   set angle(double a) {
-    super.angle = a;
-    shape.angle = a;
+    super.angle = shape.angle = a;
   }
 
   ShapeComponent(

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -53,9 +53,6 @@ class ShapeComponent extends PositionComponent with HasHitboxes {
   void render(Canvas canvas) {
     shape.render(canvas, paint);
   }
-
-  //@override
-  //bool containsPoint(Vector2 point) => shape.containsPoint(point);
 }
 
 class CircleComponent extends ShapeComponent {

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -50,6 +50,7 @@ class CircleComponent extends ShapeComponent {
     Vector2? position,
     Vector2? scale,
     double? angle,
+    Anchor? anchor,
     int? priority,
   }) : super(
           HitboxCircle(),
@@ -58,6 +59,7 @@ class CircleComponent extends ShapeComponent {
           size: Vector2.all(radius * 2),
           scale: scale,
           angle: angle,
+          anchor: anchor,
           priority: priority,
         );
 }
@@ -69,6 +71,7 @@ class RectangleComponent extends ShapeComponent {
     Vector2? position,
     Vector2? scale,
     double? angle,
+    Anchor? anchor,
     int? priority,
   }) : super(
           HitboxRectangle(),
@@ -77,6 +80,7 @@ class RectangleComponent extends ShapeComponent {
           size: size,
           scale: scale,
           angle: angle,
+          anchor: anchor,
           priority: priority,
         );
 
@@ -86,6 +90,7 @@ class RectangleComponent extends ShapeComponent {
     Vector2? position,
     Vector2? scale,
     double? angle,
+    Anchor? anchor,
     int? priority,
   }) : super(
           HitboxRectangle(),
@@ -94,6 +99,7 @@ class RectangleComponent extends ShapeComponent {
           size: Vector2.all(size),
           scale: scale,
           angle: angle,
+          anchor: anchor,
           priority: priority,
         );
 }
@@ -109,6 +115,7 @@ class PolygonComponent extends ShapeComponent {
     Vector2? size,
     Vector2? scale,
     double? angle,
+    Anchor? anchor,
     int? priority,
   }) : super(
           HitboxPolygon(normalizedVertices),
@@ -117,6 +124,7 @@ class PolygonComponent extends ShapeComponent {
           size: size,
           scale: scale,
           angle: angle,
+          anchor: anchor,
           priority: priority,
         );
 
@@ -130,16 +138,24 @@ class PolygonComponent extends ShapeComponent {
     Vector2? size,
     Vector2? scale,
     double? angle,
+    Anchor? anchor,
     int? priority,
   }) {
     final polygon = Polygon(points);
+    final anchorPosition = position ??
+        Anchor.center.toOtherAnchorPosition(
+          polygon.position,
+          anchor ?? Anchor.topLeft,
+          size ?? polygon.size,
+        );
     return PolygonComponent(
       normalizedVertices: polygon.normalizedVertices,
       paint: paint,
-      position: position ?? polygon.position,
+      position: anchorPosition,
       size: size ?? polygon.size,
       scale: scale,
       angle: angle,
+      anchor: anchor,
       priority: priority,
     );
   }

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -15,11 +15,6 @@ class ShapeComponent extends PositionComponent with HasHitboxes {
   final HitboxShape shape;
   Paint paint;
 
-  /// Currently the [anchor] can only be center for [ShapeComponent], since
-  /// shape doesn't take any anchor into consideration.
-  @override
-  final Anchor anchor = Anchor.center;
-
   ShapeComponent(
     this.shape, {
     Paint? paint,
@@ -27,6 +22,7 @@ class ShapeComponent extends PositionComponent with HasHitboxes {
     Vector2? size,
     Vector2? scale,
     double? angle,
+    Anchor? anchor,
     int? priority,
   })  : paint = paint ?? BasicPalette.white.paint(),
         super(
@@ -34,7 +30,7 @@ class ShapeComponent extends PositionComponent with HasHitboxes {
           size: size,
           scale: scale,
           angle: angle,
-          anchor: Anchor.center,
+          anchor: anchor,
           priority: priority,
         ) {
     shape.isCanvasPrepared = true;

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -8,6 +8,9 @@ import '../../palette.dart';
 import '../anchor.dart';
 import '../extensions/vector2.dart';
 
+/// A [ShapeComponent] is a [Shape] wrapped in a [PositionComponent] so that it
+/// can be added to a component tree and take the camera and viewport into
+/// consideration when rendering.
 class ShapeComponent extends PositionComponent {
   final Shape shape;
   Paint paint;
@@ -17,19 +20,29 @@ class ShapeComponent extends PositionComponent {
   @override
   final Anchor anchor = Anchor.center;
 
+  @override
+  set angle(double a) {
+    super.angle = a;
+    shape.angle = a;
+  }
+
   ShapeComponent(
     this.shape, {
     Paint? paint,
+    Vector2? scale,
     int? priority,
   })  : paint = paint ?? BasicPalette.white.paint(),
         super(
           position: shape.position,
           size: shape.size,
+          scale: scale,
           angle: shape.angle,
           anchor: Anchor.center,
           priority: priority,
         ) {
     shape.isCanvasPrepared = true;
+    position.addListener(() => shape.position.setFrom(position));
+    size.addListener(() => shape.size.setFrom(position));
   }
 
   @override

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -23,11 +23,6 @@ class ShapeComponent extends PositionComponent with HasHitboxes {
   @override
   final Anchor anchor = Anchor.center;
 
-  @override
-  set angle(double a) {
-    super.angle = shape.angle = a;
-  }
-
   ShapeComponent(
     this.shape, {
     Paint? paint,

--- a/packages/flame/lib/src/extensions/vector2.dart
+++ b/packages/flame/lib/src/extensions/vector2.dart
@@ -37,6 +37,9 @@ extension Vector2Extension on Vector2 {
   /// Whether the [Vector2] is the zero vector or not
   bool isZero() => x == 0 && y == 0;
 
+  /// Whether the [Vector2] is the identity vector or not
+  bool isIdentity() => x == 1 && y == 1;
+
   /// Rotates the [Vector2] with [angle] in radians
   /// rotates around [center] if it is defined
   /// In a screen coordinate system (where the y-axis is flipped) it rotates in
@@ -119,4 +122,7 @@ extension Vector2Extension on Vector2 {
 
   /// Creates a heading [Vector2] with the given angle in degrees.
   static Vector2 fromDegrees(double d) => fromRadians(d * degrees2Radians);
+
+  /// Creates a new identity [Vector2] (1.0, 1.0).
+  static Vector2 identity() => Vector2.all(1.0);
 }

--- a/packages/flame/lib/src/extensions/vector2.dart
+++ b/packages/flame/lib/src/extensions/vector2.dart
@@ -102,7 +102,7 @@ extension Vector2Extension on Vector2 {
   ///
   /// Since on a canvas/screen y is smaller the further up you go, instead of
   /// larger like on a normal coordinate system, to get an angle that is in that
-  /// coordinate system we have to flip the Y-axis of the [Vector].
+  /// coordinate system we have to flip the Y-axis of the [Vector2].
   ///
   /// Example:
   /// Up: Vector(0.0, -1.0).screenAngle == 0

--- a/packages/flame/lib/src/geometry/circle.dart
+++ b/packages/flame/lib/src/geometry/circle.dart
@@ -7,8 +7,8 @@ import '../extensions/vector2.dart';
 import 'shape.dart';
 
 class Circle extends Shape {
-  /// The [normalizedRadius] is what ration (0.0, 1.0] of the shortest edge of
-  /// [size] that the circle should cover.
+  /// The [normalizedRadius] is what ratio (0.0, 1.0] of the shortest edge of
+  /// [size]/2 that the circle should cover.
   double normalizedRadius = 1.0;
 
   /// With this constructor you can create your [Circle] from a radius and

--- a/packages/flame/lib/src/geometry/circle.dart
+++ b/packages/flame/lib/src/geometry/circle.dart
@@ -35,7 +35,16 @@ class Circle extends Shape {
   })  : normalizedRadius = relation ?? 1.0,
         super(position: position, size: size, angle: angle ?? 0);
 
-  double get radius => (min(size.x, size.y) / 2) * normalizedRadius;
+  // Used to not create new Vector2 objects every time radius is called.
+  final Vector2 _scaledSize = Vector2.zero();
+
+  /// Get the radius of the circle after it has been sized and scaled.
+  double get radius {
+    _scaledSize
+      ..setFrom(size)
+      ..multiply(scale);
+    return (min(_scaledSize.x, _scaledSize.y) / 2) * normalizedRadius;
+  }
 
   /// This render method doesn't rotate the canvas according to angle since a
   /// circle will look the same rotated as not rotated.

--- a/packages/flame/lib/src/geometry/circle.dart
+++ b/packages/flame/lib/src/geometry/circle.dart
@@ -7,9 +7,9 @@ import '../extensions/vector2.dart';
 import 'shape.dart';
 
 class Circle extends Shape {
-  /// The [normalizedRadius] is how many percentages of the shortest edge of
+  /// The [normalizedRadius] is what ration (0.0, 1.0] of the shortest edge of
   /// [size] that the circle should cover.
-  double normalizedRadius = 1;
+  double normalizedRadius = 1.0;
 
   /// With this constructor you can create your [Circle] from a radius and
   /// a position. It will also calculate the bounding rectangle [size] for the
@@ -25,14 +25,15 @@ class Circle extends Shape {
         );
 
   /// This constructor is used by [HitboxCircle]
-  /// definition is the percentages of the shortest edge of [size] that the
-  /// circle should fill.
+  /// [relation] is the relation [0.0, 1.0] of the shortest edge of [size] that
+  /// the circle should fill.
   Circle.fromDefinition({
-    this.normalizedRadius = 1.0,
+    double? relation,
     Vector2? position,
     Vector2? size,
     double? angle,
-  }) : super(position: position, size: size, angle: angle ?? 0);
+  })  : normalizedRadius = relation ?? 1.0,
+        super(position: position, size: size, angle: angle ?? 0);
 
   double get radius => (min(size.x, size.y) / 2) * normalizedRadius;
 
@@ -100,9 +101,15 @@ class Circle extends Shape {
 }
 
 class HitboxCircle extends Circle with HitboxShape {
-  @override
-  HitboxCircle({double definition = 1})
-      : super.fromDefinition(
-          normalizedRadius: definition,
+  HitboxCircle({
+    double? normalizedRadius,
+    Vector2? position,
+    Vector2? size,
+    double? angle,
+  }) : super.fromDefinition(
+          relation: normalizedRadius,
+          position: position,
+          size: size,
+          angle: angle ?? 0,
         );
 }

--- a/packages/flame/lib/src/geometry/line_segment.dart
+++ b/packages/flame/lib/src/geometry/line_segment.dart
@@ -9,6 +9,8 @@ class LineSegment {
 
   LineSegment(this.from, this.to);
 
+  factory LineSegment.zero() => LineSegment(Vector2.zero(), Vector2.zero());
+
   /// Returns an empty list if there are no intersections between the segments
   /// If the segments are concurrent, the intersecting point is returned as a
   /// list with a single point

--- a/packages/flame/lib/src/geometry/polygon.dart
+++ b/packages/flame/lib/src/geometry/polygon.dart
@@ -42,7 +42,6 @@ class Polygon extends Shape {
     final halfSize = (boundingRect.bottomRight - centerOffset).toVector2();
     final definition =
         points.map<Vector2>((v) => (v - center)..divide(halfSize)).toList();
-    print(definition);
     return Polygon.fromDefinition(
       definition,
       position: center,
@@ -55,7 +54,8 @@ class Polygon extends Shape {
   /// percentages of the size of the shape.
   /// Example: [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
   /// This will form a diamond shape within the bounding size box.
-  /// NOTE: Always define your shape in a clockwise fashion
+  /// NOTE: Always define your shape in a counter-clockwise fashion (in the
+  /// screen coordinate system).
   Polygon.fromDefinition(
     this.normalizedVertices, {
     Vector2? position,
@@ -113,7 +113,6 @@ class Polygon extends Shape {
     }
     if (!_cachedScaledVertices.isCacheValid([size, scale])) {
       final sizedVertices = this.sizedVertices();
-      print('Sized vertices $sizedVertices');
       var i = 0;
       for (final point in sizedVertices) {
         _scaledVertices[i]
@@ -180,7 +179,7 @@ class Polygon extends Shape {
       }
       _cachedHitbox.updateCache(
         _hitboxVertices,
-        [absoluteCenter, size.clone(), scale, parentAngle, angle],
+        [absoluteCenter, size.clone(), scale.clone(), parentAngle, angle],
       );
     }
     return _cachedHitbox.value!;
@@ -194,6 +193,7 @@ class Polygon extends Shape {
     if (size.x == 0 || size.y == 0) {
       return false;
     }
+    print('Tap down: $point');
 
     final vertices = hitbox();
     for (var i = 0; i < vertices.length; i++) {

--- a/packages/flame/lib/src/geometry/polygon.dart
+++ b/packages/flame/lib/src/geometry/polygon.dart
@@ -84,6 +84,7 @@ class Polygon extends Shape {
   }
 
   final _cachedRenderPath = ValueCache<Path>();
+  final _path = Path();
 
   @override
   void render(Canvas canvas, Paint paint) {
@@ -91,7 +92,8 @@ class Polygon extends Shape {
         .isCacheValid([offsetPosition, relativeOffset, size, angle])) {
       final center = localCenter;
       _cachedRenderPath.updateCache(
-        Path()
+        _path
+          ..reset()
           ..addPolygon(
             scaled().map(
               (point) {

--- a/packages/flame/lib/src/geometry/polygon.dart
+++ b/packages/flame/lib/src/geometry/polygon.dart
@@ -9,7 +9,6 @@ import '../extensions/rect.dart';
 import '../extensions/vector2.dart';
 import 'shape.dart';
 
-// TODO(spydon): Migrate this to [Path]
 class Polygon extends Shape {
   final List<Vector2> normalizedVertices;
   // These lists are used to minimize the amount of objects that are created,

--- a/packages/flame/lib/src/geometry/polygon.dart
+++ b/packages/flame/lib/src/geometry/polygon.dart
@@ -56,7 +56,7 @@ class Polygon extends Shape {
 
   /// With this constructor you define the [Polygon] from the center of and with
   /// percentages of the size of the shape.
-  /// Example: [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
+  /// Example: [[1.0, 0.0], [0.0, -1.0], [-1.0, 0.0], [0.0, 1.0]]
   /// This will form a diamond shape within the bounding size box.
   /// NOTE: Always define your shape in a counter-clockwise fashion (in the
   /// screen coordinate system).

--- a/packages/flame/lib/src/geometry/shape.dart
+++ b/packages/flame/lib/src/geometry/shape.dart
@@ -131,10 +131,10 @@ mixin HitboxShape on Shape {
   late PositionComponent component;
 
   @override
-  Vector2 get size => component.scaledSize;
+  Vector2 get size => component.absoluteScaledSize;
 
   @override
-  double get parentAngle => component.angle;
+  double get parentAngle => component.absoluteAngle;
 
   @override
   Vector2 get position => component.absoluteCenter;

--- a/packages/flame/lib/src/geometry/shape.dart
+++ b/packages/flame/lib/src/geometry/shape.dart
@@ -137,6 +137,9 @@ mixin HitboxShape on Shape {
   late PositionComponent component;
 
   @override
+  bool isCanvasPrepared = true;
+
+  @override
   Vector2 get size => component.size;
 
   @override

--- a/packages/flame/lib/src/geometry/shape.dart
+++ b/packages/flame/lib/src/geometry/shape.dart
@@ -14,7 +14,9 @@ abstract class Shape {
   final ValueCache<Vector2> _halfSizeCache = ValueCache();
   final ValueCache<Vector2> _localCenterCache = ValueCache();
   final ValueCache<Vector2> _absoluteCenterCache = ValueCache();
+  final ValueCache<Vector2> _relativePositionCache = ValueCache();
 
+  // These are used to avoid creating new vector objects on some method calls
   final Vector2 _identityVector2 = Vector2Extension.identity();
 
   /// Should be the center of that [offsetPosition] and [relativeOffset]
@@ -47,11 +49,19 @@ abstract class Shape {
   Vector2 relativeOffset = Vector2.zero();
 
   /// The [relativeOffset] converted to a length vector
-  Vector2 get relativePosition => (size / 2)..multiply(relativeOffset);
+  Vector2 get relativePosition {
+    if (!_relativePositionCache.isCacheValid([size, relativeOffset])) {
+      _relativePositionCache.updateCache(
+        (size / 2)..multiply(relativeOffset),
+        [size.clone(), relativeOffset.clone()],
+      );
+    }
+    return _relativePositionCache.value!;
+  }
 
   /// The angle of the parent that has to be taken into consideration for some
   /// applications of [Shape], for example [HitboxShape]
-  double parentAngle;
+  double parentAngle = 0;
 
   /// Whether the context that the shape is in has already prepared (rotated
   /// and translated) the canvas before coming to the shape's render method.
@@ -109,7 +119,6 @@ abstract class Shape {
     Vector2? position,
     Vector2? size,
     this.angle = 0,
-    this.parentAngle = 0,
   })  : position = position ?? Vector2.zero(),
         size = size ?? Vector2.zero();
 

--- a/packages/flame/lib/src/geometry/shape.dart
+++ b/packages/flame/lib/src/geometry/shape.dart
@@ -143,7 +143,7 @@ mixin HitboxShape on Shape {
   Vector2 get size => component.size;
 
   @override
-  Vector2 get scale => component.absoluteScale;
+  Vector2 get scale => component.scale;
 
   @override
   double get parentAngle => component.absoluteAngle;

--- a/packages/flame/lib/src/geometry/shape.dart
+++ b/packages/flame/lib/src/geometry/shape.dart
@@ -23,6 +23,10 @@ abstract class Shape {
   /// The size is the bounding box of the [Shape]
   Vector2 size;
 
+  /// The scaled size of the bounding box of the [Shape], if no scaling of the
+  /// parent is supported this should be set to null.
+  Vector2? scaledSize;
+
   Vector2 get halfSize {
     if (!_halfSizeCache.isCacheValid([size])) {
       _halfSizeCache.updateCache(size / 2, [size.clone()]);
@@ -116,22 +120,16 @@ abstract class Shape {
   Set<Vector2> intersections(Shape other) {
     return intersection_system.intersections(this, other);
   }
-
-  /// Turns a [Shape] into a [ShapeComponent]
-  ///
-  /// Do note that while a [Shape] is defined from the center, a
-  /// [ShapeComponent] like all other components default to an [Anchor] in the
-  /// top left corner.
-  ShapeComponent toComponent({Paint? paint}) {
-    return ShapeComponent(this, paint: paint);
-  }
 }
 
 mixin HitboxShape on Shape {
   late PositionComponent component;
 
   @override
-  Vector2 get size => component.absoluteScaledSize;
+  Vector2 get size => component.size;
+
+  @override
+  Vector2 get scaledSize => component.absoluteScaledSize;
 
   @override
   double get parentAngle => component.absoluteAngle;

--- a/packages/flame/lib/src/geometry/shape.dart
+++ b/packages/flame/lib/src/geometry/shape.dart
@@ -15,6 +15,8 @@ abstract class Shape {
   final ValueCache<Vector2> _localCenterCache = ValueCache();
   final ValueCache<Vector2> _absoluteCenterCache = ValueCache();
 
+  final Vector2 _identityVector2 = Vector2Extension.identity();
+
   /// Should be the center of that [offsetPosition] and [relativeOffset]
   /// should be calculated from, if they are not set this is the center of the
   /// shape
@@ -24,8 +26,8 @@ abstract class Shape {
   Vector2 size;
 
   /// The scaled size of the bounding box of the [Shape], if no scaling of the
-  /// parent is supported this should be set to null.
-  Vector2? scaledSize;
+  /// parent is supported this will return [size].
+  Vector2 get scale => _identityVector2;
 
   Vector2 get halfSize {
     if (!_halfSizeCache.isCacheValid([size])) {
@@ -129,7 +131,7 @@ mixin HitboxShape on Shape {
   Vector2 get size => component.size;
 
   @override
-  Vector2 get scaledSize => component.absoluteScaledSize;
+  Vector2 get scale => component.absoluteScale;
 
   @override
   double get parentAngle => component.absoluteAngle;

--- a/packages/flame/test/components/joystick_component_test.dart
+++ b/packages/flame/test/components/joystick_component_test.dart
@@ -1,6 +1,5 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
-import 'package:flame/geometry.dart';
 import 'package:flame/input.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/widgets.dart';
@@ -14,7 +13,7 @@ void main() {
   group('JoystickDirection tests', () {
     test('Can convert angle to JoystickDirection', () {
       final joystick = JoystickComponent(
-        knob: Circle(radius: 5.0).toComponent(),
+        knob: CircleComponent(radius: 5.0),
         size: 20,
         margin: const EdgeInsets.only(left: 20, bottom: 20),
       );
@@ -47,7 +46,7 @@ void main() {
       'knob should stay on correct side when the total delta is larger than the size and then the knob is moved slightly back again',
       (game) async {
         final joystick = JoystickComponent(
-          knob: Circle(radius: 5.0).toComponent(),
+          knob: CircleComponent(radius: 5.0),
           size: 20,
           margin: const EdgeInsets.only(left: 20, top: 20),
         );

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -1,18 +1,17 @@
 import 'dart:math';
 
+import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/geometry.dart';
-import 'package:flame/src/geometry/circle.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('ShapeComponent.containsPoint tests', () {
     test('Simple circle contains point', () {
-      final shape = Circle(
+      final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
       );
-      final component = shape.toComponent();
       expect(
         component.containsPoint(Vector2.all(1.5)),
         true,
@@ -20,11 +19,10 @@ void main() {
     });
 
     test('Simple rectangle contains point', () {
-      final shape = Rectangle(
+      final component = RectangleComponent(
         position: Vector2(1, 1),
         size: Vector2(1, 1),
       );
-      final component = shape.toComponent();
       expect(
         component.containsPoint(Vector2.all(1.5)),
         true,
@@ -32,14 +30,12 @@ void main() {
     });
 
     test('Simple polygon contains point', () {
-      final shape = Polygon([
+      final component = Polygon([
         Vector2(2, 2),
         Vector2(2, 1),
         Vector2(2, 0),
         Vector2(1, 1),
       ]);
-      final component = shape.toComponent();
-      print(component.position);
       expect(
         component.containsPoint(Vector2(2.0, 1.9)),
         true,
@@ -47,12 +43,11 @@ void main() {
     });
 
     test('Rotated circle does not contain point', () {
-      final shape = Circle(
+      final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
         angle: pi / 2,
       );
-      final component = shape.toComponent();
       expect(
         component.containsPoint(Vector2.all(1.9)),
         false,
@@ -60,12 +55,11 @@ void main() {
     });
 
     test('Rotated rectangle does not contain point', () {
-      final shape = Rectangle(
+      final component = RectangleComponent(
         position: Vector2(1, 1),
         size: Vector2(1, 1),
         angle: pi / 2,
       );
-      final component = shape.toComponent();
       expect(
         component.containsPoint(Vector2.all(1.9)),
         false,
@@ -73,7 +67,7 @@ void main() {
     });
 
     test('Rotated polygon does not contain point', () {
-      final shape = Polygon(
+      final component = Polygon(
         [
           Vector2(2, 2),
           Vector2(2, 1),
@@ -82,7 +76,6 @@ void main() {
         ],
         angle: pi / 2,
       );
-      final component = shape.toComponent();
       expect(
         component.containsPoint(Vector2.all(1.9)),
         false,
@@ -90,11 +83,11 @@ void main() {
     });
 
     test('Rotated CircleComponent does not contain point', () {
-      final shape = Circle(
+      final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
+        angle: pi / 2,
       );
-      final component = shape.toComponent()..angle = pi / 2;
       expect(
         component.containsPoint(Vector2.all(1.9)),
         false,
@@ -102,11 +95,11 @@ void main() {
     });
 
     test('Rotated RectangleComponent does not contain point', () {
-      final shape = Rectangle(
+      final component = RectangleComponent(
         position: Vector2(1, 1),
         size: Vector2(1, 1),
+        angle: pi / 2,
       );
-      final component = shape.toComponent()..angle = pi / 2;
       expect(
         component.containsPoint(Vector2.all(1.9)),
         false,
@@ -114,13 +107,15 @@ void main() {
     });
 
     test('Rotated PolygonComponent does not contain point', () {
-      final shape = Polygon([
-        Vector2(2, 2),
-        Vector2(2, 1),
-        Vector2(2, 0),
-        Vector2(1, 1),
-      ]);
-      final component = shape.toComponent()..angle = pi / 2;
+      final component = PolygonComponent.fromPoints(
+        [
+          Vector2(2, 2),
+          Vector2(2, 1),
+          Vector2(2, 0),
+          Vector2(1, 1),
+        ],
+        angle: pi / 2,
+      );
       expect(
         component.containsPoint(Vector2.all(1.9)),
         false,
@@ -128,11 +123,10 @@ void main() {
     });
 
     test('Moved CircleComponent contains point', () {
-      final shape = Circle(
+      final component = CircleComponent(
         radius: 1.0,
-        position: Vector2(1, 1),
+        position: Vector2(2, 2),
       );
-      final component = shape.toComponent()..position += Vector2.all(1.0);
       expect(
         component.containsPoint(Vector2.all(2.1)),
         true,
@@ -140,11 +134,10 @@ void main() {
     });
 
     test('Moved RectangleComponent contains point', () {
-      final shape = Rectangle(
-        position: Vector2(1, 1),
+      final component = RectangleComponent(
+        position: Vector2(2, 2),
         size: Vector2(1, 1),
       );
-      final component = shape.toComponent()..position += Vector2.all(1.0);
       expect(
         component.containsPoint(Vector2.all(2.1)),
         true,
@@ -152,13 +145,15 @@ void main() {
     });
 
     test('Moved PolygonComponent contains point', () {
-      final shape = Polygon([
-        Vector2(2, 2),
-        Vector2(2, 1),
-        Vector2(2, 0),
-        Vector2(1, 1),
-      ]);
-      final component = shape.toComponent()..position += Vector2.all(1.0);
+      final component = PolygonComponent.fromPoints(
+        [
+          Vector2(2, 2),
+          Vector2(2, 1),
+          Vector2(2, 0),
+          Vector2(1, 1),
+        ],
+        position: Vector2.all(1.0),
+      );
       expect(
         component.containsPoint(Vector2.all(2.1)),
         true,
@@ -166,11 +161,11 @@ void main() {
     });
 
     test('Sized up CircleComponent does not contain point', () {
-      final shape = Circle(
+      final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
       );
-      final component = shape.toComponent()..size += Vector2.all(1.0);
+      component.size += Vector2.all(1.0);
       expect(
         component.containsPoint(Vector2.all(2.1)),
         false,
@@ -178,11 +173,10 @@ void main() {
     });
 
     test('Sized up RectangleComponent does not contain point', () {
-      final shape = Rectangle(
+      final component = RectangleComponent(
         position: Vector2(1, 1),
-        size: Vector2(1, 1),
+        size: Vector2(2, 2),
       );
-      final component = shape.toComponent()..size += Vector2.all(1.0);
       expect(
         component.containsPoint(Vector2.all(2.1)),
         false,
@@ -190,13 +184,13 @@ void main() {
     });
 
     test('Sized PolygonComponent does not contain point', () {
-      final shape = Polygon([
+      final component = PolygonComponent.fromPoints([
         Vector2(2, 2),
         Vector2(2, 1),
         Vector2(2, 0),
         Vector2(1, 1),
       ]);
-      final component = shape.toComponent()..size += Vector2.all(1.0);
+      component.size += Vector2.all(1.0);
       expect(
         component.containsPoint(Vector2.all(2.1)),
         false,

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -127,7 +127,6 @@ void main() {
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
       )..flipVerticallyAroundCenter();
-      print((component.hitboxes[0] as Polygon).globalVertices());
       expect(
         component.containsPoint(Vector2(2.0, 2.0)),
         true,

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -1,0 +1,206 @@
+import 'dart:math';
+
+import 'package:flame/extensions.dart';
+import 'package:flame/geometry.dart';
+import 'package:flame/src/geometry/circle.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ShapeComponent.containsPoint tests', () {
+    test('Simple circle contains point', () {
+      final shape = Circle(
+        radius: 1.0,
+        position: Vector2(1, 1),
+      );
+      final component = shape.toComponent();
+      expect(
+        component.containsPoint(Vector2.all(1.5)),
+        true,
+      );
+    });
+
+    test('Simple rectangle contains point', () {
+      final shape = Rectangle(
+        position: Vector2(1, 1),
+        size: Vector2(1, 1),
+      );
+      final component = shape.toComponent();
+      expect(
+        component.containsPoint(Vector2.all(1.9)),
+        true,
+      );
+    });
+
+    test('Simple polygon contains point', () {
+      final shape = Polygon([
+        Vector2(2, 2),
+        Vector2(2, 1),
+        Vector2(2, 0),
+        Vector2(1, 1),
+      ]);
+      final component = shape.toComponent();
+      print(component.position);
+      expect(
+        component.containsPoint(Vector2(2.0, 1.9)),
+        true,
+      );
+    });
+
+    test('Rotated circle does not contain point', () {
+      final shape = Circle(
+        radius: 1.0,
+        position: Vector2(1, 1),
+        angle: pi / 2,
+      );
+      final component = shape.toComponent();
+      expect(
+        component.containsPoint(Vector2.all(1.9)),
+        false,
+      );
+    });
+
+    test('Rotated rectangle does not contain point', () {
+      final shape = Rectangle(
+        position: Vector2(1, 1),
+        size: Vector2(1, 1),
+        angle: pi / 2,
+      );
+      final component = shape.toComponent();
+      expect(
+        component.containsPoint(Vector2.all(1.9)),
+        false,
+      );
+    });
+
+    test('Rotated polygon does not contain point', () {
+      final shape = Polygon(
+        [
+          Vector2(2, 2),
+          Vector2(2, 1),
+          Vector2(2, 0),
+          Vector2(1, 1),
+        ],
+        angle: pi / 2,
+      );
+      final component = shape.toComponent();
+      expect(
+        component.containsPoint(Vector2.all(1.9)),
+        false,
+      );
+    });
+
+    test('Rotated CircleComponent does not contain point', () {
+      final shape = Circle(
+        radius: 1.0,
+        position: Vector2(1, 1),
+      );
+      final component = shape.toComponent()..angle = pi / 2;
+      expect(
+        component.containsPoint(Vector2.all(1.9)),
+        false,
+      );
+    });
+
+    test('Rotated RectangleComponent does not contain point', () {
+      final shape = Rectangle(
+        position: Vector2(1, 1),
+        size: Vector2(1, 1),
+      );
+      final component = shape.toComponent()..angle = pi / 2;
+      expect(
+        component.containsPoint(Vector2.all(1.9)),
+        false,
+      );
+    });
+
+    test('Rotated PolygonComponent does not contain point', () {
+      final shape = Polygon([
+        Vector2(2, 2),
+        Vector2(2, 1),
+        Vector2(2, 0),
+        Vector2(1, 1),
+      ]);
+      final component = shape.toComponent()..angle = pi / 2;
+      expect(
+        component.containsPoint(Vector2.all(1.9)),
+        false,
+      );
+    });
+
+    test('Moved CircleComponent contains point', () {
+      final shape = Circle(
+        radius: 1.0,
+        position: Vector2(1, 1),
+      );
+      final component = shape.toComponent()..position += Vector2.all(1.0);
+      expect(
+        component.containsPoint(Vector2.all(2.1)),
+        true,
+      );
+    });
+
+    test('Moved RectangleComponent contains point', () {
+      final shape = Rectangle(
+        position: Vector2(1, 1),
+        size: Vector2(1, 1),
+      );
+      final component = shape.toComponent()..position += Vector2.all(1.0);
+      expect(
+        component.containsPoint(Vector2.all(2.1)),
+        true,
+      );
+    });
+
+    test('Moved PolygonComponent contains point', () {
+      final shape = Polygon([
+        Vector2(2, 2),
+        Vector2(2, 1),
+        Vector2(2, 0),
+        Vector2(1, 1),
+      ]);
+      final component = shape.toComponent()..position += Vector2.all(1.0);
+      expect(
+        component.containsPoint(Vector2.all(2.1)),
+        true,
+      );
+    });
+
+    test('Sized up CircleComponent does not contain point', () {
+      final shape = Circle(
+        radius: 1.0,
+        position: Vector2(1, 1),
+      );
+      final component = shape.toComponent()..size += Vector2.all(1.0);
+      expect(
+        component.containsPoint(Vector2.all(2.1)),
+        false,
+      );
+    });
+
+    test('Sized up RectangleComponent does not contain point', () {
+      final shape = Rectangle(
+        position: Vector2(1, 1),
+        size: Vector2(1, 1),
+      );
+      final component = shape.toComponent()..size += Vector2.all(1.0);
+      expect(
+        component.containsPoint(Vector2.all(2.1)),
+        false,
+      );
+    });
+
+    test('Sized PolygonComponent does not contain point', () {
+      final shape = Polygon([
+        Vector2(2, 2),
+        Vector2(2, 1),
+        Vector2(2, 0),
+        Vector2(1, 1),
+      ]);
+      final component = shape.toComponent()..size += Vector2.all(1.0);
+      expect(
+        component.containsPoint(Vector2.all(2.1)),
+        false,
+      );
+    });
+  });
+}

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -46,7 +46,7 @@ void main() {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
-        angle: pi / 2,
+        angle: pi / 4,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
@@ -56,9 +56,9 @@ void main() {
 
     test('Rotated rectangle does not contain point', () {
       final component = RectangleComponent(
-        position: Vector2(1, 1),
-        size: Vector2(1, 1),
-        angle: pi / 2,
+        position: Vector2.all(1.0),
+        size: Vector2.all(2.0),
+        angle: pi / 4,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
@@ -74,7 +74,7 @@ void main() {
           Vector2(2, 0),
           Vector2(1, 1),
         ],
-        angle: pi / 2,
+        angle: pi / 4,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
@@ -82,43 +82,99 @@ void main() {
       );
     });
 
-    test('Rotated CircleComponent does not contain point', () {
+    test('Rotated circle contains point', () {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
-        angle: pi / 2,
+        angle: pi / 4,
       );
       expect(
-        component.containsPoint(Vector2.all(1.9)),
-        false,
+        component.containsPoint(Vector2(1.0, 1.9)),
+        true,
       );
     });
 
-    test('Rotated RectangleComponent does not contain point', () {
+    test('Rotated rectangle contains point', () {
       final component = RectangleComponent(
-        position: Vector2(1, 1),
-        size: Vector2(1, 1),
-        angle: pi / 2,
+        position: Vector2.all(1.0),
+        size: Vector2.all(2.0),
+        angle: pi / 4,
       );
       expect(
-        component.containsPoint(Vector2.all(1.9)),
-        false,
+        component.containsPoint(Vector2(1.0, 2.1)),
+        true,
       );
     });
 
-    test('Rotated PolygonComponent does not contain point', () {
-      final component = PolygonComponent.fromPoints(
+    test('Rotated polygon contains point', () {
+      final component = Polygon(
         [
           Vector2(2, 2),
-          Vector2(2, 1),
+          Vector2(3, 1),
           Vector2(2, 0),
           Vector2(1, 1),
         ],
-        angle: pi / 2,
+        angle: pi / 4,
+      );
+      expect(
+        component.containsPoint(Vector2(2.7, 1.7)),
+        true,
+      );
+    });
+
+    test('Initially rotated CircleComponent does not contain point', () {
+      final component = CircleComponent(
+        radius: 1.0,
+        position: Vector2(1, 1),
+        angle: pi / 4,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
         false,
+      );
+    });
+
+    test('Initially rotated RectangleComponent does not contain point', () {
+      final component = RectangleComponent(
+        position: Vector2.all(1.0),
+        size: Vector2.all(2.0),
+        angle: pi / 4,
+      );
+      expect(
+        component.containsPoint(Vector2.all(1.9)),
+        false,
+      );
+    });
+
+    test('Initially rotated PolygonComponent does not contain point', () {
+      final component = PolygonComponent.fromPoints(
+        [
+          Vector2(2, 2),
+          Vector2(3, 1),
+          Vector2(2, 0),
+          Vector2(1, 1),
+        ],
+        angle: pi / 4,
+      );
+      expect(
+        component.containsPoint(Vector2.all(1.9)),
+        false,
+      );
+    });
+
+    test('Rotated PolygonComponent contains point', () {
+      final component = PolygonComponent.fromPoints(
+        [
+          Vector2(2, 2),
+          Vector2(3, 1),
+          Vector2(2, 0),
+          Vector2(1, 1),
+        ],
+      );
+      component.angle = pi / 4;
+      expect(
+        component.containsPoint(Vector2(2.7, 1.7)),
+        true,
       );
     });
 
@@ -147,15 +203,15 @@ void main() {
     test('Moved PolygonComponent contains point', () {
       final component = PolygonComponent.fromPoints(
         [
-          Vector2(2, 2),
-          Vector2(2, 1),
           Vector2(2, 0),
           Vector2(1, 1),
+          Vector2(2, 2),
+          Vector2(3, 1),
         ],
         position: Vector2.all(1.0),
       );
       expect(
-        component.containsPoint(Vector2.all(2.1)),
+        component.containsPoint(Vector2(0.9, 1.0)),
         true,
       );
     });
@@ -185,14 +241,14 @@ void main() {
 
     test('Sized PolygonComponent does not contain point', () {
       final component = PolygonComponent.fromPoints([
-        Vector2(2, 2),
-        Vector2(2, 1),
         Vector2(2, 0),
         Vector2(1, 1),
+        Vector2(2, 2),
+        Vector2(3, 1),
       ]);
       component.size += Vector2.all(1.0);
       expect(
-        component.containsPoint(Vector2.all(2.1)),
+        component.containsPoint(Vector2(2.0, 2.6)),
         false,
       );
     });

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -26,7 +26,7 @@ void main() {
       );
       final component = shape.toComponent();
       expect(
-        component.containsPoint(Vector2.all(1.9)),
+        component.containsPoint(Vector2.all(1.5)),
         true,
       );
     });

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -15,7 +15,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(1.5)),
-        true,
+        isTrue,
       );
     });
 
@@ -26,7 +26,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(1.5)),
-        true,
+        isTrue,
       );
     });
 
@@ -42,7 +42,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2(2.0, 1.9)),
-        true,
+        isTrue,
       );
     });
 
@@ -55,7 +55,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
-        false,
+        isFalse,
       );
     });
 
@@ -68,7 +68,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
-        false,
+        isFalse,
       );
     });
 
@@ -85,7 +85,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
-        false,
+        isFalse,
       );
     });
 
@@ -98,7 +98,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2(1.0, 1.9)),
-        true,
+        isTrue,
       );
     });
 
@@ -111,7 +111,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2(1.0, 2.1)),
-        true,
+        isTrue,
       );
     });
 
@@ -128,7 +128,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2(2.7, 1.7)),
-        true,
+        isTrue,
       );
     });
 
@@ -140,7 +140,7 @@ void main() {
       )..flipVerticallyAroundCenter();
       expect(
         component.containsPoint(Vector2(2.0, 2.0)),
-        true,
+        isTrue,
       );
     });
 
@@ -153,7 +153,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
-        false,
+        isFalse,
       );
     });
 
@@ -166,7 +166,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
-        false,
+        isFalse,
       );
     });
 
@@ -183,7 +183,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
-        false,
+        isFalse,
       );
     });
 
@@ -200,7 +200,7 @@ void main() {
       component.angle = pi / 4;
       expect(
         component.containsPoint(Vector2(2.7, 1.7)),
-        true,
+        isTrue,
       );
     });
 
@@ -212,7 +212,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(2.1)),
-        true,
+        isTrue,
       );
     });
 
@@ -224,7 +224,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(2.1)),
-        true,
+        isTrue,
       );
     });
 
@@ -241,7 +241,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2(0.9, 1.0)),
-        true,
+        isTrue,
       );
     });
 
@@ -254,7 +254,7 @@ void main() {
       component.size += Vector2.all(1.0);
       expect(
         component.containsPoint(Vector2.all(2.1)),
-        false,
+        isFalse,
       );
     });
 
@@ -266,7 +266,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2.all(2.1)),
-        false,
+        isFalse,
       );
     });
 
@@ -283,7 +283,7 @@ void main() {
       component.size += Vector2.all(1.0);
       expect(
         component.containsPoint(Vector2(2.0, 2.6)),
-        false,
+        isFalse,
       );
     });
 
@@ -295,7 +295,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2(0.9, 2.0)),
-        true,
+        isTrue,
       );
     });
 
@@ -307,7 +307,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2(0.9, 2.0)),
-        true,
+        isTrue,
       );
     });
 
@@ -323,7 +323,7 @@ void main() {
       );
       expect(
         component.containsPoint(Vector2(1.0, 0.99)),
-        true,
+        isTrue,
       );
     });
 
@@ -350,7 +350,7 @@ void main() {
         await game.add(grandParent);
         expect(
           component.containsPoint(Vector2(-1.0, 1.0)),
-          true,
+          isTrue,
         );
       },
     );
@@ -378,7 +378,7 @@ void main() {
         await game.add(grandParent);
         expect(
           component.containsPoint(Vector2(-1.0, 1.0)),
-          true,
+          isTrue,
         );
       },
     );
@@ -412,7 +412,7 @@ void main() {
         await game.add(grandParent);
         expect(
           component.containsPoint(Vector2(-1.0, 1.0)),
-          true,
+          isTrue,
         );
       },
     );

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -325,5 +326,95 @@ void main() {
         true,
       );
     });
+
+    flameGame.test(
+      'CircleComponent with multiple parents contains point',
+      (game) async {
+        PositionComponent createParent() {
+          return PositionComponent(
+            position: Vector2.all(1.0),
+            size: Vector2.all(2.0),
+            angle: pi / 2,
+          );
+        }
+
+        final component = CircleComponent(
+          radius: 1.0,
+          position: Vector2.all(1.0),
+          anchor: Anchor.center,
+        );
+        final grandParent = createParent();
+        final parent = createParent();
+        grandParent.add(parent);
+        parent.add(component);
+        await game.add(grandParent);
+        expect(
+          component.containsPoint(Vector2(-1.0, 1.0)),
+          true,
+        );
+      },
+    );
+
+    flameGame.test(
+      'RectangleComponent with multiple parents contains point',
+      (game) async {
+        PositionComponent createParent() {
+          return PositionComponent(
+            position: Vector2.all(1.0),
+            size: Vector2.all(2.0),
+            angle: pi / 2,
+          );
+        }
+
+        final component = RectangleComponent(
+          size: Vector2.all(1.0),
+          position: Vector2.all(1.0),
+          anchor: Anchor.center,
+        );
+        final grandParent = createParent();
+        final parent = createParent();
+        grandParent.add(parent);
+        parent.add(component);
+        await game.add(grandParent);
+        expect(
+          component.containsPoint(Vector2(-1.0, 1.0)),
+          true,
+        );
+      },
+    );
+
+    flameGame.test(
+      'PolygonComponent with multiple parents contains point',
+      (game) async {
+        PositionComponent createParent() {
+          return PositionComponent(
+            position: Vector2.all(1.0),
+            size: Vector2.all(2.0),
+            angle: pi / 2,
+          );
+        }
+
+        final component = PolygonComponent(
+          normalizedVertices: [
+            Vector2(1, 0),
+            Vector2(0, -1),
+            Vector2(-1, 0),
+            Vector2(0, 1),
+          ],
+          size: Vector2.all(1.0),
+          position: Vector2.all(1.0),
+          anchor: Anchor.center,
+        );
+        final grandParent = createParent();
+        final parent = createParent();
+        grandParent.add(parent);
+        parent.add(component);
+        await game.add(grandParent);
+        expect(
+          component.containsPoint(Vector2(-1.0, 1.0)),
+          true,
+        );
+      },
+    );
   });
 }

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
-import 'package:flame/geometry.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -11,6 +10,7 @@ void main() {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(1.5)),
@@ -30,12 +30,15 @@ void main() {
     });
 
     test('Simple polygon contains point', () {
-      final component = Polygon([
-        Vector2(2, 2),
-        Vector2(2, 1),
-        Vector2(2, 0),
-        Vector2(1, 1),
-      ]);
+      final component = PolygonComponent.fromPoints(
+        [
+          Vector2(2, 2),
+          Vector2(2, 1),
+          Vector2(2, 0),
+          Vector2(1, 1),
+        ],
+        anchor: Anchor.center,
+      );
       expect(
         component.containsPoint(Vector2(2.0, 1.9)),
         true,
@@ -47,6 +50,7 @@ void main() {
         radius: 1.0,
         position: Vector2(1, 1),
         angle: pi / 4,
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
@@ -59,6 +63,7 @@ void main() {
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
         angle: pi / 4,
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
@@ -67,7 +72,7 @@ void main() {
     });
 
     test('Rotated polygon does not contain point', () {
-      final component = Polygon(
+      final component = PolygonComponent.fromPoints(
         [
           Vector2(2, 2),
           Vector2(2, 1),
@@ -75,6 +80,7 @@ void main() {
           Vector2(1, 1),
         ],
         angle: pi / 4,
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
@@ -87,6 +93,7 @@ void main() {
         radius: 1.0,
         position: Vector2(1, 1),
         angle: pi / 4,
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2(1.0, 1.9)),
@@ -99,6 +106,7 @@ void main() {
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
         angle: pi / 4,
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2(1.0, 2.1)),
@@ -107,7 +115,7 @@ void main() {
     });
 
     test('Rotated polygon contains point', () {
-      final component = Polygon(
+      final component = PolygonComponent.fromPoints(
         [
           Vector2(2, 2),
           Vector2(3, 1),
@@ -115,6 +123,7 @@ void main() {
           Vector2(1, 1),
         ],
         angle: pi / 4,
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2(2.7, 1.7)),
@@ -126,6 +135,7 @@ void main() {
       final component = RectangleComponent(
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
+        anchor: Anchor.center,
       )..flipVerticallyAroundCenter();
       expect(
         component.containsPoint(Vector2(2.0, 2.0)),
@@ -138,6 +148,7 @@ void main() {
         radius: 1.0,
         position: Vector2(1, 1),
         angle: pi / 4,
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
@@ -150,6 +161,7 @@ void main() {
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
         angle: pi / 4,
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
@@ -166,6 +178,7 @@ void main() {
           Vector2(1, 1),
         ],
         angle: pi / 4,
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(1.9)),
@@ -181,6 +194,7 @@ void main() {
           Vector2(2, 0),
           Vector2(1, 1),
         ],
+        anchor: Anchor.center,
       );
       component.angle = pi / 4;
       expect(
@@ -193,6 +207,7 @@ void main() {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(2, 2),
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(2.1)),
@@ -204,6 +219,7 @@ void main() {
       final component = RectangleComponent(
         position: Vector2(2, 2),
         size: Vector2(1, 1),
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(2.1)),
@@ -220,6 +236,7 @@ void main() {
           Vector2(3, 1),
         ],
         position: Vector2.all(1.0),
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2(0.9, 1.0)),
@@ -231,6 +248,7 @@ void main() {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
+        anchor: Anchor.center,
       );
       component.size += Vector2.all(1.0);
       expect(
@@ -243,6 +261,7 @@ void main() {
       final component = RectangleComponent(
         position: Vector2(1, 1),
         size: Vector2(2, 2),
+        anchor: Anchor.center,
       );
       expect(
         component.containsPoint(Vector2.all(2.1)),
@@ -251,16 +270,59 @@ void main() {
     });
 
     test('Sized PolygonComponent does not contain point', () {
-      final component = PolygonComponent.fromPoints([
-        Vector2(2, 0),
-        Vector2(1, 1),
-        Vector2(2, 2),
-        Vector2(3, 1),
-      ]);
+      final component = PolygonComponent.fromPoints(
+        [
+          Vector2(2, 0),
+          Vector2(1, 1),
+          Vector2(2, 2),
+          Vector2(3, 1),
+        ],
+        anchor: Anchor.center,
+      );
       component.size += Vector2.all(1.0);
       expect(
         component.containsPoint(Vector2(2.0, 2.6)),
         false,
+      );
+    });
+
+    test('CircleComponent with default anchor (topLeft) contains point', () {
+      final component = CircleComponent(
+        radius: 1.0,
+        position: Vector2.all(1.0),
+        angle: pi / 4,
+      );
+      expect(
+        component.containsPoint(Vector2(0.9, 2.0)),
+        true,
+      );
+    });
+
+    test('RectangleComponent with default anchor (topLeft) contains point', () {
+      final component = RectangleComponent(
+        position: Vector2.all(1.0),
+        size: Vector2.all(1.0),
+        angle: pi / 4,
+      );
+      expect(
+        component.containsPoint(Vector2(0.9, 2.0)),
+        true,
+      );
+    });
+
+    test('PolygonComponent with default anchor (topLeft) contains point', () {
+      final component = PolygonComponent.fromPoints(
+        [
+          Vector2(2, 0),
+          Vector2(1, 1),
+          Vector2(2, 2),
+          Vector2(3, 1),
+        ],
+        angle: pi / 4,
+      );
+      expect(
+        component.containsPoint(Vector2(1.0, 0.99)),
+        true,
       );
     });
   });

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -127,10 +127,9 @@ void main() {
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
       )..flipVerticallyAroundCenter();
-      print(component.absoluteScale);
       print((component.hitboxes[0] as Polygon).globalVertices());
       expect(
-        component.containsPoint(Vector2(1.0, 2.1)),
+        component.containsPoint(Vector2(2.0, 2.0)),
         true,
       );
     });

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -122,6 +122,19 @@ void main() {
       );
     });
 
+    test('Horizontally flipped rectangle contains point', () {
+      final component = RectangleComponent(
+        position: Vector2.all(1.0),
+        size: Vector2.all(2.0),
+      )..flipVerticallyAroundCenter();
+      print(component.absoluteScale);
+      print((component.hitboxes[0] as Polygon).globalVertices());
+      expect(
+        component.containsPoint(Vector2(1.0, 2.1)),
+        true,
+      );
+    });
+
     test('Initially rotated CircleComponent does not contain point', () {
       final component = CircleComponent(
         radius: 1.0,

--- a/packages/flame/test/game/base_game_test.dart
+++ b/packages/flame/test/game/base_game_test.dart
@@ -229,7 +229,7 @@ void main() {
 
     const message = '"prepare/add" called before the game is ready. '
         'Did you try to access it on the Game constructor? '
-        'Use the "onLoad" or "onParentMethod" method instead.';
+        'Use the "onLoad" or "onMount" method instead.';
 
     expect(
       () => game.add(component),

--- a/packages/flame_rive/example/lib/main.dart
+++ b/packages/flame_rive/example/lib/main.dart
@@ -77,19 +77,3 @@ class SkillsAnimationComponent extends RiveComponent with Tappable {
     return true;
   }
 }
-
-class Square extends PositionComponent with HasGameRef<RiveExampleGame> {
-  late final Paint paint;
-
-  Square(Vector2 position) {
-    this.position.setFrom(position);
-    size.setValues(100, 100);
-    paint = PaintExtension.random(withAlpha: 0.9, base: 100);
-  }
-
-  @override
-  void render(Canvas canvas) {
-    super.render(canvas);
-    canvas.drawRect(size.toRect(), paint);
-  }
-}


### PR DESCRIPTION
# Description

The hitboxes didn't take the full ancestor tree of the parent component into consideration, now they do (except for multiple scales).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
