### PR TITLE
Remove unnecessary `super.render` calls

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -83,7 +83,6 @@ class GameOverPanel extends PositionComponent with HasGameRef<MyGame> {
   @override
   void render(Canvas canvas) {
     if (visible) {
-      super.render(canvas);
     } // If not visible none of the children will be rendered
   }
 }
@@ -100,10 +99,6 @@ When implementing the `render` method for a component that extends `PositionComp
 render from the top left corner (0.0). Your render method should not handle where on the screen your
 component should be rendered. To handle where and how your component should be rendered use the
 `position`, `angle` and `anchor` properties and flame will automatically handle the rest for you.
-
-If you really want to handle the canvas translations yourself you can just omit the
-`super.render(canvas)` line and suppress the warning, but for most use cases this is not
-recommended.
 
 If you want to know where on the screen the bounding box of the component is you can use the
 `toRect` method.

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -7,7 +7,7 @@ that extends from `Game`. Once applied you can access the current fps by using t
 like shown in the example below.
 
 ```dart
-class MyGame extends Game with FPSCounter {
+class MyGame extends FlameGame with FPSCounter {
   static final fpsTextConfig = TextConfig(color: BasicPalette.white.color);
 
   @override

--- a/examples/lib/stories/camera_and_viewport/fixed_resolution.dart
+++ b/examples/lib/stories/camera_and_viewport/fixed_resolution.dart
@@ -57,7 +57,6 @@ class Background extends PositionComponent with HasGameRef {
 
   @override
   void render(Canvas c) {
-    super.render(c);
     c.drawRect(hugeRect, white);
   }
 }

--- a/examples/lib/stories/camera_and_viewport/follow_object.dart
+++ b/examples/lib/stories/camera_and_viewport/follow_object.dart
@@ -47,7 +47,6 @@ class MovableSquare extends SquareComponent
 
   @override
   void render(Canvas c) {
-    super.render(c);
     final text = '(${x.toInt()}, ${y.toInt()})';
     textRenderer.render(c, text, size / 2, anchor: Anchor.center);
   }
@@ -96,7 +95,6 @@ class Map extends Component {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawRect(bounds, _paintBg);
     canvas.drawRect(bounds, _paintBorder);
   }

--- a/examples/lib/stories/collision_detection/circles.dart
+++ b/examples/lib/stories/collision_detection/circles.dart
@@ -51,7 +51,6 @@ class MyCollidable extends PositionComponent
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     renderHitboxes(canvas);
   }
 

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -76,7 +76,6 @@ abstract class MyCollidable extends PositionComponent
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     renderHitboxes(canvas, paint: _activePaint);
     if (_isDragged) {
       final localCenter = (scaledSize / 2).toOffset();

--- a/examples/lib/stories/components/priority.dart
+++ b/examples/lib/stories/components/priority.dart
@@ -30,7 +30,6 @@ class Square extends PositionComponent with HasGameRef<Priority>, Tappable {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawRect(size.toRect(), paint);
   }
 }

--- a/examples/lib/stories/effects/rotate_effect_example.dart
+++ b/examples/lib/stories/effects/rotate_effect_example.dart
@@ -107,7 +107,6 @@ class Compass extends PositionComponent {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawCircle(Offset(_radius, _radius), _radius, _bgPaint);
     canvas.drawPath(_marksPath, _marksPaint);
   }
@@ -144,7 +143,6 @@ class CompassArrow extends PositionComponent {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawPath(_northPath, _northPaint);
     canvas.drawPath(_southPath, _southPaint);
   }
@@ -193,7 +191,6 @@ class CompassRim extends PositionComponent {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawCircle(Offset(_radius, _radius), _radius - _width / 2, _bgPaint);
     canvas.drawCircle(Offset(_radius, _radius), _radius - _width, _marksPaint);
     canvas.drawPath(_marksPath, _marksPaint);

--- a/examples/lib/stories/input/hoverables.dart
+++ b/examples/lib/stories/input/hoverables.dart
@@ -15,7 +15,6 @@ class HoverableSquare extends PositionComponent with Hoverable {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawRect(size.toRect(), isHovered ? _grey : _white);
   }
 }

--- a/examples/lib/stories/input/overlapping_tappables.dart
+++ b/examples/lib/stories/input/overlapping_tappables.dart
@@ -15,7 +15,6 @@ class TappableSquare extends PositionComponent with Tappable {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawRect(size.toRect(), currentPaint);
   }
 

--- a/examples/lib/stories/input/tappables.dart
+++ b/examples/lib/stories/input/tappables.dart
@@ -17,7 +17,6 @@ class TappableSquare extends PositionComponent with Tappable {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawRect(size.toRect(), _beenPressed ? _grey : _white);
   }
 

--- a/examples/lib/stories/utils/particles.dart
+++ b/examples/lib/stories/utils/particles.dart
@@ -561,7 +561,6 @@ class TrafficLightComponent extends Component {
 
   @override
   void render(Canvas c) {
-    super.render(c);
     c.drawRect(rect, Paint()..color = currentColor);
   }
 

--- a/examples/lib/stories/utils/timer_component.dart
+++ b/examples/lib/stories/utils/timer_component.dart
@@ -20,7 +20,6 @@ class RenderedTimeComponent extends TimerComponent {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     textPaint.render(
       canvas,
       'Elapsed time: ${timer.current.toStringAsFixed(3)}',

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -20,6 +20,7 @@
  - `randomColor` method in the `Color` extension
  - Calling super-method in `.render()` is now optional
  - Components that manipulate canvas state are now responsible for saving/restoring that state
+ - Remove `super.render` calls that are no longer needed
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/example/lib/main.dart
+++ b/packages/flame/example/lib/main.dart
@@ -26,8 +26,6 @@ class Square extends PositionComponent {
 
   @override
   void render(Canvas c) {
-    super.render(c);
-
     c.drawRect(size.toRect(), white);
     c.drawRect(const Rect.fromLTWH(0, 0, 3, 3), red);
     c.drawRect(Rect.fromLTWH(width / 2, height / 2, 3, 3), blue);

--- a/packages/flame/lib/src/components/custom_painter_component.dart
+++ b/packages/flame/lib/src/components/custom_painter_component.dart
@@ -36,8 +36,6 @@ class CustomPainterComponent extends PositionComponent {
   @override
   @mustCallSuper
   void render(Canvas canvas) {
-    super.render(canvas);
-
     painter?.paint(canvas, size.toSize());
   }
 }

--- a/packages/flame/lib/src/components/isometric_tile_map_component.dart
+++ b/packages/flame/lib/src/components/isometric_tile_map_component.dart
@@ -66,8 +66,6 @@ class IsometricTileMapComponent extends PositionComponent {
 
   @override
   void render(Canvas c) {
-    super.render(c);
-
     final size = effectiveTileSize;
     for (var i = 0; i < matrix.length; i++) {
       for (var j = 0; j < matrix[i].length; j++) {

--- a/packages/flame/lib/src/components/nine_tile_box_component.dart
+++ b/packages/flame/lib/src/components/nine_tile_box_component.dart
@@ -36,7 +36,6 @@ class NineTileBoxComponent extends PositionComponent {
   @mustCallSuper
   @override
   void render(Canvas c) {
-    super.render(c);
     nineTileBox.drawRect(c, size.toRect());
   }
 }

--- a/packages/flame/lib/src/components/parallax_component.dart
+++ b/packages/flame/lib/src/components/parallax_component.dart
@@ -116,7 +116,6 @@ class ParallaxComponent<T extends FlameGame> extends PositionComponent
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     parallax?.render(canvas);
   }
 

--- a/packages/flame/lib/src/components/particle_component.dart
+++ b/packages/flame/lib/src/components/particle_component.dart
@@ -25,7 +25,6 @@ class ParticleComponent extends Component {
   /// [Particle] within this [Component].
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     particle.render(canvas);
   }
 

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -34,7 +34,6 @@ class ShapeComponent extends PositionComponent {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     shape.render(canvas, paint);
   }
 

--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -91,7 +91,6 @@ class SpriteAnimationComponent extends PositionComponent with HasPaint {
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     animation?.getSprite().render(
           canvas,
           size: size,

--- a/packages/flame/lib/src/components/sprite_animation_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_group_component.dart
@@ -102,7 +102,6 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent with HasPaint {
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     animation?.getSprite().render(
           canvas,
           size: size,

--- a/packages/flame/lib/src/components/sprite_batch_component.dart
+++ b/packages/flame/lib/src/components/sprite_batch_component.dart
@@ -21,7 +21,6 @@ class SpriteBatchComponent extends Component {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     spriteBatch?.render(
       canvas,
       blendMode: blendMode,

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -71,7 +71,6 @@ class SpriteComponent extends PositionComponent with HasPaint {
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     sprite?.render(
       canvas,
       size: size,

--- a/packages/flame/lib/src/components/sprite_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_group_component.dart
@@ -48,7 +48,6 @@ class SpriteGroupComponent<T> extends PositionComponent with HasPaint {
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     sprite?.render(
       canvas,
       size: size,

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -187,7 +187,6 @@ class TextBoxComponent<T extends TextRenderer> extends PositionComponent {
     if (_cache == null) {
       return;
     }
-    super.render(c);
     c.save();
     c.scale(1 / pixelRatio);
     c.drawImage(_cache!, Offset.zero, _imagePaint);

--- a/packages/flame/lib/src/components/text_component.dart
+++ b/packages/flame/lib/src/components/text_component.dart
@@ -57,7 +57,6 @@ class TextComponent<T extends TextRenderer> extends PositionComponent {
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     _textRenderer.render(canvas, text, Vector2.zero());
   }
 }

--- a/packages/flame/test/game/base_game_test.dart
+++ b/packages/flame/test/game/base_game_test.dart
@@ -33,7 +33,6 @@ class MyComponent extends PositionComponent with Tappable, HasGameRef {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     isRenderCalled = true;
   }
 

--- a/packages/flame/test/game/camera_and_viewport_test.dart
+++ b/packages/flame/test/game/camera_and_viewport_test.dart
@@ -17,7 +17,6 @@ class TestComponent extends PositionComponent {
 
   @override
   void render(Canvas c) {
-    super.render(c);
     c.drawRect(size.toRect(), _paint);
   }
 }

--- a/packages/flame_flare/example/lib/main.dart
+++ b/packages/flame_flare/example/lib/main.dart
@@ -100,7 +100,6 @@ class BGComponent extends Component with HasGameRef {
 
   @override
   void render(Canvas c) {
-    super.render(c);
     c.drawRect(gameRef.size.toRect(), paint);
   }
 }

--- a/packages/flame_flare/lib/src/flare_actor_component.dart
+++ b/packages/flame_flare/lib/src/flare_actor_component.dart
@@ -20,13 +20,13 @@ class FlareActorComponent extends PositionComponent {
   }
 
   @override
+  @mustCallSuper
   void render(Canvas canvas) {
-    super.render(canvas);
     flareAnimation.render(canvas, size);
   }
 
-  @mustCallSuper
   @override
+  @mustCallSuper
   void update(double dt) {
     super.update(dt);
     flareAnimation.advance(dt);

--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -5,7 +5,6 @@ import 'dart:ui' as ui;
 import 'package:flame/components.dart';
 import 'package:flutter/rendering.dart';
 import 'package:rive/rive.dart';
-
 // ignore_for_file: implementation_imports
 import 'package:rive/src/rive_core/math/aabb.dart';
 import 'package:rive/src/rive_core/math/mat2d.dart';
@@ -47,7 +46,6 @@ class RiveComponent extends PositionComponent {
 
   @override
   void render(ui.Canvas canvas) {
-    super.render(canvas);
     _renderer.render(canvas, size.toSize());
   }
 

--- a/packages/flame_svg/lib/svg_component.dart
+++ b/packages/flame_svg/lib/svg_component.dart
@@ -16,7 +16,6 @@ class SvgComponent extends PositionComponent {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     svg.render(canvas, size);
   }
 }

--- a/packages/flame_tiled/lib/src/tiled_component.dart
+++ b/packages/flame_tiled/lib/src/tiled_component.dart
@@ -15,7 +15,6 @@ class TiledComponent extends Component {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     tileMap.render(canvas);
   }
 

--- a/tutorials/space_shooter/lib/steps/1_getting_started/1_flame_game/code.dart
+++ b/tutorials/space_shooter/lib/steps/1_getting_started/1_flame_game/code.dart
@@ -7,7 +7,6 @@ class Player extends PositionComponent {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawRect(size.toRect(), _paint);
   }
 }

--- a/tutorials/space_shooter/lib/steps/1_getting_started/1_flame_game/tutorial.dart
+++ b/tutorials/space_shooter/lib/steps/1_getting_started/1_flame_game/tutorial.dart
@@ -45,7 +45,6 @@ class Player extends PositionComponent {
 
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawRect(size.toRect(), _paint);
   }
 }

--- a/tutorials/space_shooter/lib/steps/1_getting_started/2_input_and_graphics/tutorial.dart
+++ b/tutorials/space_shooter/lib/steps/1_getting_started/2_input_and_graphics/tutorial.dart
@@ -41,7 +41,6 @@ class Player extends PositionComponent {
   
   @override
   void render(Canvas canvas) {
-    super.render(canvas);
     canvas.drawRect(size.toRect(), _paint);
   }
 
@@ -133,7 +132,7 @@ removed from the Flutter widget tree.
 
 Before we close this step, there is one small improvement that we can do. Right now, we are loading
 the sprite and passing it to our component. For now, this may seen fine, but imagine a game with
-a lot of components; if the game is responsible for loading assets for all coponents, our code can
+a lot of components; if the game is responsible for loading assets for all components, our code can
 become a mess quite fast.
 
 Just like `FlameGame`, components also have an `onLoad` method that can be overridden to do


### PR DESCRIPTION
# Description

Remove unnecessary `super.render` calls since #1082 removed the need for it.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
