### PR TITLE
Documentation style fixes

### DIFF
--- a/doc/_sphinx/styles/custom.css
+++ b/doc/_sphinx/styles/custom.css
@@ -358,5 +358,5 @@ main.bd-content #main-content .prev-next-area a.right-next:hover {
 }
 
 main.bd-content #main-content .prev-next-area a:hover p.prev-next-title {
-	text-decoration: none;
+    text-decoration: none;
 }

--- a/doc/_sphinx/styles/custom.css
+++ b/doc/_sphinx/styles/custom.css
@@ -311,47 +311,52 @@ div#search-results > h2 {
 
 /* Previous/next buttons */
 
-main.bd-content #main-content .prev-next-bottom {
+main.bd-content #main-content .prev-next-area {
     background: #202225;
+    height: 105px;
     margin: 0 -25px -20px -25px;
     padding: 20px 0;
 }
 
-main.bd-content #main-content .prev-next-bottom a.left-prev {
+main.bd-content #main-content .prev-next-area a.left-prev {
     border-radius: 100px 0 0 100px;
     padding-left: 15px;
     padding-right: 20px;
 }
 
-main.bd-content #main-content .prev-next-bottom a.right-next {
+main.bd-content #main-content .prev-next-area a.right-next {
     border-radius: 0 100px 100px 0;
     padding-left: 20px;
     padding-right: 15px;
 }
 
-main.bd-content #main-content .prev-next-bottom a.left-prev > i,
-main.bd-content #main-content .prev-next-bottom a.right-next > i {
+main.bd-content #main-content .prev-next-area a.left-prev > i,
+main.bd-content #main-content .prev-next-area a.right-next > i {
     font-size: 200%;
 }
 
-main.bd-content #main-content .prev-next-bottom a.right-next .prevnext-label,
-main.bd-content #main-content .prev-next-bottom a.left-prev .prevnext-label {
+main.bd-content #main-content .prev-next-area a.right-next .prevnext-label,
+main.bd-content #main-content .prev-next-area a.left-prev .prevnext-label {
     color: #808080;
 }
 
-main.bd-content #main-content .prev-next-bottom a.right-next:hover .prevnext-label,
-main.bd-content #main-content .prev-next-bottom a.left-prev:hover .prevnext-label {
+main.bd-content #main-content .prev-next-area a.right-next:hover .prevnext-label,
+main.bd-content #main-content .prev-next-area a.left-prev:hover .prevnext-label {
     color: #BBB;
 }
 
-main.bd-content #main-content .prev-next-bottom a.right-next:hover .prevnext-title,
-main.bd-content #main-content .prev-next-bottom a.left-prev:hover .prevnext-title {
+main.bd-content #main-content .prev-next-area a.right-next:hover .prevnext-title,
+main.bd-content #main-content .prev-next-area a.left-prev:hover .prevnext-title {
     color: #8CE4FF;
 }
 
-main.bd-content #main-content .prev-next-bottom a.left-prev:hover,
-main.bd-content #main-content .prev-next-bottom a.right-next:hover {
+main.bd-content #main-content .prev-next-area a.left-prev:hover,
+main.bd-content #main-content .prev-next-area a.right-next:hover {
     background: #484848;
     box-shadow: 1px 1px 2px #000;
     text-decoration: none;
+}
+
+main.bd-content #main-content .prev-next-area a:hover p.prev-next-title {
+	text-decoration: none;
 }

--- a/doc/other-inputs.md
+++ b/doc/other-inputs.md
@@ -126,7 +126,7 @@ when the button is pressed and one that represents when the button is released.
 
 A `ButtonComponent` is a button that is defined by two `PositionComponent`s, one that represents
 when the button is pressed and one that represents when the button is released. If you only want
-to use sprites for the button, use the [](#SpriteButtonComponent) instead, but this component can be
+to use sprites for the button, use the [](#spritebuttoncomponent) instead, but this component can be
 good to use if you for example want to have a `SpriteAnimationComponent` as a button, or anything
 else which isn't a pure sprite.
 


### PR DESCRIPTION
# Description

Navigation buttons at the bottom of the page will now be rendered correctly. This was broken by a style change in an upstream library `sphinx-book-theme`.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
