### PR TITLE
Move effects

### DIFF
--- a/examples/lib/stories/effects/effects.dart
+++ b/examples/lib/stories/effects/effects.dart
@@ -6,6 +6,7 @@ import 'color_effect.dart';
 import 'combined_effect.dart';
 import 'infinite_effect.dart';
 import 'move_effect.dart';
+import 'move_effect_example.dart';
 import 'opacity_effect.dart';
 import 'remove_effect_example.dart';
 import 'rotate_effect.dart';
@@ -69,6 +70,12 @@ void addEffectsStories(Dashbook dashbook) {
       'Color Effect',
       (_) => GameWidget(game: ColorEffectGame()),
       codeLink: baseLink('effects/color_effect.dart'),
+    )
+    ..add(
+      'Move Effect (v2)',
+      (_) => GameWidget(game: MoveEffectExample()),
+      codeLink: baseLink('effects/move_effect_example.dart'),
+      info: MoveEffectExample.description,
     )
     ..add(
       'Rotate Effect (v2)',

--- a/examples/lib/stories/effects/move_effect_example.dart
+++ b/examples/lib/stories/effects/move_effect_example.dart
@@ -96,12 +96,13 @@ class MoveEffectExample extends FlameGame {
         SquareComponent(size: 10)
           ..paint = (Paint()..color = const Color(0xFF00FFF7))
           ..add(MoveEffect.along(
-              path2,
-              StandardEffectController(
-                duration: 6,
-                startDelay: i * 0.3,
-                infinite: true,
-              ))),
+            path2,
+            StandardEffectController(
+              duration: 6,
+              startDelay: i * 0.3,
+              infinite: true,
+            ),
+          )),
       );
     }
   }

--- a/examples/lib/stories/effects/move_effect_example.dart
+++ b/examples/lib/stories/effects/move_effect_example.dart
@@ -1,0 +1,109 @@
+import 'dart:math';
+
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame/src/effects2/move_effect.dart'; // ignore: implementation_imports
+import 'package:flame/src/effects2/standard_effect_controller.dart'; // ignore: implementation_imports
+import 'package:flutter/material.dart';
+import '../../commons/square_component.dart';
+
+class MoveEffectExample extends FlameGame {
+  static const description = '''
+    Top square has `MoveEffect.to` effect that makes the component move along a
+    straight line back and forth. The effect uses a non-linear progression
+    curve, which makes the movement non-uniform.
+
+    The middle green square has a combination of two movement effects: a
+    `MoveEffect.to` and a `MoveEffect.by` which forces it to periodically jump.
+
+    At the bottom there are 60 more components which demonstrate movement along
+    an arbitrary path using `MoveEffect.along`.
+  ''';
+
+  @override
+  void onMount() {
+    const tau = Transform2D.tau;
+    camera.viewport = FixedResolutionViewport(Vector2(400, 600));
+
+    final paint1 = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 5.0
+      ..color = const Color(0xFFFF6622);
+    final paint2 = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 5.0
+      ..color = const Color(0xFF22FF66);
+
+    add(
+      SquareComponent(position: Vector2(20, 50), size: 20, paint: paint1)
+        ..add(MoveEffect.to(
+          Vector2(380, 50),
+          StandardEffectController(
+            duration: 3,
+            reverseDuration: 3,
+            infinite: true,
+            curve: Curves.easeOut,
+          ),
+        )),
+    );
+    add(
+      SquareComponent(position: Vector2(20, 150), size: 20, paint: paint2)
+        ..add(MoveEffect.to(
+          Vector2(380, 150),
+          StandardEffectController(
+            duration: 3,
+            reverseDuration: 3,
+            infinite: true,
+          ),
+        ))
+        ..add(MoveEffect.by(
+          Vector2(0, -50),
+          StandardEffectController(
+            duration: 0.25,
+            reverseDuration: 0.25,
+            startDelay: 1,
+            atMinDuration: 2,
+            curve: Curves.ease,
+            infinite: true,
+          ),
+        )),
+    );
+
+    final path1 = Path()..moveTo(200, 250);
+    for (var i = 1; i <= 5; i++) {
+      final x = 200 + 100 * sin(i * tau * 2 / 5);
+      final y = 350 - 100 * cos(i * tau * 2 / 5);
+      path1.lineTo(x, y);
+    }
+    for (var i = 0; i < 40; i++) {
+      add(
+        CircleComponent(5)
+          ..add(
+            MoveEffect.along(
+                path1,
+                StandardEffectController(
+                  duration: 10,
+                  startDelay: i * 0.2,
+                  infinite: true,
+                )),
+          ),
+      );
+    }
+
+    final path2 = Path()
+      ..addArc(const Rect.fromLTRB(80, 230, 320, 470), 0, tau);
+    for (var i = 0; i < 20; i++) {
+      add(
+        SquareComponent(size: 10)
+          ..paint = (Paint()..color = const Color(0xFF00FFF7))
+          ..add(MoveEffect.along(
+              path2,
+              StandardEffectController(
+                duration: 6,
+                startDelay: i * 0.3,
+                infinite: true,
+              ))),
+      );
+    }
+  }
+}

--- a/examples/lib/stories/effects/move_effect_example.dart
+++ b/examples/lib/stories/effects/move_effect_example.dart
@@ -90,8 +90,7 @@ class MoveEffectExample extends FlameGame {
       );
     }
 
-    final path2 = Path()
-      ..addArc(const Rect.fromLTRB(80, 230, 320, 470), 0, tau);
+    final path2 = Path()..addOval(const Rect.fromLTRB(80, 230, 320, 470));
     for (var i = 0; i < 20; i++) {
       add(
         SquareComponent(size: 10)

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Removed `runOnCreation` attribute in favor of the `paused` attribute on `FlameGame`
  - Add `CustomPainterComponent`
  - Alternative implementation of `RotateEffect`, based on `Transform2DEffect`
+ - Alternative implementation of `MoveEffect`, based on `Transform2DEffect`
  - Fix `onGameResize` margin bug in `HudMarginComponent`
  - `PositionComponent.size` now returns a `NotifyingVector2`
  - Possibility to manually remove `TimerComponent`

--- a/packages/flame/lib/src/effects2/move_effect.dart
+++ b/packages/flame/lib/src/effects2/move_effect.dart
@@ -1,0 +1,102 @@
+import 'dart:ui';
+
+import 'package:flame/src/effects2/effect.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'effect_controller.dart';
+import 'transform2d_effect.dart';
+
+/// Move a component to a new position.
+///
+/// The following constructors are provided:
+///
+///   - [MoveEffect.by] will move the target in a straight line to a new
+///     position that is at an `offset` from the target's position at the onset
+///     of the effect;
+///
+///   - [MoveEffect.to] will move the target in a straight line to the specified
+///     coordinates
+///
+///   - [MoveEffect.along] will move the target along the specified path, which
+///     may contain curved segments, but must be simply-connected. 
+///
+/// This effect applies incremental changes to the component's position, and
+/// requires that any other effect or update logic applied to the same component
+/// also used incremental updates.
+class MoveEffect extends Transform2DEffect {
+  MoveEffect.by(Vector2 offset, EffectController controller)
+      : _offset = offset.clone(),
+        super(controller);
+
+  factory MoveEffect.to(Vector2 destination, EffectController controller)
+      => _MoveToEffect(destination, controller);
+
+  factory MoveEffect.along(Path path, EffectController controller)
+      => _MoveAlongPathEffect(path, controller);
+
+  Vector2 _offset;
+
+  @override
+  void apply(double progress) {
+    final dProgress = progress - previousProgress;
+    target.position += _offset * dProgress;
+    super.apply(progress);
+  }
+}
+
+/// Implementation class for [MoveEffect.to]
+class _MoveToEffect extends MoveEffect {
+  _MoveToEffect(Vector2 destination, EffectController controller)
+      : _destination = destination.clone(),
+        super.by(Vector2.zero(), controller);
+
+  final Vector2 _destination;
+
+  @override
+  void onStart() {
+    _offset = _destination - target.position;
+  }
+}
+
+/// Implementation class for [MoveEffect.along].
+class _MoveAlongPathEffect extends MoveEffect {
+  _MoveAlongPathEffect(Path path, EffectController controller)
+      : super.by(Vector2.zero(), controller) {
+    final metrics = path.computeMetrics().toList();
+    if (metrics.length != 1) {
+      throw ArgumentError(
+        'Only single-contour paths are allowed in MoveEffect.along',
+      );
+    }
+    _pathMetric = metrics[0];
+    _pathLength = _pathMetric.length;
+    if (_pathLength == 0) {
+      throw ArgumentError(
+        'Zero-length paths are not allowed in MoveEffect.along',
+      );
+    }
+    reset(); // initializes _lastPosition
+  }
+
+  late final PathMetric _pathMetric;
+  late final double _pathLength;
+  late Vector2 _lastPosition;
+
+  @override
+  void apply(double progress) {
+    final distance = progress * _pathLength;
+    final tangent = _pathMetric.getTangentForOffset(distance)!;
+    final offset = tangent.position;
+    final newPosition = Vector2(offset.dx, offset.dy);
+    target.position += newPosition - _lastPosition;
+    _lastPosition = newPosition;
+    super.apply(progress);
+  }
+
+  @override
+  void reset() {
+    super.reset();
+    final tangent = _pathMetric.getTangentForOffset(0)!;
+    _lastPosition = Vector2(tangent.position.dx, tangent.position.dy);
+  }
+}

--- a/packages/flame/lib/src/effects2/move_effect.dart
+++ b/packages/flame/lib/src/effects2/move_effect.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:flame/src/effects2/effect.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'effect_controller.dart';
@@ -18,7 +17,7 @@ import 'transform2d_effect.dart';
 ///     coordinates
 ///
 ///   - [MoveEffect.along] will move the target along the specified path, which
-///     may contain curved segments, but must be simply-connected. 
+///     may contain curved segments, but must be simply-connected.
 ///
 /// This effect applies incremental changes to the component's position, and
 /// requires that any other effect or update logic applied to the same component
@@ -28,11 +27,11 @@ class MoveEffect extends Transform2DEffect {
       : _offset = offset.clone(),
         super(controller);
 
-  factory MoveEffect.to(Vector2 destination, EffectController controller)
-      => _MoveToEffect(destination, controller);
+  factory MoveEffect.to(Vector2 destination, EffectController controller) =>
+      _MoveToEffect(destination, controller);
 
-  factory MoveEffect.along(Path path, EffectController controller)
-      => _MoveAlongPathEffect(path, controller);
+  factory MoveEffect.along(Path path, EffectController controller) =>
+      _MoveAlongPathEffect(path, controller);
 
   Vector2 _offset;
 

--- a/packages/flame/lib/src/effects2/move_effect.dart
+++ b/packages/flame/lib/src/effects2/move_effect.dart
@@ -14,10 +14,12 @@ import 'transform2d_effect.dart';
 ///     of the effect;
 ///
 ///   - [MoveEffect.to] will move the target in a straight line to the specified
-///     coordinates
+///     coordinates;
 ///
 ///   - [MoveEffect.along] will move the target along the specified path, which
-///     may contain curved segments, but must be simply-connected.
+///     may contain curved segments, but must be simply-connected. The `path`
+///     argument is taken as relative to the target's position at the start of
+///     the effect.
 ///
 /// This effect applies incremental changes to the component's position, and
 /// requires that any other effect or update logic applied to the same component
@@ -60,7 +62,8 @@ class _MoveToEffect extends MoveEffect {
 /// Implementation class for [MoveEffect.along].
 class _MoveAlongPathEffect extends MoveEffect {
   _MoveAlongPathEffect(Path path, EffectController controller)
-      : super.by(Vector2.zero(), controller) {
+      : _lastPosition = Vector2.zero(),
+        super.by(Vector2.zero(), controller) {
     final metrics = path.computeMetrics().toList();
     if (metrics.length != 1) {
       throw ArgumentError(
@@ -74,7 +77,6 @@ class _MoveAlongPathEffect extends MoveEffect {
         'Zero-length paths are not allowed in MoveEffect.along',
       );
     }
-    reset(); // initializes _lastPosition
   }
 
   late final PathMetric _pathMetric;
@@ -95,7 +97,6 @@ class _MoveAlongPathEffect extends MoveEffect {
   @override
   void reset() {
     super.reset();
-    final tangent = _pathMetric.getTangentForOffset(0)!;
-    _lastPosition = Vector2(tangent.position.dx, tangent.position.dy);
+    _lastPosition = Vector2.zero();
   }
 }

--- a/packages/flame/lib/src/effects2/move_effect.dart
+++ b/packages/flame/lib/src/effects2/move_effect.dart
@@ -84,9 +84,9 @@ class _MoveAlongPathEffect extends MoveEffect {
     final distance = progress * _pathLength;
     final tangent = _pathMetric.getTangentForOffset(distance)!;
     final offset = tangent.position;
-    final newPosition = Vector2(offset.dx, offset.dy);
-    target.position += newPosition - _lastPosition;
-    _lastPosition = newPosition;
+    target.position.x += offset.dx - _lastPosition.x;
+    target.position.y += offset.dy - _lastPosition.y;
+    _lastPosition.setValues(offset.dx, offset.dy);
     super.apply(progress);
   }
 

--- a/packages/flame/lib/src/effects2/move_effect.dart
+++ b/packages/flame/lib/src/effects2/move_effect.dart
@@ -72,11 +72,7 @@ class _MoveAlongPathEffect extends MoveEffect {
     }
     _pathMetric = metrics[0];
     _pathLength = _pathMetric.length;
-    if (_pathLength == 0) {
-      throw ArgumentError(
-        'Zero-length paths are not allowed in MoveEffect.along',
-      );
-    }
+    assert(_pathLength > 0);
   }
 
   late final PathMetric _pathMetric;

--- a/packages/flame/test/effects2/move_effect_test.dart
+++ b/packages/flame/test/effects2/move_effect_test.dart
@@ -46,7 +46,7 @@ void main() {
     });
 
     test('MoveEffect.along()', () {
-      final tau = Transform2D.tau;
+      const tau = Transform2D.tau;
       final game = FlameGame();
       game.onGameResize(Vector2(100, 100));
       final object = PositionComponent()..position = Vector2(3, 4);

--- a/packages/flame/test/effects2/move_effect_test.dart
+++ b/packages/flame/test/effects2/move_effect_test.dart
@@ -1,0 +1,99 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame/src/effects2/move_effect.dart';
+import 'package:flame/src/effects2/simple_effect_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MoveEffect', () {
+    test('MoveEffect.by()', () {
+      final game = FlameGame();
+      game.onGameResize(Vector2(100, 100));
+      final object = PositionComponent()..position = Vector2(3, 4);
+      game.add(object);
+      game.update(0);
+
+      object.add(
+        MoveEffect.by(Vector2(5, -1), SimpleEffectController(duration: 1)),
+      );
+      game.update(0.5);
+      expect(object.position.x, closeTo(3 + 2.5, 1e-15));
+      expect(object.position.y, closeTo(4 + -0.5, 1e-15));
+      game.update(0.5);
+      expect(object.position.x, closeTo(3 + 5, 1e-15));
+      expect(object.position.y, closeTo(4 + -1, 1e-15));
+    });
+
+    test('MoveEffect.to()', () {
+      final game = FlameGame();
+      game.onGameResize(Vector2(100, 100));
+      final object = PositionComponent()..position = Vector2(3, 4);
+      game.add(object);
+      game.update(0);
+
+      object.add(
+        MoveEffect.to(Vector2(5, -1), SimpleEffectController(duration: 1)),
+      );
+      game.update(0.5);
+      expect(object.position.x, closeTo(3 * 0.5 + 5 * 0.5, 1e-15));
+      expect(object.position.y, closeTo(4 * 0.5 + -1 * 0.5, 1e-15));
+      game.update(0.5);
+      expect(object.position.x, closeTo(5, 1e-15));
+      expect(object.position.y, closeTo(-1, 1e-15));
+    });
+
+    test('MoveEffect.along()', () {
+      final tau = Transform2D.tau;
+      final game = FlameGame();
+      game.onGameResize(Vector2(100, 100));
+      final object = PositionComponent()..position = Vector2(3, 4);
+      game.add(object);
+      game.update(0);
+
+      object.add(
+        MoveEffect.along(
+          Path()
+            ..addOval(Rect.fromCircle(center: const Offset(6, 10), radius: 50)),
+          SimpleEffectController(duration: 1),
+        ),
+      );
+      game.update(0);
+      for (var i = 0; i < 100; i++) {
+        final a = tau * i / 100;
+        // Apparently, in Flutter circle paths are not truly circles, but only
+        // appear circle-ish to an unsuspecting observer. Which is why the
+        // precision in `closeTo()` is so low: only 0.1 pixels.
+        expect(object.position.x, closeTo(3 + 6 + 50 * cos(a), 0.1));
+        expect(object.position.y, closeTo(4 + 10 + 50 * sin(a), 0.1));
+        game.update(0.01);
+      }
+    });
+
+    test('MoveEffect.along() wrong arguments', () {
+      final controller = SimpleEffectController();
+      expect(
+        () => MoveEffect.along(Path(), controller),
+        throwsArgumentError,
+      );
+
+      final path2 = Path()
+        ..moveTo(10, 10)
+        ..lineTo(10, 10);
+      expect(
+        () => MoveEffect.along(path2, controller),
+        throwsArgumentError,
+      );
+
+      final path3 = Path()
+        ..addOval(const Rect.fromLTWH(0, 0, 1, 1))
+        ..addOval(const Rect.fromLTWH(2, 2, 1, 1));
+      expect(
+        () => MoveEffect.along(path3, controller),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

Added new `MoveEffect` class based on `Transform2DEffect`. Compared to the original `MoveEffect`, these are some differences:
  - `MoveEffect.to` implements movement towards a specific point in the world;
  - `MoveEffect.by` is a relative motion that changes the position of a component by the given offset;
  - `MoveEffect.along` is for moving the component along an arbitrary path (which includes curved paths too);
  - multiple move effects can be applied to a component at the same time.

Added new example in the Dashbook demonstrating different kinds of move effects.


https://user-images.githubusercontent.com/744771/140383592-36a9c090-f6f8-40a9-804e-cb405d29d89d.mp4

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

Replaces #1031
