### PR TITLE
[DO NOT MERGE] Broken test framework!

### DIFF
--- a/packages/flame/test/timer_test.dart
+++ b/packages/flame/test/timer_test.dart
@@ -1,4 +1,6 @@
+import 'package:flame/components.dart';
 import 'package:flame/timer.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -80,5 +82,31 @@ void main() {
       timer.update(1.1);
       expect(timer.finished, false);
     });
+
+    flameGame.test(
+      'broken test',
+      (game) async {
+        print('1');
+        await game.ensureAdd(Component());
+        print('2');
+        await game.ensureAdd(Component());
+        print('3');
+        await game.ensureAdd(Component());
+        print('4');
+        await game.ensureAdd(Component());
+        print('5');
+        await game.ensureAdd(Component());
+        print('6');
+        await game.ensureAdd(Component());
+        print('7');
+        await game.ensureAdd(Component());
+
+        print('8');
+        expect(game.children, -1);
+        print('9');
+        expect(true, false);
+        print('0');
+      },
+    );
   });
 }


### PR DESCRIPTION
This is not a PR to be merged; rather it's a MWE reproducing a terrible, terrible bug.

I don't know the reason, but if we have several await's inside a test, the test framework is not awaiting until the end.
Runt the test added:

1. via `f test test/timer_test.dart`
2. via `f test` (run all tests)
3. via IDE
4. github actions are green

In all cases, the test go up to a certain number, never past 8. And therefore the test passes, because the assertions in the end never run.

Unless I am doing something really stupid, this could be a MASSIVE bug with flame_test (but more likely with flutter_test itself), that compromises our entire test suit and stability.

I'm using flutter stable btw. I will try to repro this with flutter test directly, bypassing flame_test -- I imagine the issue has to come from below as we don't seem to do anything at the flame_test level that could cause this.