### PR TITLE
Deprecate preRender/postRender

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -28,7 +28,7 @@
  - Renamed `FlameTester` to `GameTester`
  - Modified `FlameTester` to be specific for `T extends FlameGame`
  - Improved `TimerComponent`
- - Method `preRender()` and `postRender()` are now deprecated
+ - Removed methods `preRender()` and `postRender()` in `Component`
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -28,6 +28,7 @@
  - Renamed `FlameTester` to `GameTester`
  - Modified `FlameTester` to be specific for `T extends FlameGame`
  - Improved `TimerComponent`
+ - Method `preRender()` and `postRender()` are now deprecated
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -131,7 +131,6 @@ class Component with Loadable {
   void render(Canvas canvas) {}
 
   void renderTree(Canvas canvas) {
-    preRender(canvas); // ignore: deprecated_member_use_from_same_package
     render(canvas);
     children.forEach((c) => c.renderTree(canvas));
 
@@ -139,24 +138,7 @@ class Component with Loadable {
     if (debugMode) {
       renderDebugMode(canvas);
     }
-    postRender(canvas); // ignore: deprecated_member_use_from_same_package
   }
-
-  /// A render cycle callback that runs before the component and its children
-  /// has been rendered.
-  ///
-  /// A possible use-case for this function is to transform the canvas, in which
-  /// case you would also override `postRender()` in order to restore the state
-  /// of the canvas as it was originally.
-  @nonVirtual
-  @Deprecated('Override renderTree() instead')
-  void preRender(Canvas canvas) {}
-
-  /// A render cycle callback that runs after the component and its children
-  /// has been rendered.
-  @nonVirtual
-  @Deprecated('Override renderTree() instead')
-  void postRender(Canvas canvas) {}
 
   void renderDebugMode(Canvas canvas) {}
 

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -131,7 +131,7 @@ class Component with Loadable {
   void render(Canvas canvas) {}
 
   void renderTree(Canvas canvas) {
-    preRender(canvas);
+    preRender(canvas); // ignore: deprecated_member_use_from_same_package
     render(canvas);
     children.forEach((c) => c.renderTree(canvas));
 
@@ -139,7 +139,7 @@ class Component with Loadable {
     if (debugMode) {
       renderDebugMode(canvas);
     }
-    postRender(canvas);
+    postRender(canvas); // ignore: deprecated_member_use_from_same_package
   }
 
   /// A render cycle callback that runs before the component and its children
@@ -148,12 +148,14 @@ class Component with Loadable {
   /// A possible use-case for this function is to transform the canvas, in which
   /// case you would also override `postRender()` in order to restore the state
   /// of the canvas as it was originally.
-  @protected
+  @nonVirtual
+  @Deprecated('Override renderTree() instead')
   void preRender(Canvas canvas) {}
 
   /// A render cycle callback that runs after the component and its children
   /// has been rendered.
-  @protected
+  @nonVirtual
+  @Deprecated('Override renderTree() instead')
   void postRender(Canvas canvas) {}
 
   void renderDebugMode(Canvas canvas) {}

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -1,8 +1,6 @@
 import 'dart:math' as math;
 import 'dart:ui' hide Offset;
 
-import 'package:meta/meta.dart';
-
 import '../anchor.dart';
 import '../extensions/offset.dart';
 import '../extensions/rect.dart';
@@ -342,16 +340,11 @@ class PositionComponent extends Component {
     }
   }
 
-  @mustCallSuper
   @override
-  void preRender(Canvas canvas) {
+  void renderTree(Canvas canvas) {
     canvas.save();
     canvas.transform(transformMatrix.storage);
-  }
-
-  @mustCallSuper
-  @override
-  void postRender(Canvas canvas) {
+    super.renderTree(canvas);
     canvas.restore();
   }
 

--- a/packages/flame_forge2d/lib/body_component.dart
+++ b/packages/flame_forge2d/lib/body_component.dart
@@ -55,7 +55,7 @@ abstract class BodyComponent<T extends Forge2DGame> extends Component
 
   @mustCallSuper
   @override
-  void preRender(Canvas canvas) {
+  void renderTree(Canvas canvas) {
     if (_transform.m14 != body.position.x ||
         _transform.m24 != body.position.y ||
         _lastAngle != angle) {
@@ -66,11 +66,7 @@ abstract class BodyComponent<T extends Forge2DGame> extends Component
     }
     canvas.save();
     canvas.transform(_transform.storage);
-  }
-
-  @mustCallSuper
-  @override
-  void postRender(Canvas canvas) {
+    super.renderTree(canvas);
     canvas.restore();
   }
 


### PR DESCRIPTION
# Description

Methods `preRender()` and `postRender()` needlessly complicate Flame's pipeline, and can actually be removed without loss of functionality and with a gain to simplicity. Specifically, if a class currently overrides `preRender/postRender`, that class can replace both methods with
```dart
@override
void renderTree(Canvas canvas) {
  ... preRender code
  super.renderTree(canvas);
  ... postRender code
}
``` 

I have currently marked the two methods as deprecated, however if any project is currently uses them, they will not lose any functionality, and will only see a warning. It is up to the team whether we want to:
  - keep them deprecated until the version 1.0; or
  - remove the deprecated status, allowing external users to keep using them without any warnings; or
  - [x] remove both methods immediately (which will now become a breaking change).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] YES, this is a breaking change.
