### PR TITLE
Use `FlameTester` everywhere where it makes sense

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -28,6 +28,7 @@
  - Renamed `FlameTester` to `GameTester`
  - Modified `FlameTester` to be specific for `T extends FlameGame`
  - Improved `TimerComponent`
+ - Use `FlameTester` everywhere where it makes sense in the tests
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/components/mixins/has_paint.dart
+++ b/packages/flame/lib/src/components/mixins/has_paint.dart
@@ -81,7 +81,7 @@ mixin HasPaint<T extends Object> on Component {
 
   /// Applies a color filter to the paint which will make
   /// things rendered with the paint looking like it was
-  // tinted with the given color
+  /// tinted with the given color
   void tint(Color color, {T? paintId}) {
     getPaint(paintId).colorFilter = ColorFilter.mode(color, BlendMode.multiply);
   }

--- a/packages/flame/test/components/collidable_type_test.dart
+++ b/packages/flame/test/components/collidable_type_test.dart
@@ -6,12 +6,12 @@ import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-class HasCollidablesGame extends FlameGame with HasCollidables {}
+class _HasCollidablesGame extends FlameGame with HasCollidables {}
 
-class TestBlock extends PositionComponent with HasHitboxes, Collidable {
+class _TestBlock extends PositionComponent with HasHitboxes, Collidable {
   final List<Collidable> collisions = List.empty(growable: true);
 
-  TestBlock(Vector2 position, Vector2 size, CollidableType type)
+  _TestBlock(Vector2 position, Vector2 size, CollidableType type)
       : super(position: position, size: size) {
     collidableType = type;
     addHitbox(
@@ -40,20 +40,16 @@ class TestBlock extends PositionComponent with HasHitboxes, Collidable {
 }
 
 void main() {
-  FlameTester withCollidables() {
-    return FlameTester(
-      () => HasCollidablesGame(),
-    );
-  }
+  final withCollidables = FlameTester(() => _HasCollidablesGame());
 
   group('Varying CollisionType tests', () {
-    withCollidables().test('Actives do collide', (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Actives do collide', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.active,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(1),
         Vector2.all(10),
         CollidableType.active,
@@ -65,13 +61,13 @@ void main() {
       expect(blockB.collisions.length, 1);
     });
 
-    withCollidables().test('Sensors do not collide', (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Sensors do not collide', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.passive,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(1),
         Vector2.all(10),
         CollidableType.passive,
@@ -82,13 +78,13 @@ void main() {
       expect(blockB.collisions.isEmpty, true);
     });
 
-    withCollidables().test('Inactives do not collide', (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Inactives do not collide', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.inactive,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(1),
         Vector2.all(10),
         CollidableType.inactive,
@@ -98,13 +94,13 @@ void main() {
       expect(blockB.collisions.isEmpty, true);
     });
 
-    withCollidables().test('Active collides with static', (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Active collides with static', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.active,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(1),
         Vector2.all(10),
         CollidableType.passive,
@@ -116,13 +112,13 @@ void main() {
       expect(blockB.collisions.length, 1);
     });
 
-    withCollidables().test('Sensor collides with active', (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Sensor collides with active', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.passive,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(1),
         Vector2.all(10),
         CollidableType.active,
@@ -134,14 +130,13 @@ void main() {
       expect(blockB.collisions.length, 1);
     });
 
-    withCollidables().test('Sensor does not collide with inactive',
-        (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Sensor does not collide with inactive', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.passive,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(1),
         Vector2.all(10),
         CollidableType.inactive,
@@ -151,14 +146,13 @@ void main() {
       expect(blockB.collisions.length, 0);
     });
 
-    withCollidables().test('Inactive does not collide with static',
-        (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Inactive does not collide with static', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.inactive,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(1),
         Vector2.all(10),
         CollidableType.passive,
@@ -168,14 +162,13 @@ void main() {
       expect(blockB.collisions.length, 0);
     });
 
-    withCollidables().test('Active does not collide with inactive',
-        (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Active does not collide with inactive', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.active,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(1),
         Vector2.all(10),
         CollidableType.inactive,
@@ -185,14 +178,13 @@ void main() {
       expect(blockB.collisions.length, 0);
     });
 
-    withCollidables().test('Inactive does not collide with active',
-        (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Inactive does not collide with active', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.inactive,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(1),
         Vector2.all(10),
         CollidableType.active,
@@ -202,12 +194,12 @@ void main() {
       expect(blockB.collisions.length, 0);
     });
 
-    withCollidables().test(
+    withCollidables.test(
       'Correct collisions with many involved collidables',
       (game) async {
         final actives = List.generate(
           100,
-          (_) => TestBlock(
+          (_) => _TestBlock(
             Vector2.random() - Vector2.random(),
             Vector2.all(10),
             CollidableType.active,
@@ -215,7 +207,7 @@ void main() {
         );
         final statics = List.generate(
           100,
-          (_) => TestBlock(
+          (_) => _TestBlock(
             Vector2.random() - Vector2.random(),
             Vector2.all(10),
             CollidableType.passive,
@@ -223,7 +215,7 @@ void main() {
         );
         final inactives = List.generate(
           100,
-          (_) => TestBlock(
+          (_) => _TestBlock(
             Vector2.random() - Vector2.random(),
             Vector2.all(10),
             CollidableType.inactive,
@@ -255,13 +247,13 @@ void main() {
       },
     );
 
-    withCollidables().test('Detects collision after scale', (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Detects collision after scale', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.active,
       );
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(11),
         Vector2.all(10),
         CollidableType.active,
@@ -279,8 +271,8 @@ void main() {
       expect(blockB.collisions.length, 1);
     });
 
-    withCollidables().test('TestPoint detects point after scale', (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('TestPoint detects point after scale', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.active,
@@ -292,26 +284,25 @@ void main() {
       expect(blockA.containsPoint(Vector2.all(11)), true);
     });
 
-    withCollidables().test('Detects collision on child components',
-        (game) async {
-      final blockA = TestBlock(
+    withCollidables.test('Detects collision on child components', (game) async {
+      final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
         CollidableType.active,
       );
-      final innerBlockA = TestBlock(
+      final innerBlockA = _TestBlock(
         blockA.size / 4,
         blockA.size / 2,
         CollidableType.active,
       );
       blockA.add(innerBlockA);
 
-      final blockB = TestBlock(
+      final blockB = _TestBlock(
         Vector2.all(5),
         Vector2.all(10),
         CollidableType.active,
       );
-      final innerBlockB = TestBlock(
+      final innerBlockB = _TestBlock(
         blockA.size / 4,
         blockA.size / 2,
         CollidableType.active,

--- a/packages/flame/test/components/collidable_type_test.dart
+++ b/packages/flame/test/components/collidable_type_test.dart
@@ -42,8 +42,8 @@ class _TestBlock extends PositionComponent with HasHitboxes, Collidable {
 void main() {
   final withCollidables = FlameTester(() => _HasCollidablesGame());
 
-  group('Varying CollisionType tests', () {
-    withCollidables.test('Actives do collide', (game) async {
+  group('Varying CollisionType', () {
+    withCollidables.test('actives do collide', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -61,7 +61,7 @@ void main() {
       expect(blockB.collisions.length, 1);
     });
 
-    withCollidables.test('Sensors do not collide', (game) async {
+    withCollidables.test('sensors do not collide', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -78,7 +78,7 @@ void main() {
       expect(blockB.collisions.isEmpty, true);
     });
 
-    withCollidables.test('Inactives do not collide', (game) async {
+    withCollidables.test('inactives do not collide', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -94,7 +94,7 @@ void main() {
       expect(blockB.collisions.isEmpty, true);
     });
 
-    withCollidables.test('Active collides with static', (game) async {
+    withCollidables.test('active collides with static', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -112,7 +112,7 @@ void main() {
       expect(blockB.collisions.length, 1);
     });
 
-    withCollidables.test('Sensor collides with active', (game) async {
+    withCollidables.test('sensor collides with active', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -130,7 +130,7 @@ void main() {
       expect(blockB.collisions.length, 1);
     });
 
-    withCollidables.test('Sensor does not collide with inactive', (game) async {
+    withCollidables.test('sensor does not collide with inactive', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -146,7 +146,7 @@ void main() {
       expect(blockB.collisions.length, 0);
     });
 
-    withCollidables.test('Inactive does not collide with static', (game) async {
+    withCollidables.test('inactive does not collide with static', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -162,7 +162,7 @@ void main() {
       expect(blockB.collisions.length, 0);
     });
 
-    withCollidables.test('Active does not collide with inactive', (game) async {
+    withCollidables.test('active does not collide with inactive', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -178,7 +178,7 @@ void main() {
       expect(blockB.collisions.length, 0);
     });
 
-    withCollidables.test('Inactive does not collide with active', (game) async {
+    withCollidables.test('inactive does not collide with active', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -195,7 +195,7 @@ void main() {
     });
 
     withCollidables.test(
-      'Correct collisions with many involved collidables',
+      'correct collisions with many involved collidables',
       (game) async {
         final actives = List.generate(
           100,
@@ -247,7 +247,7 @@ void main() {
       },
     );
 
-    withCollidables.test('Detects collision after scale', (game) async {
+    withCollidables.test('detects collision after scale', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -271,7 +271,7 @@ void main() {
       expect(blockB.collisions.length, 1);
     });
 
-    withCollidables.test('TestPoint detects point after scale', (game) async {
+    withCollidables.test('testPoint detects point after scale', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -284,7 +284,7 @@ void main() {
       expect(blockA.containsPoint(Vector2.all(11)), true);
     });
 
-    withCollidables.test('Detects collision on child components', (game) async {
+    withCollidables.test('detects collision on child components', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),
         Vector2.all(10),

--- a/packages/flame/test/components/collision_callback_test.dart
+++ b/packages/flame/test/components/collision_callback_test.dart
@@ -56,7 +56,7 @@ class _TestBlock extends PositionComponent with HasHitboxes, Collidable {
 void main() {
   final withCollidables = FlameTester(() => _HasCollidablesGame());
 
-  group('Collision callbacks are called properly', () {
+  group('Collision callbacks', () {
     withCollidables.test('collidable callbacks are called', (game) async {
       final blockA = _TestBlock(
         Vector2.zero(),

--- a/packages/flame/test/components/collision_callback_test.dart
+++ b/packages/flame/test/components/collision_callback_test.dart
@@ -2,20 +2,16 @@ import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
 import 'package:flame/geometry.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
-import 'package:vector_math/vector_math_64.dart';
 
-class TestGame extends FlameGame with HasCollidables {
-  TestGame() {
-    onGameResize(Vector2.all(200));
-  }
-}
+class _HasCollidablesGame extends FlameGame with HasCollidables {}
 
-class TestHitbox extends HitboxRectangle {
+class _TestHitbox extends HitboxRectangle {
   final Set<HitboxShape> collisions = {};
   int endCounter = 0;
 
-  TestHitbox() {
+  _TestHitbox() {
     onCollision = (_, shape) => collisions.add(shape);
     onCollisionEnd = (shape) {
       endCounter++;
@@ -28,12 +24,12 @@ class TestHitbox extends HitboxRectangle {
   }
 }
 
-class TestBlock extends PositionComponent with HasHitboxes, Collidable {
+class _TestBlock extends PositionComponent with HasHitboxes, Collidable {
   final Set<Collidable> collisions = {};
-  final hitbox = TestHitbox();
+  final hitbox = _TestHitbox();
   int endCounter = 0;
 
-  TestBlock(Vector2 position, Vector2 size)
+  _TestBlock(Vector2 position, Vector2 size)
       : super(
           position: position,
           size: size,
@@ -58,73 +54,63 @@ class TestBlock extends PositionComponent with HasHitboxes, Collidable {
 }
 
 void main() {
-  Future<TestGame> gameWithCollidables(List<Collidable> collidables) async {
-    final game = TestGame();
-    await game.onLoad();
-    await game.addAll(collidables);
-    game.update(0);
-    expect(game.children.isNotEmpty, collidables.isNotEmpty);
-    return game;
-  }
+  final withCollidables = FlameTester(() => _HasCollidablesGame());
 
-  group(
-    'Collision callbacks are called properly',
-    () {
-      test('collidable callbacks are called', () async {
-        final blockA = TestBlock(
-          Vector2.zero(),
-          Vector2.all(10),
-        );
-        final blockB = TestBlock(
-          Vector2.all(1),
-          Vector2.all(10),
-        );
-        final game = await gameWithCollidables([blockA, blockB]);
-        expect(blockA.hasCollisionWith(blockB), true);
-        expect(blockB.hasCollisionWith(blockA), true);
-        expect(blockA.collisions.length, 1);
-        expect(blockB.collisions.length, 1);
-        blockB.position = Vector2.all(21);
-        expect(blockA.endCounter, 0);
-        expect(blockB.endCounter, 0);
-        game.update(0);
-        expect(blockA.hasCollisionWith(blockB), false);
-        expect(blockB.hasCollisionWith(blockA), false);
-        expect(blockA.collisions.length, 0);
-        expect(blockB.collisions.length, 0);
-        game.update(0);
-        expect(blockA.endCounter, 1);
-        expect(blockB.endCounter, 1);
-      });
+  group('Collision callbacks are called properly', () {
+    withCollidables.test('collidable callbacks are called', (game) async {
+      final blockA = _TestBlock(
+        Vector2.zero(),
+        Vector2.all(10),
+      );
+      final blockB = _TestBlock(
+        Vector2.all(1),
+        Vector2.all(10),
+      );
+      await game.ensureAddAll([blockA, blockB]);
+      expect(blockA.hasCollisionWith(blockB), true);
+      expect(blockB.hasCollisionWith(blockA), true);
+      expect(blockA.collisions.length, 1);
+      expect(blockB.collisions.length, 1);
+      blockB.position = Vector2.all(21);
+      expect(blockA.endCounter, 0);
+      expect(blockB.endCounter, 0);
+      game.update(0);
+      expect(blockA.hasCollisionWith(blockB), false);
+      expect(blockB.hasCollisionWith(blockA), false);
+      expect(blockA.collisions.length, 0);
+      expect(blockB.collisions.length, 0);
+      game.update(0);
+      expect(blockA.endCounter, 1);
+      expect(blockB.endCounter, 1);
+    });
 
-      test('hitbox callbacks are called', () async {
-        final blockA = TestBlock(
-          Vector2.zero(),
-          Vector2.all(10),
-        );
-        final blockB = TestBlock(
-          Vector2.all(1),
-          Vector2.all(10),
-        );
-        final hitboxA = blockA.hitbox;
-        final hitboxB = blockB.hitbox;
-        final game = await gameWithCollidables([blockA, blockB]);
-        expect(hitboxA.hasCollisionWith(hitboxB), true);
-        expect(hitboxB.hasCollisionWith(hitboxA), true);
-        expect(hitboxA.collisions.length, 1);
-        expect(hitboxB.collisions.length, 1);
-        blockB.position = Vector2.all(21);
-        expect(hitboxA.endCounter, 0);
-        expect(hitboxB.endCounter, 0);
-        game.update(0);
-        expect(hitboxA.hasCollisionWith(hitboxB), false);
-        expect(hitboxB.hasCollisionWith(hitboxA), false);
-        expect(hitboxA.collisions.length, 0);
-        expect(hitboxB.collisions.length, 0);
-        game.update(0);
-        expect(hitboxA.endCounter, 1);
-        expect(hitboxB.endCounter, 1);
-      });
-    },
-  );
+    withCollidables.test('hitbox callbacks are called', (game) async {
+      final blockA = _TestBlock(
+        Vector2.zero(),
+        Vector2.all(10),
+      );
+      final blockB = _TestBlock(
+        Vector2.all(1),
+        Vector2.all(10),
+      );
+      final hitboxA = blockA.hitbox;
+      final hitboxB = blockB.hitbox;
+      await game.ensureAddAll([blockA, blockB]);
+      expect(hitboxA.hasCollisionWith(hitboxB), true);
+      expect(hitboxB.hasCollisionWith(hitboxA), true);
+      expect(hitboxA.collisions.length, 1);
+      expect(hitboxB.collisions.length, 1);
+      blockB.position = Vector2.all(21);
+      expect(hitboxA.endCounter, 0);
+      expect(hitboxB.endCounter, 0);
+      game.update(0);
+      expect(hitboxA.hasCollisionWith(hitboxB), false);
+      expect(hitboxB.hasCollisionWith(hitboxA), false);
+      expect(hitboxA.collisions.length, 0);
+      expect(hitboxB.collisions.length, 0);
+      game.update(0);
+      expect(hitboxA.endCounter, 1);
+      expect(hitboxB.endCounter, 1);
+    });
+  });
 }

--- a/packages/flame/test/components/collision_detection_test.dart
+++ b/packages/flame/test/components/collision_detection_test.dart
@@ -7,8 +7,8 @@ import 'package:flame/src/geometry/line_segment.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('LineSegment.isPointOnSegment tests', () {
-    test('Can catch simple point', () {
+  group('LineSegment.isPointOnSegment', () {
+    test('can catch simple point', () {
       final segment = LineSegment(
         Vector2.all(0),
         Vector2.all(1),
@@ -21,7 +21,7 @@ void main() {
       );
     });
 
-    test('Should not catch point outside of segment, but on line', () {
+    test('should not catch point outside of segment, but on line', () {
       final segment = LineSegment(
         Vector2.all(0),
         Vector2.all(1),
@@ -34,7 +34,7 @@ void main() {
       );
     });
 
-    test('Should not catch point outside of segment', () {
+    test('should not catch point outside of segment', () {
       final segment = LineSegment(
         Vector2.all(0),
         Vector2.all(1),
@@ -47,7 +47,7 @@ void main() {
       );
     });
 
-    test('Point on end of segment', () {
+    test('point on end of segment', () {
       final segment = LineSegment(
         Vector2.all(0),
         Vector2.all(1),
@@ -60,7 +60,7 @@ void main() {
       );
     });
 
-    test('Point on beginning of segment', () {
+    test('point on beginning of segment', () {
       final segment = LineSegment(
         Vector2.all(0),
         Vector2.all(1),
@@ -74,8 +74,8 @@ void main() {
     });
   });
 
-  group('LineSegment.intersections tests', () {
-    test('Simple intersection', () {
+  group('LineSegment.intersections', () {
+    test('simple intersection', () {
       final segmentA = LineSegment(Vector2.all(0), Vector2.all(1));
       final segmentB = LineSegment(Vector2(0, 1), Vector2(1, 0));
       final intersection = segmentA.intersections(segmentB);
@@ -87,7 +87,7 @@ void main() {
       expect(intersection.first == Vector2.all(0.5), true);
     });
 
-    test('No intersection', () {
+    test('no intersection', () {
       final segmentA = LineSegment(Vector2.all(0), Vector2.all(1));
       final segmentB = LineSegment(Vector2(0, 1), Vector2(1, 2));
       final intersection = segmentA.intersections(segmentB);
@@ -98,7 +98,7 @@ void main() {
       );
     });
 
-    test('Same line segments', () {
+    test('same line segments', () {
       final segmentA = LineSegment(Vector2.all(0), Vector2.all(1));
       final segmentB = LineSegment(Vector2.all(0), Vector2.all(1));
       final intersection = segmentA.intersections(segmentB);
@@ -110,7 +110,7 @@ void main() {
       expect(intersection.first == Vector2.all(0.5), true);
     });
 
-    test('Overlapping line segments', () {
+    test('overlapping line segments', () {
       final segmentA = LineSegment(Vector2.all(0), Vector2.all(1));
       final segmentB = LineSegment(Vector2.all(0.5), Vector2.all(1.5));
       final intersection = segmentA.intersections(segmentB);
@@ -122,7 +122,7 @@ void main() {
       expect(intersection.first == Vector2.all(0.75), true);
     });
 
-    test('One pixel overlap in different angles', () {
+    test('one pixel overlap in different angles', () {
       final segmentA = LineSegment(Vector2.all(0), Vector2.all(1));
       final segmentB = LineSegment(Vector2.all(0), Vector2(1, -1));
       final intersection = segmentA.intersections(segmentB);
@@ -134,7 +134,7 @@ void main() {
       expect(intersection.first == Vector2.all(0), true);
     });
 
-    test('One pixel parallel overlap in same angle', () {
+    test('one pixel parallel overlap in same angle', () {
       final segmentA = LineSegment(Vector2.all(0), Vector2.all(1));
       final segmentB = LineSegment(Vector2.all(1), Vector2.all(2));
       final intersection = segmentA.intersections(segmentB);
@@ -147,8 +147,8 @@ void main() {
     });
   });
 
-  group('Line.intersections tests', () {
-    test('Simple line intersection', () {
+  group('Line.intersections', () {
+    test('simple line intersection', () {
       const line1 = Line(1, -1, 0);
       const line2 = Line(1, 1, 0);
       final intersection = line1.intersections(line2);
@@ -156,7 +156,7 @@ void main() {
       expect(intersection.first == Vector2.all(0), true);
     });
 
-    test('Lines with c value', () {
+    test('lines with c value', () {
       const line1 = Line(1, 1, 1);
       const line2 = Line(1, -1, 1);
       final intersection = line1.intersections(line2);
@@ -164,7 +164,7 @@ void main() {
       expect(intersection.first == Vector2(1, 0), true);
     });
 
-    test('Does not catch parallel lines', () {
+    test('does not catch parallel lines', () {
       const line1 = Line(1, 1, -3);
       const line2 = Line(1, 1, 6);
       final intersection = line1.intersections(line2);
@@ -175,7 +175,7 @@ void main() {
       );
     });
 
-    test('Does not catch same line', () {
+    test('does not catch same line', () {
       const line1 = Line(1, 1, 1);
       const line2 = Line(1, 1, 1);
       final intersection = line1.intersections(line2);
@@ -187,29 +187,29 @@ void main() {
     });
   });
 
-  group('LinearEquation.fromPoints tests', () {
-    test('Simple line from points', () {
+  group('LinearEquation.fromPoints', () {
+    test('simple line from points', () {
       final line = Line.fromPoints(Vector2.zero(), Vector2.all(1));
       expect(line.a == 1.0, true, reason: 'a value is not correct');
       expect(line.b == -1.0, true, reason: 'b value is not correct');
       expect(line.c == 0.0, true, reason: 'c value is not correct');
     });
 
-    test('Line not going through origin', () {
+    test('line not going through origin', () {
       final line = Line.fromPoints(Vector2(-2, 0), Vector2(0, 2));
       expect(line.a == 2.0, true, reason: 'a value is not correct');
       expect(line.b == -2.0, true, reason: 'b value is not correct');
       expect(line.c == -4.0, true, reason: 'c value is not correct');
     });
 
-    test('Straight vertical line', () {
+    test('straight vertical line', () {
       final line = Line.fromPoints(Vector2.all(1), Vector2(1, -1));
       expect(line.a == -2.0, true, reason: 'a value is not correct');
       expect(line.b == 0.0, true, reason: 'b value is not correct');
       expect(line.c == -2.0, true, reason: 'c value is not correct');
     });
 
-    test('Straight horizontal line', () {
+    test('straight horizontal line', () {
       final line = Line.fromPoints(Vector2.all(1), Vector2(2, 1));
       expect(line.a == 0.0, true, reason: 'a value is not correct');
       expect(line.b == -1.0, true, reason: 'b value is not correct');
@@ -217,36 +217,36 @@ void main() {
     });
   });
 
-  group('LineSegment.pointsAt tests', () {
-    test('Simple pointing', () {
+  group('LineSegment.pointsAt', () {
+    test('simple pointing', () {
       final segment = LineSegment(Vector2.zero(), Vector2.all(1));
       const line = Line(1, 1, 3);
       final isPointingAt = segment.pointsAt(line);
       expect(isPointingAt, true, reason: 'Line should be pointed at');
     });
 
-    test('Is not pointed at when crossed', () {
+    test('is not pointed at when crossed', () {
       final segment = LineSegment(Vector2.zero(), Vector2.all(3));
       const line = Line(1, 1, 3);
       final isPointingAt = segment.pointsAt(line);
       expect(isPointingAt, false, reason: 'Line should not be pointed at');
     });
 
-    test('Is not pointed at when parallel', () {
+    test('is not pointed at when parallel', () {
       final segment = LineSegment(Vector2.zero(), Vector2(1, -1));
       const line = Line(1, 1, 3);
       final isPointingAt = segment.pointsAt(line);
       expect(isPointingAt, false, reason: 'Line should not be pointed at');
     });
 
-    test('Horizontal line can be pointed at', () {
+    test('horizontal line can be pointed at', () {
       final segment = LineSegment(Vector2.zero(), Vector2.all(1));
       const line = Line(0, 1, 2);
       final isPointingAt = segment.pointsAt(line);
       expect(isPointingAt, true, reason: 'Line should be pointed at');
     });
 
-    test('Vertical line can be pointed at', () {
+    test('vertical line can be pointed at', () {
       final segment = LineSegment(Vector2.zero(), Vector2.all(1));
       const line = Line(1, 0, 2);
       final isPointingAt = segment.pointsAt(line);
@@ -255,7 +255,7 @@ void main() {
   });
 
   group('Polygon intersections tests', () {
-    test('Simple polygon collision', () {
+    test('simple polygon collision', () {
       final polygonA = Polygon([
         Vector2(2, 2),
         Vector2(3, 1),
@@ -286,7 +286,7 @@ void main() {
       );
     });
 
-    test('Collision on shared line segment', () {
+    test('collision on shared line segment', () {
       final polygonA = Polygon([
         Vector2(1, 1),
         Vector2(1, 2),
@@ -316,7 +316,7 @@ void main() {
       );
     });
 
-    test('One point collision', () {
+    test('one point collision', () {
       final polygonA = Polygon([
         Vector2(1, 1),
         Vector2(1, 2),
@@ -342,7 +342,7 @@ void main() {
       );
     });
 
-    test('Collision while no corners are inside the other body', () {
+    test('collision while no corners are inside the other body', () {
       final polygonA = Polygon.fromDefinition(
         [
           Vector2(1, 1),
@@ -381,7 +381,7 @@ void main() {
       );
     });
 
-    test('Collision with advanced hitboxes in different quadrants', () {
+    test('collision with advanced hitboxes in different quadrants', () {
       final polygonA = Polygon([
         Vector2(0, 0),
         Vector2(-1, 1),
@@ -412,7 +412,7 @@ void main() {
   });
 
   group('Rectangle intersections tests', () {
-    test('Simple intersection', () {
+    test('simple intersection', () {
       final rectangleA = Rectangle(
         position: Vector2(4, 0),
         size: Vector2.all(4),
@@ -440,7 +440,7 @@ void main() {
   });
 
   group('Circle intersections tests', () {
-    test('Simple collision', () {
+    test('simple collision', () {
       final circleA = Circle.fromDefinition(
         position: Vector2(4, 0),
         size: Vector2.all(4),
@@ -462,7 +462,7 @@ void main() {
       );
     });
 
-    test('Two point collision', () {
+    test('two point collision', () {
       final circleA = Circle.fromDefinition(
         position: Vector2(3, 0),
         size: Vector2.all(4),
@@ -489,7 +489,7 @@ void main() {
       );
     });
 
-    test('Same size and position', () {
+    test('same size and position', () {
       final circleA = Circle.fromDefinition(
         position: Vector2.all(3),
         size: Vector2.all(4),
@@ -516,7 +516,7 @@ void main() {
       );
     });
 
-    test('Not overlapping', () {
+    test('not overlapping', () {
       final circleA = Circle.fromDefinition(
         position: Vector2.all(-1),
         size: Vector2.all(4),
@@ -533,7 +533,7 @@ void main() {
       );
     });
 
-    test('In third quadrant', () {
+    test('in third quadrant', () {
       final circleA = Circle.fromDefinition(
         position: Vector2.all(-1),
         size: Vector2.all(2),
@@ -558,7 +558,7 @@ void main() {
       );
     });
 
-    test('In different quadrants', () {
+    test('in different quadrants', () {
       final circleA = Circle.fromDefinition(
         position: Vector2.all(-1),
         size: Vector2.all(4),
@@ -585,7 +585,7 @@ void main() {
   });
 
   group('Circle-Polygon intersections tests', () {
-    test('Simple circle-polygon intersection', () {
+    test('simple circle-polygon intersection', () {
       final circle = Circle.fromDefinition(
         position: Vector2.zero(),
         size: Vector2.all(2),
@@ -609,7 +609,7 @@ void main() {
       );
     });
 
-    test('Single point circle-polygon intersection', () {
+    test('single point circle-polygon intersection', () {
       final circle = Circle.fromDefinition(
         position: Vector2(-1, 1),
         size: Vector2.all(2),
@@ -633,7 +633,7 @@ void main() {
       );
     });
 
-    test('Four point circle-polygon intersection', () {
+    test('four point circle-polygon intersection', () {
       final circle = Circle.fromDefinition(
         position: Vector2.all(1),
         size: Vector2.all(2),
@@ -662,7 +662,7 @@ void main() {
       );
     });
 
-    test('Polygon within circle, no intersections', () {
+    test('polygon within circle, no intersections', () {
       final circle = Circle.fromDefinition(
         position: Vector2.all(1),
         size: Vector2.all(2.1),

--- a/packages/flame/test/components/component_lifecycle_test.dart
+++ b/packages/flame/test/components/component_lifecycle_test.dart
@@ -1,11 +1,12 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MyComponent extends Component {
+class _MyComponent extends Component {
   final List<String> events;
 
-  MyComponent(this.events);
+  _MyComponent(this.events);
 
   @override
   void prepare(Component parent) {
@@ -33,11 +34,9 @@ class MyComponent extends Component {
 
 void main() {
   group('Component - Lifecycle', () {
-    test('Lifecycle in correct order', () async {
+    flameGame.test('Lifecycle in correct order', (game) async {
       final events = <String>[];
-      final game = FlameGame();
-      game.onGameResize(Vector2.zero());
-      await game.add(MyComponent(events));
+      await game.ensureAdd(_MyComponent(events));
 
       expect(
         events,
@@ -45,14 +44,12 @@ void main() {
       );
     });
 
-    test('Parent prepares the component', () async {
+    flameGame.test('Parent prepares the component', (game) async {
       final parentEvents = <String>[];
       final childEvents = <String>[];
-      final game = FlameGame();
-      game.onGameResize(Vector2.zero());
-      final parent = MyComponent(parentEvents);
-      await parent.add(MyComponent(childEvents));
-      await game.add(parent);
+      final parent = _MyComponent(parentEvents);
+      await parent.add(_MyComponent(childEvents));
+      await game.ensureAdd(parent);
 
       // The parent tries to prepare the component before it is added to the
       // game and fails since it doesn't have a game root and therefore re-adds
@@ -73,16 +70,13 @@ void main() {
       );
     });
 
-    test('Correct lifecycle on parent change', () async {
+    flameGame.test('Correct lifecycle on parent change', (game) async {
       final parentEvents = <String>[];
       final childEvents = <String>[];
-      final game = FlameGame();
-      game.onGameResize(Vector2.zero());
-      final parent = MyComponent(parentEvents);
-      final child = MyComponent(childEvents);
+      final parent = _MyComponent(parentEvents);
+      final child = _MyComponent(childEvents);
       await parent.add(child);
-      await game.add(parent);
-      game.update(0);
+      await game.ensureAdd(parent);
       child.changeParent(game);
       game.update(0);
 

--- a/packages/flame/test/components/component_lifecycle_test.dart
+++ b/packages/flame/test/components/component_lifecycle_test.dart
@@ -33,8 +33,8 @@ class _MyComponent extends Component {
 }
 
 void main() {
-  group('Component - Lifecycle', () {
-    flameGame.test('Lifecycle in correct order', (game) async {
+  group('Component Lifecycle', () {
+    flameGame.test('correct order', (game) async {
       final events = <String>[];
       await game.ensureAdd(_MyComponent(events));
 
@@ -44,7 +44,7 @@ void main() {
       );
     });
 
-    flameGame.test('Parent prepares the component', (game) async {
+    flameGame.test('parent prepares the component', (game) async {
       final parentEvents = <String>[];
       final childEvents = <String>[];
       final parent = _MyComponent(parentEvents);
@@ -70,7 +70,7 @@ void main() {
       );
     });
 
-    flameGame.test('Correct lifecycle on parent change', (game) async {
+    flameGame.test('correct lifecycle on parent change', (game) async {
       final parentEvents = <String>[];
       final childEvents = <String>[];
       final parent = _MyComponent(parentEvents);

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -4,7 +4,7 @@ import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class RemoveComponent extends Component {
+class _RemoveComponent extends Component {
   int removeCounter = 0;
 
   @override
@@ -15,8 +15,8 @@ class RemoveComponent extends Component {
 }
 
 void main() {
-  group('component test', () {
-    test('test get/set x/y or position', () {
+  group('Component', () {
+    test('get/set x/y or position', () {
       final PositionComponent c = SpriteComponent();
       c.position.setValues(2.2, 3.4);
       expect(c.x, 2.2);
@@ -27,7 +27,7 @@ void main() {
       expect(c.y, 0.0);
     });
 
-    test('test get/set width/height or size', () {
+    test('get/set width/height or size', () {
       final PositionComponent c = SpriteComponent();
       c.size.setValues(2.2, 3.4);
       expect(c.size.x, 2.2);
@@ -38,7 +38,7 @@ void main() {
       expect(c.height, 0.0);
     });
 
-    test('test get/set rect', () {
+    test('get/set rect', () {
       final PositionComponent c = SpriteComponent();
       c.position.setValues(0.0, 1.0);
       c.size.setValues(2.0, 2.0);
@@ -55,7 +55,7 @@ void main() {
       expect(c.height, 1.0);
     });
 
-    test('test get/set rect with anchor', () {
+    test('get/set rect with anchor', () {
       final PositionComponent c = SpriteComponent();
       c.position.setValues(0.0, 1.0);
       c.size.setValues(2.0, 2.0);
@@ -73,7 +73,7 @@ void main() {
       expect(c.height, 1.0);
     });
 
-    test('test get/set anchorPosition', () {
+    test('get/set anchorPosition', () {
       final PositionComponent c = SpriteComponent();
       c.position.setValues(0.0, 1.0);
       c.size.setValues(2.0, 2.0);
@@ -83,7 +83,7 @@ void main() {
       expect(anchorPosition.y, 0.0);
     });
 
-    test('test remove and shouldRemove', () {
+    test('remove and shouldRemove', () {
       final c1 = SpriteComponent();
       expect(c1.shouldRemove, equals(false));
       c1.removeFromParent();
@@ -101,7 +101,7 @@ void main() {
     flameGame.test(
       'remove and re-add should not double trigger onRemove',
       (game) async {
-        final component = RemoveComponent();
+        final component = _RemoveComponent();
 
         await game.ensureAdd(component);
         component.removeFromParent();

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
-import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 class RemoveComponent extends Component {
@@ -98,21 +98,21 @@ void main() {
       expect(c2.shouldRemove, equals(false));
     });
 
-    test('remove and re-add should not double trigger onRemove', () {
-      final game = FlameGame()..onGameResize(Vector2.zero());
-      final component = RemoveComponent();
+    flameGame.test(
+      'remove and re-add should not double trigger onRemove',
+      (game) async {
+        final component = RemoveComponent();
 
-      game.add(component);
-      game.update(0);
-      component.removeFromParent();
-      game.update(0);
-      expect(component.removeCounter, 1);
-      component.shouldRemove = false;
-      component.removeCounter = 0;
-      game.add(component);
-      game.update(0);
-      expect(component.removeCounter, 0);
-      expect(game.children.length, 1);
-    });
+        await game.ensureAdd(component);
+        component.removeFromParent();
+        game.update(0);
+        expect(component.removeCounter, 1);
+        component.shouldRemove = false;
+        component.removeCounter = 0;
+        await game.ensureAdd(component);
+        expect(component.removeCounter, 0);
+        expect(game.children.length, 1);
+      },
+    );
   });
 }

--- a/packages/flame/test/components/composed_component_test.dart
+++ b/packages/flame/test/components/composed_component_test.dart
@@ -6,9 +6,9 @@ import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class HasTappablesGame extends FlameGame with HasTappableComponents {}
+class _HasTappablesGame extends FlameGame with HasTappableComponents {}
 
-class MyTap extends PositionComponent with Tappable {
+class _MyTap extends PositionComponent with Tappable {
   late Vector2 gameSize;
 
   int tapTimes = 0;
@@ -41,7 +41,7 @@ class MyTap extends PositionComponent with Tappable {
   }
 }
 
-class MyAsyncChild extends MyTap {
+class _MyAsyncChild extends _MyTap {
   @override
   Future<void> onLoad() async {
     await super.onLoad();
@@ -49,23 +49,15 @@ class MyAsyncChild extends MyTap {
   }
 }
 
-class MyComposed extends PositionComponent with HasGameRef, Tappable {}
-
-class MySimpleComposed extends Component with HasGameRef, Tappable {}
-
-// composed w/o HasGameRef
-class PlainComposed extends Component {}
-
-Vector2 size = Vector2.all(300);
-
 void main() {
-  final withTappables = FlameTester(() => HasTappablesGame());
+  final size = Vector2.all(300);
+  final withTappables = FlameTester(() => _HasTappablesGame());
 
-  group('composable component test', () {
+  group('Composability', () {
     withTappables.test('child is not added until the component is prepared',
         (game) async {
-      final child = MyTap();
-      final wrapper = MyComposed();
+      final child = Component();
+      final wrapper = Component();
       await wrapper.add(child);
 
       expect(child.isPrepared, false);
@@ -80,8 +72,8 @@ void main() {
     });
 
     withTappables.test('removes the child from the component', (game) async {
-      final child = MyTap();
-      final wrapper = MyComposed();
+      final child = Component();
+      final wrapper = Component();
       await game.ensureAdd(wrapper);
 
       await wrapper.add(child);
@@ -98,8 +90,8 @@ void main() {
     withTappables.test(
       'when child is async loading, adds the child to the component after loading',
       (game) async {
-        final child = MyAsyncChild();
-        final wrapper = MyComposed();
+        final child = _MyAsyncChild();
+        final wrapper = Component();
         await game.ensureAdd(wrapper);
 
         final future = wrapper.add(child);
@@ -112,8 +104,8 @@ void main() {
     );
 
     withTappables.test('taps and resizes children', (game) async {
-      final child = MyTap();
-      final wrapper = MyComposed();
+      final child = _MyTap();
+      final wrapper = Component();
 
       game.onGameResize(size);
       child.size.setValues(1.0, 1.0);
@@ -126,8 +118,8 @@ void main() {
     });
 
     withTappables.test('add multiple children with addAll', (game) async {
-      final children = List.generate(10, (_) => MyTap());
-      final wrapper = MyComposed();
+      final children = List.generate(10, (_) => _MyTap());
+      final wrapper = Component();
       await wrapper.addAll(children);
 
       await game.ensureAdd(wrapper);
@@ -135,10 +127,10 @@ void main() {
     });
 
     withTappables.test('tap on offset children', (game) async {
-      final child = MyTap()
+      final child = _MyTap()
         ..position.setFrom(Vector2.all(100))
         ..size.setFrom(Vector2.all(100));
-      final wrapper = MyComposed()
+      final wrapper = PositionComponent()
         ..position.setFrom(Vector2.all(100))
         ..size.setFrom(Vector2.all(300));
 
@@ -159,8 +151,8 @@ void main() {
     });
 
     withTappables.test('updates and renders children', (game) async {
-      final child = MyTap();
-      final wrapper = MyComposed();
+      final child = _MyTap();
+      final wrapper = Component();
 
       await wrapper.ensureAdd(child);
       await game.ensureAdd(wrapper);
@@ -171,8 +163,8 @@ void main() {
     });
 
     withTappables.test('initially same debugMode as parent', (game) async {
-      final child = MyTap();
-      final wrapper = MyComposed();
+      final child = Component();
+      final wrapper = Component();
       wrapper.debugMode = true;
 
       wrapper.add(child);
@@ -180,18 +172,6 @@ void main() {
 
       expect(child.debugMode, true);
       wrapper.debugMode = false;
-      expect(child.debugMode, true);
-    });
-
-    withTappables.test('initially same debugMode as parent when Component',
-        (game) async {
-      final child = MyTap();
-      final wrapper = MySimpleComposed();
-      wrapper.debugMode = true;
-
-      wrapper.add(child);
-      await game.ensureAdd(wrapper);
-
       expect(child.debugMode, true);
     });
   });

--- a/packages/flame/test/components/custom_painter_component_test.dart
+++ b/packages/flame/test/components/custom_painter_component_test.dart
@@ -4,11 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-class MockCustomPainter extends Mock implements CustomPainter {}
+class _MockCustomPainter extends Mock implements CustomPainter {}
 
 void main() {
   test('correctly calls the paint method of the painter', () {
-    final painter = MockCustomPainter();
+    final painter = _MockCustomPainter();
     final component = CustomPainterComponent(
       painter: painter,
     )..size = Vector2.all(100);

--- a/packages/flame/test/components/draggable_test.dart
+++ b/packages/flame/test/components/draggable_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 class _GameHasDraggables extends FlameGame with HasDraggableComponents {}
 
-class DraggableComponent extends PositionComponent with Draggable {
+class _DraggableComponent extends PositionComponent with Draggable {
   bool hasStartedDragging = false;
 
   @override
@@ -20,11 +20,11 @@ class DraggableComponent extends PositionComponent with Draggable {
 void main() {
   final withDraggables = FlameTester(() => _GameHasDraggables());
 
-  group('draggables test', () {
+  group('Draggables', () {
     withDraggables.test(
       'make sure they can be added to game with HasDraggables',
       (game) async {
-        await game.add(DraggableComponent());
+        await game.add(_DraggableComponent());
       },
     );
 
@@ -36,7 +36,7 @@ void main() {
             'HasDraggableComponents';
 
         expect(
-          () => game.add(DraggableComponent()),
+          () => game.add(_DraggableComponent()),
           throwsA(
             predicate(
               (e) => e is AssertionError && e.message == message,
@@ -47,7 +47,7 @@ void main() {
     );
 
     withDraggables.test('can be dragged', (game) async {
-      final component = DraggableComponent()
+      final component = _DraggableComponent()
         ..x = 10
         ..y = 10
         ..width = 10
@@ -69,7 +69,7 @@ void main() {
 
     withDraggables.test('when the game has camera zoom, can be dragged',
         (game) async {
-      final component = DraggableComponent()
+      final component = _DraggableComponent()
         ..x = 10
         ..y = 10
         ..width = 10
@@ -92,7 +92,7 @@ void main() {
 
     withDraggables.test('when the game has a moved camera, dragging works',
         (game) async {
-      final component = DraggableComponent()
+      final component = _DraggableComponent()
         ..x = 50
         ..y = 50
         ..width = 10
@@ -116,7 +116,7 @@ void main() {
   });
 
   withDraggables.test('isDragged is changed', (game) async {
-    final component = DraggableComponent()
+    final component = _DraggableComponent()
       ..x = 10
       ..y = 10
       ..width = 10

--- a/packages/flame/test/components/draggable_test.dart
+++ b/packages/flame/test/components/draggable_test.dart
@@ -1,12 +1,11 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame/input.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:flutter/gestures.dart';
 import 'package:test/test.dart';
 
-class _GameWithDraggables extends FlameGame with HasDraggableComponents {}
-
-class _GameWithoutDraggables extends FlameGame {}
+class _GameHasDraggables extends FlameGame with HasDraggableComponents {}
 
 class DraggableComponent extends PositionComponent with Draggable {
   bool hasStartedDragging = false;
@@ -19,42 +18,42 @@ class DraggableComponent extends PositionComponent with Draggable {
 }
 
 void main() {
+  final withDraggables = FlameTester(() => _GameHasDraggables());
+
   group('draggables test', () {
-    test('make sure they cannot be added to invalid games', () async {
-      final game1 = _GameWithDraggables();
-      game1.onGameResize(Vector2.all(100));
-      // should be ok
-      await game1.add(DraggableComponent());
+    withDraggables.test(
+      'make sure they can be added to game with HasDraggables',
+      (game) async {
+        await game.add(DraggableComponent());
+      },
+    );
 
-      final game2 = _GameWithoutDraggables();
-      game2.onGameResize(Vector2.all(100));
+    flameGame.test(
+      'make sure they cannot be added to invalid games',
+      (game) async {
+        const message =
+            'Draggable Components can only be added to a FlameGame with '
+            'HasDraggableComponents';
 
-      const message =
-          'Draggable Components can only be added to a FlameGame with '
-          'HasDraggableComponents';
-
-      expect(
-        () => game2.add(DraggableComponent()),
-        throwsA(
-          predicate(
-            (e) => e is AssertionError && e.message == message,
+        expect(
+          () => game.add(DraggableComponent()),
+          throwsA(
+            predicate(
+              (e) => e is AssertionError && e.message == message,
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
 
-    test('can be dragged', () async {
-      final game = _GameWithDraggables();
-      game.onGameResize(Vector2.all(100));
+    withDraggables.test('can be dragged', (game) async {
       final component = DraggableComponent()
         ..x = 10
         ..y = 10
         ..width = 10
         ..height = 10;
 
-      await game.add(component);
-      // So component is added
-      game.update(0.01);
+      await game.ensureAdd(component);
       game.onDragStart(
         1,
         DragStartInfo.fromDetails(
@@ -68,19 +67,16 @@ void main() {
       expect(component.hasStartedDragging, true);
     });
 
-    test('when the game has camera zoom, can be dragged', () async {
-      final game = _GameWithDraggables();
-      game.onGameResize(Vector2.all(100));
+    withDraggables.test('when the game has camera zoom, can be dragged',
+        (game) async {
       final component = DraggableComponent()
         ..x = 10
         ..y = 10
         ..width = 10
         ..height = 10;
 
-      await game.add(component);
+      await game.ensureAdd(component);
       game.camera.zoom = 1.5;
-      // So component is added
-      game.update(0.01);
       game.onDragStart(
         1,
         DragStartInfo.fromDetails(
@@ -94,20 +90,17 @@ void main() {
       expect(component.hasStartedDragging, true);
     });
 
-    test('when the game has a moved camera, dragging works', () async {
-      final game = _GameWithDraggables();
-      game.onGameResize(Vector2.all(100));
+    withDraggables.test('when the game has a moved camera, dragging works',
+        (game) async {
       final component = DraggableComponent()
         ..x = 50
         ..y = 50
         ..width = 10
         ..height = 10;
 
-      await game.add(component);
+      await game.ensureAdd(component);
       game.camera.zoom = 1.5;
       game.camera.snapTo(Vector2.all(50));
-      // So component is added
-      game.update(0.01);
       game.onDragStart(
         1,
         DragStartInfo.fromDetails(
@@ -122,18 +115,14 @@ void main() {
     });
   });
 
-  test('isDragged is changed', () async {
-    final game = _GameWithDraggables();
-    game.onGameResize(Vector2.all(100));
+  withDraggables.test('isDragged is changed', (game) async {
     final component = DraggableComponent()
       ..x = 10
       ..y = 10
       ..width = 10
       ..height = 10;
 
-    await game.add(component);
-    // So component is added
-    game.update(0.01);
+    await game.ensureAdd(component);
     expect(component.isDragged, false);
     game.onDragStart(
       1,

--- a/packages/flame/test/components/has_game_ref_test.dart
+++ b/packages/flame/test/components/has_game_ref_test.dart
@@ -2,24 +2,24 @@ import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:test/test.dart';
 
-class MyGame extends FlameGame {
+class _MyGame extends FlameGame {
   bool calledFoo = false;
   void foo() {
     calledFoo = true;
   }
 }
 
-class MyComponent extends PositionComponent with HasGameRef<MyGame> {
+class _MyComponent extends Component with HasGameRef<_MyGame> {
   void foo() {
     gameRef.foo();
   }
 }
 
 void main() {
-  group('has game ref test', () {
+  group('HasGameRef', () {
     test('simple test', () {
-      final c = MyComponent();
-      final game = MyGame();
+      final c = _MyComponent();
+      final game = _MyGame();
       game.onGameResize(Vector2.all(200));
       game.add(c);
       c.foo();

--- a/packages/flame/test/components/has_game_ref_test.dart
+++ b/packages/flame/test/components/has_game_ref_test.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 class _MyGame extends FlameGame {
@@ -16,11 +17,11 @@ class _MyComponent extends Component with HasGameRef<_MyGame> {
 }
 
 void main() {
+  final withHasGameRef = FlameTester(() => _MyGame());
+
   group('HasGameRef', () {
-    test('simple test', () {
+    withHasGameRef.test('simple test', (game) {
       final c = _MyComponent();
-      final game = _MyGame();
-      game.onGameResize(Vector2.all(200));
       game.add(c);
       c.foo();
       expect(game.calledFoo, true);

--- a/packages/flame/test/components/hoverable_test.dart
+++ b/packages/flame/test/components/hoverable_test.dart
@@ -10,9 +10,7 @@ import 'package:test/test.dart';
 
 class _GameWithHoverables extends FlameGame with HasHoverableComponents {}
 
-final withHoverables = FlameTester(() => _GameWithHoverables());
-
-class HoverableComponent extends PositionComponent with Hoverable {
+class _HoverableComponent extends PositionComponent with Hoverable {
   int enterCount = 0;
   int leaveCount = 0;
 
@@ -29,7 +27,7 @@ class HoverableComponent extends PositionComponent with Hoverable {
   }
 }
 
-class NonPropagatingComponent extends HoverableComponent {
+class _NonPropagatingComponent extends _HoverableComponent {
   @override
   bool onHoverEnter(PointerHoverInfo info) {
     super.onHoverEnter(info);
@@ -44,11 +42,13 @@ class NonPropagatingComponent extends HoverableComponent {
 }
 
 void main() {
-  group('hoverable test', () {
+  final withHoverables = FlameTester(() => _GameWithHoverables());
+
+  group('Hoverable', () {
     withHoverables.test(
       'make sure they can be added to game with HasHoverables',
       (game) async {
-        await game.add(HoverableComponent());
+        await game.add(_HoverableComponent());
       },
     );
 
@@ -60,7 +60,7 @@ void main() {
             'HasHoverableComponents';
 
         expect(
-          () => game.add(HoverableComponent()),
+          () => game.add(_HoverableComponent()),
           throwsA(
             predicate(
               (e) => e is AssertionError && e.message == message,
@@ -73,7 +73,7 @@ void main() {
     withHoverables.test(
       'single component',
       (game) async {
-        final c = HoverableComponent()
+        final c = _HoverableComponent()
           ..position = Vector2(10, 20)
           ..size = Vector2(3, 3);
         await game.ensureAdd(c);
@@ -117,7 +117,7 @@ void main() {
     withHoverables.test(
       'camera is respected',
       (game) async {
-        final c = HoverableComponent()
+        final c = _HoverableComponent()
           ..position = Vector2(10, 20)
           ..size = Vector2(3, 3);
         await game.ensureAdd(c);
@@ -139,13 +139,13 @@ void main() {
     withHoverables.test(
       'multiple components',
       (game) async {
-        final a = HoverableComponent()
+        final a = _HoverableComponent()
           ..position = Vector2(10, 0)
           ..size = Vector2(2, 20);
-        final b = HoverableComponent()
+        final b = _HoverableComponent()
           ..position = Vector2(10, 10)
           ..size = Vector2(2, 2);
-        final c = HoverableComponent()
+        final c = _HoverableComponent()
           ..position = Vector2(0, 7)
           ..size = Vector2(20, 2);
         await game.ensureAdd(a);
@@ -177,10 +177,10 @@ void main() {
     withHoverables.test(
       'composed components',
       (game) async {
-        final parent = HoverableComponent()
+        final parent = _HoverableComponent()
           ..position = Vector2.all(10)
           ..size = Vector2.all(10);
-        final child = NonPropagatingComponent()
+        final child = _NonPropagatingComponent()
           ..position = Vector2.all(0)
           ..size = Vector2.all(10);
         await parent.add(child);

--- a/packages/flame/test/components/hoverable_test.dart
+++ b/packages/flame/test/components/hoverable_test.dart
@@ -12,10 +12,6 @@ class _GameWithHoverables extends FlameGame with HasHoverableComponents {}
 
 final withHoverables = FlameTester(() => _GameWithHoverables());
 
-class _GameWithoutHoverables extends FlameGame {}
-
-final withoutHoverables = FlameTester(() => _GameWithoutHoverables());
-
 class HoverableComponent extends PositionComponent with Hoverable {
   int enterCount = 0;
   int leaveCount = 0;
@@ -50,20 +46,21 @@ class NonPropagatingComponent extends HoverableComponent {
 void main() {
   group('hoverable test', () {
     withHoverables.test(
+      'make sure they can be added to game with HasHoverables',
+      (game) async {
+        await game.add(HoverableComponent());
+      },
+    );
+
+    flameGame.test(
       'make sure they cannot be added to invalid games',
       (game) async {
-        // should be ok
-        await game.add(HoverableComponent());
-
-        final game2 = _GameWithoutHoverables();
-        game2.onGameResize(Vector2.all(100));
-
         const message =
             'Hoverable Components can only be added to a FlameGame with '
             'HasHoverableComponents';
 
         expect(
-          () => game2.add(HoverableComponent()),
+          () => game.add(HoverableComponent()),
           throwsA(
             predicate(
               (e) => e is AssertionError && e.message == message,
@@ -79,8 +76,7 @@ void main() {
         final c = HoverableComponent()
           ..position = Vector2(10, 20)
           ..size = Vector2(3, 3);
-        await game.add(c);
-        game.update(0);
+        await game.ensureAdd(c);
 
         expect(c.isHovered, false);
         expect(c.enterCount, 0);
@@ -124,8 +120,7 @@ void main() {
         final c = HoverableComponent()
           ..position = Vector2(10, 20)
           ..size = Vector2(3, 3);
-        await game.add(c);
-        game.update(0);
+        await game.ensureAdd(c);
 
         // component is now at the corner of the screen
         game.camera.snapTo(Vector2(10, 20));
@@ -153,10 +148,9 @@ void main() {
         final c = HoverableComponent()
           ..position = Vector2(0, 7)
           ..size = Vector2(20, 2);
-        await game.add(a);
-        await game.add(b);
-        await game.add(c);
-        game.update(0);
+        await game.ensureAdd(a);
+        await game.ensureAdd(b);
+        await game.ensureAdd(c);
 
         _triggerMouseMove(game, 0, 0);
         expect(a.isHovered, false);
@@ -190,8 +184,7 @@ void main() {
           ..position = Vector2.all(0)
           ..size = Vector2.all(10);
         await parent.add(child);
-        await game.add(parent);
-        game.update(0);
+        await game.ensureAdd(parent);
         _triggerMouseMove(game, 15, 15);
         expect(child.isHovered, true);
         expect(parent.isHovered, false);

--- a/packages/flame/test/components/hud_margin_component_test.dart
+++ b/packages/flame/test/components/hud_margin_component_test.dart
@@ -13,8 +13,7 @@ void main() async {
           margin: const EdgeInsets.only(right: 10, bottom: 20),
           size: Vector2.all(20),
         );
-        await game.add(marginComponent);
-        game.update(0);
+        await game.ensureAdd(marginComponent);
         // The position should be (470, 460) since the game size is (500, 500)
         // and the component has its anchor in the top left corner (which then
         // is were the margin will be calculated from).

--- a/packages/flame/test/components/joystick_component_test.dart
+++ b/packages/flame/test/components/joystick_component_test.dart
@@ -11,7 +11,7 @@ void main() {
   final withDraggables = FlameTester(() => _GameHasDraggables());
 
   group('JoystickDirection tests', () {
-    withDraggables.test('Can convert angle to JoystickDirection', (game) async {
+    withDraggables.test('can convert angle to JoystickDirection', (game) async {
       final joystick = JoystickComponent(
         knob: CircleComponent(radius: 5.0),
         size: 20,

--- a/packages/flame/test/components/joystick_component_test.dart
+++ b/packages/flame/test/components/joystick_component_test.dart
@@ -5,21 +5,19 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 
-class TestGame extends FlameGame with HasDraggableComponents {}
-
-final testGame = FlameTester(() => TestGame());
+class _GameHasDraggables extends FlameGame with HasDraggableComponents {}
 
 void main() {
+  final withDraggables = FlameTester(() => _GameHasDraggables());
+
   group('JoystickDirection tests', () {
-    test('Can convert angle to JoystickDirection', () {
+    withDraggables.test('Can convert angle to JoystickDirection', (game) async {
       final joystick = JoystickComponent(
         knob: CircleComponent(radius: 5.0),
         size: 20,
         margin: const EdgeInsets.only(left: 20, bottom: 20),
       );
-      final game = TestGame()..onGameResize(Vector2.all(200));
-      game.add(joystick);
-      game.update(0);
+      await game.ensureAdd(joystick);
 
       expect(joystick.direction, JoystickDirection.idle);
       joystick.delta.setValues(1.0, 0.0);
@@ -42,7 +40,7 @@ void main() {
   });
 
   group('Joystick input tests', () {
-    testGame.test(
+    withDraggables.test(
       'knob should stay on correct side when the total delta is larger than the size and then the knob is moved slightly back again',
       (game) async {
         final joystick = JoystickComponent(

--- a/packages/flame/test/components/mixins/has_collidable_test.dart
+++ b/packages/flame/test/components/mixins/has_collidable_test.dart
@@ -2,7 +2,7 @@ import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MyCollidable extends PositionComponent with HasHitboxes, Collidable {}
+class _MyCollidable extends PositionComponent with HasHitboxes, Collidable {}
 
 void main() {
   group('HasCollidables', () {
@@ -13,7 +13,7 @@ void main() {
             'You can only use the HasHitboxes/Collidable feature with games '
             'that has the HasCollidables mixin';
         expect(
-          () => game.add(MyCollidable()),
+          () => game.add(_MyCollidable()),
           throwsA(
             predicate(
               (e) => e is AssertionError && e.message == message,

--- a/packages/flame/test/components/mixins/has_paint_test.dart
+++ b/packages/flame/test/components/mixins/has_paint_test.dart
@@ -90,11 +90,11 @@ void main() {
       () {
         final comp = _MyComponentWithType();
 
-        comp.setPaint(_MyComponentKeys.background, Paint());
-        comp.deletePaint(_MyComponentKeys.background);
+        comp.setPaint(_MyComponentKeys.foreground, Paint());
+        comp.deletePaint(_MyComponentKeys.foreground);
 
         expect(
-          () => comp.getPaint(_MyComponentKeys.background),
+          () => comp.getPaint(_MyComponentKeys.foreground),
           throwsArgumentError,
         );
       },

--- a/packages/flame/test/components/mixins/has_paint_test.dart
+++ b/packages/flame/test/components/mixins/has_paint_test.dart
@@ -3,20 +3,20 @@ import 'dart:ui';
 import 'package:flame/components.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MyComponent extends PositionComponent with HasPaint {}
+class _MyComponent extends PositionComponent with HasPaint {}
 
-enum MyComponentKeys {
+enum _MyComponentKeys {
   background,
   foreground,
 }
 
-class MyComponentWithType extends PositionComponent
-    with HasPaint<MyComponentKeys> {}
+class _MyComponentWithType extends PositionComponent
+    with HasPaint<_MyComponentKeys> {}
 
 void main() {
-  group('Components - HasPaint', () {
+  group('HasPaint', () {
     test('paint returns the default paint', () {
-      final comp = MyComponent();
+      final comp = _MyComponent();
 
       expect(comp.paint, comp.getPaint());
     });
@@ -24,7 +24,7 @@ void main() {
     test(
       'paint setter sets the main paint',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
 
         const color = Color(0xFFE5E5E5);
         comp.paint = Paint()..color = color;
@@ -36,10 +36,10 @@ void main() {
     test(
       'getPaint throws exception when retrieving a paint that does not exists',
       () {
-        final comp = MyComponentWithType();
+        final comp = _MyComponentWithType();
 
         expect(
-          () => comp.getPaint(MyComponentKeys.background),
+          () => comp.getPaint(_MyComponentKeys.background),
           throwsArgumentError,
         );
       },
@@ -48,10 +48,10 @@ void main() {
     test(
       'getPaint throws exception when used on genericless component',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
 
         expect(
-          () => comp.getPaint(MyComponentKeys.background),
+          () => comp.getPaint(_MyComponentKeys.background),
           throwsAssertionError,
         );
       },
@@ -60,24 +60,24 @@ void main() {
     test(
       'setPaint sets a paint',
       () {
-        final comp = MyComponentWithType();
+        final comp = _MyComponentWithType();
 
         const color = Color(0xFFA9A9A9);
-        comp.setPaint(MyComponentKeys.background, Paint()..color = color);
+        comp.setPaint(_MyComponentKeys.background, Paint()..color = color);
 
-        expect(comp.getPaint(MyComponentKeys.background).color, color);
+        expect(comp.getPaint(_MyComponentKeys.background).color, color);
       },
     );
 
     test(
       'setPaint throws exception when used on genericless component',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
 
         const color = Color(0xFFA9A9A9);
         expect(
           () => comp.setPaint(
-            MyComponentKeys.background,
+            _MyComponentKeys.background,
             Paint()..color = color,
           ),
           throwsAssertionError,
@@ -88,13 +88,13 @@ void main() {
     test(
       'deletePaint removes a paint from the map',
       () {
-        final comp = MyComponentWithType();
+        final comp = _MyComponentWithType();
 
-        comp.setPaint(MyComponentKeys.background, Paint());
-        comp.deletePaint(MyComponentKeys.background);
+        comp.setPaint(_MyComponentKeys.background, Paint());
+        comp.deletePaint(_MyComponentKeys.background);
 
         expect(
-          () => comp.getPaint(MyComponentKeys.background),
+          () => comp.getPaint(_MyComponentKeys.background),
           throwsArgumentError,
         );
       },
@@ -103,10 +103,10 @@ void main() {
     test(
       'deletePaint throws exception when used on genericless component',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
 
         expect(
-          () => comp.deletePaint(MyComponentKeys.background),
+          () => comp.deletePaint(_MyComponentKeys.background),
           throwsAssertionError,
         );
       },
@@ -115,7 +115,7 @@ void main() {
     test(
       'makeTransparent sets opacity to 0 on the main when paintId is omitted',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
         comp.makeTransparent();
 
         expect(comp.paint.color.opacity, 0);
@@ -125,18 +125,18 @@ void main() {
     test(
       'makeTransparent sets opacity to 0 on informed paintId',
       () {
-        final comp = MyComponentWithType();
-        comp.setPaint(MyComponentKeys.background, Paint());
-        comp.makeTransparent(paintId: MyComponentKeys.background);
+        final comp = _MyComponentWithType();
+        comp.setPaint(_MyComponentKeys.background, Paint());
+        comp.makeTransparent(paintId: _MyComponentKeys.background);
 
-        expect(comp.getPaint(MyComponentKeys.background).color.opacity, 0);
+        expect(comp.getPaint(_MyComponentKeys.background).color.opacity, 0);
       },
     );
 
     test(
       'makeOpaque sets opacity to 1 on the main when paintId is omitted',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
         comp.makeTransparent();
         comp.makeOpaque();
 
@@ -147,21 +147,21 @@ void main() {
     test(
       'makeOpaque sets opacity to 1 on informed paintId',
       () {
-        final comp = MyComponentWithType();
+        final comp = _MyComponentWithType();
         comp.setPaint(
-          MyComponentKeys.background,
+          _MyComponentKeys.background,
           Paint()..color = const Color(0x00E5E5E5),
         );
-        comp.makeOpaque(paintId: MyComponentKeys.background);
+        comp.makeOpaque(paintId: _MyComponentKeys.background);
 
-        expect(comp.getPaint(MyComponentKeys.background).color.opacity, 1);
+        expect(comp.getPaint(_MyComponentKeys.background).color.opacity, 1);
       },
     );
 
     test(
       'setOpacity sets opacity of the main when paintId is omitted',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
         comp.setOpacity(0.2);
 
         expect(comp.paint.color.opacity, 0.2);
@@ -171,18 +171,18 @@ void main() {
     test(
       'setOpacity sets opacity of the informed paintId',
       () {
-        final comp = MyComponentWithType();
-        comp.setPaint(MyComponentKeys.background, Paint());
-        comp.setOpacity(0.2, paintId: MyComponentKeys.background);
+        final comp = _MyComponentWithType();
+        comp.setPaint(_MyComponentKeys.background, Paint());
+        comp.setOpacity(0.2, paintId: _MyComponentKeys.background);
 
-        expect(comp.getPaint(MyComponentKeys.background).color.opacity, 0.2);
+        expect(comp.getPaint(_MyComponentKeys.background).color.opacity, 0.2);
       },
     );
 
     test(
       'throws error if opacity is less than 0',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
 
         expect(
           () => comp.setOpacity(-0.5),
@@ -194,7 +194,7 @@ void main() {
     test(
       'throws error if opacity is greater than 1',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
 
         expect(
           () => comp.setOpacity(1.1),
@@ -206,7 +206,7 @@ void main() {
     test(
       'setColor sets color of the main when paintId is omitted',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
         const color = Color(0xFFE5E5E5);
         comp.setColor(color);
 
@@ -217,19 +217,19 @@ void main() {
     test(
       'setOpacity sets opacity of the informed paintId',
       () {
-        final comp = MyComponentWithType();
+        final comp = _MyComponentWithType();
         const color = Color(0xFFE5E5E5);
-        comp.setPaint(MyComponentKeys.background, Paint());
-        comp.setColor(color, paintId: MyComponentKeys.background);
+        comp.setPaint(_MyComponentKeys.background, Paint());
+        comp.setColor(color, paintId: _MyComponentKeys.background);
 
-        expect(comp.getPaint(MyComponentKeys.background).color, color);
+        expect(comp.getPaint(_MyComponentKeys.background).color, color);
       },
     );
 
     test(
       'tint sets the correct color filter of the main when paintId is omitted',
       () {
-        final comp = MyComponent();
+        final comp = _MyComponent();
         const color = Color(0xFFE5E5E5);
         comp.tint(color);
 
@@ -243,13 +243,13 @@ void main() {
     test(
       'setOpacity sets opacity of the informed paintId',
       () {
-        final comp = MyComponentWithType();
+        final comp = _MyComponentWithType();
         const color = Color(0xFFE5E5E5);
-        comp.setPaint(MyComponentKeys.background, Paint());
-        comp.tint(color, paintId: MyComponentKeys.background);
+        comp.setPaint(_MyComponentKeys.background, Paint());
+        comp.tint(color, paintId: _MyComponentKeys.background);
 
         expect(
-          comp.getPaint(MyComponentKeys.background).colorFilter,
+          comp.getPaint(_MyComponentKeys.background).colorFilter,
           const ColorFilter.mode(color, BlendMode.multiply),
         );
       },

--- a/packages/flame/test/components/parallax_test.dart
+++ b/packages/flame/test/components/parallax_test.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 class ParallaxGame extends FlameGame {
@@ -24,19 +25,19 @@ class ParallaxGame extends FlameGame {
 }
 
 void main() {
-  group('parallax test', () {
-    test('can have non-fullscreen ParallaxComponent', () async {
-      final parallaxSize = Vector2.all(100);
-      final game = ParallaxGame(parallaxSize: parallaxSize.clone());
-      await game.onLoad();
-      game.update(0);
-      expect(game.parallaxComponent.size, parallaxSize);
-    });
+  final parallaxGame = FlameTester(() => ParallaxGame());
 
-    test('can have fullscreen ParallaxComponent', () async {
-      final game = ParallaxGame();
-      await game.onLoad();
-      game.update(0);
+  group('parallax test', () {
+    parallaxGame.test(
+      'can have non-fullscreen ParallaxComponent',
+      (game) async {
+        final parallaxSize = Vector2.all(100);
+        game.onGameResize(parallaxSize);
+        expect(game.parallaxComponent.size, parallaxSize);
+      },
+    );
+
+    parallaxGame.test('can have fullscreen ParallaxComponent', (game) async {
       expect(game.parallaxComponent.size, game.size);
     });
   });

--- a/packages/flame/test/components/parallax_test.dart
+++ b/packages/flame/test/components/parallax_test.dart
@@ -3,11 +3,11 @@ import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class ParallaxGame extends FlameGame {
+class _ParallaxGame extends FlameGame {
   late final ParallaxComponent parallaxComponent;
   late final Vector2? parallaxSize;
 
-  ParallaxGame({this.parallaxSize}) {
+  _ParallaxGame({this.parallaxSize}) {
     onGameResize(Vector2.all(500));
   }
 
@@ -25,7 +25,7 @@ class ParallaxGame extends FlameGame {
 }
 
 void main() {
-  final parallaxGame = FlameTester(() => ParallaxGame());
+  final parallaxGame = FlameTester(() => _ParallaxGame());
 
   group('parallax test', () {
     parallaxGame.test(

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -9,9 +9,9 @@ import 'package:flame/geometry.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class MyHitboxComponent extends PositionComponent with HasHitboxes {}
+class _MyHitboxComponent extends PositionComponent with HasHitboxes {}
 
-class MyDebugComponent extends PositionComponent {
+class _MyDebugComponent extends PositionComponent {
   int? precision = 0;
 
   @override
@@ -101,7 +101,7 @@ void main() {
     });
 
     test('component with hitbox contains point', () {
-      final HasHitboxes component = MyHitboxComponent();
+      final HasHitboxes component = _MyHitboxComponent();
       component.position.setValues(1.0, 1.0);
       component.anchor = Anchor.topLeft;
       component.size.setValues(2.0, 2.0);
@@ -118,7 +118,7 @@ void main() {
     });
 
     test('component with anchor topLeft contains point on edge', () {
-      final HasHitboxes component = MyHitboxComponent();
+      final HasHitboxes component = _MyHitboxComponent();
       component.position.setValues(-1, -1);
       component.anchor = Anchor.topLeft;
       component.size.setValues(2.0, 2.0);
@@ -132,7 +132,7 @@ void main() {
     });
 
     test('component with anchor bottomRight contains point on edge', () {
-      final HasHitboxes component = MyHitboxComponent();
+      final HasHitboxes component = _MyHitboxComponent();
       component.position.setValues(1, 1);
       component.anchor = Anchor.bottomRight;
       component.size.setValues(2.0, 2.0);
@@ -146,7 +146,7 @@ void main() {
     });
 
     test('component with anchor topRight does not contain close points', () {
-      final HasHitboxes component = MyHitboxComponent();
+      final HasHitboxes component = _MyHitboxComponent();
       component.position.setValues(1, 1);
       component.anchor = Anchor.topLeft;
       component.size.setValues(2.0, 2.0);
@@ -160,7 +160,7 @@ void main() {
     });
 
     test('component with hitbox does not contains point', () {
-      final HasHitboxes component = MyHitboxComponent();
+      final HasHitboxes component = _MyHitboxComponent();
       component.position.setValues(1.0, 1.0);
       component.anchor = Anchor.topLeft;
       component.size.setValues(2.0, 2.0);
@@ -324,7 +324,7 @@ void main() {
       expect(component.scaledSize.y, 14);
     });
 
-    test('.positionOf', () {
+    test('positionOf', () {
       final component = PositionComponent()
         ..size = Vector2(50, 100)
         ..position = Vector2(500, 700)
@@ -572,7 +572,7 @@ void main() {
 
   group('rendering', () {
     test('render in debug mode', () {
-      final component = MyDebugComponent()
+      final component = _MyDebugComponent()
         ..position = Vector2(23, 17)
         ..size = Vector2.all(10);
       final canvas = MockCanvas();
@@ -590,7 +590,7 @@ void main() {
     });
 
     test('render without coordinates', () {
-      final component = MyDebugComponent()
+      final component = _MyDebugComponent()
         ..position = Vector2(23, 17)
         ..size = Vector2.all(10)
         ..anchor = Anchor.center

--- a/packages/flame/test/components/priority_test.dart
+++ b/packages/flame/test/components/priority_test.dart
@@ -2,19 +2,14 @@ import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class PriorityComponent extends Component {
-  PriorityComponent(int priority) : super(priority: priority);
+class _PriorityComponent extends Component {
+  _PriorityComponent(int priority) : super(priority: priority);
 }
 
-void componentsSorted(Iterable<Component> components) {
-  final priorities = components.map<int>((c) => c.priority).toList();
-  expect(priorities.toList(), orderedEquals(priorities..sort()));
-}
-
-class ParentWithReorderSpy extends Component {
+class _ParentWithReorderSpy extends Component {
   int callCount = 0;
 
-  ParentWithReorderSpy(int priority) : super(priority: priority);
+  _ParentWithReorderSpy(int priority) : super(priority: priority);
 
   @override
   void reorderChildren() {
@@ -29,12 +24,17 @@ class ParentWithReorderSpy extends Component {
 }
 
 void main() {
+  void componentsSorted(Iterable<Component> components) {
+    final priorities = components.map<int>((c) => c.priority).toList();
+    expect(priorities.toList(), orderedEquals(priorities..sort()));
+  }
+
   group('priority test', () {
     flameGame.test(
       'components with different priorities are sorted in the list',
       (game) async {
         final priorityComponents =
-            List.generate(10, (i) => PriorityComponent(i));
+            List.generate(10, (i) => _PriorityComponent(i));
         priorityComponents.shuffle();
         await game.ensureAddAll(priorityComponents);
         componentsSorted(game.children);
@@ -44,9 +44,9 @@ void main() {
     flameGame.test(
       'changing priority should reorder component list',
       (game) async {
-        final firstCompopnent = PriorityComponent(-1);
+        final firstCompopnent = _PriorityComponent(-1);
         final priorityComponents =
-            List.generate(10, (i) => PriorityComponent(i))
+            List.generate(10, (i) => _PriorityComponent(i))
               ..add(firstCompopnent);
         priorityComponents.shuffle();
         final components = game.children;
@@ -63,7 +63,7 @@ void main() {
       'changing priorities should reorder component list',
       (game) async {
         final priorityComponents =
-            List.generate(10, (i) => PriorityComponent(i));
+            List.generate(10, (i) => _PriorityComponent(i));
         priorityComponents.shuffle();
         final components = game.children;
         await game.ensureAddAll(priorityComponents);
@@ -83,9 +83,9 @@ void main() {
     flameGame.test(
       'changing child priority should reorder component list',
       (game) async {
-        final parentComponent = PriorityComponent(0);
+        final parentComponent = _PriorityComponent(0);
         final priorityComponents =
-            List.generate(10, (i) => PriorityComponent(i));
+            List.generate(10, (i) => _PriorityComponent(i));
         priorityComponents.shuffle();
         await game.ensureAdd(parentComponent);
         await parentComponent.ensureAddAll(priorityComponents);
@@ -102,9 +102,9 @@ void main() {
     flameGame.test(
       'changing child priorities should reorder component list',
       (game) async {
-        final parentComponent = PriorityComponent(0);
+        final parentComponent = _PriorityComponent(0);
         final priorityComponents =
-            List.generate(10, (i) => PriorityComponent(i));
+            List.generate(10, (i) => _PriorityComponent(i));
         priorityComponents.shuffle();
         await game.ensureAdd(parentComponent);
         await parentComponent.ensureAddAll(priorityComponents);
@@ -125,10 +125,10 @@ void main() {
     flameGame.test(
       'changing grand child priority should reorder component list',
       (game) async {
-        final grandParentComponent = PriorityComponent(0);
-        final parentComponent = PriorityComponent(0);
+        final grandParentComponent = _PriorityComponent(0);
+        final parentComponent = _PriorityComponent(0);
         final priorityComponents =
-            List.generate(10, (i) => PriorityComponent(i));
+            List.generate(10, (i) => _PriorityComponent(i));
         priorityComponents.shuffle();
         await game.ensureAdd(grandParentComponent);
         await grandParentComponent.ensureAdd(parentComponent);
@@ -146,19 +146,19 @@ void main() {
     flameGame.test(
       '#reorderChildren is only called once per parent per tick',
       (game) async {
-        final a = ParentWithReorderSpy(1);
-        final a1 = PriorityComponent(1);
-        final a2 = PriorityComponent(2);
+        final a = _ParentWithReorderSpy(1);
+        final a1 = _PriorityComponent(1);
+        final a2 = _PriorityComponent(2);
         a.addAll([a1, a2]);
 
-        final b = ParentWithReorderSpy(3);
-        final b1 = PriorityComponent(1);
+        final b = _ParentWithReorderSpy(3);
+        final b1 = _PriorityComponent(1);
         b.add(b1);
 
-        final c = ParentWithReorderSpy(2);
-        final c1 = PriorityComponent(1);
-        final c2 = PriorityComponent(0);
-        final c3 = PriorityComponent(-1);
+        final c = _ParentWithReorderSpy(2);
+        final c1 = _PriorityComponent(1);
+        final c2 = _PriorityComponent(0);
+        final c3 = _PriorityComponent(-1);
         c.addAll([c1, c2, c3]);
 
         await game.ensureAddAll([a, b, c]);

--- a/packages/flame/test/components/priority_test.dart
+++ b/packages/flame/test/components/priority_test.dart
@@ -32,27 +32,25 @@ void main() {
   group('priority test', () {
     flameGame.test(
       'components with different priorities are sorted in the list',
-      (game) {
+      (game) async {
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i));
         priorityComponents.shuffle();
-        game.addAll(priorityComponents);
-        game.update(0);
+        await game.ensureAddAll(priorityComponents);
         componentsSorted(game.children);
       },
     );
 
     flameGame.test(
       'changing priority should reorder component list',
-      (game) {
+      (game) async {
         final firstCompopnent = PriorityComponent(-1);
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i))
               ..add(firstCompopnent);
         priorityComponents.shuffle();
         final components = game.children;
-        game.addAll(priorityComponents);
-        game.update(0);
+        await game.ensureAddAll(priorityComponents);
         componentsSorted(components);
         expect(components.first, firstCompopnent);
         game.children.changePriority(firstCompopnent, 11);
@@ -63,13 +61,12 @@ void main() {
 
     flameGame.test(
       'changing priorities should reorder component list',
-      (game) {
+      (game) async {
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i));
         priorityComponents.shuffle();
         final components = game.children;
-        game.addAll(priorityComponents);
-        game.update(0);
+        await game.ensureAddAll(priorityComponents);
         componentsSorted(components);
         final first = components.first;
         final last = components.last;
@@ -85,15 +82,14 @@ void main() {
 
     flameGame.test(
       'changing child priority should reorder component list',
-      (game) {
+      (game) async {
         final parentComponent = PriorityComponent(0);
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i));
         priorityComponents.shuffle();
-        game.add(parentComponent);
-        parentComponent.addAll(priorityComponents);
+        await game.ensureAdd(parentComponent);
+        await parentComponent.ensureAddAll(priorityComponents);
         final children = parentComponent.children;
-        game.update(0);
         componentsSorted(children);
         final first = children.first;
         game.children.changePriority(first, 20);
@@ -105,15 +101,14 @@ void main() {
 
     flameGame.test(
       'changing child priorities should reorder component list',
-      (game) {
+      (game) async {
         final parentComponent = PriorityComponent(0);
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i));
         priorityComponents.shuffle();
-        game.add(parentComponent);
-        parentComponent.addAll(priorityComponents);
+        await game.ensureAdd(parentComponent);
+        await parentComponent.ensureAddAll(priorityComponents);
         final children = parentComponent.children;
-        game.update(0);
         componentsSorted(children);
         final first = children.first;
         final last = children.last;
@@ -129,17 +124,16 @@ void main() {
 
     flameGame.test(
       'changing grand child priority should reorder component list',
-      (game) {
+      (game) async {
         final grandParentComponent = PriorityComponent(0);
         final parentComponent = PriorityComponent(0);
         final priorityComponents =
             List.generate(10, (i) => PriorityComponent(i));
         priorityComponents.shuffle();
-        game.add(grandParentComponent);
-        grandParentComponent.add(parentComponent);
-        parentComponent.addAll(priorityComponents);
+        await game.ensureAdd(grandParentComponent);
+        await grandParentComponent.ensureAdd(parentComponent);
+        await parentComponent.ensureAddAll(priorityComponents);
         final children = parentComponent.children;
-        game.update(0);
         componentsSorted(children);
         final first = children.first;
         game.children.changePriority(first, 20);
@@ -151,7 +145,7 @@ void main() {
 
     flameGame.test(
       '#reorderChildren is only called once per parent per tick',
-      (game) {
+      (game) async {
         final a = ParentWithReorderSpy(1);
         final a1 = PriorityComponent(1);
         final a2 = PriorityComponent(2);
@@ -167,7 +161,7 @@ void main() {
         final c3 = PriorityComponent(-1);
         c.addAll([c1, c2, c3]);
 
-        game.addAll([a, b, c]);
+        await game.ensureAddAll([a, b, c]);
         componentsSorted(game.children);
         componentsSorted(a.children);
         componentsSorted(b.children);

--- a/packages/flame/test/components/resizable_test.dart
+++ b/packages/flame/test/components/resizable_test.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 class MyComponent extends PositionComponent {
@@ -15,19 +16,17 @@ class MyComponent extends PositionComponent {
   }
 }
 
-Vector2 size = Vector2(1.0, 1.0);
-
 void main() {
+  final size = Vector2(1.0, 1.0);
+  // These tests do not use FlameTester since we want to call `onGameResize`
+  // manually in them.
   group('resizable test', () {
     test('game calls resize on add', () async {
       final a = MyComponent('a');
       final game = FlameGame();
       game.onGameResize(size);
 
-      await game.add(a);
-      // component is just added on the next iteration
-      game.update(0);
-
+      await game.ensureAdd(a);
       expect(a.gameSize, size);
     });
 
@@ -36,10 +35,7 @@ void main() {
       final game = FlameGame();
       game.onGameResize(Vector2.all(10));
 
-      await game.add(a);
-      // component is just added on the next iteration
-      game.update(0);
-
+      await game.ensureAdd(a);
       game.onGameResize(size);
       expect(a.gameSize, size);
     });
@@ -49,10 +45,7 @@ void main() {
       final game = FlameGame();
       game.onGameResize(Vector2.all(10));
 
-      await game.add(a);
-      // component is just added on the next iteration
-      game.update(0);
-
+      await game.ensureAdd(a);
       game.onGameResize(size);
       expect(a.size, isNot(size));
     });

--- a/packages/flame/test/components/resizable_test.dart
+++ b/packages/flame/test/components/resizable_test.dart
@@ -3,11 +3,11 @@ import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class MyComponent extends PositionComponent {
+class _MyComponent extends PositionComponent {
   String name;
   late Vector2 gameSize;
 
-  MyComponent(this.name) : super(size: Vector2.all(2.0));
+  _MyComponent(this.name) : super(size: Vector2.all(2.0));
 
   @override
   void onGameResize(Vector2 gameSize) {
@@ -22,7 +22,7 @@ void main() {
   // manually in them.
   group('resizable test', () {
     test('game calls resize on add', () async {
-      final a = MyComponent('a');
+      final a = _MyComponent('a');
       final game = FlameGame();
       game.onGameResize(size);
 
@@ -31,7 +31,7 @@ void main() {
     });
 
     test('game calls resize after added', () async {
-      final a = MyComponent('a');
+      final a = _MyComponent('a');
       final game = FlameGame();
       game.onGameResize(Vector2.all(10));
 
@@ -41,7 +41,7 @@ void main() {
     });
 
     test("game calls doesn't change component size", () async {
-      final a = MyComponent('a');
+      final a = _MyComponent('a');
       final game = FlameGame();
       game.onGameResize(Vector2.all(10));
 

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -6,8 +6,8 @@ import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('ShapeComponent.containsPoint tests', () {
-    test('Simple circle contains point', () {
+  group('ShapeComponent.containsPoint', () {
+    test('circle contains point', () {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
@@ -19,7 +19,7 @@ void main() {
       );
     });
 
-    test('Simple rectangle contains point', () {
+    test('rectangle contains point', () {
       final component = RectangleComponent(
         position: Vector2(1, 1),
         size: Vector2(1, 1),
@@ -30,7 +30,7 @@ void main() {
       );
     });
 
-    test('Simple polygon contains point', () {
+    test('polygon contains point', () {
       final component = PolygonComponent.fromPoints(
         [
           Vector2(2, 2),
@@ -46,7 +46,7 @@ void main() {
       );
     });
 
-    test('Rotated circle does not contain point', () {
+    test('rotated circle does not contain point', () {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
@@ -59,7 +59,7 @@ void main() {
       );
     });
 
-    test('Rotated rectangle does not contain point', () {
+    test('rotated rectangle does not contain point', () {
       final component = RectangleComponent(
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
@@ -72,7 +72,7 @@ void main() {
       );
     });
 
-    test('Rotated polygon does not contain point', () {
+    test('rotated polygon does not contain point', () {
       final component = PolygonComponent.fromPoints(
         [
           Vector2(2, 2),
@@ -89,7 +89,7 @@ void main() {
       );
     });
 
-    test('Rotated circle contains point', () {
+    test('rotated circle contains point', () {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
@@ -102,7 +102,7 @@ void main() {
       );
     });
 
-    test('Rotated rectangle contains point', () {
+    test('rotated rectangle contains point', () {
       final component = RectangleComponent(
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
@@ -115,7 +115,7 @@ void main() {
       );
     });
 
-    test('Rotated polygon contains point', () {
+    test('rotated polygon contains point', () {
       final component = PolygonComponent.fromPoints(
         [
           Vector2(2, 2),
@@ -132,7 +132,7 @@ void main() {
       );
     });
 
-    test('Horizontally flipped rectangle contains point', () {
+    test('horizontally flipped rectangle contains point', () {
       final component = RectangleComponent(
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
@@ -144,7 +144,7 @@ void main() {
       );
     });
 
-    test('Initially rotated CircleComponent does not contain point', () {
+    test('initially rotated CircleComponent does not contain point', () {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
@@ -157,7 +157,7 @@ void main() {
       );
     });
 
-    test('Initially rotated RectangleComponent does not contain point', () {
+    test('initially rotated RectangleComponent does not contain point', () {
       final component = RectangleComponent(
         position: Vector2.all(1.0),
         size: Vector2.all(2.0),
@@ -170,7 +170,7 @@ void main() {
       );
     });
 
-    test('Initially rotated PolygonComponent does not contain point', () {
+    test('initially rotated PolygonComponent does not contain point', () {
       final component = PolygonComponent.fromPoints(
         [
           Vector2(2, 2),
@@ -187,7 +187,7 @@ void main() {
       );
     });
 
-    test('Rotated PolygonComponent contains point', () {
+    test('rotated PolygonComponent contains point', () {
       final component = PolygonComponent.fromPoints(
         [
           Vector2(2, 2),
@@ -204,7 +204,7 @@ void main() {
       );
     });
 
-    test('Moved CircleComponent contains point', () {
+    test('moved CircleComponent contains point', () {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(2, 2),
@@ -216,7 +216,7 @@ void main() {
       );
     });
 
-    test('Moved RectangleComponent contains point', () {
+    test('moved RectangleComponent contains point', () {
       final component = RectangleComponent(
         position: Vector2(2, 2),
         size: Vector2(1, 1),
@@ -228,7 +228,7 @@ void main() {
       );
     });
 
-    test('Moved PolygonComponent contains point', () {
+    test('moved PolygonComponent contains point', () {
       final component = PolygonComponent.fromPoints(
         [
           Vector2(2, 0),
@@ -245,7 +245,7 @@ void main() {
       );
     });
 
-    test('Sized up CircleComponent does not contain point', () {
+    test('sized up CircleComponent does not contain point', () {
       final component = CircleComponent(
         radius: 1.0,
         position: Vector2(1, 1),
@@ -258,7 +258,7 @@ void main() {
       );
     });
 
-    test('Sized up RectangleComponent does not contain point', () {
+    test('sized up RectangleComponent does not contain point', () {
       final component = RectangleComponent(
         position: Vector2(1, 1),
         size: Vector2(2, 2),
@@ -270,7 +270,7 @@ void main() {
       );
     });
 
-    test('Sized PolygonComponent does not contain point', () {
+    test('sized PolygonComponent does not contain point', () {
       final component = PolygonComponent.fromPoints(
         [
           Vector2(2, 0),
@@ -287,45 +287,54 @@ void main() {
       );
     });
 
-    test('CircleComponent with default anchor (topLeft) contains point', () {
-      final component = CircleComponent(
-        radius: 1.0,
-        position: Vector2.all(1.0),
-        angle: pi / 4,
-      );
-      expect(
-        component.containsPoint(Vector2(0.9, 2.0)),
-        isTrue,
-      );
-    });
+    test(
+      'rotated CircleComponent with default anchor (topLeft) contains point',
+      () {
+        final component = CircleComponent(
+          radius: 1.0,
+          position: Vector2.all(1.0),
+          angle: pi / 4,
+        );
+        expect(
+          component.containsPoint(Vector2(0.9, 2.0)),
+          isTrue,
+        );
+      },
+    );
 
-    test('RectangleComponent with default anchor (topLeft) contains point', () {
-      final component = RectangleComponent(
-        position: Vector2.all(1.0),
-        size: Vector2.all(1.0),
-        angle: pi / 4,
-      );
-      expect(
-        component.containsPoint(Vector2(0.9, 2.0)),
-        isTrue,
-      );
-    });
+    test(
+      'rotated RectangleComponent with default anchor (topLeft) contains point',
+      () {
+        final component = RectangleComponent(
+          position: Vector2.all(1.0),
+          size: Vector2.all(1.0),
+          angle: pi / 4,
+        );
+        expect(
+          component.containsPoint(Vector2(0.9, 2.0)),
+          isTrue,
+        );
+      },
+    );
 
-    test('PolygonComponent with default anchor (topLeft) contains point', () {
-      final component = PolygonComponent.fromPoints(
-        [
-          Vector2(2, 0),
-          Vector2(1, 1),
-          Vector2(2, 2),
-          Vector2(3, 1),
-        ],
-        angle: pi / 4,
-      );
-      expect(
-        component.containsPoint(Vector2(1.0, 0.99)),
-        isTrue,
-      );
-    });
+    test(
+      'rotated PolygonComponent with default anchor (topLeft) contains point',
+      () {
+        final component = PolygonComponent.fromPoints(
+          [
+            Vector2(2, 0),
+            Vector2(1, 1),
+            Vector2(2, 2),
+            Vector2(3, 1),
+          ],
+          angle: pi / 4,
+        );
+        expect(
+          component.containsPoint(Vector2(1.0, 0.99)),
+          isTrue,
+        );
+      },
+    );
 
     flameGame.test(
       'CircleComponent with multiple parents contains point',

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -1,5 +1,4 @@
 import 'package:flame/components.dart';
-import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
@@ -7,11 +6,9 @@ void main() async {
   // Generate an image
   final image = await generateImage();
 
-  final size = Vector2(1.0, 1.0);
-
   group('SpriteAnimationComponent shouldRemove test', () {
-    test('removeOnFinish is true and animation#loop is false', () {
-      final game = FlameGame();
+    flameGame.test('removeOnFinish is true and animation#loop is false',
+        (game) async {
       final animation = SpriteAnimation.spriteList(
         [
           Sprite(image),
@@ -25,11 +22,8 @@ void main() async {
         removeOnFinish: true,
       );
 
-      game.onGameResize(size);
-      game.add(component);
+      await game.ensureAdd(component);
 
-      // runs a cycle to add the component
-      game.update(0.1);
       expect(component.shouldRemove, false);
       expect(game.children.length, 1);
 
@@ -41,8 +35,8 @@ void main() async {
       expect(game.children.length, 0);
     });
 
-    test('removeOnFinish is true and animation#loop is true', () {
-      final game = FlameGame();
+    flameGame.test('removeOnFinish is true and animation#loop is true',
+        (game) async {
       final animation = SpriteAnimation.spriteList(
         [
           Sprite(image),
@@ -57,11 +51,8 @@ void main() async {
         removeOnFinish: true,
       );
 
-      game.onGameResize(size);
-      game.add(component);
+      await game.ensureAdd(component);
 
-      // runs a cycle to add the component
-      game.update(0.1);
       expect(component.shouldRemove, false);
       expect(game.children.length, 1);
 
@@ -73,8 +64,8 @@ void main() async {
       expect(game.children.length, 1);
     });
 
-    test('removeOnFinish is false and animation#loop is false', () {
-      final game = FlameGame();
+    flameGame.test('removeOnFinish is false and animation#loop is false',
+        (game) async {
       final animation = SpriteAnimation.spriteList(
         [
           Sprite(image),
@@ -89,11 +80,8 @@ void main() async {
         removeOnFinish: false,
       );
 
-      game.onGameResize(size);
-      game.add(component);
+      await game.ensureAdd(component);
 
-      // runs a cycle to add the component
-      game.update(0.1);
       expect(component.shouldRemove, false);
       expect(game.children.length, 1);
 
@@ -105,8 +93,8 @@ void main() async {
       expect(game.children.length, 1);
     });
 
-    test('removeOnFinish is false and animation#loop is true', () {
-      final game = FlameGame();
+    flameGame.test('removeOnFinish is false and animation#loop is true',
+        (game) async {
       final animation = SpriteAnimation.spriteList(
         [
           Sprite(image),
@@ -122,11 +110,8 @@ void main() async {
         removeOnFinish: false,
       );
 
-      game.onGameResize(size);
-      game.add(component);
+      await game.ensureAdd(component);
 
-      // runs a cycle to add the component
-      game.update(0.1);
       expect(component.shouldRemove, false);
       expect(game.children.length, 1);
 
@@ -138,8 +123,8 @@ void main() async {
       expect(game.children.length, 1);
     });
 
-    test("component isn't removed if it is not playing", () {
-      final game = FlameGame();
+    flameGame.test("component isn't removed if it is not playing",
+        (game) async {
       final animation = SpriteAnimation.spriteList(
         [
           Sprite(image),
@@ -154,11 +139,8 @@ void main() async {
         playing: false,
       );
 
-      game.onGameResize(size);
-      game.add(component);
+      await game.ensureAdd(component);
 
-      // runs a cycle to add the component
-      game.update(0.1);
       expect(component.shouldRemove, false);
       expect(game.children.length, 1);
 
@@ -172,9 +154,8 @@ void main() async {
   });
 
   group('SpriteAnimation timing of animation frames', () {
-    test('Last animation frame is not skipped', () {
-      // See https://github.com/flame-engine/flame/issues/895
-      final game = FlameGame();
+    // See https://github.com/flame-engine/flame/issues/895
+    flameGame.test('Last animation frame is not skipped', (game) async {
       // Non-looping animation, with the expected total duration of 0.500 s
       final animation = SpriteAnimation.spriteList(
         List.filled(5, Sprite(image)),
@@ -186,8 +167,7 @@ void main() async {
         callbackInvoked++;
       };
       final component = SpriteAnimationComponent(animation: animation);
-      game.onGameResize(size);
-      game.add(component);
+      await game.ensureAdd(component);
       game.update(0.01);
       expect(animation.currentIndex, 0);
       game.update(0.1);

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -6,7 +6,7 @@ void main() async {
   // Generate an image
   final image = await generateImage();
 
-  group('SpriteAnimationComponent shouldRemove test', () {
+  group('SpriteAnimationComponent shouldRemove', () {
     flameGame.test('removeOnFinish is true and animation#loop is false',
         (game) async {
       final animation = SpriteAnimation.spriteList(

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -7,150 +7,160 @@ void main() async {
   final image = await generateImage();
 
   group('SpriteAnimationComponent shouldRemove', () {
-    flameGame.test('removeOnFinish is true and animation#loop is false',
-        (game) async {
-      final animation = SpriteAnimation.spriteList(
-        [
-          Sprite(image),
-          Sprite(image),
-        ],
-        stepTime: 1,
-        loop: false,
-      );
-      final component = SpriteAnimationComponent(
-        animation: animation,
-        removeOnFinish: true,
-      );
+    flameGame.test(
+      'removeOnFinish is true and animation#loop is false',
+      (game) async {
+        final animation = SpriteAnimation.spriteList(
+          [
+            Sprite(image),
+            Sprite(image),
+          ],
+          stepTime: 1,
+          loop: false,
+        );
+        final component = SpriteAnimationComponent(
+          animation: animation,
+          removeOnFinish: true,
+        );
 
-      await game.ensureAdd(component);
+        await game.ensureAdd(component);
 
-      expect(component.shouldRemove, false);
-      expect(game.children.length, 1);
+        expect(component.shouldRemove, false);
+        expect(game.children.length, 1);
 
-      game.update(2);
-      expect(component.shouldRemove, true);
+        game.update(2);
+        expect(component.shouldRemove, true);
 
-      // runs a cycle to remove the component
-      game.update(0.1);
-      expect(game.children.length, 0);
-    });
+        // runs a cycle to remove the component
+        game.update(0.1);
+        expect(game.children.length, 0);
+      },
+    );
 
-    flameGame.test('removeOnFinish is true and animation#loop is true',
-        (game) async {
-      final animation = SpriteAnimation.spriteList(
-        [
-          Sprite(image),
-          Sprite(image),
-        ],
-        stepTime: 1,
-        // ignore: avoid_redundant_argument_values
-        loop: true,
-      );
-      final component = SpriteAnimationComponent(
-        animation: animation,
-        removeOnFinish: true,
-      );
+    flameGame.test(
+      'removeOnFinish is true and animation#loop is true',
+      (game) async {
+        final animation = SpriteAnimation.spriteList(
+          [
+            Sprite(image),
+            Sprite(image),
+          ],
+          stepTime: 1,
+          // ignore: avoid_redundant_argument_values
+          loop: true,
+        );
+        final component = SpriteAnimationComponent(
+          animation: animation,
+          removeOnFinish: true,
+        );
 
-      await game.ensureAdd(component);
+        await game.ensureAdd(component);
 
-      expect(component.shouldRemove, false);
-      expect(game.children.length, 1);
+        expect(component.shouldRemove, false);
+        expect(game.children.length, 1);
 
-      game.update(2);
-      expect(component.shouldRemove, false);
+        game.update(2);
+        expect(component.shouldRemove, false);
 
-      // runs a cycle to remove the component, but failed
-      game.update(0.1);
-      expect(game.children.length, 1);
-    });
+        // runs a cycle to remove the component, but failed
+        game.update(0.1);
+        expect(game.children.length, 1);
+      },
+    );
 
-    flameGame.test('removeOnFinish is false and animation#loop is false',
-        (game) async {
-      final animation = SpriteAnimation.spriteList(
-        [
-          Sprite(image),
-          Sprite(image),
-        ],
-        stepTime: 1,
-        loop: false,
-      );
-      final component = SpriteAnimationComponent(
-        animation: animation,
-        // ignore: avoid_redundant_argument_values
-        removeOnFinish: false,
-      );
+    flameGame.test(
+      'removeOnFinish is false and animation#loop is false',
+      (game) async {
+        final animation = SpriteAnimation.spriteList(
+          [
+            Sprite(image),
+            Sprite(image),
+          ],
+          stepTime: 1,
+          loop: false,
+        );
+        final component = SpriteAnimationComponent(
+          animation: animation,
+          // ignore: avoid_redundant_argument_values
+          removeOnFinish: false,
+        );
 
-      await game.ensureAdd(component);
+        await game.ensureAdd(component);
 
-      expect(component.shouldRemove, false);
-      expect(game.children.length, 1);
+        expect(component.shouldRemove, false);
+        expect(game.children.length, 1);
 
-      game.update(2);
-      expect(component.shouldRemove, false);
+        game.update(2);
+        expect(component.shouldRemove, false);
 
-      // runs a cycle to remove the component, but failed
-      game.update(0.1);
-      expect(game.children.length, 1);
-    });
+        // runs a cycle to remove the component, but failed
+        game.update(0.1);
+        expect(game.children.length, 1);
+      },
+    );
 
-    flameGame.test('removeOnFinish is false and animation#loop is true',
-        (game) async {
-      final animation = SpriteAnimation.spriteList(
-        [
-          Sprite(image),
-          Sprite(image),
-        ],
-        stepTime: 1,
-        // ignore: avoid_redundant_argument_values
-        loop: true,
-      );
-      final component = SpriteAnimationComponent(
-        animation: animation,
-        // ignore: avoid_redundant_argument_values
-        removeOnFinish: false,
-      );
+    flameGame.test(
+      'removeOnFinish is false and animation#loop is true',
+      (game) async {
+        final animation = SpriteAnimation.spriteList(
+          [
+            Sprite(image),
+            Sprite(image),
+          ],
+          stepTime: 1,
+          // ignore: avoid_redundant_argument_values
+          loop: true,
+        );
+        final component = SpriteAnimationComponent(
+          animation: animation,
+          // ignore: avoid_redundant_argument_values
+          removeOnFinish: false,
+        );
 
-      await game.ensureAdd(component);
+        await game.ensureAdd(component);
 
-      expect(component.shouldRemove, false);
-      expect(game.children.length, 1);
+        expect(component.shouldRemove, false);
+        expect(game.children.length, 1);
 
-      game.update(2);
-      expect(component.shouldRemove, false);
+        game.update(2);
+        expect(component.shouldRemove, false);
 
-      // runs a cycle to remove the component, but failed
-      game.update(0.1);
-      expect(game.children.length, 1);
-    });
+        // runs a cycle to remove the component, but failed
+        game.update(0.1);
+        expect(game.children.length, 1);
+      },
+    );
 
-    flameGame.test("component isn't removed if it is not playing",
-        (game) async {
-      final animation = SpriteAnimation.spriteList(
-        [
-          Sprite(image),
-          Sprite(image),
-        ],
-        stepTime: 1,
-        loop: false,
-      );
-      final component = SpriteAnimationComponent(
-        animation: animation,
-        removeOnFinish: true,
-        playing: false,
-      );
+    flameGame.test(
+      "component isn't removed if it is not playing",
+      (game) async {
+        final animation = SpriteAnimation.spriteList(
+          [
+            Sprite(image),
+            Sprite(image),
+          ],
+          stepTime: 1,
+          loop: false,
+        );
+        final component = SpriteAnimationComponent(
+          animation: animation,
+          removeOnFinish: true,
+          playing: false,
+        );
 
-      await game.ensureAdd(component);
+        await game.ensureAdd(component);
 
-      expect(component.shouldRemove, false);
-      expect(game.children.length, 1);
+        expect(component.shouldRemove, false);
+        expect(game.children.length, 1);
 
-      game.update(2);
-      expect(component.shouldRemove, false);
+        game.update(2);
+        expect(component.shouldRemove, false);
 
-      // runs a cycle to potentially remove the component
-      game.update(0.1);
-      expect(game.children.length, 1);
-    });
+        // runs a cycle to potentially remove the component
+        game.update(0.1);
+        expect(game.children.length, 1);
+      },
+    );
   });
 
   group('SpriteAnimation timing of animation frames', () {

--- a/packages/flame/test/components/sprite_animation_group_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_group_component_test.dart
@@ -50,8 +50,8 @@ void main() async {
     });
   });
   group('SpriteAnimationGroupComponent shouldRemove test', () {
-    test('removeOnFinish is true and there is no any state yet', () {
-      final game = FlameGame();
+    flameGame.test('removeOnFinish is true and there is no any state yet',
+        (game) async {
       final animation = SpriteAnimation.spriteList(
         [
           Sprite(image),
@@ -65,11 +65,7 @@ void main() async {
         removeOnFinish: {AnimationState.idle: true},
       );
 
-      game.onGameResize(size);
-      game.add(component);
-
-      // runs a cycle to add the component
-      game.update(0.1);
+      await game.ensureAdd(component);
       expect(component.shouldRemove, false);
       expect(game.children.length, 1);
 
@@ -81,10 +77,9 @@ void main() async {
       expect(game.children.length, 1);
     });
 
-    test(
+    flameGame.test(
       'removeOnFinish is true and current state animation#loop is false',
-      () {
-        final game = FlameGame();
+      (game) async {
         final animation = SpriteAnimation.spriteList(
           [
             Sprite(image),
@@ -99,11 +94,7 @@ void main() async {
           current: AnimationState.idle,
         );
 
-        game.onGameResize(size);
-        game.add(component);
-
-        // runs a cycle to add the component
-        game.update(0.1);
+        await game.ensureAdd(component);
         expect(component.shouldRemove, false);
         expect(game.children.length, 1);
 
@@ -116,8 +107,8 @@ void main() async {
       },
     );
 
-    test('removeOnFinish is true and current animation#loop is true', () {
-      final game = FlameGame();
+    flameGame.test('removeOnFinish is true and current animation#loop is true',
+        (game) async {
       final animation = SpriteAnimation.spriteList(
         [
           Sprite(image),
@@ -133,11 +124,7 @@ void main() async {
         current: AnimationState.idle,
       );
 
-      game.onGameResize(size);
-      game.add(component);
-
-      // runs a cycle to add the component
-      game.update(0.1);
+      await game.ensureAdd(component);
       expect(component.shouldRemove, false);
       expect(game.children.length, 1);
 
@@ -149,8 +136,9 @@ void main() async {
       expect(game.children.length, 1);
     });
 
-    test('removeOnFinish is false and current animation#loop is false', () {
-      final game = FlameGame();
+    flameGame
+        .test('removeOnFinish is false and current animation#loop is false',
+            (game) async {
       final animation = SpriteAnimation.spriteList(
         [
           Sprite(image),
@@ -162,14 +150,10 @@ void main() async {
       final component = SpriteAnimationGroupComponent<AnimationState>(
         animations: {AnimationState.idle: animation},
         current: AnimationState.idle,
-        // when omited, removeOnFinish is false for all states
+        // when omitted, removeOnFinish is false for all states
       );
 
-      game.onGameResize(size);
-      game.add(component);
-
-      // runs a cycle to add the component
-      game.update(0.1);
+      await game.ensureAdd(component);
       expect(component.shouldRemove, false);
       expect(game.children.length, 1);
 
@@ -181,8 +165,8 @@ void main() async {
       expect(game.children.length, 1);
     });
 
-    test('removeOnFinish is false and current animation#loop is true', () {
-      final game = FlameGame();
+    flameGame.test('removeOnFinish is false and current animation#loop is true',
+        (game) async {
       final animation = SpriteAnimation.spriteList(
         [
           Sprite(image),
@@ -198,11 +182,8 @@ void main() async {
         current: AnimationState.idle,
       );
 
-      game.onGameResize(size);
-      game.add(component);
+      await game.ensureAdd(component);
 
-      // runs a cycle to add the component
-      game.update(0.1);
       expect(component.shouldRemove, false);
       expect(game.children.length, 1);
 

--- a/packages/flame/test/components/sprite_animation_group_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_group_component_test.dart
@@ -1,9 +1,8 @@
 import 'package:flame/components.dart';
-import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-enum AnimationState {
+enum _AnimationState {
   idle,
   running,
 }
@@ -12,9 +11,7 @@ void main() async {
   // Generate a image
   final image = await generateImage();
 
-  final size = Vector2(1.0, 1.0);
-
-  group('SpriteAnimationGroupComponent test', () {
+  group('SpriteAnimationGroupComponent', () {
     test('returns the correct animation according to its state', () {
       final animation1 = SpriteAnimation.spriteList(
         [
@@ -30,10 +27,10 @@ void main() async {
         ],
         stepTime: 1,
       );
-      final component = SpriteAnimationGroupComponent<AnimationState>(
+      final component = SpriteAnimationGroupComponent<_AnimationState>(
         animations: {
-          AnimationState.idle: animation1,
-          AnimationState.running: animation2,
+          _AnimationState.idle: animation1,
+          _AnimationState.running: animation2,
         },
       );
 
@@ -41,15 +38,16 @@ void main() async {
       expect(component.animation, null);
 
       // Setting the idle state, we need to see the animation1
-      component.current = AnimationState.idle;
+      component.current = _AnimationState.idle;
       expect(component.animation, animation1);
 
       // Setting the running state, we need to see the animation2
-      component.current = AnimationState.running;
+      component.current = _AnimationState.running;
       expect(component.animation, animation2);
     });
   });
-  group('SpriteAnimationGroupComponent shouldRemove test', () {
+
+  group('SpriteAnimationGroupComponent.shouldRemove', () {
     flameGame.test('removeOnFinish is true and there is no any state yet',
         (game) async {
       final animation = SpriteAnimation.spriteList(
@@ -60,9 +58,9 @@ void main() async {
         stepTime: 1,
         loop: false,
       );
-      final component = SpriteAnimationGroupComponent<AnimationState>(
-        animations: {AnimationState.idle: animation},
-        removeOnFinish: {AnimationState.idle: true},
+      final component = SpriteAnimationGroupComponent<_AnimationState>(
+        animations: {_AnimationState.idle: animation},
+        removeOnFinish: {_AnimationState.idle: true},
       );
 
       await game.ensureAdd(component);
@@ -88,10 +86,10 @@ void main() async {
           stepTime: 1,
           loop: false,
         );
-        final component = SpriteAnimationGroupComponent<AnimationState>(
-          animations: {AnimationState.idle: animation},
-          removeOnFinish: {AnimationState.idle: true},
-          current: AnimationState.idle,
+        final component = SpriteAnimationGroupComponent<_AnimationState>(
+          animations: {_AnimationState.idle: animation},
+          removeOnFinish: {_AnimationState.idle: true},
+          current: _AnimationState.idle,
         );
 
         await game.ensureAdd(component);
@@ -118,10 +116,10 @@ void main() async {
         // ignore: avoid_redundant_argument_values
         loop: true,
       );
-      final component = SpriteAnimationGroupComponent<AnimationState>(
-        animations: {AnimationState.idle: animation},
-        removeOnFinish: {AnimationState.idle: true},
-        current: AnimationState.idle,
+      final component = SpriteAnimationGroupComponent<_AnimationState>(
+        animations: {_AnimationState.idle: animation},
+        removeOnFinish: {_AnimationState.idle: true},
+        current: _AnimationState.idle,
       );
 
       await game.ensureAdd(component);
@@ -147,9 +145,9 @@ void main() async {
         stepTime: 1,
         loop: false,
       );
-      final component = SpriteAnimationGroupComponent<AnimationState>(
-        animations: {AnimationState.idle: animation},
-        current: AnimationState.idle,
+      final component = SpriteAnimationGroupComponent<_AnimationState>(
+        animations: {_AnimationState.idle: animation},
+        current: _AnimationState.idle,
         // when omitted, removeOnFinish is false for all states
       );
 
@@ -176,10 +174,10 @@ void main() async {
         // ignore: avoid_redundant_argument_values
         loop: true,
       );
-      final component = SpriteAnimationGroupComponent<AnimationState>(
-        animations: {AnimationState.idle: animation},
+      final component = SpriteAnimationGroupComponent<_AnimationState>(
+        animations: {_AnimationState.idle: animation},
         // when omited, removeOnFinish is false for all states
-        current: AnimationState.idle,
+        current: _AnimationState.idle,
       );
 
       await game.ensureAdd(component);

--- a/packages/flame/test/components/sprite_component_test.dart
+++ b/packages/flame/test/components/sprite_component_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() async {
   final image = await generateImage();
 
-  group('SpriteComponent test', () {
+  group('SpriteComponent', () {
     test('check sizing of SpriteComponent', () {
       expect(image.width, 1);
       expect(image.height, 1);

--- a/packages/flame/test/components/sprite_group_component_test.dart
+++ b/packages/flame/test/components/sprite_group_component_test.dart
@@ -2,7 +2,7 @@ import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-enum SpriteState {
+enum _SpriteState {
   idle,
   running,
 }
@@ -11,14 +11,14 @@ void main() async {
   // Generate a image
   final image = await generateImage();
 
-  group('SpriteGroupComponent test', () {
+  group('SpriteGroupComponent', () {
     test('returns the correct sprite according to its state', () {
       final sprite1 = Sprite(image);
       final sprite2 = Sprite(image);
-      final component = SpriteGroupComponent<SpriteState>(
+      final component = SpriteGroupComponent<_SpriteState>(
         sprites: {
-          SpriteState.idle: sprite1,
-          SpriteState.running: sprite2,
+          _SpriteState.idle: sprite1,
+          _SpriteState.running: sprite2,
         },
       );
 
@@ -26,11 +26,11 @@ void main() async {
       expect(component.sprite, null);
 
       // Setting the idle state, we need to see the sprite1
-      component.current = SpriteState.idle;
+      component.current = _SpriteState.idle;
       expect(component.sprite, sprite1);
 
       // Setting the running state, we need to see the sprite2
-      component.current = SpriteState.running;
+      component.current = _SpriteState.running;
       expect(component.sprite, sprite2);
     });
   });

--- a/packages/flame/test/components/tappables_test.dart
+++ b/packages/flame/test/components/tappables_test.dart
@@ -1,36 +1,39 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 class _GameWithTappables extends FlameGame with HasTappableComponents {}
 
-class _GameWithoutTappables extends FlameGame {}
-
-class TappableComponent extends PositionComponent with Tappable {}
+class _TappableComponent extends PositionComponent with Tappable {}
 
 void main() {
+  final withTappables = FlameTester(() => _GameWithTappables());
+
   group('tappables test', () {
-    test('make sure they cannot be added to invalid games', () async {
-      final game1 = _GameWithTappables();
-      game1.onGameResize(Vector2.all(100));
-      // should be ok
-      await game1.add(TappableComponent());
+    withTappables.test(
+      'make sure Tappables can be added to valid games',
+      (game) async {
+        await game.ensureAdd(_TappableComponent());
+      },
+    );
 
-      final game2 = _GameWithoutTappables();
-      game2.onGameResize(Vector2.all(100));
+    flameGame.test(
+      'make sure Tappables cannot be added to invalid games',
+      (game) async {
+        const message =
+            'Tappable Components can only be added to a FlameGame with '
+            'HasTappableComponents';
 
-      const message =
-          'Tappable Components can only be added to a FlameGame with '
-          'HasTappableComponents';
-
-      expect(
-        () => game2.add(TappableComponent()),
-        throwsA(
-          predicate(
-            (e) => e is AssertionError && e.message == message,
+        expect(
+          () => game.add(_TappableComponent()),
+          throwsA(
+            predicate(
+              (e) => e is AssertionError && e.message == message,
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
   });
 }

--- a/packages/flame/test/components/tappables_test.dart
+++ b/packages/flame/test/components/tappables_test.dart
@@ -10,7 +10,7 @@ class _TappableComponent extends PositionComponent with Tappable {}
 void main() {
   final withTappables = FlameTester(() => _GameWithTappables());
 
-  group('tappables test', () {
+  group('Tappable', () {
     withTappables.test(
       'make sure Tappables can be added to valid games',
       (game) async {

--- a/packages/flame/test/components/text_box_component_test.dart
+++ b/packages/flame/test/components/text_box_component_test.dart
@@ -7,7 +7,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('text box component test', () {
+  group('TextBoxComponent', () {
     test('size is properly computed', () async {
       final c = TextBoxComponent(
         'The quick brown fox jumps over the lazy dog.',

--- a/packages/flame/test/components/text_box_component_test.dart
+++ b/packages/flame/test/components/text_box_component_test.dart
@@ -2,8 +2,8 @@ import 'dart:ui';
 
 import 'package:canvas_test/canvas_test.dart';
 import 'package:flame/components.dart';
-import 'package:flame/game.dart';
 import 'package:flame/palette.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -19,14 +19,11 @@ void main() {
       expect(c.size.x, 100 + 2 * 8);
       expect(c.size.y, greaterThan(1));
     });
-    test('onLoad waits for cache to be done', () async {
+
+    flameGame.test('onLoad waits for cache to be done', (game) async {
       final c = TextBoxComponent('foo bar');
 
-      final game = FlameGame();
-      game.onGameResize(Vector2.all(100));
-
-      await game.add(c);
-      game.update(0);
+      await game.ensureAdd(c);
 
       final canvas = MockCanvas();
       game.render(canvas); // this should render the cache

--- a/packages/flame/test/components/timer_component_test.dart
+++ b/packages/flame/test/components/timer_component_test.dart
@@ -3,10 +3,10 @@ import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MyTimerComponent extends TimerComponent {
+class _MyTimerComponent extends TimerComponent {
   int count = 0;
 
-  MyTimerComponent()
+  _MyTimerComponent()
       : super(
           period: 1,
           repeat: true,
@@ -19,8 +19,8 @@ class MyTimerComponent extends TimerComponent {
   }
 }
 
-class NonRepeatingTimerComponent extends TimerComponent {
-  NonRepeatingTimerComponent()
+class _NonRepeatingTimerComponent extends TimerComponent {
+  _NonRepeatingTimerComponent()
       : super(
           period: 1,
           repeat: false,
@@ -33,7 +33,7 @@ void main() {
     final tester = FlameTester(() => FlameGame());
 
     tester.test('runs the tick method', (game) {
-      final timer = MyTimerComponent();
+      final timer = _MyTimerComponent();
       game.add(timer);
       game.update(0);
 
@@ -44,7 +44,7 @@ void main() {
     });
 
     tester.test('never remove from the game when is repeating', (game) {
-      game.add(MyTimerComponent());
+      game.add(_MyTimerComponent());
       game.update(0);
 
       game.update(1.2);
@@ -54,7 +54,7 @@ void main() {
     });
 
     tester.test('is removed from the game when is finished', (game) {
-      game.add(NonRepeatingTimerComponent());
+      game.add(_NonRepeatingTimerComponent());
       game.update(0);
 
       game.update(1.2);

--- a/packages/flame/test/effects/combined_effect_test.dart
+++ b/packages/flame/test/effects/combined_effect_test.dart
@@ -7,10 +7,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'effect_test_utils.dart';
 
-class Elements extends BaseElements {
+class _Elements extends BaseElements {
   bool onCompleteCalled = false;
 
-  Elements(Random random) : super(random);
+  _Elements(Random random) : super(random);
 
   @override
   TestComponent component() {
@@ -57,41 +57,44 @@ class Elements extends BaseElements {
 }
 
 void main() {
-  testWidgetsRandom(
-    'CombinedEffect can combine',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final component = e.component();
-      final game = e.game();
-      final effect = e.effect();
-      await game.add(component);
-      await component.add(effect);
-      var timePassed = 0.0;
-      const timeStep = 1 / 60;
-      while (timePassed <= effect.iterationTime) {
-        game.update(timeStep);
-        timePassed += timeStep;
-      }
-      game.update(0);
-      expect(effect.hasCompleted(), true);
-      expect(e.onCompleteCalled, true);
-    },
-  );
+  group('CombinedEffect', () {
+    testWidgetsRandom(
+      'can combine',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final component = e.component();
+        final game = e.game();
+        final effect = e.effect();
+        await game.add(component);
+        await component.add(effect);
+        var timePassed = 0.0;
+        const timeStep = 1 / 60;
+        while (timePassed <= effect.iterationTime) {
+          game.update(timeStep);
+          timePassed += timeStep;
+        }
+        game.update(0);
+        expect(effect.hasCompleted(), true);
+        expect(e.onCompleteCalled, true);
+      },
+    );
 
-  testWidgetsRandom(
-    'CombinedEffect can not contain children of same type',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final component = e.component();
-      final game = e.game();
-      final effect = e.effect();
-      await game.add(component);
-      await component.add(effect);
-      game.update(0);
-      expect(
-        () async => effect.add(SizeEffect(duration: 1.0, size: Vector2.zero())),
-        throwsA(isA<AssertionError>()),
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can not contain children of same type',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final component = e.component();
+        final game = e.game();
+        final effect = e.effect();
+        await game.add(component);
+        await component.add(effect);
+        game.update(0);
+        expect(
+          () async =>
+              effect.add(SizeEffect(duration: 1.0, size: Vector2.zero())),
+          throwsA(isA<AssertionError>()),
+        );
+      },
+    );
+  });
 }

--- a/packages/flame/test/effects/combined_effect_test.dart
+++ b/packages/flame/test/effects/combined_effect_test.dart
@@ -7,12 +7,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'effect_test_utils.dart';
 
-class ReadyGame extends FlameGame {
-  ReadyGame() {
-    onGameResize(Vector2.zero());
-  }
-}
-
 class Elements extends BaseElements {
   bool onCompleteCalled = false;
 
@@ -27,7 +21,7 @@ class Elements extends BaseElements {
     );
   }
 
-  FlameGame game() => ReadyGame();
+  FlameGame game() => FlameGame()..onGameResize(Vector2.zero());
 
   CombinedEffect effect({
     bool hasAlternatingMoveEffect = false,

--- a/packages/flame/test/effects/effect_test_utils.dart
+++ b/packages/flame/test/effects/effect_test_utils.dart
@@ -6,7 +6,7 @@ import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class Callback {
+class _Callback {
   int calledNumber = 0;
 
   void call() => calledNumber++;
@@ -28,7 +28,7 @@ void effectTest(
   expectedPosition ??= Vector2.zero();
   expectedSize ??= Vector2.all(100.0);
   expectedScale ??= Vector2.all(1.0);
-  final callback = Callback();
+  final callback = _Callback();
   effect.onComplete = callback.call;
   final game = FlameGame();
   game.onGameResize(Vector2.all(200));
@@ -125,6 +125,7 @@ void effectTest(
   );
 }
 
+/// A component for testing, it's just a PositionComponent with size (100, 100)
 class TestComponent extends PositionComponent {
   TestComponent({
     Vector2? position,

--- a/packages/flame/test/effects/move_effect_test.dart
+++ b/packages/flame/test/effects/move_effect_test.dart
@@ -6,8 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'effect_test_utils.dart';
 
-class Elements extends BaseElements {
-  Elements(Random random) : super(random);
+class _Elements extends BaseElements {
+  _Elements(Random random) : super(random);
 
   @override
   TestComponent component() => TestComponent(position: randomVector2());
@@ -23,97 +23,99 @@ class Elements extends BaseElements {
 }
 
 void main() {
-  testWidgetsRandom(
-    'MoveEffect can move',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedPosition: e.path.last,
-        random: random,
-      );
-    },
-  );
+  group('MoveEffect', () {
+    testWidgetsRandom(
+      'can move',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedPosition: e.path.last,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'MoveEffect will stop moving after it is done',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedPosition: e.path.last,
-        iterations: 1.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'will stop moving after it is done',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedPosition: e.path.last,
+          iterations: 1.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'MoveEffect can alternate',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedPosition: positionComponent.position.clone(),
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedPosition: positionComponent.position.clone(),
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'MoveEffect can alternate and be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true, isAlternating: true),
-        expectedPosition: positionComponent.position.clone(),
-        shouldComplete: false,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate and be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true, isAlternating: true),
+          expectedPosition: positionComponent.position.clone(),
+          shouldComplete: false,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'MoveEffect alternation can peak',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedPosition: e.path.last,
-        shouldComplete: false,
-        iterations: 0.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'alternation can peak',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedPosition: e.path.last,
+          shouldComplete: false,
+          iterations: 0.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'MoveEffect can be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true),
-        expectedPosition: e.path.last,
-        iterations: 3.0,
-        shouldComplete: false,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true),
+          expectedPosition: e.path.last,
+          iterations: 3.0,
+          shouldComplete: false,
+          random: random,
+        );
+      },
+    );
+  });
 }

--- a/packages/flame/test/effects/paint_effect_test.dart
+++ b/packages/flame/test/effects/paint_effect_test.dart
@@ -2,23 +2,19 @@ import 'dart:ui';
 
 import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
-import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MyComponent extends PositionComponent with HasPaint {}
+class _MyComponent extends PositionComponent with HasPaint {}
 
 void main() {
   group('Paint Effects', () {
     group('OpacityEffect', () {
-      test(
+      flameGame.test(
         'Sets the correct opacity on the paint',
-        () async {
-          final component = MyComponent();
-          final game = FlameGame();
-
-          game.onGameResize(Vector2.all(100));
-          game.add(component);
-          game.update(0); // Making sure the component was added
+        (game) async {
+          final component = _MyComponent();
+          game.ensureAdd(component);
 
           await component.add(
             OpacityEffect(
@@ -35,15 +31,11 @@ void main() {
     });
 
     group('ColorEffect', () {
-      test(
+      flameGame.test(
         'Sets the correct color filter on the paint',
-        () async {
-          final component = MyComponent();
-          final game = FlameGame();
-
-          game.onGameResize(Vector2.all(100));
-          game.add(component);
-          game.update(0); // Making sure the component was added
+        (game) async {
+          final component = _MyComponent();
+          game.ensureAdd(component);
 
           await component.add(
             ColorEffect(

--- a/packages/flame/test/effects/paint_effect_test.dart
+++ b/packages/flame/test/effects/paint_effect_test.dart
@@ -11,7 +11,7 @@ void main() {
   group('Paint Effects', () {
     group('OpacityEffect', () {
       flameGame.test(
-        'Sets the correct opacity on the paint',
+        'sets the correct opacity on the paint',
         (game) async {
           final component = _MyComponent();
           game.ensureAdd(component);
@@ -32,7 +32,7 @@ void main() {
 
     group('ColorEffect', () {
       flameGame.test(
-        'Sets the correct color filter on the paint',
+        'sets the correct color filter on the paint',
         (game) async {
           final component = _MyComponent();
           game.ensureAdd(component);

--- a/packages/flame/test/effects/rotate_effect_test.dart
+++ b/packages/flame/test/effects/rotate_effect_test.dart
@@ -6,10 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'effect_test_utils.dart';
 
-const defaultAngle = 6.0;
+const _defaultAngle = 6.0;
 
-class Elements extends BaseElements {
-  Elements(Random random) : super(random);
+class _Elements extends BaseElements {
+  _Elements(Random random) : super(random);
 
   @override
   TestComponent component() => TestComponent(angle: 0.5);
@@ -18,7 +18,7 @@ class Elements extends BaseElements {
     bool isInfinite = false,
     bool isAlternating = false,
     bool isRelative = false,
-    double angle = defaultAngle,
+    double angle = _defaultAngle,
   }) {
     return RotateEffect(
       angle: angle,
@@ -31,128 +31,130 @@ class Elements extends BaseElements {
 }
 
 void main() {
-  testWidgetsRandom(
-    'RotateEffect can rotate',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedAngle: defaultAngle,
-        random: random,
-      );
-    },
-  );
+  group('RotateEffect', () {
+    testWidgetsRandom(
+      'can rotate',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedAngle: _defaultAngle,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'RotateEffect will stop rotating after it is done',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedAngle: defaultAngle,
-        iterations: 1.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'will stop rotating after it is done',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedAngle: _defaultAngle,
+          iterations: 1.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'RotateEffect can alternate',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedAngle: positionComponent.angle,
-        iterations: 2.0,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedAngle: positionComponent.angle,
+          iterations: 2.0,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'RotateEffect can alternate and be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true, isAlternating: true),
-        expectedAngle: positionComponent.angle,
-        shouldComplete: false,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate and be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true, isAlternating: true),
+          expectedAngle: positionComponent.angle,
+          shouldComplete: false,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'RotateEffect alternation can peak',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedAngle: defaultAngle,
-        shouldComplete: false,
-        iterations: 0.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'alternation can peak',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedAngle: _defaultAngle,
+          shouldComplete: false,
+          iterations: 0.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'RotateEffect can be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true),
-        expectedAngle: defaultAngle,
-        iterations: 3.0,
-        shouldComplete: false,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true),
+          expectedAngle: _defaultAngle,
+          iterations: 3.0,
+          shouldComplete: false,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'RotateEffect can handle negative relative angles',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(angle: -1, isRelative: true),
-        expectedAngle: e.component().angle - 1,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can handle negative relative angles',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(angle: -1, isRelative: true),
+          expectedAngle: e.component().angle - 1,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'RotateEffect can handle absolute relative angles',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(angle: -1),
-        expectedAngle: -1,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can handle absolute relative angles',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(angle: -1),
+          expectedAngle: -1,
+          random: random,
+        );
+      },
+    );
+  });
 }

--- a/packages/flame/test/effects/scale_effect_test.dart
+++ b/packages/flame/test/effects/scale_effect_test.dart
@@ -6,8 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'effect_test_utils.dart';
 
-class Elements extends BaseElements {
-  Elements(Random random) : super(random);
+class _Elements extends BaseElements {
+  _Elements(Random random) : super(random);
 
   @override
   TestComponent component() => TestComponent(scale: randomVector2());
@@ -23,97 +23,99 @@ class Elements extends BaseElements {
 }
 
 void main() {
-  testWidgetsRandom(
-    'ScaleEffect can scale',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedScale: e.argumentScale,
-        random: random,
-      );
-    },
-  );
+  group('ScaleEffect', () {
+    testWidgetsRandom(
+      'can scale',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedScale: e.argumentScale,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'ScaleEffect will stop scaling after it is done',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedScale: e.argumentScale,
-        iterations: 1.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'will stop scaling after it is done',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedScale: e.argumentScale,
+          iterations: 1.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'ScaleEffect can alternate',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedScale: positionComponent.scale.clone(),
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedScale: positionComponent.scale.clone(),
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'ScaleEffect can alternate and be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true, isAlternating: true),
-        expectedScale: positionComponent.scale.clone(),
-        shouldComplete: false,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate and be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true, isAlternating: true),
+          expectedScale: positionComponent.scale.clone(),
+          shouldComplete: false,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'ScaleEffect alternation can peak',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedScale: e.argumentScale,
-        shouldComplete: false,
-        iterations: 0.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'alternation can peak',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedScale: e.argumentScale,
+          shouldComplete: false,
+          iterations: 0.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'ScaleEffect can be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true),
-        expectedScale: e.argumentScale,
-        iterations: 3.0,
-        shouldComplete: false,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true),
+          expectedScale: e.argumentScale,
+          iterations: 3.0,
+          shouldComplete: false,
+          random: random,
+        );
+      },
+    );
+  });
 }

--- a/packages/flame/test/effects/sequence_effect_test.dart
+++ b/packages/flame/test/effects/sequence_effect_test.dart
@@ -6,8 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'effect_test_utils.dart';
 
-class Elements extends BaseElements {
-  Elements(Random random) : super(random);
+class _Elements extends BaseElements {
+  _Elements(Random random) : super(random);
 
   @override
   TestComponent component() => TestComponent(
@@ -47,162 +47,164 @@ class Elements extends BaseElements {
 }
 
 void main() {
-  testWidgetsRandom(
-    'SequenceEffect can sequence',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedPosition: e.path.last,
-        expectedAngle: e.argumentAngle,
-        expectedSize: e.argumentSize,
-        random: random,
-      );
-    },
-  );
+  group('SequenceEffect', () {
+    testWidgetsRandom(
+      'can sequence',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedPosition: e.path.last,
+          expectedAngle: e.argumentAngle,
+          expectedSize: e.argumentSize,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SequenceEffect will stop sequence after it is done',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedPosition: e.path.last,
-        expectedAngle: e.argumentAngle,
-        expectedSize: e.argumentSize,
-        iterations: 1.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'will stop sequence after it is done',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedPosition: e.path.last,
+          expectedAngle: e.argumentAngle,
+          expectedSize: e.argumentSize,
+          iterations: 1.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SequenceEffect can alternate',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedPosition: positionComponent.position.clone(),
-        expectedAngle: positionComponent.angle,
-        expectedSize: positionComponent.size.clone(),
-        iterations: 2.0,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedPosition: positionComponent.position.clone(),
+          expectedAngle: positionComponent.angle,
+          expectedSize: positionComponent.size.clone(),
+          iterations: 2.0,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SequenceEffect can alternate and be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true, isAlternating: true),
-        expectedPosition: positionComponent.position.clone(),
-        expectedAngle: positionComponent.angle,
-        expectedSize: positionComponent.size.clone(),
-        shouldComplete: false,
-        epsilon: 3.0,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate and be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true, isAlternating: true),
+          expectedPosition: positionComponent.position.clone(),
+          expectedAngle: positionComponent.angle,
+          expectedSize: positionComponent.size.clone(),
+          shouldComplete: false,
+          epsilon: 3.0,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SequenceEffect alternation can peak',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedPosition: e.path.last,
-        expectedAngle: e.argumentAngle,
-        expectedSize: e.argumentSize,
-        shouldComplete: false,
-        iterations: 0.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'alternation can peak',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedPosition: e.path.last,
+          expectedAngle: e.argumentAngle,
+          expectedSize: e.argumentSize,
+          shouldComplete: false,
+          iterations: 0.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SequenceEffect can be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true),
-        expectedPosition: e.path.last,
-        expectedAngle: e.argumentAngle,
-        expectedSize: e.argumentSize,
-        iterations: 3.0,
-        shouldComplete: false,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true),
+          expectedPosition: e.path.last,
+          expectedAngle: e.argumentAngle,
+          expectedSize: e.argumentSize,
+          iterations: 3.0,
+          shouldComplete: false,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SequenceEffect can contain alternating MoveEffect',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(hasAlternatingMoveEffect: true),
-        expectedPosition: positionComponent.position.clone(),
-        expectedAngle: e.argumentAngle,
-        expectedSize: e.argumentSize,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can contain alternating MoveEffect',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(hasAlternatingMoveEffect: true),
+          expectedPosition: positionComponent.position.clone(),
+          expectedAngle: e.argumentAngle,
+          expectedSize: e.argumentSize,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SequenceEffect can contain alternating RotateEffect',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(hasAlternatingRotateEffect: true),
-        expectedPosition: e.path.last,
-        expectedAngle: positionComponent.angle,
-        expectedSize: e.argumentSize,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can contain alternating RotateEffect',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(hasAlternatingRotateEffect: true),
+          expectedPosition: e.path.last,
+          expectedAngle: positionComponent.angle,
+          expectedSize: e.argumentSize,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SequenceEffect can contain alternating SizeEffect',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(hasAlternatingSizeEffect: true),
-        expectedPosition: e.path.last,
-        expectedAngle: e.argumentAngle,
-        expectedSize: positionComponent.size.clone(),
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can contain alternating SizeEffect',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(hasAlternatingSizeEffect: true),
+          expectedPosition: e.path.last,
+          expectedAngle: e.argumentAngle,
+          expectedSize: positionComponent.size.clone(),
+          random: random,
+        );
+      },
+    );
+  });
 }

--- a/packages/flame/test/effects/size_effect_test.dart
+++ b/packages/flame/test/effects/size_effect_test.dart
@@ -6,8 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'effect_test_utils.dart';
 
-class Elements extends BaseElements {
-  Elements(Random random) : super(random);
+class _Elements extends BaseElements {
+  _Elements(Random random) : super(random);
 
   @override
   TestComponent component() => TestComponent(size: randomVector2());
@@ -23,97 +23,99 @@ class Elements extends BaseElements {
 }
 
 void main() {
-  testWidgetsRandom(
-    'SizeEffect can scale',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedSize: e.argumentSize,
-        random: random,
-      );
-    },
-  );
+  group('SizeEffect', () {
+    testWidgetsRandom(
+      'can scale',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedSize: e.argumentSize,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SizeEffect will stop scaling after it is done',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      effectTest(
-        tester,
-        e.component(),
-        e.effect(),
-        expectedSize: e.argumentSize,
-        iterations: 1.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'will stop scaling after it is done',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        effectTest(
+          tester,
+          e.component(),
+          e.effect(),
+          expectedSize: e.argumentSize,
+          iterations: 1.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SizeEffect can alternate',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedSize: positionComponent.size.clone(),
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedSize: positionComponent.size.clone(),
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SizeEffect can alternate and be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true, isAlternating: true),
-        expectedSize: positionComponent.size.clone(),
-        shouldComplete: false,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can alternate and be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true, isAlternating: true),
+          expectedSize: positionComponent.size.clone(),
+          shouldComplete: false,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SizeEffect alternation can peak',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isAlternating: true),
-        expectedSize: e.argumentSize,
-        shouldComplete: false,
-        iterations: 0.5,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'alternation can peak',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isAlternating: true),
+          expectedSize: e.argumentSize,
+          shouldComplete: false,
+          iterations: 0.5,
+          random: random,
+        );
+      },
+    );
 
-  testWidgetsRandom(
-    'SizeEffect can be infinite',
-    (Random random, WidgetTester tester) async {
-      final e = Elements(random);
-      final positionComponent = e.component();
-      effectTest(
-        tester,
-        positionComponent,
-        e.effect(isInfinite: true),
-        expectedSize: e.argumentSize,
-        iterations: 3.0,
-        shouldComplete: false,
-        random: random,
-      );
-    },
-  );
+    testWidgetsRandom(
+      'can be infinite',
+      (Random random, WidgetTester tester) async {
+        final e = _Elements(random);
+        final positionComponent = e.component();
+        effectTest(
+          tester,
+          positionComponent,
+          e.effect(isInfinite: true),
+          expectedSize: e.argumentSize,
+          iterations: 3.0,
+          shouldComplete: false,
+          random: random,
+        );
+      },
+    );
+  });
 }

--- a/packages/flame/test/effects2/effect_test.dart
+++ b/packages/flame/test/effects2/effect_test.dart
@@ -5,14 +5,12 @@ import 'package:flame/src/effects2/standard_effect_controller.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-typedef VoidCallback = void Function();
-
-class MyEffect extends Effect {
-  MyEffect(EffectController controller) : super(controller);
+class _MyEffect extends Effect {
+  _MyEffect(EffectController controller) : super(controller);
 
   double x = -1;
-  VoidCallback? onStartCallback;
-  VoidCallback? onFinishCallback;
+  Function()? onStartCallback;
+  Function()? onFinishCallback;
 
   @override
   void apply(double progress) {
@@ -40,8 +38,8 @@ class MyEffect extends Effect {
 
 void main() {
   group('Effect', () {
-    test('Pause & Resume', () {
-      final effect = MyEffect(StandardEffectController(duration: 10));
+    test('pause & resume', () {
+      final effect = _MyEffect(StandardEffectController(duration: 10));
       expect(effect.x, -1);
       expect(effect.isPaused, false);
 
@@ -83,7 +81,7 @@ void main() {
       (game) {
         final obj = Component();
         game.add(obj);
-        final effect = MyEffect(StandardEffectController(duration: 1));
+        final effect = _MyEffect(StandardEffectController(duration: 1));
         obj.add(effect);
         game.update(0);
         expect(obj.children.length, 1);
@@ -104,7 +102,7 @@ void main() {
       (game) {
         final obj = Component();
         game.add(obj);
-        final effect = MyEffect(StandardEffectController(duration: 1));
+        final effect = _MyEffect(StandardEffectController(duration: 1));
         effect.removeOnFinish = false;
         obj.add(effect);
         game.update(0);
@@ -151,7 +149,7 @@ void main() {
     test('onStart & onFinish', () {
       var nStarted = 0;
       var nFinished = 0;
-      final effect = MyEffect(StandardEffectController(duration: 1))
+      final effect = _MyEffect(StandardEffectController(duration: 1))
         ..onStartCallback = () {
           nStarted++;
         }

--- a/packages/flame/test/effects2/move_effect_test.dart
+++ b/packages/flame/test/effects2/move_effect_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('MoveEffect', () {
-    test('MoveEffect.by()', () {
+    test('#by', () {
       final game = FlameGame();
       game.onGameResize(Vector2(100, 100));
       final object = PositionComponent()..position = Vector2(3, 4);
@@ -27,7 +27,7 @@ void main() {
       expect(object.position.y, closeTo(4 + -1, 1e-15));
     });
 
-    test('MoveEffect.to()', () {
+    test('#to', () {
       final game = FlameGame();
       game.onGameResize(Vector2(100, 100));
       final object = PositionComponent()..position = Vector2(3, 4);
@@ -45,7 +45,7 @@ void main() {
       expect(object.position.y, closeTo(-1, 1e-15));
     });
 
-    test('MoveEffect.along()', () {
+    test('#along', () {
       const tau = Transform2D.tau;
       final game = FlameGame();
       game.onGameResize(Vector2(100, 100));
@@ -72,7 +72,7 @@ void main() {
       }
     });
 
-    test('MoveEffect.along() wrong arguments', () {
+    test('#along wrong arguments', () {
       final controller = SimpleEffectController();
       expect(
         () => MoveEffect.along(Path(), controller),

--- a/packages/flame/test/effects2/transform2d_effect_test.dart
+++ b/packages/flame/test/effects2/transform2d_effect_test.dart
@@ -5,8 +5,8 @@ import 'package:flame/src/effects2/transform2d_effect.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MyEffect extends Transform2DEffect {
-  MyEffect(EffectController controller) : super(controller);
+class _MyEffect extends Transform2DEffect {
+  _MyEffect(EffectController controller) : super(controller);
 }
 
 void main() {
@@ -18,12 +18,12 @@ void main() {
         game.add(obj);
         game.update(0);
 
-        final effect = MyEffect(StandardEffectController(duration: 1));
+        final effect = _MyEffect(StandardEffectController(duration: 1));
         obj.add(effect);
         game.update(0);
         expect(effect.target, obj.transform);
 
-        final effect2 = MyEffect(StandardEffectController(duration: 1));
+        final effect2 = _MyEffect(StandardEffectController(duration: 1));
         expect(
           () async => game.add(effect2),
           throwsA(isA<UnsupportedError>()),

--- a/packages/flame/test/extensions/color_test.dart
+++ b/packages/flame/test/extensions/color_test.dart
@@ -28,6 +28,7 @@ void main() {
         const Color(0xFFB210AF),
       );
     });
+
     test('test parse short ARGB', () {
       expect(
         ColorExtension.fromARGBHexString('#fccc'),
@@ -46,6 +47,7 @@ void main() {
         const Color(0x00BB2211),
       );
     });
+
     test('test parse long ARGB', () {
       expect(
         ColorExtension.fromARGBHexString('#ffcc1050'),

--- a/packages/flame/test/game/base_game_test.dart
+++ b/packages/flame/test/game/base_game_test.dart
@@ -10,20 +10,23 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart' as flutter;
 import 'package:flutter_test/flutter_test.dart';
 
-class MyGame extends FlameGame with HasTappableComponents {}
+class _GameWithTappables extends FlameGame with HasTappableComponents {}
 
-class MyComponent extends PositionComponent with Tappable, HasGameRef {
+class MyTappableComponent extends MyComponent with Tappable {
   bool tapped = false;
-  bool isUpdateCalled = false;
-  bool isRenderCalled = false;
-  int onRemoveCallCounter = 0;
-  late Vector2 gameSize;
 
   @override
   bool onTapDown(_) {
     tapped = true;
     return true;
   }
+}
+
+class MyComponent extends PositionComponent with HasGameRef {
+  bool isUpdateCalled = false;
+  bool isRenderCalled = false;
+  int onRemoveCallCounter = 0;
+  late Vector2 gameSize;
 
   @override
   void update(double dt) {
@@ -60,74 +63,51 @@ class MyAsyncComponent extends MyComponent {
   }
 }
 
-class PositionComponentNoNeedForRect extends PositionComponent with Tappable {}
-
-Vector2 size = Vector2(1.0, 1.0);
-
 void main() {
+  final withTappables = FlameTester(() => _GameWithTappables());
+
   group('FlameGame test', () {
-    test('adds the component to the component list', () {
-      final game = MyGame();
-      final component = MyComponent();
-
-      game.onGameResize(size);
-      game.add(component);
-      // runs a cycle to add the component
-      game.update(0.1);
-
-      expect(true, game.children.contains(component));
-    });
-
-    test(
-      'when the component has onLoad function, adds after load completion',
-      () async {
-        final game = MyGame();
-        final component = MyAsyncComponent();
-
-        game.onGameResize(size);
-        await game.add(component);
-        // runs a cycle to add the component
-        game.update(0.1);
+    flameGame.test(
+      'adds the component to the component list',
+      (game) async {
+        final component = Component();
+        await game.ensureAdd(component);
 
         expect(true, game.children.contains(component));
+      },
+    );
 
-        expect(component.gameSize, size);
+    withTappables.test(
+      'when the component has onLoad function, adds after load completion',
+      (game) async {
+        final component = MyAsyncComponent();
+        await game.ensureAdd(component);
+
+        expect(true, game.children.contains(component));
+        expect(component.gameSize, game.size);
         expect(component.gameRef, game);
       },
     );
 
-    test('prepare adds gameRef and calls onGameResize', () {
-      final game = MyGame();
+    flameGame.test('prepare adds gameRef and calls onGameResize', (game) async {
       final component = MyComponent();
+      await game.ensureAdd(component);
 
-      game.onGameResize(size);
-      game.add(component);
-
-      expect(component.gameSize, size);
+      expect(component.gameSize, game.size);
       expect(component.gameRef, game);
     });
 
-    test('component can be tapped', () {
-      final game = MyGame();
-      final component = MyComponent();
-
-      game.onGameResize(size);
-      game.add(component);
-      // The component is not added to the component list until an update has been performed
-      game.update(0.0);
+    withTappables.test('component can be tapped', (game) async {
+      final component = MyTappableComponent();
+      await game.ensureAdd(component);
       game.onTapDown(1, createTapDownEvent(game));
 
       expect(component.tapped, true);
     });
 
-    test('component is added to component list', () {
-      final game = MyGame();
+    flameGame.test('component is added to component list', (game) async {
       final component = MyComponent();
-
-      game.onGameResize(size);
-      game.add(component);
-      // The component is not added to the component list until an update has been performed
-      game.update(0.0);
+      await game.ensureAdd(component);
 
       expect(game.children.contains(component), true);
     });
@@ -135,10 +115,10 @@ void main() {
     flutter.testWidgets(
       'component render and update is called',
       (flutter.WidgetTester tester) async {
-        final game = MyGame();
+        final game = FlameGame();
         final component = MyComponent();
 
-        game.onGameResize(size);
+        game.onGameResize(Vector2.zero());
         game.add(component);
         late GameRenderBox renderBox;
         await tester.pumpWidget(
@@ -161,14 +141,10 @@ void main() {
       },
     );
 
-    test('onRemove is only called once on component', () {
-      final game = MyGame();
+    flameGame.test('onRemove is only called once on component', (game) async {
       final component = MyComponent();
 
-      game.onGameResize(size);
-      game.add(component);
-      // The component is not added to the component list until an update has been performed
-      game.update(0.0);
+      await game.ensureAdd(component);
       // The component is removed both by removing it on the game instance and
       // by the function on the component, but the onRemove callback should
       // only be called once.
@@ -181,12 +157,9 @@ void main() {
     });
   });
 
-  test('remove depend SpriteComponent.shouldRemove', () {
-    final game = MyGame()..onGameResize(size);
-
+  flameGame.test('remove depend SpriteComponent.shouldRemove', (game) async {
     // addLater here
-    game.add(SpriteComponent()..shouldRemove = true);
-    game.update(0);
+    await game.ensureAdd(SpriteComponent()..shouldRemove = true);
     expect(game.children.length, equals(1));
 
     // remove effected here
@@ -194,25 +167,20 @@ void main() {
     expect(game.children.isEmpty, equals(true));
   });
 
-  test('remove depend SpriteAnimationComponent.shouldRemove', () {
-    final game = MyGame()..onGameResize(size);
-    game.add(SpriteAnimationComponent()..shouldRemove = true);
-    game.update(0);
-    expect(game.children.length, equals(1));
+  flameGame.test(
+    'remove depend SpriteAnimationComponent.shouldRemove',
+    (game) async {
+      await game.ensureAdd(SpriteAnimationComponent()..shouldRemove = true);
+      expect(game.children.length, equals(1));
 
-    game.update(0);
-    expect(game.children.isEmpty, equals(true));
-  });
+      game.update(0);
+      expect(game.children.isEmpty, equals(true));
+    },
+  );
 
-  test('clear removes all components', () {
-    final game = MyGame();
-    final components = List.generate(3, (index) => MyComponent());
-
-    game.onGameResize(size);
-    game.addAll(components);
-
-    // The components are not added to the component list until an update has been performed
-    game.update(0.0);
+  flameGame.test('clear removes all components', (game) async {
+    final components = List.generate(3, (index) => Component());
+    await game.ensureAddAll(components);
     expect(game.children.length, equals(3));
 
     game.children.clear();
@@ -224,8 +192,8 @@ void main() {
   });
 
   test("can't add a component to a game that don't have layout yet", () {
-    final game = MyGame();
-    final component = MyComponent();
+    final game = FlameGame();
+    final component = Component();
 
     const message = '"prepare/add" called before the game is ready. '
         'Did you try to access it on the Game constructor? '

--- a/packages/flame/test/game/base_game_test.dart
+++ b/packages/flame/test/game/base_game_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 class _GameWithTappables extends FlameGame with HasTappableComponents {}
 
-class MyTappableComponent extends MyComponent with Tappable {
+class _MyTappableComponent extends _MyComponent with Tappable {
   bool tapped = false;
 
   @override
@@ -22,7 +22,7 @@ class MyTappableComponent extends MyComponent with Tappable {
   }
 }
 
-class MyComponent extends PositionComponent with HasGameRef {
+class _MyComponent extends PositionComponent with HasGameRef {
   bool isUpdateCalled = false;
   bool isRenderCalled = false;
   int onRemoveCallCounter = 0;
@@ -55,7 +55,7 @@ class MyComponent extends PositionComponent with HasGameRef {
   }
 }
 
-class MyAsyncComponent extends MyComponent {
+class _MyAsyncComponent extends _MyComponent {
   @override
   Future<void> onLoad() async {
     await super.onLoad();
@@ -80,7 +80,7 @@ void main() {
     withTappables.test(
       'when the component has onLoad function, adds after load completion',
       (game) async {
-        final component = MyAsyncComponent();
+        final component = _MyAsyncComponent();
         await game.ensureAdd(component);
 
         expect(true, game.children.contains(component));
@@ -90,7 +90,7 @@ void main() {
     );
 
     flameGame.test('prepare adds gameRef and calls onGameResize', (game) async {
-      final component = MyComponent();
+      final component = _MyComponent();
       await game.ensureAdd(component);
 
       expect(component.gameSize, game.size);
@@ -98,7 +98,7 @@ void main() {
     });
 
     withTappables.test('component can be tapped', (game) async {
-      final component = MyTappableComponent();
+      final component = _MyTappableComponent();
       await game.ensureAdd(component);
       game.onTapDown(1, createTapDownEvent(game));
 
@@ -106,7 +106,7 @@ void main() {
     });
 
     flameGame.test('component is added to component list', (game) async {
-      final component = MyComponent();
+      final component = _MyComponent();
       await game.ensureAdd(component);
 
       expect(game.children.contains(component), true);
@@ -116,7 +116,7 @@ void main() {
       'component render and update is called',
       (flutter.WidgetTester tester) async {
         final game = FlameGame();
-        final component = MyComponent();
+        final component = _MyComponent();
 
         game.onGameResize(Vector2.zero());
         game.add(component);
@@ -142,7 +142,7 @@ void main() {
     );
 
     flameGame.test('onRemove is only called once on component', (game) async {
-      final component = MyComponent();
+      final component = _MyComponent();
 
       await game.ensureAdd(component);
       // The component is removed both by removing it on the game instance and

--- a/packages/flame/test/game/camera_and_viewport_test.dart
+++ b/packages/flame/test/game/camera_and_viewport_test.dart
@@ -4,6 +4,7 @@ import 'package:canvas_test/canvas_test.dart';
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 class TestComponent extends PositionComponent {
@@ -23,16 +24,14 @@ class TestComponent extends PositionComponent {
 
 void main() {
   group('viewport', () {
-    test('default viewport does not change size', () {
-      final game = FlameGame(); // default viewport
+    flameGame.test('default viewport does not change size', (game) {
       game.onGameResize(Vector2(100.0, 200.0));
       expect(game.canvasSize, Vector2(100.0, 200.00));
       expect(game.size, Vector2(100.0, 200.00));
     });
 
-    test('fixed ratio viewport has perfect ratio', () {
-      final game = FlameGame()
-        ..camera.viewport = FixedResolutionViewport(Vector2.all(50));
+    flameGame.test('fixed ratio viewport has perfect ratio', (game) {
+      game..camera.viewport = FixedResolutionViewport(Vector2.all(50));
       game.onGameResize(Vector2.all(200.0));
       expect(game.canvasSize, Vector2.all(200.00));
       expect(game.size, Vector2.all(50.00));
@@ -52,9 +51,8 @@ void main() {
       );
     });
 
-    test('fixed ratio viewport maxes width', () {
-      final game = FlameGame()
-        ..camera.viewport = FixedResolutionViewport(Vector2.all(50));
+    flameGame.test('fixed ratio viewport maxes width', (game) {
+      game..camera.viewport = FixedResolutionViewport(Vector2.all(50));
       game.onGameResize(Vector2(100.0, 200.0));
       expect(game.canvasSize, Vector2(100.0, 200.00));
       expect(game.size, Vector2.all(50.00));
@@ -75,9 +73,8 @@ void main() {
       );
     });
 
-    test('fixed ratio viewport maxes height', () {
-      final game = FlameGame()
-        ..camera.viewport = FixedResolutionViewport(Vector2(100.0, 400.0));
+    flameGame.test('fixed ratio viewport maxes height', (game) {
+      game..camera.viewport = FixedResolutionViewport(Vector2(100.0, 400.0));
       game.onGameResize(Vector2(100.0, 200.0));
       expect(game.canvasSize, Vector2(100.0, 200.00));
       expect(game.size, Vector2(100.00, 400.0));
@@ -100,8 +97,7 @@ void main() {
   });
 
   group('camera', () {
-    test('default camera applies no translation', () {
-      final game = FlameGame(); // no camera changes
+    flameGame.test('default camera applies no translation', (game) {
       game.onGameResize(Vector2.all(100.0));
       expect(game.camera.position, Vector2.zero());
 
@@ -119,8 +115,7 @@ void main() {
       );
     });
 
-    test('camera snap movement', () {
-      final game = FlameGame(); // no camera changes
+    flameGame.test('camera snap movement', (game) {
       game.onGameResize(Vector2.all(100.0));
       expect(game.camera.position, Vector2.zero());
 
@@ -145,8 +140,7 @@ void main() {
       );
     });
 
-    test('camera smooth movement', () {
-      final game = FlameGame(); // no camera changes
+    flameGame.test('camera smooth movement', (game) {
       game.onGameResize(Vector2.all(100.0));
 
       game.camera.speed = 1; // 1 pixel per second
@@ -162,8 +156,7 @@ void main() {
       expect(game.camera.position, Vector2(0.0, 10.0));
     });
 
-    test('camera follow', () {
-      final game = FlameGame(); // no camera changes
+    flameGame.test('camera follow', (game) {
       game.onGameResize(Vector2.all(100.0));
 
       final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
@@ -190,8 +183,7 @@ void main() {
       );
     });
 
-    test('camera follow with relative position', () {
-      final game = FlameGame(); // no camera changes
+    flameGame.test('camera follow with relative position', (game) {
       game.onGameResize(Vector2.all(100.0));
 
       final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
@@ -217,8 +209,7 @@ void main() {
           ..drawRect(const Rect.fromLTWH(0, 0, 1, 1)),
       );
     });
-    test('camera follow with world boundaries', () {
-      final game = FlameGame(); // no camera changes
+    flameGame.test('camera follow with world boundaries', (game) {
       game.onGameResize(Vector2.all(100.0));
 
       final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
@@ -250,32 +241,35 @@ void main() {
       game.update(0);
       expect(game.camera.position, Vector2(900, 900));
     });
-    test('camera follow with world boundaries smaller than the screen', () {
-      final game = FlameGame(); // no camera changes
-      game.onGameResize(Vector2.all(200.0));
 
-      final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
-      game.add(p);
-      game.update(0);
-      game.camera.followComponent(
-        p,
-        worldBounds: const Rect.fromLTWH(0, 0, 100, 100),
-      );
+    flameGame.test(
+      'camera follow with world boundaries smaller than the screen',
+      (game) {
+        game.onGameResize(Vector2.all(200.0));
 
-      // in this case the camera will just center the world, no matter the player position
-      game.update(0);
-      expect(game.camera.position, Vector2(50, 50));
+        final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
+        game.add(p);
+        game.update(0);
+        game.camera.followComponent(
+          p,
+          worldBounds: const Rect.fromLTWH(0, 0, 100, 100),
+        );
 
-      p.position.setValues(60.0, 50.0);
-      game.update(0);
-      expect(game.camera.position, Vector2(50, 50));
+        // in this case the camera will just center the world, no matter the player position
+        game.update(0);
+        expect(game.camera.position, Vector2(50, 50));
 
-      p.position.setValues(-10.0, -20.0);
-      game.update(0);
-      expect(game.camera.position, Vector2(50, 50));
-    });
-    test('camera relative offset without follow', () {
-      final game = FlameGame();
+        p.position.setValues(60.0, 50.0);
+        game.update(0);
+        expect(game.camera.position, Vector2(50, 50));
+
+        p.position.setValues(-10.0, -20.0);
+        game.update(0);
+        expect(game.camera.position, Vector2(50, 50));
+      },
+    );
+
+    flameGame.test('camera relative offset without follow', (game) {
       game.onGameResize(Vector2.all(200.0));
 
       game.camera.setRelativeOffset(Anchor.center);
@@ -287,8 +281,7 @@ void main() {
       expect(game.camera.position, Vector2.all(-100.0));
     });
 
-    test('camera zoom', () {
-      final game = FlameGame();
+    flameGame.test('camera zoom', (game) {
       game.onGameResize(Vector2.all(200.0));
       game.camera.zoom = 2;
 
@@ -307,8 +300,7 @@ void main() {
       );
     });
 
-    test('camera zoom with setRelativeOffset', () {
-      final game = FlameGame();
+    flameGame.test('camera zoom with setRelativeOffset', (game) {
       game.onGameResize(Vector2.all(200.0));
       game.camera.zoom = 2;
       game.camera.setRelativeOffset(Anchor.center);
@@ -330,8 +322,7 @@ void main() {
       expect(game.camera.position, Vector2.all(-50.0));
     });
 
-    test('camera shake should return to where it started', () {
-      final game = FlameGame();
+    flameGame.test('camera shake should return to where it started', (game) {
       final camera = game.camera;
       game.onGameResize(Vector2.all(200.0));
       expect(camera.position, Vector2.zero());
@@ -344,41 +335,44 @@ void main() {
   });
 
   group('viewport & camera', () {
-    test('default ratio viewport + camera with world boundaries', () {
-      final game = FlameGame()
-        ..camera.viewport = FixedResolutionViewport(Vector2.all(100));
-      game.onGameResize(Vector2.all(200.0));
-      expect(game.canvasSize, Vector2.all(200.00));
-      expect(game.size, Vector2.all(100.00));
+    flameGame.test(
+      'default ratio viewport + camera with world boundaries',
+      (game) {
+        final game = FlameGame()
+          ..camera.viewport = FixedResolutionViewport(Vector2.all(100));
+        game.onGameResize(Vector2.all(200.0));
+        expect(game.canvasSize, Vector2.all(200.00));
+        expect(game.size, Vector2.all(100.00));
 
-      final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
-      game.add(p);
-      game.camera.followComponent(
-        p,
-        // this could be a typical mario-like platformer, where the player is
-        // more on the bottom left to allow the scenario to be seem
-        relativeOffset: const Anchor(0.25, 0.25),
-        worldBounds: const Rect.fromLTWH(0, 0, 1000, 1000),
-      );
+        final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
+        game.add(p);
+        game.camera.followComponent(
+          p,
+          // this could be a typical mario-like platformer, where the player is
+          // more on the bottom left to allow the scenario to be seem
+          relativeOffset: const Anchor(0.25, 0.25),
+          worldBounds: const Rect.fromLTWH(0, 0, 1000, 1000),
+        );
 
-      game.update(0);
-      expect(game.camera.position, Vector2(0, 0));
+        game.update(0);
+        expect(game.camera.position, Vector2(0, 0));
 
-      p.position.setValues(30.0, 0.0);
-      game.update(0);
-      expect(game.camera.position, Vector2(5, 0));
+        p.position.setValues(30.0, 0.0);
+        game.update(0);
+        expect(game.camera.position, Vector2(5, 0));
 
-      p.position.setValues(30.0, 100.0);
-      game.update(0);
-      expect(game.camera.position, Vector2(5, 75));
+        p.position.setValues(30.0, 100.0);
+        game.update(0);
+        expect(game.camera.position, Vector2(5, 75));
 
-      p.position.setValues(30.0, 1000.0);
-      game.update(0);
-      expect(game.camera.position, Vector2(5, 900));
+        p.position.setValues(30.0, 1000.0);
+        game.update(0);
+        expect(game.camera.position, Vector2(5, 900));
 
-      p.position.setValues(950.0, 20.0);
-      game.update(0);
-      expect(game.camera.position, Vector2(900, 0));
-    });
+        p.position.setValues(950.0, 20.0);
+        game.update(0);
+        expect(game.camera.position, Vector2(900, 0));
+      },
+    );
   });
 }

--- a/packages/flame/test/game/camera_and_viewport_test.dart
+++ b/packages/flame/test/game/camera_and_viewport_test.dart
@@ -7,10 +7,10 @@ import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class TestComponent extends PositionComponent {
+class _TestComponent extends PositionComponent {
   static final Paint _paint = Paint();
 
-  TestComponent(Vector2 position)
+  _TestComponent(Vector2 position)
       : super(
           position: position,
           size: Vector2.all(1.0),
@@ -101,7 +101,7 @@ void main() {
       game.onGameResize(Vector2.all(100.0));
       expect(game.camera.position, Vector2.zero());
 
-      final p = TestComponent(Vector2.all(10.0));
+      final p = _TestComponent(Vector2.all(10.0));
       game.add(p);
       game.update(0);
 
@@ -119,7 +119,7 @@ void main() {
       game.onGameResize(Vector2.all(100.0));
       expect(game.camera.position, Vector2.zero());
 
-      final p = TestComponent(Vector2.all(10.0));
+      final p = _TestComponent(Vector2.all(10.0));
       game.add(p);
       game.update(0);
 
@@ -159,7 +159,7 @@ void main() {
     flameGame.test('camera follow', (game) {
       game.onGameResize(Vector2.all(100.0));
 
-      final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
+      final p = _TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
       game.add(p);
       game.update(0);
       game.camera.followComponent(p);
@@ -186,7 +186,7 @@ void main() {
     flameGame.test('camera follow with relative position', (game) {
       game.onGameResize(Vector2.all(100.0));
 
-      final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
+      final p = _TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
       game.add(p);
       game.update(0);
       // this would be a typical vertical shoot-em-up
@@ -212,7 +212,7 @@ void main() {
     flameGame.test('camera follow with world boundaries', (game) {
       game.onGameResize(Vector2.all(100.0));
 
-      final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
+      final p = _TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
       game.add(p);
       game.update(0);
       game.camera.followComponent(
@@ -247,7 +247,7 @@ void main() {
       (game) {
         game.onGameResize(Vector2.all(200.0));
 
-        final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
+        final p = _TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
         game.add(p);
         game.update(0);
         game.camera.followComponent(
@@ -285,7 +285,7 @@ void main() {
       game.onGameResize(Vector2.all(200.0));
       game.camera.zoom = 2;
 
-      final p = TestComponent(Vector2.all(100.0))..anchor = Anchor.center;
+      final p = _TestComponent(Vector2.all(100.0))..anchor = Anchor.center;
       game.add(p);
       game.update(0);
 
@@ -305,7 +305,7 @@ void main() {
       game.camera.zoom = 2;
       game.camera.setRelativeOffset(Anchor.center);
 
-      final p = TestComponent(Vector2.all(100.0))..anchor = Anchor.center;
+      final p = _TestComponent(Vector2.all(100.0))..anchor = Anchor.center;
       game.add(p);
       game.update(10000);
 
@@ -344,7 +344,7 @@ void main() {
         expect(game.canvasSize, Vector2.all(200.00));
         expect(game.size, Vector2.all(100.00));
 
-        final p = TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
+        final p = _TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
         game.add(p);
         game.camera.followComponent(
           p,

--- a/packages/flame/test/game/game_widget/game_widget_drag_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_drag_test.dart
@@ -68,7 +68,7 @@ void main() {
     );
   });
 
-  group('GameWidget - VerticallDragDetector', () {
+  group('GameWidget - VerticalDragDetector', () {
     verticalGame.widgetTest(
       'register drags',
       (game, tester) async {

--- a/packages/flame/test/game/game_widget/game_widget_drag_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_drag_test.dart
@@ -3,7 +3,7 @@ import 'package:flame/input.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class HorizontalDragGame extends FlameGame with HorizontalDragDetector {
+class _HorizontalDragGame extends FlameGame with HorizontalDragDetector {
   bool horizontalDragStarted = false;
   bool horizontalDragEnded = false;
 
@@ -18,9 +18,7 @@ class HorizontalDragGame extends FlameGame with HorizontalDragDetector {
   }
 }
 
-final horizontalGame = FlameTester(() => HorizontalDragGame());
-
-class VerticalDragGame extends FlameGame with VerticalDragDetector {
+class _VerticalDragGame extends FlameGame with VerticalDragDetector {
   bool verticalDragStarted = false;
   bool verticalDragEnded = false;
 
@@ -35,9 +33,7 @@ class VerticalDragGame extends FlameGame with VerticalDragDetector {
   }
 }
 
-final verticalGame = FlameTester(() => VerticalDragGame());
-
-class PanGame extends FlameGame with PanDetector {
+class _PanGame extends FlameGame with PanDetector {
   bool panStarted = false;
   bool panEnded = false;
 
@@ -52,15 +48,17 @@ class PanGame extends FlameGame with PanDetector {
   }
 }
 
-final panGame = FlameTester(() => PanGame());
-
 void main() {
+  final horizontalGame = FlameTester(() => _HorizontalDragGame());
+  final verticalGame = FlameTester(() => _VerticalDragGame());
+  final panGame = FlameTester(() => _PanGame());
+
   group('GameWidget - HorizontalDragDetector', () {
     horizontalGame.widgetTest(
       'register drags',
       (game, tester) async {
         await tester.drag(
-          find.byGame<HorizontalDragGame>(),
+          find.byGame<_HorizontalDragGame>(),
           const Offset(50, 0),
         );
 
@@ -69,12 +67,13 @@ void main() {
       },
     );
   });
+
   group('GameWidget - VerticallDragDetector', () {
     verticalGame.widgetTest(
       'register drags',
       (game, tester) async {
         await tester.drag(
-          find.byGame<VerticalDragGame>(),
+          find.byGame<_VerticalDragGame>(),
           const Offset(50, 0),
         );
 
@@ -83,12 +82,13 @@ void main() {
       },
     );
   });
+
   group('GameWidget - PanDetector', () {
     panGame.widgetTest(
       'register drags',
       (game, tester) async {
         await tester.drag(
-          find.byGame<PanGame>(),
+          find.byGame<_PanGame>(),
           const Offset(50, 0),
         );
 

--- a/packages/flame/test/game/game_widget/game_widget_keyboard_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_keyboard_test.dart
@@ -80,7 +80,7 @@ class _GamePage extends StatelessWidget {
 void main() async {
   final size = Vector2(1.0, 1.0);
 
-  testWidgets('Adds focus', (tester) async {
+  testWidgets('adds focus', (tester) async {
     final focusNode = FocusNode();
 
     final game = _KeyboardEventsGame();
@@ -97,7 +97,7 @@ void main() async {
     expect(focusNode.hasFocus, true);
   });
 
-  testWidgets('KeyboardEvents receives keys', (tester) async {
+  testWidgets('game with KeyboardEvents receives keys', (tester) async {
     final game = _KeyboardEventsGame();
 
     await tester.pumpWidget(
@@ -115,26 +115,29 @@ void main() async {
     expect(game.keysPressed, ['a', 'b', 'c']);
   });
 
-  testWidgets('HasKeyboardHandlerComponents receives keys', (tester) async {
-    final game = _HasKeyboardHandlerComponentsGame();
+  testWidgets(
+    'game with HasKeyboardHandlerComponents receives keys',
+    (tester) async {
+      final game = _HasKeyboardHandlerComponentsGame();
 
-    await tester.pumpWidget(
-      _GamePage(
-        child: GameWidget(
-          game: game,
+      await tester.pumpWidget(
+        _GamePage(
+          child: GameWidget(
+            game: game,
+          ),
         ),
-      ),
-    );
+      );
 
-    game.onGameResize(size);
-    game.update(0.1);
+      game.onGameResize(size);
+      game.update(0.1);
 
-    await tester.pump();
+      await tester.pump();
 
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyF);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyI);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyF);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyI);
 
-    expect(game.keyboardHandler.keysPressed, ['z', 'f', 'i']);
-  });
+      expect(game.keyboardHandler.keysPressed, ['z', 'f', 'i']);
+    },
+  );
 }

--- a/packages/flame/test/game/game_widget/game_widget_keyboard_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_keyboard_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-Vector2 size = Vector2(1.0, 1.0);
-
 class _KeyboardEventsGame extends FlameGame with KeyboardEvents {
   final List<String> keysPressed = [];
 
@@ -80,6 +78,8 @@ class _GamePage extends StatelessWidget {
 }
 
 void main() async {
+  final size = Vector2(1.0, 1.0);
+
   testWidgets('Adds focus', (tester) async {
     final focusNode = FocusNode();
 

--- a/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
@@ -3,10 +3,10 @@ import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MyGame extends FlameGame {
+class _MyGame extends FlameGame {
   final List<String> events;
 
-  MyGame(this.events);
+  _MyGame(this.events);
 
   @override
   void onGameResize(Vector2 size) {
@@ -32,7 +32,7 @@ class MyGame extends FlameGame {
   }
 }
 
-class TitlePage extends StatelessWidget {
+class _TitlePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -46,10 +46,10 @@ class TitlePage extends StatelessWidget {
   }
 }
 
-class GamePage extends StatefulWidget {
-  final MyGame game;
+class _GamePage extends StatefulWidget {
+  final _MyGame game;
 
-  const GamePage(this.game);
+  const _GamePage(this.game);
 
   @override
   State<StatefulWidget> createState() {
@@ -57,8 +57,8 @@ class GamePage extends StatefulWidget {
   }
 }
 
-class _GamePageState extends State<GamePage> {
-  late MyGame _game;
+class _GamePageState extends State<_GamePage> {
+  late _MyGame _game;
 
   @override
   void initState() {
@@ -92,35 +92,35 @@ class _GamePageState extends State<GamePage> {
   }
 }
 
-class MyApp extends StatelessWidget {
+class _MyApp extends StatelessWidget {
   final List<String> events;
-  late final MyGame game;
+  late final _MyGame game;
 
-  MyApp(this.events) {
-    game = MyGame(events);
+  _MyApp(this.events) {
+    game = _MyGame(events);
   }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       routes: {
-        '/': (_) => TitlePage(),
-        '/game': (_) => GamePage(game),
+        '/': (_) => _TitlePage(),
+        '/game': (_) => _GamePage(game),
       },
     );
   }
 }
 
-class MyContainer extends StatefulWidget {
+class _MyContainer extends StatefulWidget {
   final List<String> events;
 
-  const MyContainer(this.events, {Key? key}) : super(key: key);
+  const _MyContainer(this.events, {Key? key}) : super(key: key);
 
   @override
-  State<MyContainer> createState() => MyContainerState();
+  State<_MyContainer> createState() => _MyContainerState();
 }
 
-class MyContainerState extends State<MyContainer> {
+class _MyContainerState extends State<_MyContainer> {
   double size = 300;
 
   void causeResize() {
@@ -132,7 +132,7 @@ class MyContainerState extends State<MyContainer> {
     return Container(
       width: size,
       height: size,
-      child: GameWidget(game: MyGame(widget.events)),
+      child: GameWidget(game: _MyGame(widget.events)),
     );
   }
 }
@@ -141,7 +141,7 @@ void main() {
   group('Game Widget - Lifecycle', () {
     testWidgets('attach upon navigation', (tester) async {
       final events = <String>[];
-      await tester.pumpWidget(MyApp(events));
+      await tester.pumpWidget(_MyApp(events));
 
       await tester.tap(find.text('Play'));
 
@@ -160,7 +160,7 @@ void main() {
 
     testWidgets('detach when navigating out of the page', (tester) async {
       final events = <String>[];
-      await tester.pumpWidget(MyApp(events));
+      await tester.pumpWidget(_MyApp(events));
 
       await tester.tap(find.text('Play'));
 
@@ -187,21 +187,22 @@ void main() {
 
     testWidgets('on resize, parents are kept', (tester) async {
       final events = <String>[];
-      await tester.pumpWidget(MyContainer(events));
+      await tester.pumpWidget(_MyContainer(events));
 
       events.clear();
-      final state = tester.state<MyContainerState>(find.byType(MyContainer));
+      final state = tester.state<_MyContainerState>(find.byType(_MyContainer));
       state.causeResize();
 
       await tester.pump();
       expect(events, ['onGameResize', 'onLoad', 'onMount']); // no onRemove
-      final game = tester.allWidgets.whereType<GameWidget<MyGame>>().first.game;
+      final game =
+          tester.allWidgets.whereType<GameWidget<_MyGame>>().first.game;
       expect(game.children, everyElement((Component c) => c.parent == game));
     });
 
     testWidgets('all events are executed in the correct order', (tester) async {
       final events = <String>[];
-      await tester.pumpWidget(MyApp(events));
+      await tester.pumpWidget(_MyApp(events));
 
       await tester.tap(find.text('Play'));
 

--- a/packages/flame/test/game/game_widget/game_widget_mouse_cursor_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_mouse_cursor_test.dart
@@ -2,13 +2,13 @@ import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-Finder byMouseCursor(MouseCursor cursor) {
-  return find.byWidgetPredicate(
-    (widget) => widget is MouseRegion && widget.cursor == cursor,
-  );
-}
-
 void main() {
+  Finder byMouseCursor(MouseCursor cursor) {
+    return find.byWidgetPredicate(
+      (widget) => widget is MouseRegion && widget.cursor == cursor,
+    );
+  }
+
   group('GameWidget - MouseCursor', () {
     testWidgets('renders with the initial cursor', (tester) async {
       await tester.pumpWidget(

--- a/packages/flame/test/game/game_widget/game_widget_pause_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_pause_test.dart
@@ -61,16 +61,16 @@ class MyGame extends FlameGame {
   }
 }
 
-FlameTester<MyGame> myGame({bool paused = false}) {
-  return FlameTester(
-    () => MyGame()..paused = paused,
-    pumpWidget: (gameWidget, tester) async {
-      await tester.pumpWidget(_Wrapper(child: gameWidget));
-    },
-  );
-}
-
 void main() {
+  FlameTester<MyGame> myGame({bool paused = false}) {
+    return FlameTester(
+      () => MyGame()..paused = paused,
+      pumpWidget: (gameWidget, tester) async {
+        await tester.pumpWidget(_Wrapper(child: gameWidget));
+      },
+    );
+  }
+
   myGame().widgetTest(
     'can pause the engine',
     (game, tester) async {

--- a/packages/flame/test/game/game_widget/game_widget_pause_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_pause_test.dart
@@ -50,7 +50,7 @@ class _WrapperState extends State<_Wrapper> {
   }
 }
 
-class MyGame extends FlameGame {
+class _MyGame extends FlameGame {
   int callCount = 0;
 
   @override
@@ -62,9 +62,9 @@ class MyGame extends FlameGame {
 }
 
 void main() {
-  FlameTester<MyGame> myGame({bool paused = false}) {
+  FlameTester<_MyGame> myGame({bool paused = false}) {
     return FlameTester(
-      () => MyGame()..paused = paused,
+      () => _MyGame()..paused = paused,
       pumpWidget: (gameWidget, tester) async {
         await tester.pumpWidget(_Wrapper(child: gameWidget));
       },

--- a/packages/flame/test/game/game_widget/game_widget_tap_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_tap_test.dart
@@ -4,7 +4,7 @@ import 'package:flame/input.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class TapGame extends FlameGame with TapDetector {
+class _TapGame extends FlameGame with TapDetector {
   bool tapRegistered = false;
 
   @override
@@ -13,7 +13,7 @@ class TapGame extends FlameGame with TapDetector {
   }
 }
 
-class DoubleTapGame extends FlameGame with DoubleTapDetector {
+class _DoubleTapGame extends FlameGame with DoubleTapDetector {
   bool doubleTapRegistered = false;
   Vector2? doubleTapPosition;
 
@@ -29,8 +29,8 @@ class DoubleTapGame extends FlameGame with DoubleTapDetector {
 }
 
 void main() {
-  final tapGame = FlameTester(() => TapGame());
-  final doubleTapGame = FlameTester(() => DoubleTapGame());
+  final tapGame = FlameTester(() => _TapGame());
+  final doubleTapGame = FlameTester(() => _DoubleTapGame());
 
   group('GameWidget - TapDetectors', () {
     tapGame.widgetTest(

--- a/packages/flame/test/game/game_widget/game_widget_tap_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_tap_test.dart
@@ -28,10 +28,10 @@ class DoubleTapGame extends FlameGame with DoubleTapDetector {
   }
 }
 
-final tapGame = FlameTester(() => TapGame());
-final doubleTapGame = FlameTester(() => DoubleTapGame());
-
 void main() {
+  final tapGame = FlameTester(() => TapGame());
+  final doubleTapGame = FlameTester(() => DoubleTapGame());
+
   group('GameWidget - TapDetectors', () {
     tapGame.widgetTest(
       'can receive taps',

--- a/packages/flame/test/game/game_widget/game_widget_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_test.dart
@@ -46,7 +46,7 @@ class _WrapperState extends State<_Wrapper> {
   }
 }
 
-class MyGame extends FlameGame {
+class _MyGame extends FlameGame {
   bool onAttachCalled = false;
   bool onDetachCalled = false;
 
@@ -65,9 +65,9 @@ class MyGame extends FlameGame {
   }
 }
 
-FlameTester<MyGame> myGame({required bool open}) {
+FlameTester<_MyGame> myGame({required bool open}) {
   return FlameTester(
-    () => MyGame(),
+    () => _MyGame(),
     pumpWidget: (gameWidget, tester) async {
       await tester.pumpWidget(_Wrapper(child: gameWidget, open: open));
     },

--- a/packages/flame/test/game/game_widget/game_widget_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_test.dart
@@ -48,7 +48,7 @@ class _WrapperState extends State<_Wrapper> {
 
 class MyGame extends FlameGame {
   bool onAttachCalled = false;
-  bool onDettachCalled = false;
+  bool onDetachCalled = false;
 
   @override
   void onAttach() {
@@ -61,7 +61,7 @@ class MyGame extends FlameGame {
   void onDetach() {
     super.onDetach();
 
-    onDettachCalled = true;
+    onDetachCalled = true;
   }
 }
 
@@ -87,12 +87,12 @@ void main() {
       await tester.pump();
 
       expect(game.onAttachCalled, isTrue);
-      expect(game.onDettachCalled, isFalse);
+      expect(game.onDetachCalled, isFalse);
 
       await tester.tap(find.text('Toggle'));
       await tester.pump();
 
-      expect(game.onDettachCalled, isTrue);
+      expect(game.onDetachCalled, isTrue);
     },
   );
   myGame(open: true).widgetTest(

--- a/packages/flame/test/game/mixins/keyboard_test.dart
+++ b/packages/flame/test/game/mixins/keyboard_test.dart
@@ -20,11 +20,9 @@ class MockRawKeyEventData extends Mock implements RawKeyEventData {
 void main() {
   group('Keyboard events', () {
     test(
-      'cannot mix KeyboardEvent and HasKeyboardHandlerComponents together',
+      'FlameGame with KeyboardEvents can handle key events',
       () {
         final validGame = ValidGame();
-        final invalidGame = InvalidGame();
-
         final event = RawKeyDownEvent(data: MockRawKeyEventData());
 
         // Should just work with the default implementation
@@ -32,6 +30,14 @@ void main() {
           validGame.onKeyEvent(event, {}),
           KeyEventResult.handled,
         );
+      },
+    );
+
+    test(
+      'cannot mix KeyboardEvent and HasKeyboardHandlerComponents together',
+      () {
+        final invalidGame = InvalidGame();
+        final event = RawKeyDownEvent(data: MockRawKeyEventData());
 
         // Should throw an assertion error
         expect(

--- a/packages/flame/test/game/mixins/keyboard_test.dart
+++ b/packages/flame/test/game/mixins/keyboard_test.dart
@@ -5,12 +5,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
-class ValidGame extends FlameGame with KeyboardEvents {}
+class _ValidGame extends FlameGame with KeyboardEvents {}
 
-class InvalidGame extends FlameGame
+class _InvalidGame extends FlameGame
     with HasKeyboardHandlerComponents, KeyboardEvents {}
 
-class MockRawKeyEventData extends Mock implements RawKeyEventData {
+class _MockRawKeyEventData extends Mock implements RawKeyEventData {
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.debug}) {
     return super.toString();
@@ -20,10 +20,10 @@ class MockRawKeyEventData extends Mock implements RawKeyEventData {
 void main() {
   group('Keyboard events', () {
     test(
-      'FlameGame with KeyboardEvents can handle key events',
+      'game with KeyboardEvents can handle key events',
       () {
-        final validGame = ValidGame();
-        final event = RawKeyDownEvent(data: MockRawKeyEventData());
+        final validGame = _ValidGame();
+        final event = RawKeyDownEvent(data: _MockRawKeyEventData());
 
         // Should just work with the default implementation
         expect(
@@ -36,8 +36,8 @@ void main() {
     test(
       'cannot mix KeyboardEvent and HasKeyboardHandlerComponents together',
       () {
-        final invalidGame = InvalidGame();
-        final event = RawKeyDownEvent(data: MockRawKeyEventData());
+        final invalidGame = _InvalidGame();
+        final event = RawKeyDownEvent(data: _MockRawKeyEventData());
 
         // Should throw an assertion error
         expect(

--- a/packages/flame/test/game/notifying_vector2_test.dart
+++ b/packages/flame/test/game/notifying_vector2_test.dart
@@ -2,30 +2,28 @@ import 'package:flame/src/game/notifying_vector2.dart';
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-typedef VectorOperation = void Function(Vector2);
+void main() {
+  /// This helper function creates a "normal" Vector2 copy of [v1],
+  /// then applies [operation] to both vectors, and verifies that the
+  /// end result is the same. It also checks that [v1] produces a
+  /// notification during a modifying operation.
+  void check(NotifyingVector2 v1, void Function(Vector2) operation) {
+    final v2 = v1.clone();
+    expect(v2 is Vector2, true);
+    expect(v2 is NotifyingVector2, false);
+    var notified = 0;
+    void listener() {
+      notified++;
+    }
 
-/// This helper function creates a "normal" Vector2 copy of [v1],
-/// then applies [operation] to both vectors, and verifies that the
-/// end result is the same. It also checks that [v1] produces a
-/// notification during a modifying operation.
-void check(NotifyingVector2 v1, VectorOperation operation) {
-  final v2 = v1.clone();
-  expect(v2 is Vector2, true);
-  expect(v2 is NotifyingVector2, false);
-  var notified = 0;
-  void listener() {
-    notified++;
+    v1.addListener(listener);
+    operation(v1);
+    operation(v2);
+    v1.removeListener(listener);
+    expect(notified, 1);
+    expect(v1, v2);
   }
 
-  v1.addListener(listener);
-  operation(v1);
-  operation(v2);
-  v1.removeListener(listener);
-  expect(notified, 1);
-  expect(v1, v2);
-}
-
-void main() {
   group('NotifyingVector2', () {
     test('constructors', () {
       final nv0 = NotifyingVector2.zero();
@@ -37,6 +35,7 @@ void main() {
       final nv3 = NotifyingVector2.copy(Vector2(4, 9));
       expect(nv3, Vector2(4, 9));
     });
+
     test('full setters', () {
       final nv = NotifyingVector2.zero();
       check(nv, (v) => v.setValues(3, 2));
@@ -52,6 +51,7 @@ void main() {
       check(nv, (v) => v.st = Vector2(-5, -89));
       check(nv, (v) => v.ts = Vector2(-5, -89));
     });
+
     test('individual field setters', () {
       final nv = NotifyingVector2.zero();
       check(nv, (v) => v[0] = 2.5);
@@ -63,6 +63,7 @@ void main() {
       check(nv, (v) => v.s = 103);
       check(nv, (v) => v.t = 104);
     });
+
     test('modification methods', () {
       final nv = NotifyingVector2(23, 3);
       check(nv, (v) => v.length = 15);
@@ -86,6 +87,7 @@ void main() {
       nv.multiply(Vector2(1.23, -4.791));
       check(nv, (v) => v.roundToZero());
     });
+
     test('storage is read-only', () {
       final nv = NotifyingVector2.zero();
       expect(nv, Vector2.zero());

--- a/packages/flame/test/game/projections_test.dart
+++ b/packages/flame/test/game/projections_test.dart
@@ -6,18 +6,21 @@ import 'package:test/test.dart';
 
 void main() {
   group('projections', () {
-    test('default viewport and camera should no-op projections', () {
-      final game = FlameGame(); // default viewport & camera
-      _assertIdentityOfProjector(game.projector);
+    flameGame.test(
+      'default viewport and camera should no-op projections',
+      (game) {
+        _assertIdentityOfProjector(game.projector);
 
-      expect(game.projector.projectVector(Vector2(1, 2)), Vector2(1, 2));
-      expect(game.projector.unprojectVector(Vector2(1, 2)), Vector2(1, 2));
-      expect(game.projector.scaleVector(Vector2(1, 2)), Vector2(1, 2));
-      expect(game.projector.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
-    });
-    test('viewport only with scale projection (no camera)', () {
+        expect(game.projector.projectVector(Vector2(1, 2)), Vector2(1, 2));
+        expect(game.projector.unprojectVector(Vector2(1, 2)), Vector2(1, 2));
+        expect(game.projector.scaleVector(Vector2(1, 2)), Vector2(1, 2));
+        expect(game.projector.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
+      },
+    );
+
+    flameGame.test('viewport only with scale projection (no camera)', (game) {
       final viewport = FixedResolutionViewport(Vector2.all(100));
-      final game = FlameGame()..camera.viewport = viewport; // default camera
+      game..camera.viewport = viewport; // default camera
       game.onGameResize(Vector2(200, 200));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2.zero()); // no translation
@@ -45,60 +48,68 @@ void main() {
         Vector2(1, 2),
       );
     });
-    test('viewport only with translation projection (no camera)', () {
-      final viewport = FixedResolutionViewport(Vector2.all(100));
-      final game = FlameGame()..camera.viewport = viewport; // default camera
-      game.onGameResize(Vector2(200, 100));
-      expect(viewport.scale, 1); // no scale
-      expect(viewport.resizeOffset, Vector2(50, 0)); // y is unchanged
-      _assertIdentityOfProjector(game.projector);
 
-      // click on x=0 means -50 in the game coordinates
-      expect(game.projector.unprojectVector(Vector2.zero()), Vector2(-50, 0));
-      // click on x=50 is right on the edge of the viewport
-      expect(game.projector.unprojectVector(Vector2.all(50)), Vector2(0, 50));
-      // click on x=150 is on the other edge
-      expect(
-        game.projector.unprojectVector(Vector2.all(150)),
-        Vector2(100, 150),
-      );
-      // 50 past the end
-      expect(
-        game.projector.unprojectVector(Vector2(200, 0)),
-        Vector2(150, 0),
-      );
+    flameGame.test(
+      'viewport only with translation projection (no camera)',
+      (game) {
+        final viewport = FixedResolutionViewport(Vector2.all(100));
+        game..camera.viewport = viewport; // default camera
+        game.onGameResize(Vector2(200, 100));
+        expect(viewport.scale, 1); // no scale
+        expect(viewport.resizeOffset, Vector2(50, 0)); // y is unchanged
+        _assertIdentityOfProjector(game.projector);
 
-      // translations should not affect projecting deltas
-      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector.unscaleVector(Vector2.all(50)), Vector2.all(50));
-      expect(
-        game.projector.unscaleVector(Vector2.all(150)),
-        Vector2.all(150),
-      );
-      expect(game.projector.unscaleVector(Vector2(200, 0)), Vector2(200, 0));
-    });
-    test('viewport only with both scale and translation (no camera)', () {
-      final viewport = FixedResolutionViewport(Vector2.all(100));
-      final game = FlameGame()..camera.viewport = viewport; // default camera
-      game.onGameResize(Vector2(200, 400));
-      expect(viewport.scale, 2);
-      expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
-      _assertIdentityOfProjector(game.projector);
+        // click on x=0 means -50 in the game coordinates
+        expect(game.projector.unprojectVector(Vector2.zero()), Vector2(-50, 0));
+        // click on x=50 is right on the edge of the viewport
+        expect(game.projector.unprojectVector(Vector2.all(50)), Vector2(0, 50));
+        // click on x=150 is on the other edge
+        expect(
+          game.projector.unprojectVector(Vector2.all(150)),
+          Vector2(100, 150),
+        );
+        // 50 past the end
+        expect(
+          game.projector.unprojectVector(Vector2(200, 0)),
+          Vector2(150, 0),
+        );
 
-      // click on y=0 means -100 in the game coordinates
-      expect(game.projector.unprojectVector(Vector2.zero()), Vector2(0, -50));
-      expect(game.projector.unprojectVector(Vector2(0, 100)), Vector2.zero());
-      expect(
-        game.projector.unprojectVector(Vector2(0, 300)),
-        Vector2(0, 100),
-      );
-      expect(
-        game.projector.unprojectVector(Vector2(0, 400)),
-        Vector2(0, 150),
-      );
-    });
-    test('camera only with zoom (default viewport)', () {
-      final game = FlameGame(); // default viewport
+        // translations should not affect projecting deltas
+        expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+        expect(game.projector.unscaleVector(Vector2.all(50)), Vector2.all(50));
+        expect(
+          game.projector.unscaleVector(Vector2.all(150)),
+          Vector2.all(150),
+        );
+        expect(game.projector.unscaleVector(Vector2(200, 0)), Vector2(200, 0));
+      },
+    );
+
+    flameGame.test(
+      'viewport only with both scale and translation (no camera)',
+      (game) {
+        final viewport = FixedResolutionViewport(Vector2.all(100));
+        game..camera.viewport = viewport; // default camera
+        game.onGameResize(Vector2(200, 400));
+        expect(viewport.scale, 2);
+        expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
+        _assertIdentityOfProjector(game.projector);
+
+        // click on y=0 means -100 in the game coordinates
+        expect(game.projector.unprojectVector(Vector2.zero()), Vector2(0, -50));
+        expect(game.projector.unprojectVector(Vector2(0, 100)), Vector2.zero());
+        expect(
+          game.projector.unprojectVector(Vector2(0, 300)),
+          Vector2(0, 100),
+        );
+        expect(
+          game.projector.unprojectVector(Vector2(0, 400)),
+          Vector2(0, 150),
+        );
+      },
+    );
+
+    flameGame.test('camera only with zoom (default viewport)', (game) {
       game.onGameResize(Vector2.all(1));
 
       game.camera.zoom = 3; // 3x zoom
@@ -120,8 +131,8 @@ void main() {
       expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
       expect(game.projector.unscaleVector(Vector2(3, 6)), Vector2(1, 2));
     });
-    test('camera only with translation (default viewport)', () {
-      final game = FlameGame(); // default viewport
+
+    flameGame.test('camera only with translation (default viewport)', (game) {
       game.onGameResize(Vector2.all(1));
 
       // top left corner of the screen is (50, 100)
@@ -141,8 +152,10 @@ void main() {
       expect(game.projector.scaleVector(Vector2.zero()), Vector2.zero());
       expect(game.projector.scaleVector(Vector2(-50, 50)), Vector2(-50, 50));
     });
-    test('camera only with both zoom and translation (default viewport)', () {
-      final game = FlameGame(); // default viewport
+
+    flameGame
+        .test('camera only with both zoom and translation (default viewport)',
+            (game) {
       game.onGameResize(Vector2.all(10));
 
       // no-op because the default is already top left
@@ -194,9 +207,10 @@ void main() {
       expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
       expect(game.projector.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
-    test('camera & viewport - two translations', () {
+
+    flameGame.test('camera & viewport - two translations', (game) {
       final viewport = FixedResolutionViewport(Vector2.all(100));
-      final game = FlameGame()..camera.viewport = viewport; // default camera
+      game..camera.viewport = viewport; // default camera
       game.onGameResize(Vector2(200, 100));
       game.camera.snapTo(Vector2(10, 100));
       expect(viewport.scale, 1); // no scale
@@ -228,9 +242,10 @@ void main() {
       expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
       expect(game.projector.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
     });
-    test('camera zoom & viewport translation', () {
+
+    flameGame.test('camera zoom & viewport translation', (game) {
       final viewport = FixedResolutionViewport(Vector2.all(100));
-      final game = FlameGame()..camera.viewport = viewport;
+      game..camera.viewport = viewport;
       game.onGameResize(Vector2(200, 100));
       game.camera.zoom = 2;
       game.camera.snap();
@@ -259,9 +274,10 @@ void main() {
       expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
       expect(game.projector.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
-    test('camera translation & viewport scale+translation', () {
+
+    flameGame.test('camera translation & viewport scale+translation', (game) {
       final viewport = FixedResolutionViewport(Vector2.all(100));
-      final game = FlameGame()..camera.viewport = viewport;
+      game..camera.viewport = viewport;
       game.onGameResize(Vector2(200, 400));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
@@ -289,57 +305,62 @@ void main() {
       expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
       expect(game.projector.unscaleVector(Vector2(2, 4)), Vector2(1, 2));
     });
-    test('camera & viewport scale/zoom + translation (cancel out scaling)', () {
+
+    flameGame.test(
+      'camera & viewport scale/zoom + translation (cancel out scaling)',
+      (game) {
+        final viewport = FixedResolutionViewport(Vector2.all(100));
+        game..camera.viewport = viewport;
+        game.onGameResize(Vector2(200, 400));
+        expect(viewport.scale, 2);
+        expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
+
+        // the camera should apply a (10, 10) translation + a 0.5x zoom on top of
+        // the viewport coordinate system
+        game.camera.zoom = 0.5;
+        game.camera.snapTo(Vector2.all(10));
+
+        _assertIdentityOfProjector(game.projector);
+
+        // in the viewport space the top left of the screen would be (0, -100)
+        // that means 100 screen units above the top left of the camera (10, 10)
+        // each viewport unit is exactly one camera unit, because the zoom
+        // cancels out the scale
+        expect(
+          game.projector.unprojectVector(Vector2.zero()),
+          Vector2(10, -90),
+        );
+        // the top-left most visible pixel on the viewport would be at (0, 100)
+        // in screen coordinates. That should be the top left of the camera that
+        // is snapped to 10,10 by definition.
+        expect(
+          game.projector.unprojectVector(Vector2(0, 100)),
+          Vector2(10, 10),
+        );
+        // now each unit we walk in screen space means only 2 units on the
+        // viewport space because of the scale. however, since the camera applies
+        // a 1/2x zoom, each unit step equals to 1 unit on the game space
+        expect(
+          game.projector.unprojectVector(Vector2(1, 100)),
+          Vector2(11, 10),
+        );
+        // the last pixel of the viewport is on screen coordinates of (200, 300)
+        // for the camera, that should be: top left (10,10) + effective size
+        // (100, 100) * zoom (1/2)
+        expect(
+          game.projector.unprojectVector(Vector2(200, 300)),
+          Vector2.all(210),
+        );
+
+        // for deltas, since the scale and the zoom cancel out, this should no-op
+        expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
+        expect(game.projector.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
+      },
+    );
+
+    flameGame.test('camera & viewport scale/zoom + translation', (game) {
       final viewport = FixedResolutionViewport(Vector2.all(100));
-      final game = FlameGame()..camera.viewport = viewport;
-      game.onGameResize(Vector2(200, 400));
-      expect(viewport.scale, 2);
-      expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
-
-      // the camera should apply a (10, 10) translation + a 0.5x zoom on top of
-      // the viewport coordinate system
-      game.camera.zoom = 0.5;
-      game.camera.snapTo(Vector2.all(10));
-
-      _assertIdentityOfProjector(game.projector);
-
-      // in the viewport space the top left of the screen would be (0, -100)
-      // that means 100 screen units above the top left of the camera (10, 10)
-      // each viewport unit is exactly one camera unit, because the zoom
-      // cancels out the scale
-      expect(
-        game.projector.unprojectVector(Vector2.zero()),
-        Vector2(10, -90),
-      );
-      // the top-left most visible pixel on the viewport would be at (0, 100)
-      // in screen coordinates. That should be the top left of the camera that
-      // is snapped to 10,10 by definition.
-      expect(
-        game.projector.unprojectVector(Vector2(0, 100)),
-        Vector2(10, 10),
-      );
-      // now each unit we walk in screen space means only 2 units on the
-      // viewport space because of the scale. however, since the camera applies
-      // a 1/2x zoom, each unit step equals to 1 unit on the game space
-      expect(
-        game.projector.unprojectVector(Vector2(1, 100)),
-        Vector2(11, 10),
-      );
-      // the last pixel of the viewport is on screen coordinates of (200, 300)
-      // for the camera, that should be: top left (10,10) + effective size
-      // (100, 100) * zoom (1/2)
-      expect(
-        game.projector.unprojectVector(Vector2(200, 300)),
-        Vector2.all(210),
-      );
-
-      // for deltas, since the scale and the zoom cancel out, this should no-op
-      expect(game.projector.unscaleVector(Vector2.zero()), Vector2.zero());
-      expect(game.projector.unscaleVector(Vector2(1, 2)), Vector2(1, 2));
-    });
-    test('camera & viewport scale/zoom + translation', () {
-      final viewport = FixedResolutionViewport(Vector2.all(100));
-      final game = FlameGame()..camera.viewport = viewport;
+      game..camera.viewport = viewport;
       game.onGameResize(Vector2(200, 400));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged

--- a/packages/flame/test/game/projections_test.dart
+++ b/packages/flame/test/game/projections_test.dart
@@ -5,6 +5,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final viewport = FixedResolutionViewport(Vector2.all(100));
   group('projections', () {
     flameGame.test(
       'default viewport and camera should no-op projections',
@@ -19,8 +20,7 @@ void main() {
     );
 
     flameGame.test('viewport only with scale projection (no camera)', (game) {
-      final viewport = FixedResolutionViewport(Vector2.all(100));
-      game..camera.viewport = viewport; // default camera
+      game.camera.viewport = viewport;
       game.onGameResize(Vector2(200, 200));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2.zero()); // no translation
@@ -52,8 +52,7 @@ void main() {
     flameGame.test(
       'viewport only with translation projection (no camera)',
       (game) {
-        final viewport = FixedResolutionViewport(Vector2.all(100));
-        game..camera.viewport = viewport; // default camera
+        game.camera.viewport = viewport;
         game.onGameResize(Vector2(200, 100));
         expect(viewport.scale, 1); // no scale
         expect(viewport.resizeOffset, Vector2(50, 0)); // y is unchanged
@@ -88,8 +87,7 @@ void main() {
     flameGame.test(
       'viewport only with both scale and translation (no camera)',
       (game) {
-        final viewport = FixedResolutionViewport(Vector2.all(100));
-        game..camera.viewport = viewport; // default camera
+        game.camera.viewport = viewport;
         game.onGameResize(Vector2(200, 400));
         expect(viewport.scale, 2);
         expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
@@ -209,8 +207,7 @@ void main() {
     });
 
     flameGame.test('camera & viewport - two translations', (game) {
-      final viewport = FixedResolutionViewport(Vector2.all(100));
-      game..camera.viewport = viewport; // default camera
+      game.camera.viewport = viewport; // default camera
       game.onGameResize(Vector2(200, 100));
       game.camera.snapTo(Vector2(10, 100));
       expect(viewport.scale, 1); // no scale
@@ -244,8 +241,7 @@ void main() {
     });
 
     flameGame.test('camera zoom & viewport translation', (game) {
-      final viewport = FixedResolutionViewport(Vector2.all(100));
-      game..camera.viewport = viewport;
+      game.camera.viewport = viewport;
       game.onGameResize(Vector2(200, 100));
       game.camera.zoom = 2;
       game.camera.snap();
@@ -276,8 +272,7 @@ void main() {
     });
 
     flameGame.test('camera translation & viewport scale+translation', (game) {
-      final viewport = FixedResolutionViewport(Vector2.all(100));
-      game..camera.viewport = viewport;
+      game.camera.viewport = viewport;
       game.onGameResize(Vector2(200, 400));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
@@ -309,8 +304,7 @@ void main() {
     flameGame.test(
       'camera & viewport scale/zoom + translation (cancel out scaling)',
       (game) {
-        final viewport = FixedResolutionViewport(Vector2.all(100));
-        game..camera.viewport = viewport;
+        game.camera.viewport = viewport;
         game.onGameResize(Vector2(200, 400));
         expect(viewport.scale, 2);
         expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged
@@ -359,8 +353,7 @@ void main() {
     );
 
     flameGame.test('camera & viewport scale/zoom + translation', (game) {
-      final viewport = FixedResolutionViewport(Vector2.all(100));
-      game..camera.viewport = viewport;
+      game.camera.viewport = viewport;
       game.onGameResize(Vector2(200, 400));
       expect(viewport.scale, 2);
       expect(viewport.resizeOffset, Vector2(0, 100)); // x is unchanged

--- a/packages/flame/test/spritesheet_test.dart
+++ b/packages/flame/test/spritesheet_test.dart
@@ -42,20 +42,21 @@ void main() {
     });
 
     test(
-        'throws assertion error when the length of stepTime is different from sprite',
-        () {
-      final sprite = SpriteSheet(
-        image: image,
-        srcSize: Vector2(50, 50),
-      );
+      'throws assertion error when the length of stepTime is different from sprite',
+      () {
+        final sprite = SpriteSheet(
+          image: image,
+          srcSize: Vector2(50, 50),
+        );
 
-      expect(
-        () => sprite.createAnimationWithVariableStepTimes(
-          row: 1,
-          stepTimes: [2.0],
-        ),
-        throwsException,
-      );
-    });
+        expect(
+          () => sprite.createAnimationWithVariableStepTimes(
+            row: 1,
+            stepTimes: [2.0],
+          ),
+          throwsException,
+        );
+      },
+    );
   });
 }

--- a/packages/flame/test/text_test.dart
+++ b/packages/flame/test/text_test.dart
@@ -33,6 +33,7 @@ void main() {
       expect(tp.style.fontSize, 12);
       expect(tp.style.fontFamily, 'Helvetica');
     });
+
     test('createDefault', () {
       final tp = TextRenderer.createDefault<TextPaint>();
       expect(tp, isNotNull);
@@ -42,6 +43,7 @@ void main() {
       expect(tr, isNotNull);
       expect(tr, isA<TextRenderer>());
     });
+
     test('change parameters of text component', () {
       final tc = TextComponent<TextPaint>('foo');
       tc.textRenderer = tc.textRenderer.copyWith(
@@ -49,12 +51,14 @@ void main() {
       );
       expect(tc.textRenderer.style.fontSize, 200);
     });
+
     test('custom renderer', () {
       TextRenderer.defaultRenderersRegistry[_CustomTextRenderer] =
           () => _CustomTextRenderer();
       final tc = TextComponent<_CustomTextRenderer>('foo');
       expect(tc.textRenderer, isA<_CustomTextRenderer>());
     });
+
     test('text component size is set', () {
       final t = TextComponent('foobar');
       expect(t.size, isNot(equals(Vector2.zero())));

--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -12,6 +12,7 @@ extension FlameFinds on CommonFinders {
   }
 }
 
+@visibleForTesting
 extension FlameGameExtension on Component {
   /// Makes sure that the [component] is added to the tree if you wait for the
   /// returned future to resolve.

--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -12,7 +12,7 @@ extension FlameFinds on CommonFinders {
   }
 }
 
-extension FlameGameExtension on FlameGame {
+extension FlameGameExtension on Component {
   /// Makes sure that the [component] is added to the tree if you wait for the
   /// returned future to resolve.
   Future<void> ensureAdd(Component component) async {


### PR DESCRIPTION
# Description
Uses the `FlameTester` everywhere where it makes sense and unifies the style a little bit on the tests (there is still a lot to do and we need to set up some standards).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

Closes #946 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
