### PR TITLE
Fix typo in error message

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -20,6 +20,7 @@
  - `randomColor` method in the `Color` extension
  - Calling super-method in `.render()` is now optional
  - Components that manipulate canvas state are now responsible for saving/restoring that state
+ - Fixed typo in error message
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -321,7 +321,7 @@ class Component with Loadable {
         parentGame.hasLayout,
         '"prepare/add" called before the game is ready. '
         'Did you try to access it on the Game constructor? '
-        'Use the "onLoad" ot "onParentMethod" method instead.',
+        'Use the "onLoad" or "onParentMethod" method instead.',
       );
       if (parentGame is FlameGame) {
         parentGame.prepareComponent(this);

--- a/packages/flame/test/game/base_game_test.dart
+++ b/packages/flame/test/game/base_game_test.dart
@@ -230,7 +230,7 @@ void main() {
 
     const message = '"prepare/add" called before the game is ready. '
         'Did you try to access it on the Game constructor? '
-        'Use the "onLoad" ot "onParentMethod" method instead.';
+        'Use the "onLoad" or "onParentMethod" method instead.';
 
     expect(
       () => game.add(component),


### PR DESCRIPTION
# Description

Fixes a typo in an error message ("ot" should be "or").

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.