### PR TITLE
Fix `flipHorizontallyAroundCenter` and `flipVerticallyAroundCenter`

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -33,6 +33,7 @@
  - Removed methods `preRender()` and `postRender()` in `Component`
  - Use `FlameTester` everywhere where it makes sense in the tests
  - Improved `IsometricTileMap`
+ - Fix `PositionComponent`'s `flipHorizontallyAroundCenter` and `flipVerticallyAroundCenter`
 
 ## [1.0.0-releasecandidate.16]
  - `changePriority` no longer breaks game loop iteration

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -284,10 +284,9 @@ class PositionComponent extends Component {
   /// Flip the component horizontally around its center line.
   void flipHorizontallyAroundCenter() {
     if (_anchor.x != 0.5) {
-      final delta = (1 - 2 * _anchor.x) * width;
-      final scale = transform.scale;
-      transform.x += delta * math.cos(transform.angle) * scale.x.sign;
-      transform.y += delta * math.sin(transform.angle) * scale.y.sign;
+      final delta = (1 - 2 * _anchor.x) * width * transform.scale.x;
+      transform.x += delta * math.cos(transform.angle);
+      transform.y += delta * math.sin(transform.angle);
     }
     transform.flipHorizontally();
   }
@@ -295,10 +294,9 @@ class PositionComponent extends Component {
   /// Flip the component vertically around its center line.
   void flipVerticallyAroundCenter() {
     if (anchor.y != 0.5) {
-      final delta = (1 - 2 * _anchor.y) * height;
-      final scale = transform.scale;
-      transform.x += -delta * math.sin(transform.angle) * scale.x.sign;
-      transform.y += delta * math.cos(transform.angle) * scale.y.sign;
+      final delta = (1 - 2 * _anchor.y) * height * transform.scale.y;
+      transform.x += -delta * math.sin(transform.angle);
+      transform.y += delta * math.cos(transform.angle);
     }
     transform.flipVertically();
   }

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -285,8 +285,9 @@ class PositionComponent extends Component {
   void flipHorizontallyAroundCenter() {
     if (_anchor.x != 0.5) {
       final delta = (1 - 2 * _anchor.x) * width;
-      transform.x += delta * math.cos(transform.angle);
-      transform.y += delta * math.sin(transform.angle);
+      final scale = transform.scale;
+      transform.x += delta * math.cos(transform.angle) * scale.x.sign;
+      transform.y += delta * math.sin(transform.angle) * scale.y.sign;
     }
     transform.flipHorizontally();
   }
@@ -295,8 +296,9 @@ class PositionComponent extends Component {
   void flipVerticallyAroundCenter() {
     if (anchor.y != 0.5) {
       final delta = (1 - 2 * _anchor.y) * height;
-      transform.x += -delta * math.sin(transform.angle);
-      transform.y += delta * math.cos(transform.angle);
+      final scale = transform.scale;
+      transform.x += -delta * math.sin(transform.angle) * scale.x.sign;
+      transform.y += delta * math.cos(transform.angle) * scale.y.sign;
     }
     transform.flipVertically();
   }

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -404,6 +404,51 @@ void main() {
       expect(component.positionOf(Vector2(10, 0)), Vector2(44, 22));
     });
 
+    test('double center flips', () {
+      final startPosition = Vector2(50, 20);
+      final component = PositionComponent()
+        ..size = Vector2(10, 20)
+        ..position = startPosition;
+      final centerPosition = component.center;
+
+      component.flipVerticallyAroundCenter();
+      // Same position after one vertical flip.
+      expectVector2(component.center, centerPosition);
+
+      component.flipVerticallyAroundCenter();
+      // Same position after flipping back the vertical flip.
+      expectVector2(component.center, centerPosition);
+
+      component.flipHorizontallyAroundCenter();
+      // Same position after one horizontal flip.
+      expectVector2(component.center, centerPosition);
+
+      component.flipHorizontallyAroundCenter();
+      // Same position after flipping back the horizontal flip.
+      expectVector2(component.center, centerPosition);
+
+      component.flipVerticallyAroundCenter();
+      component.flipHorizontallyAroundCenter();
+      // Same position after flipping both vertically and horizontally.
+      expectVector2(component.center, centerPosition);
+
+      component.flipVerticallyAroundCenter();
+      component.flipHorizontallyAroundCenter();
+      // Same position after flipping back both vertically and horizontally.
+      expectVector2(component.center, centerPosition);
+
+      component.flipHorizontallyAroundCenter();
+      component.flipVerticallyAroundCenter();
+      // Same position after flipping both horizontally and vertically.
+      expectVector2(component.center, centerPosition);
+
+      component.flipVerticallyAroundCenter();
+      component.flipHorizontallyAroundCenter();
+      // Same position after flipping back both horizontally and vertically in
+      // the reverse order.
+      expectVector2(component.center, centerPosition);
+    });
+
     test('rotations', () {
       final component = PositionComponent()
         ..size = Vector2(8, 6)

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -408,6 +408,8 @@ void main() {
       final startPosition = Vector2(50, 20);
       final component = PositionComponent()
         ..size = Vector2(10, 20)
+        ..angle = 2
+        ..scale = Vector2(2.0, 3.0)
         ..position = startPosition;
       final centerPosition = component.center;
 


### PR DESCRIPTION
# Description

Since it wasn't taken into regard whether it was already flipped or not before if changed position when trying to flip back.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
