### PR TITLE
Adding example from sprite animation with variable step time

### DIFF
--- a/examples/lib/stories/sprites/spritesheet.dart
+++ b/examples/lib/stories/sprites/spritesheet.dart
@@ -13,8 +13,17 @@ class SpritesheetGame extends FlameGame {
 
     final vampireAnimation =
         spriteSheet.createAnimation(row: 0, stepTime: 0.1, to: 7);
+
     final ghostAnimation =
         spriteSheet.createAnimation(row: 1, stepTime: 0.1, to: 7);
+
+    final ghostAnimationVariableStepTimes =
+        spriteSheet.createAnimationWithVariableStepTimes(
+      row: 1,
+      to: 7,
+      stepTimes: [0.1, 0.1, 0.3, 0.3, 0.5, 0.3, 0.1],
+    );
+
     final spriteSize = Vector2(80.0, 90.0);
 
     final vampireComponent = SpriteAnimationComponent(
@@ -29,8 +38,15 @@ class SpritesheetGame extends FlameGame {
       size: spriteSize,
     );
 
+    final ghostAnimationVariableStepTimesComponent = SpriteAnimationComponent(
+      animation: ghostAnimationVariableStepTimes,
+      position: Vector2(150, 340),
+      size: spriteSize,
+    );
+
     add(vampireComponent);
     add(ghostComponent);
+    add(ghostAnimationVariableStepTimesComponent);
 
     // Some plain sprites
     final vampireSpriteComponent = SpriteComponent(
@@ -45,7 +61,14 @@ class SpritesheetGame extends FlameGame {
       position: Vector2(50, 220),
     );
 
+    final ghostVariableSpriteComponent = SpriteComponent(
+      sprite: spriteSheet.getSprite(1, 0),
+      size: spriteSize,
+      position: Vector2(50, 340),
+    );
+
     add(vampireSpriteComponent);
     add(ghostSpriteComponent);
+    add(ghostVariableSpriteComponent);
   }
 }


### PR DESCRIPTION
# Description

This PR only introduces an example from `createAnimationWithVariableStepTimes`.

## Checklist


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [ ] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [ ] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

This PR is related with [this](https://github.com/flame-engine/flame/pull/1018) PR


https://user-images.githubusercontent.com/29265526/140622016-78207568-fe01-4610-936e-21541bc675f0.mov


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
