### PR TITLE
Added Makefile to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ _build/
 coverage
 
 .fvm
+Makefile
+!doc/_sphinx/Makefile


### PR DESCRIPTION
# Description

Following the discussion in #1092, this PR adds `Makefile` to the `.gitignore` file, so that developers who want to, can have one, without having to commit it to the project.

- [x] No, this is *not* a breaking change.
