### PR TITLE
Fix typos & grammar in TextBoxComponent docs

### DIFF
--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -10,25 +10,24 @@ import '../palette.dart';
 import '../text.dart';
 import 'position_component.dart';
 
-/// A set of configurations for the [TextBoxComponent] itself (as opposed to
-/// the [TextRenderer], that contains the configuration for how to render the
-/// text only (font size, color, family, etc)).
+/// A set of configurations for the [TextBoxComponent] itself, as opposed to
+/// the [TextRenderer], which contains the configuration for how to render the
+/// text only (font size, color, family, etc).
 class TextBoxConfig {
   /// Max width this paragraph can take. Lines will be broken trying to respect
   /// word boundaries in as many lines as necessary.
   final double maxWidth;
 
-  /// Margins of the text box w.r.t the [PositionComponent.size].
+  /// Margins of the text box with respect to the [PositionComponent.size].
   final EdgeInsets margins;
 
-  /// Defaults to 0. If not zero the characters will appear one by one giving
-  /// a typying effect to the text box, and this will be the delay in seconds
-  /// between each char.
+  /// Defaults to 0. If not zero, the characters will appear one-by-one giving
+  /// a typing effect to the text box, and this will be the delay in seconds
+  /// between each character.
   final double timePerChar;
 
-  /// Defaults to 9. If not zero, this component will disapear this amount of
-  /// seconds after being completed (if [timePerChar] is set) or after first
-  /// appearing (otherwise).
+  /// Defaults to 0. If not zero, this component will disappear after this many
+  /// seconds after being fully typed out.
   final double dismissDelay;
 
   /// Only relevant if [timePerChar] is set. If true, the box will start with


### PR DESCRIPTION
# Description

Documentation fixes. For `dismissDelay` property the doc said the default was 9, whereas in fact it was 0, so fixed that as well.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
