### PR TITLE
Add a noClip option to fixed viewport

### DIFF
--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Forcing portrait and landscape mode is now supported on web
  - Fixed margin calculation in `HudMarginComponent` when using a viewport
  - Fixed position calculation in `HudMarginComponent` when using a viewport
+ - Add noClip option to `FixedResolutionViewport`
 
 ## [1.0.0-releasecandidate.17]
  - Added `StandardEffectController` class

--- a/packages/flame/lib/src/game/camera/viewport.dart
+++ b/packages/flame/lib/src/game/camera/viewport.dart
@@ -122,6 +122,10 @@ class DefaultViewport extends Viewport {
 /// transformation whatsoever, and if the a device with a different ratio is
 /// used it will try to adapt the best as possible.
 class FixedResolutionViewport extends Viewport {
+  /// By default, the viewport will clip anything rendered outside.
+  /// Use this variable to control that behaviour.
+  bool noClip;
+
   @override
   late Vector2 effectiveSize;
 
@@ -140,7 +144,7 @@ class FixedResolutionViewport extends Viewport {
   /// The Rect that is used to clip the canvas
   late Rect _clipRect;
 
-  FixedResolutionViewport(this.effectiveSize);
+  FixedResolutionViewport(this.effectiveSize, {this.noClip = false});
 
   @override
   void resize(Vector2 newCanvasSize) {
@@ -169,7 +173,9 @@ class FixedResolutionViewport extends Viewport {
   @override
   void render(Canvas c, void Function(Canvas) renderGame) {
     c.save();
-    c.clipRect(_clipRect);
+    if (!noClip) {
+      c.clipRect(_clipRect);
+    }
     c.transform(_transform.storage);
     renderGame(c);
     c.restore();


### PR DESCRIPTION
# Description

I am porting Gravity Runner (aka Gravitational Waves) to the latest Flame.
I think it will be very good to have a fully functional, complete big game example before release.
Most of it was painless or even deleting stuff that we had incorporated from GR to Flame (like camera, viewport, etc).
However, I did come out with a list of things that were easier to do before. So I am putting out a few PRs.
This adds an option to the viewport for noClip.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
