### PR TITLE
Unify mixin names

### DIFF
--- a/doc/gesture-input.md
+++ b/doc/gesture-input.md
@@ -179,7 +179,7 @@ children tree and then passed further down until a method returns `false`.
 
 ### Tappable components
 
-By adding the `HasTappableComponents` mixin to your game, and using the mixin `Tappable` on your
+By adding the `HasTappables` mixin to your game, and using the mixin `Tappable` on your
 components, you can override the following methods on your components:
 
 ```dart
@@ -216,21 +216,21 @@ class TappableComponent extends PositionComponent with Tappable {
   }
 }
 
-class MyGame extends FlameGame with HasTappableComponents {
+class MyGame extends FlameGame with HasTappables {
   MyGame() {
     add(TappableComponent());
   }
 }
 ```
 
-**Note**: `HasTappableComponents` uses an advanced gesture detector under the hood and as explained
+**Note**: `HasTappables` uses an advanced gesture detector under the hood and as explained
 further up on this page it shouldn't be used alongside basic detectors.
 
 ### Draggable components
 
 Just like with `Tappable`, Flame offers a mixin for `Draggable`.
 
-By adding the `HasDraggableComponents` mixin to your game, and by using the mixin `Draggable` on
+By adding the `HasDraggables` mixin to your game, and by using the mixin `Draggable` on
 your components, they can override the simple methods that enable an easy to use drag api on your
 components.
 
@@ -291,14 +291,14 @@ class DraggableComponent extends PositionComponent with Draggable {
   }
 }
 
-class MyGame extends FlameGame with HasDraggableComponents {
+class MyGame extends FlameGame with HasDraggables {
   MyGame() {
     add(DraggableComponent());
   }
 }
 ```
 
-**Note**: `HasDraggableComponents` uses an advanced gesture detector under the hood and as explained
+**Note**: `HasDraggables` uses an advanced gesture detector under the hood and as explained
 further up on this page, shouldn't be used alongside basic detectors.
 
 ### Hoverable components
@@ -306,7 +306,7 @@ further up on this page, shouldn't be used alongside basic detectors.
 Just like the others, this mixin allows for easy wiring of your component to listen to hover states
 and events.
 
-By adding the `HasHoverableComponents` mixin to your base game, and by using the mixin `Hoverable` on
+By adding the `HasHoverables` mixin to your base game, and by using the mixin `Hoverable` on
 your components, they get an `isHovered` field and a couple of methods (`onHoverStart`, `onHoverEnd`) that
 you can override if you want to listen to the events.
 

--- a/doc/other-inputs.md
+++ b/doc/other-inputs.md
@@ -16,7 +16,7 @@ add it to your game.
 Check this example to get a better understanding:
 
 ```dart
-class MyGame extends FlameGame with HasDraggableComponents {
+class MyGame extends FlameGame with HasDraggables {
 
   MyGame() {
     joystick.addObserver(player);

--- a/examples/lib/stories/camera_and_viewport/follow_object.dart
+++ b/examples/lib/stories/camera_and_viewport/follow_object.dart
@@ -132,7 +132,7 @@ class Rock extends SquareComponent with Collidable, Tappable {
 }
 
 class CameraAndViewportGame extends FlameGame
-    with HasCollidables, HasTappableComponents, HasKeyboardHandlerComponents {
+    with HasCollidables, HasTappables, HasKeyboardHandlerComponents {
   late MovableSquare square;
 
   final Vector2 viewportResolution;

--- a/examples/lib/stories/collision_detection/multiple_shapes.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes.dart
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart' hide Image, Draggable;
 enum Shapes { circle, rectangle, polygon }
 
 class MultipleShapesExample extends FlameGame
-    with HasCollidables, HasDraggableComponents, FPSCounter {
+    with HasCollidables, HasDraggables, FPSCounter {
   static const description = '''
     An example with many hitboxes that move around on the screen and during
     collisions they change color depending on what it is that they have collided

--- a/examples/lib/stories/collision_detection/simple_shapes.dart
+++ b/examples/lib/stories/collision_detection/simple_shapes.dart
@@ -11,7 +11,7 @@ import 'package:flame/palette.dart';
 
 enum Shapes { circle, rectangle, polygon }
 
-class SimpleShapesExample extends FlameGame with HasTappableComponents {
+class SimpleShapesExample extends FlameGame with HasTappables {
   static const description = '''
     An example which adds random shapes on the screen when you tap it, if you
     tap on an already existing shape it will remove that shape and replace it

--- a/examples/lib/stories/components/composability.dart
+++ b/examples/lib/stories/components/composability.dart
@@ -33,9 +33,9 @@ class ParentSquare extends Square with HasGameRef {
   }
 }
 
-// This class only has `HasDraggableComponents` since the game-in-game example
+// This class only has `HasDraggables` since the game-in-game example
 // moves a draggable component to this game.
-class Composability extends FlameGame with HasDraggableComponents {
+class Composability extends FlameGame with HasDraggables {
   late ParentSquare parentSquare;
 
   @override

--- a/examples/lib/stories/components/game_in_game.dart
+++ b/examples/lib/stories/components/game_in_game.dart
@@ -26,7 +26,7 @@ class GameChangeTimer extends TimerComponent with HasGameRef<GameInGame> {
   }
 }
 
-class GameInGame extends FlameGame with HasDraggableComponents {
+class GameInGame extends FlameGame with HasDraggables {
   @override
   bool debugMode = true;
   late final Composability composedGame;

--- a/examples/lib/stories/components/priority.dart
+++ b/examples/lib/stories/components/priority.dart
@@ -34,7 +34,7 @@ class Square extends PositionComponent with HasGameRef<Priority>, Tappable {
   }
 }
 
-class Priority extends FlameGame with HasTappableComponents {
+class Priority extends FlameGame with HasTappables {
   @override
   Future<void> onLoad() async {
     await super.onLoad();

--- a/examples/lib/stories/effects/remove_effect_example.dart
+++ b/examples/lib/stories/effects/remove_effect_example.dart
@@ -6,7 +6,7 @@ import 'package:flame/input.dart';
 import 'package:flame/src/effects2/remove_effect.dart'; // ignore: implementation_imports
 import 'package:flutter/material.dart';
 
-class RemoveEffectExample extends FlameGame with HasTappableComponents {
+class RemoveEffectExample extends FlameGame with HasTappables {
   static const description = '''
     Click on any circle to apply a RemoveEffect, which will make the circle
     disappear after a 0.5 second delay.

--- a/examples/lib/stories/input/draggables.dart
+++ b/examples/lib/stories/input/draggables.dart
@@ -59,7 +59,7 @@ class DraggableSquare extends PositionComponent with Draggable, HasGameRef {
   }
 }
 
-class DraggablesGame extends FlameGame with HasDraggableComponents {
+class DraggablesGame extends FlameGame with HasDraggables {
   final double zoom;
   late final DraggableSquare square;
 

--- a/examples/lib/stories/input/hoverables.dart
+++ b/examples/lib/stories/input/hoverables.dart
@@ -19,8 +19,7 @@ class HoverableSquare extends PositionComponent with Hoverable {
   }
 }
 
-class HoverablesGame extends FlameGame
-    with HasHoverableComponents, TapDetector {
+class HoverablesGame extends FlameGame with HasHoverables, TapDetector {
   @override
   Future<void> onLoad() async {
     await super.onLoad();

--- a/examples/lib/stories/input/joystick.dart
+++ b/examples/lib/stories/input/joystick.dart
@@ -6,7 +6,7 @@ import 'package:flutter/painting.dart';
 
 import 'joystick_player.dart';
 
-class JoystickGame extends FlameGame with HasDraggableComponents {
+class JoystickGame extends FlameGame with HasDraggables {
   late final JoystickPlayer player;
   late final JoystickComponent joystick;
 

--- a/examples/lib/stories/input/joystick_advanced.dart
+++ b/examples/lib/stories/input/joystick_advanced.dart
@@ -12,8 +12,7 @@ import 'package:flutter/painting.dart';
 
 import 'joystick_player.dart';
 
-class JoystickAdvancedGame extends FlameGame
-    with HasDraggableComponents, HasTappableComponents {
+class JoystickAdvancedGame extends FlameGame with HasDraggables, HasTappables {
   late final JoystickPlayer player;
   late final JoystickComponent joystick;
   late final TextComponent speedText;

--- a/examples/lib/stories/input/overlapping_tappables.dart
+++ b/examples/lib/stories/input/overlapping_tappables.dart
@@ -35,7 +35,7 @@ class TappableSquare extends PositionComponent with Tappable {
   }
 }
 
-class OverlappingTappablesGame extends FlameGame with HasTappableComponents {
+class OverlappingTappablesGame extends FlameGame with HasTappables {
   @override
   Future<void> onLoad() async {
     await super.onLoad();

--- a/examples/lib/stories/input/tappables.dart
+++ b/examples/lib/stories/input/tappables.dart
@@ -40,7 +40,7 @@ class TappableSquare extends PositionComponent with Tappable {
   }
 }
 
-class TappablesGame extends FlameGame with HasTappableComponents {
+class TappablesGame extends FlameGame with HasTappables {
   @override
   Future<void> onLoad() async {
     await super.onLoad();

--- a/examples/lib/stories/sprites/sprite_group.dart
+++ b/examples/lib/stories/sprites/sprite_group.dart
@@ -45,7 +45,7 @@ class ButtonComponent extends SpriteGroupComponent<ButtonState>
   }
 }
 
-class SpriteGroupExample extends FlameGame with HasTappableComponents {
+class SpriteGroupExample extends FlameGame with HasTappables {
   @override
   Future<void> onLoad() async {
     await super.onLoad();

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -33,6 +33,9 @@
  - Removed methods `preRender()` and `postRender()` in `Component`
  - Use `FlameTester` everywhere where it makes sense in the tests
  - Improved `IsometricTileMap`
+ - Rename `HasTappableComponents` to `HasTappables`
+ - Rename `HasDraggableComponents` to `HasDraggables`
+ - Rename `HasHoverableComponents` to `HasHoverableis`
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/components/mixins/draggable.dart
+++ b/packages/flame/lib/src/components/mixins/draggable.dart
@@ -68,15 +68,15 @@ mixin Draggable on Component {
     if (isPrepared) {
       final parentGame = findParent<FlameGame>();
       assert(
-        parentGame is HasDraggableComponents,
+        parentGame is HasDraggables,
         'Draggable Components can only be added to a FlameGame with '
-        'HasDraggableComponents',
+        'HasDraggables',
       );
     }
   }
 }
 
-mixin HasDraggableComponents on FlameGame {
+mixin HasDraggables on FlameGame {
   @mustCallSuper
   void onDragStart(int pointerId, DragStartInfo info) {
     _onGenericEventReceived((c) => c.handleDragStart(pointerId, info));

--- a/packages/flame/lib/src/components/mixins/hoverable.dart
+++ b/packages/flame/lib/src/components/mixins/hoverable.dart
@@ -39,15 +39,15 @@ mixin Hoverable on Component {
     if (isPrepared) {
       final parentGame = findParent<FlameGame>();
       assert(
-        parentGame is HasHoverableComponents,
+        parentGame is HasHoverables,
         'Hoverable Components can only be added to a FlameGame with '
-        'HasHoverableComponents',
+        'HasHoverables',
       );
     }
   }
 }
 
-mixin HasHoverableComponents on FlameGame {
+mixin HasHoverables on FlameGame {
   @mustCallSuper
   void onMouseMove(PointerHoverInfo info) {
     bool _mouseMoveHandler(Hoverable c) {

--- a/packages/flame/lib/src/components/mixins/tappable.dart
+++ b/packages/flame/lib/src/components/mixins/tappable.dart
@@ -53,15 +53,15 @@ mixin Tappable on Component {
     if (isPrepared) {
       final parentGame = findParent<FlameGame>();
       assert(
-        parentGame is HasTappableComponents,
+        parentGame is HasTappables,
         'Tappable Components can only be added to a FlameGame with '
-        'HasTappableComponents',
+        'HasTappables',
       );
     }
   }
 }
 
-mixin HasTappableComponents on FlameGame {
+mixin HasTappables on FlameGame {
   void _handleTapEvent(bool Function(Tappable child) tapEventHandler) {
     for (final c in children.reversed()) {
       var shouldContinue = c.propagateToChildren<Tappable>(tapEventHandler);

--- a/packages/flame/lib/src/game/game_widget/gestures.dart
+++ b/packages/flame/lib/src/game/game_widget/gestures.dart
@@ -23,13 +23,13 @@ bool hasBasicGestureDetectors(Game game) =>
 bool hasAdvancedGesturesDetectors(Game game) =>
     game is MultiTouchTapDetector ||
     game is MultiTouchDragDetector ||
-    game is HasTappableComponents ||
-    game is HasDraggableComponents;
+    game is HasTappables ||
+    game is HasDraggables;
 
 bool hasMouseDetectors(Game game) =>
     game is MouseMovementDetector ||
     game is ScrollDetector ||
-    game is HasHoverableComponents;
+    game is HasHoverables;
 
 Widget applyBasicGesturesDetectors(Game game, Widget child) {
   return GestureDetector(
@@ -236,7 +236,7 @@ Widget applyAdvancedGesturesDetectors(Game game, Widget child) {
       instance.onTapCancel = game.onTapCancel;
       instance.onTap = game.onTap;
     });
-  } else if (game is HasTappableComponents) {
+  } else if (game is HasTappables) {
     addAndConfigureRecognizer(
       () => MultiTapGestureRecognizer(),
       (MultiTapGestureRecognizer instance) {
@@ -257,7 +257,7 @@ Widget applyAdvancedGesturesDetectors(Game game, Widget child) {
         ..onEnd = ((details) => game.onDragEnd(pointerId, details))
         ..onCancel = (() => game.onDragCancel(pointerId));
     });
-  } else if (game is HasDraggableComponents) {
+  } else if (game is HasDraggables) {
     addDragRecognizer(game, (int pointerId, DragStartInfo position) {
       game.onDragStart(pointerId, position);
       return _DragEvent(game)
@@ -277,7 +277,7 @@ Widget applyAdvancedGesturesDetectors(Game game, Widget child) {
 Widget applyMouseDetectors(Game game, Widget child) {
   final mouseMoveFn = game is MouseMovementDetector
       ? game.onMouseMove
-      : (game is HasHoverableComponents ? game.onMouseMove : null);
+      : (game is HasHoverables ? game.onMouseMove : null);
   return Listener(
     child: MouseRegion(
       child: child,

--- a/packages/flame/test/components/composed_component_test.dart
+++ b/packages/flame/test/components/composed_component_test.dart
@@ -6,7 +6,7 @@ import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class _HasTappablesGame extends FlameGame with HasTappableComponents {}
+class _HasTappablesGame extends FlameGame with HasTappables {}
 
 class _MyTap extends PositionComponent with Tappable {
   late Vector2 gameSize;

--- a/packages/flame/test/components/draggable_test.dart
+++ b/packages/flame/test/components/draggable_test.dart
@@ -5,7 +5,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/gestures.dart';
 import 'package:test/test.dart';
 
-class _GameHasDraggables extends FlameGame with HasDraggableComponents {}
+class _GameHasDraggables extends FlameGame with HasDraggables {}
 
 class _DraggableComponent extends PositionComponent with Draggable {
   bool hasStartedDragging = false;
@@ -33,7 +33,7 @@ void main() {
       (game) async {
         const message =
             'Draggable Components can only be added to a FlameGame with '
-            'HasDraggableComponents';
+            'HasDraggables';
 
         expect(
           () => game.add(_DraggableComponent()),

--- a/packages/flame/test/components/hoverable_test.dart
+++ b/packages/flame/test/components/hoverable_test.dart
@@ -8,7 +8,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/gestures.dart' show PointerHoverEvent;
 import 'package:test/test.dart';
 
-class _GameWithHoverables extends FlameGame with HasHoverableComponents {}
+class _GameWithHoverables extends FlameGame with HasHoverables {}
 
 class _HoverableComponent extends PositionComponent with Hoverable {
   int enterCount = 0;
@@ -57,7 +57,7 @@ void main() {
       (game) async {
         const message =
             'Hoverable Components can only be added to a FlameGame with '
-            'HasHoverableComponents';
+            'HasHoverables';
 
         expect(
           () => game.add(_HoverableComponent()),
@@ -201,7 +201,7 @@ void main() {
 }
 
 // TODO(luan) we can probably provide some helpers to facilitate testing events
-void _triggerMouseMove(HasHoverableComponents game, double dx, double dy) {
+void _triggerMouseMove(HasHoverables game, double dx, double dy) {
   game.onMouseMove(
     PointerHoverInfo.fromDetails(
       game,

--- a/packages/flame/test/components/joystick_component_test.dart
+++ b/packages/flame/test/components/joystick_component_test.dart
@@ -5,7 +5,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 
-class _GameHasDraggables extends FlameGame with HasDraggableComponents {}
+class _GameHasDraggables extends FlameGame with HasDraggables {}
 
 void main() {
   final withDraggables = FlameTester(() => _GameHasDraggables());

--- a/packages/flame/test/components/tappables_test.dart
+++ b/packages/flame/test/components/tappables_test.dart
@@ -3,7 +3,7 @@ import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-class _GameWithTappables extends FlameGame with HasTappableComponents {}
+class _GameWithTappables extends FlameGame with HasTappables {}
 
 class _TappableComponent extends PositionComponent with Tappable {}
 
@@ -23,7 +23,7 @@ void main() {
       (game) async {
         const message =
             'Tappable Components can only be added to a FlameGame with '
-            'HasTappableComponents';
+            'HasTappables';
 
         expect(
           () => game.add(_TappableComponent()),

--- a/packages/flame/test/game/base_game_test.dart
+++ b/packages/flame/test/game/base_game_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart' as flutter;
 import 'package:flutter_test/flutter_test.dart';
 
-class _GameWithTappables extends FlameGame with HasTappableComponents {}
+class _GameWithTappables extends FlameGame with HasTappables {}
 
 class _MyTappableComponent extends _MyComponent with Tappable {
   bool tapped = false;

--- a/packages/flame_forge2d/example/lib/composition_sample.dart
+++ b/packages/flame_forge2d/example/lib/composition_sample.dart
@@ -8,7 +8,7 @@ import 'package:forge2d/forge2d.dart';
 import 'balls.dart';
 import 'boundaries.dart';
 
-class CompositionSample extends Forge2DGame with HasTappableComponents {
+class CompositionSample extends Forge2DGame with HasTappables {
   static const info = '''
 This example shows how to compose a `BodyComponent` together with a normal Flame
 component. Click the ball to see the number increment.

--- a/packages/flame_forge2d/example/lib/draggable_sample.dart
+++ b/packages/flame_forge2d/example/lib/draggable_sample.dart
@@ -9,7 +9,7 @@ import 'package:forge2d/forge2d.dart';
 import 'balls.dart';
 import 'boundaries.dart';
 
-class DraggableSample extends Forge2DGame with HasDraggableComponents {
+class DraggableSample extends Forge2DGame with HasDraggables {
   DraggableSample() : super(gravity: Vector2.all(0.0));
 
   @override

--- a/packages/flame_forge2d/example/lib/tappable_sample.dart
+++ b/packages/flame_forge2d/example/lib/tappable_sample.dart
@@ -7,7 +7,7 @@ import 'package:forge2d/forge2d.dart';
 import 'balls.dart';
 import 'boundaries.dart';
 
-class TappableSample extends Forge2DGame with HasTappableComponents {
+class TappableSample extends Forge2DGame with HasTappables {
   TappableSample() : super(zoom: 20, gravity: Vector2(0, -10.0));
 
   @override

--- a/packages/flame_rive/example/lib/main.dart
+++ b/packages/flame_rive/example/lib/main.dart
@@ -29,7 +29,7 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
-class RiveExampleGame extends FlameGame with HasTappableComponents {
+class RiveExampleGame extends FlameGame with HasTappables {
   @override
   Color backgroundColor() {
     return const Color(0xFFFFFFFF);


### PR DESCRIPTION
# Description

Since we had an inconsistency with the mixin names I have renamed `HasTappableComponents` to `HasTappables`, and the same for `HasDraggableComponents` and `HasHoverableComponents`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [ ] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
