### PR TITLE
Remove `BaseComponent` from docs

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -45,7 +45,7 @@ lifetime. This method is executed after the initial "preparation" of the compone
 `onGameResize` and `onLoad`, but before the inclusion of the component in the parent's list of
 components.
 
-## BaseComponent
+## Component
 Usually if you are going to make your own component you want to extend `PositionComponent`, but if
 you want to be able to handle effects and child components but handle the positioning differently
 you can extend the `Component` directly.

--- a/doc/gesture-input.md
+++ b/doc/gesture-input.md
@@ -165,7 +165,7 @@ You can also check more complete examples
 
 ## Tappable, Draggable and Hoverable components
 
-Any component derived from `BaseComponent` (most components) can add the `Tappable`, the
+Any component derived from `Component` (most components) can add the `Tappable`, the
 `Draggable`, and/or the `Hoverable` mixins to handle taps, drags and hovers on the component.
 
 All overridden methods return a boolean to control if the event should be passed down further along

--- a/doc/keyboard-input.md
+++ b/doc/keyboard-input.md
@@ -14,8 +14,8 @@ The keyboard API on flame relies on the
 
 To customize focus behavior, see [Controlling focus](#controlling-focus).
 
-There are two ways a game can be sensitive to key strokes; at the game level and at a component level.
-For each we have a mixin that can me added to  `Game`s and `BaseComponent`s, respectively. 
+There are two ways a game can react to key strokes; at the game level and at a component level.
+For each we have a mixin that can me added to a `Game` or `Component` class.
 
 ### Receive keyboard events in a game level
 
@@ -23,21 +23,28 @@ To make a `Game` sub class sensitive to key stroke, mix it with `KeyboardEvents`
 
 After that, it will be possible to override an `onKeyEvent` method.
 
-This method receives two parameters, first the [`RawKeyEvent`](https://api.flutter.dev/flutter/services/RawKeyEvent-class.html) 
-that triggered the callback in the first place. The second is a set of the currently pressed [`LogicalKeyboardKey`](https://api.flutter.dev/flutter/widgets/KeyEventResult-class.html).
+This method receives two parameters, first the
+[`RawKeyEvent`](https://api.flutter.dev/flutter/services/RawKeyEvent-class.html)
+that triggers the callback in the first place. The second is a set of the currently pressed
+[`LogicalKeyboardKey`](https://api.flutter.dev/flutter/widgets/KeyEventResult-class.html).
 
-The return value should be a [`KeyEventResult`](https://api.flutter.dev/flutter/widgets/KeyEventResult-class.html). 
+The return value is a
+[`KeyEventResult`](https://api.flutter.dev/flutter/widgets/KeyEventResult-class.html).
 
-`KeyEventResult.handled` will tell the framework that the key stroke was resolved inside of Flame and skip any other keyboard handler widgets apart of `GameWidget`.
+`KeyEventResult.handled` will tell the framework that the key stroke was resolved inside of Flame
+and skip any other keyboard handler widgets apart of `GameWidget`.
 
-`KeyEventResult.ignored` will tell the framework to keep testing this event in any other keyboard handler widget apart of `GameWidget`. If the event is not resolved by any handler, the framework will trigger `SystemSoundType.alert`.
+`KeyEventResult.ignored` will tell the framework to keep testing this event in any other keyboard
+handler widget apart of `GameWidget`. If the event is not resolved by any handler, the framework
+will trigger `SystemSoundType.alert`.
 
-`KeyEventResult.skipRemainingHandlers` is very similar to `.ignored`, apart from the fact that will skip any other handler widget and will straight up play the alert sound.
+`KeyEventResult.skipRemainingHandlers` is very similar to `.ignored`, apart from the fact that will
+skip any other handler widget and will straight up play the alert sound.
 
 Minimal example:
 
 ```dart
-class MyGame extends Game with KeyboardEvents {
+class MyGame extends FlameGame with KeyboardEvents {
   // ...
   @override
   KeyEventResult onKeyEvent(
@@ -66,29 +73,34 @@ class MyGame extends Game with KeyboardEvents {
 
 To receive keyboard events directly in components, there is the mixin `KeyboardHandler`.
 
-Similarly to `Tappable` and `Draggable`, `KeyboardHandler` can be mixed into any `BaseComponent` 
-subclass. 
+Similarly to `Tappable` and `Draggable`, `KeyboardHandler` can be mixed into any subclass of
+`Component`.
 
 KeyboardHandlers must only be added to games that are mixed with `HasKeyboardHandlerComponents`.
 
-> ⚠️ Attention: If `HasKeyboardHandlerComponents` is used, you must remove `KeyboardEvents` 
+> ⚠️ Note: If `HasKeyboardHandlerComponents` is used, you must remove `KeyboardEvents`
 > from the game mixin list to avoid conflicts.
 
-After applying `HasKeyboardHandlerComponents`, it will be possible to override an `onKeyEvent` method.
+After applying `KeyboardHandler`, it will be possible to override an `onKeyEvent` method.
 
-This method receives two parameters. First the [`RawKeyEvent`](https://api.flutter.dev/flutter/services/RawKeyEvent-class.html) 
-that triggered the callback in the first place. The second is a set of the currently pressed [`LogicalKeyboardKey`](https://api.flutter.dev/flutter/widgets/KeyEventResult-class.html)s.
+This method receives two parameters. First the
+[`RawKeyEvent`](https://api.flutter.dev/flutter/services/RawKeyEvent-class.html)
+that triggered the callback in the first place. The second is a set of the currently pressed
+[`LogicalKeyboardKey`](https://api.flutter.dev/flutter/widgets/KeyEventResult-class.html)s.
 
-The returned value should be `true` to allow the continuous propagation of the key event among other components. 
-To not allow any other component to receive the event, return `false`.
+The returned value should be `true` to allow the continuous propagation of the key event among other
+components. To not allow any other component to receive the event, return `false`.
 
 ### Controlling focus
 
-On the widget level, it is possible to use the [`FocusNode`](https://api.flutter.dev/flutter/widgets/FocusNode-class.html) API to control whether the game is focused or not. 
+On the widget level, it is possible to use the
+[`FocusNode`](https://api.flutter.dev/flutter/widgets/FocusNode-class.html) API to control whether
+the game is focused or not.
 
 `GameWidget` has an optional `focusNode` parameter that allow its focus to be controlled externally.
 
-By default `GameWidget` has its `autofocus` set to true, which means it will get focused once it is mounted. To override that behavior, set `autofocus` to false.
+By default `GameWidget` has its `autofocus` set to true, which means it will get focused once it is
+mounted. To override that behavior, set `autofocus` to false.
 
 For a more complete example see 
 [here](https://github.com/flame-engine/flame/tree/main/examples/lib/stories/input/keyboard.dart).


### PR DESCRIPTION
# Description

Apparently we still had some mentions of `BaseComponent` in the docs.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `./scripts/format.sh` and the Flame analyzer (`./scripts/analyze.sh`) does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
