### PR TITLE
Fix documentation warnings

### DIFF
--- a/doc/_sphinx/conf.py
+++ b/doc/_sphinx/conf.py
@@ -35,7 +35,7 @@ myst_enable_extensions = [
 ]
 
 # Auto-generate link anchors for headers at levels H1 and H2
-myst_heading_anchors = 2
+myst_heading_anchors = 4
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/collision_detection.md
+++ b/doc/collision_detection.md
@@ -1,5 +1,5 @@
 # Collision detection
-If you want to have a full blown physics engine in your game we recommend that you use
+If you want to have a full-blown physics engine in your game we recommend that you use
 Forge2D by adding [flame_forge2d](https://github.com/flame-engine/flame_forge2d) as a dependency.
 But if you have a simpler use-case and just want to check for collisions of components and improve
 the accuracy of gestures, Flame's built-in collision detection will serve you very well.
@@ -70,7 +70,7 @@ class MyCollidable extends PositionComponent with HasHitboxes, Collidable {
 ```
 
 The `HitboxPolygon` added to the `Collidable` here is a diamond shape(◇).
-More about how the different shapes are defined in the [Shapes](#Shapes) section.
+More about how the different shapes are defined in the [Shapes](#shapes) section.
 
 Remember that you can add as many `HitboxShape`s as you want to your `Collidable` to make up more
 complex hitboxes. For example a snowman with a hat could be represented by three `HitboxCircle`s and
@@ -111,7 +111,7 @@ implemented. The same goes for the `onCollisionEnd` method, which is called when
 shapes that were previously colliding no longer colliding with each other.
 
 If you want to check collisions with the screen edges, as we do in the example above, you can use
-the predefined [ScreenCollidable](#ScreenCollidable) class and since that one also is a `Collidable`
+the predefined [ScreenCollidable](#screencollidable) class and since that one also is a `Collidable`
 you can implement your own `onCollision` method for that class if needed.
 
 #### CollidableType
@@ -166,8 +166,7 @@ A Shape is the base class for representing a scalable geometrical shape. The sha
 ways of defining how they look, but they all have a size and angle that can be modified and the
 shape definition will scale or rotate the shape accordingly.
 
-There are currently three shapes: [Polygon](#Polygon), [Rectangle](#Rectangle) and
-[Cirlce](#Circle).
+There are currently three shapes: [](#polygon), [](#rectangle) and [](#circle).
 
 ### HitboxShape
 A `HitboxShape` is a `Shape` defined from the center position of the component that it is attached
@@ -182,10 +181,10 @@ the polygon needs to be convex. So always use convex polygons or you will most l
 problems if you don't really know what you are doing. It should also be noted that you should always
 define the vertices in your polygon in a clockwise order.
 
-In comparision to the normal `Polygon`, there is only one way to create a `HitboxPolygon`, the only
+In comparison to the normal `Polygon`, there is only one way to create a `HitboxPolygon`, the only
 mandatory argument is a list of `Vector2` which defines how your polygon should look, but not the
 size or position for it (since that sill be defined by the component that you attach it to).
-For example you could create a diamond like in the [Collidable](#Collidable) example like this:
+For example you could create a diamond like in the [](#collidable) example like this:
 
 ```dart
 HitboxPolygon([
@@ -203,7 +202,7 @@ definition in the constructor for this shape.
 
 The vectors in the example defines percentages of the length from the center to the edge of the
 screen in both x and y axis, so for our first item in our list (`Vector2(0, 1)`) we are pointing on
-on the middle of the top wall of the bounding box, since the cordinate system here is defined from
+on the middle of the top wall of the bounding box, since the coordinate system here is defined from
 the center of the polygon.
 
 ![An example of how to define a polygon shape](images/polygon_shape.png)
@@ -256,7 +255,7 @@ you can use the optional arguments `radius` and `position` to set those, if the 
 `size` of the `Circle` will be automatically set too.
 
 ## Examples
-https://examples.flame-engine.org/#/Collision%20Detection_Circles
-https://examples.flame-engine.org/#/Collision%20Detection_Multiple%20shapes
-https://examples.flame-engine.org/#/Collision%20Detection_Shapes%20without%20components
-https://github.com/flame-engine/flame/tree/main/examples/lib/stories/collision_detection
+- https://examples.flame-engine.org/#/Collision%20Detection_Circles
+- https://examples.flame-engine.org/#/Collision%20Detection_Multiple%20shapes
+- https://examples.flame-engine.org/#/Collision%20Detection_Shapes%20without%20components
+- https://github.com/flame-engine/flame/tree/main/examples/lib/stories/collision_detection

--- a/doc/components.md
+++ b/doc/components.md
@@ -8,7 +8,7 @@ This diagram might look intimidating, but don't worry, it is not as complex as i
 All components inherit from the abstract class `Component`.
 
 If you want to skip reading about abstract classes you can jump directly to
-[PositionComponent](./components.md#PositionComponent).
+[PositionComponent](#positioncomponent).
 
 Every `Component` has a few methods that you can optionally implement, which are used by the
 `FlameGame` class. If you are not using `FlameGame`, you can use these methods on your own game loop
@@ -188,8 +188,8 @@ enum RobotState {
   running,
 }
 
-final running = await loadSpriteAnimation(/* omited */);
-final idle = await loadSpriteAnimation(/* omited */);
+final running = await loadSpriteAnimation(/* omitted */);
+final idle = await loadSpriteAnimation(/* omitted */);
 
 final robot = SpriteAnimationGroupComponent<RobotState>(
   animations: {
@@ -214,8 +214,8 @@ class ButtonComponent extends SpriteGroupComponent<ButtonState>
     with HasGameRef<SpriteGroupExample>, Tappable {
   @override
   Future<void>? onLoad() async {
-    final pressedSprite = await gameRef.loadSprite(/* omited */);
-    final unpressedSprite = await gameRef.loadSprite(/* omited /*);
+    final pressedSprite = await gameRef.loadSprite(/* omitted */);
+    final unpressedSprite = await gameRef.loadSprite(/* omitted /*);
 
     sprites = {
       ButtonState.pressed: pressedSprite,
@@ -225,7 +225,7 @@ class ButtonComponent extends SpriteGroupComponent<ButtonState>
     current = ButtonState.unpressed;
   }
 
-  // tap methods handler omited...
+  // tap methods handler omitted...
 }
 
 ```
@@ -350,14 +350,13 @@ class MyGame extends FlameGame {
 }
 ```
 
-This creates a static background, if you want a moving parallax (which is the whole point of a
-parallax), you can do it in a few different ways depending on how fine grained you want to set the
+This creates a static background. If you want a moving parallax (which is the whole point of a
+parallax), you can do it in a few different ways depending on how fine-grained you want to set the
 settings for each layer.
-They simplest way is to set the named optional parameters `baseVelocity` and
-`velocityMultiplierDelta` in the `load` helper function.
 
-For example if you want to move your background images along the X-axis with a faster speed the
-"closer" the image is:
+They simplest way is to set the named optional parameters `baseVelocity` and
+`velocityMultiplierDelta` in the `load` helper function. For example if you want to move your 
+background images along the X-axis with a faster speed the "closer" the image is:
 
 ```dart
 final parallaxComponent = await loadParallaxComponent(
@@ -376,9 +375,9 @@ parallax.baseSpeed = Vector2(100, 0);
 parallax.velocityMultiplierDelta = Vector2(2.0, 1.0);
 ```
 
-By default the images are aligned to the bottom left, repeated along the X-axis and scaled
+By default, the images are aligned to the bottom left, repeated along the X-axis and scaled
 proportionally so that the image covers the height of the screen. If you want to change this
-behavior, for example if you are not making a side scrolling game, you can set the `repeat`,
+behavior, for example if you are not making a side-scrolling game, you can set the `repeat`,
 `alignment` and `fill` parameters for each `ParallaxRenderer` and add them to `ParallaxLayer`s that you
 then pass in to the `ParallaxComponent`'s constructor.
 
@@ -564,6 +563,7 @@ Flame's Example app contains a more in-depth example, featuring how to parse coo
 selector. The code can be found
 [here](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/tile_maps/isometric_tile_map.dart),
 and a live version can be seen [here](https://examples.flame-engine.org/#/Tile%20Maps_Isometric%20Tile%20Map).
+
 ## NineTileBoxComponent
 
 A Nine Tile Box is a rectangle drawn using a grid sprite.

--- a/doc/other-inputs.md
+++ b/doc/other-inputs.md
@@ -95,7 +95,7 @@ These are the fields that should be used to know the state of the joystick:
   pulled from its base position to a edge of the joystick.
 
 If you want to create buttons to go with your joystick, check out
-[`MarginButtonComponent`](#HudButtonComponent).
+[`HudButtonComponent`](#hudbuttoncomponent).
 
 A full examples of how to use it can be found
 [here](https://github.com/flame-engine/flame/tree/main/examples/lib/stories/input/joystick.dart).
@@ -115,9 +115,9 @@ setting `hudButtonComponent.isHud = false;`.
 
 If you want to act upon the button being pressed (which would be the common thing to do) you can either pass in
 a callback function as the `onPressed` argument, or you extend the component and override
-`onTapDown`, `onTapUp` and/or `onTapCancel` and implement your logic in there.
+`onTapDown`, `onTapUp` and/or `onTapCancel` and implement your logic there.
 
 ## Gamepad
 
-Flame has a separate plugin to support external game controllers (gamepads), checkout
+Flame has a separate plugin to support external game controllers (gamepads), check
 [here](https://github.com/flame-engine/flame_gamepad) for more information.

--- a/doc/oxygen.md
+++ b/doc/oxygen.md
@@ -1,6 +1,6 @@
 # Oxygen
 
-We (the Flame organization) built an ECS(Entity Component System) named Oxygen.
+We (the Flame organization) built an ECS (Entity Component System) named Oxygen.
 
 If you want to use Oxygen specifically for Flame as a replacement for the 
 FCS(Flame Component System) you should use our bridge library
@@ -11,10 +11,10 @@ just want to use it in a Dart project you can use the
 If you are not familiar with Oxygen yet we recommend you read up on its 
 [documentation](https://github.com/flame-engine/oxygen/tree/main/doc).
 
-To use it in your game you just need to add `flame_oxygen` to your pubspec.yaml, as can be seen
+To use it in your game you just need to add `flame_oxygen` to your `pubspec.yaml`, as can be seen
 in the
 [Oxygen example](https://github.com/flame-engine/flame/tree/main/packages/flame_oxygen/example)
-and in the pub.dev [installation instructions](https://pub.dev/packages/flame_oxygen).
+and in the `pub.dev` [installation instructions](https://pub.dev/packages/flame_oxygen).
 
 ## OxygenGame (Game extension)
 
@@ -31,31 +31,31 @@ to register components and systems and do anything else that you normally would 
 A simple `OxygenGame` implementation example can be seen in the
 [example folder](https://github.com/flame-engine/flame/tree/main/packages/flame_oxygen/example).
 
-The `OxygenGame` also comes with it's own `createEntity` method that automically adds certain
-default components on the entity. This is especially helpfull when you are using the 
-[BaseSystem](#BaseSystem) as your base.
+The `OxygenGame` also comes with it's own `createEntity` method that automatically adds certain
+default components on the entity. This is especially helpful when you are using the 
+[BaseSystem](#basesystem) as your base.
 
 ## Systems
 
 Systems define the logic of your game. In FCS you normally would add your logic inside a component 
-with Oxygen we use systems for that. Oxygen itself is completly platform agnostic, meaning it has
+with Oxygen we use systems for that. Oxygen itself is completely platform agnostic, meaning it has
 no render loop. It only knows `execute`, which is a method equal to the `update` method in Flame.
 
 On each `execute` Oxygen automatically calls all the systems that were registered in order. But in
 Flame we can have different logic for different loops (render/update). So in `flame_oxygen` we 
 introduced the `RenderSystem` and `UpdateSystem` mixin. These mixins allow you to add the `render`
-method and the `update` method respectivally to your custom system. For more information see the 
-[RenderSystem](#RenderSystem) and [UpdateSystem](#UpdateSystem) section.
+method and the `update` method respectively to your custom system. For more information see the 
+[RenderSystem](#mixin-rendersystem) and [UpdateSystem](#mixin-updatesystem) section.
 
 If you are coming from FCS you might expect certain default functionality that you normally got 
 from the `PositionComponent`. As mentioned before components do not contain any kind of logic, but
 to give you the same default functionality we also created a class called `BaseSystem`. This system 
 acts almost identical to the prerender logic from the `PositionComponent` in FCS. You only have 
 to subclass it to your own system. For more information see the 
-[BaseSystem](#BaseSystem) section.
+[BaseSystem](#basesystem) section.
 
 Systems can be registered to the world using the `world.registerSystem` method on 
-[OxygenGame](#OxygenGame).
+[OxygenGame](#oxygengame-game-extension).
 
 ### mixin GameRef
 
@@ -156,7 +156,7 @@ class SimpleBaseSystem extends BaseSystem {
 ### ParticleSystem
 
 The `ParticleSystem` is a simple system that brings the Particle API from Flame to Oxygen. This
-allows you to use the [ParticleComponent](#ParticleComponent) without having to worry about how
+allows you to use the [ParticleComponent](#particlecomponent) without having to worry about how
 it will render or when to update it. As most of that logic is already contained in the Particle 
 itself.
 
@@ -169,7 +169,7 @@ world.registerComponent<ParticleComponent, Particle>(() => ParticleComponent);
 ```
 
 You can now create a new entity with a `ParticleComponent`. For more info about that see the 
-[ParticleComponent](#ParticleComponent) section.
+[ParticleComponent](#particlecomponent) section.
 
 ## Components
 
@@ -182,7 +182,7 @@ you get started. Some of these components are based on the multiple functionalit
 functionality, they are often accompanied by predefined systems that you can use.
 
 Components can be registered to the world using the `world.registerComponent` method on 
-[OxygenGame](#OxygenGame).
+[OxygenGame](#oxygengame-game-extension).
 
 ### PositionComponent
 
@@ -231,7 +231,7 @@ world.createEntity()
 The `AnchorComponent` is as its name implies is a component that describe the anchor position of an 
 entity. And it is registered to the world by default.
 
-This component is especially useful when you are using the [BaseSystem](#BaseSystem). But can also 
+This component is especially useful when you are using the [BaseSystem](#basesystem). But can also 
 be used for your own anchoring logic.
 
 Creating an anchored entity using OxygenGame:
@@ -256,7 +256,7 @@ world.createEntity()
 The `AngleComponent` is as its name implies is a component that describe the angle of an entity. 
 And it is registered to the world by default. The angle is in radians.
 
-This component is especially useful when you are using the [BaseSystem](#BaseSystem). But can also 
+This component is especially useful when you are using the [BaseSystem](#basesystem). But can also 
 be used for your own angle logic.
 
 Creating an angled entity using OxygenGame:
@@ -281,7 +281,7 @@ world.createEntity()
 The `FlipComponent` can be used to flip your rendering on either the X or Y axis. It is registered 
 to the world by default.
 
-This component is especially useful when you are using the [BaseSystem](#BaseSystem). But can also 
+This component is especially useful when you are using the [BaseSystem](#basesystem). But can also 
 be used for your own flipping logic.
 
 Creating an entity that is flipped on it's X axis using OxygenGame:
@@ -365,7 +365,7 @@ world.createEntity()
 ### ParticleComponent
 
 The `ParticleComponent` wraps a `Particle` from Flame. Combined with the 
-[ParticleSystem](#ParticleSystem) you can easily add particles to your game without having to 
+[ParticleSystem](#particlesystem) you can easily add particles to your game without having to 
 worry about how to render a particle or when/how to update one.
 
 Creating an entity with a particle using OxygenGame:

--- a/doc/widgets.md
+++ b/doc/widgets.md
@@ -23,7 +23,7 @@ is expanded both ways.
 The `NineTileBox` widget implements a `Container` using that standard. This pattern is also
 implemented as a component in the `NineTileBoxComponent` so that you can add this feature directly
 to your `FlameGame`. To get to know more about this, check the component docs
-[here](components.md#nine-tile-box-component).
+[here](components.md#ninetileboxcomponent).
 
 Here you can find an example of how to use it (without using the `NineTileBoxComponent`):
 


### PR DESCRIPTION
# Description

This fixes all the warnings that were produced when generating the documentation:
```
/Users/stpasha/github/st-pasha/flame/doc/collision_detection.md:72: WARNING: 'myst' reference target not found: #Shapes
/Users/stpasha/github/st-pasha/flame/doc/collision_detection.md:113: WARNING: 'myst' reference target not found: #ScreenCollidable
/Users/stpasha/github/st-pasha/flame/doc/collision_detection.md:169: WARNING: 'myst' reference target not found: #Polygon
/Users/stpasha/github/st-pasha/flame/doc/collision_detection.md:169: WARNING: 'myst' reference target not found: #Rectangle
/Users/stpasha/github/st-pasha/flame/doc/collision_detection.md:169: WARNING: 'myst' reference target not found: #Circle
/Users/stpasha/github/st-pasha/flame/doc/collision_detection.md:185: WARNING: 'myst' reference target not found: #Collidable
/Users/stpasha/github/st-pasha/flame/doc/components.md:10: WARNING: 'myst' reference target not found: ./components.md#PositionComponent
/Users/stpasha/github/st-pasha/flame/doc/keyboard-input.md:15: WARNING: 'myst' reference target not found: #controlling-focus
/Users/stpasha/github/st-pasha/flame/doc/other-inputs.md:97: WARNING: 'myst' reference target not found: #HudButtonComponent
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:34: WARNING: 'myst' reference target not found: #BaseSystem
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:44: WARNING: 'myst' reference target not found: #RenderSystem
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:44: WARNING: 'myst' reference target not found: #UpdateSystem
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:50: WARNING: 'myst' reference target not found: #BaseSystem
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:57: WARNING: 'myst' reference target not found: #OxygenGame
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:158: WARNING: 'myst' reference target not found: #ParticleComponent
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:171: WARNING: 'myst' reference target not found: #ParticleComponent
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:184: WARNING: 'myst' reference target not found: #OxygenGame
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:234: WARNING: 'myst' reference target not found: #BaseSystem
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:259: WARNING: 'myst' reference target not found: #BaseSystem
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:284: WARNING: 'myst' reference target not found: #BaseSystem
/Users/stpasha/github/st-pasha/flame/doc/oxygen.md:367: WARNING: 'myst' reference target not found: #ParticleSystem
/Users/stpasha/github/st-pasha/flame/doc/widgets.md:23: WARNING: 'myst' reference target not found: components.md#nine-tile-box-component
```

Also some typos/grammar fixes.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
