### PR TITLE
Fix `HitboxCircle` on flip

### DIFF
--- a/examples/lib/stories/collision_detection/circles_example.dart
+++ b/examples/lib/stories/collision_detection/circles_example.dart
@@ -39,13 +39,12 @@ class MyCollidable extends PositionComponent
           position: position,
           size: Vector2.all(100),
           anchor: Anchor.center,
-        ) {
-    addHitbox(HitboxCircle());
-  }
+        );
 
   @override
   Future<void> onLoad() async {
     await super.onLoad();
+    addHitbox(HitboxCircle());
     final center = gameRef.size / 2;
     velocity = (center - position)..scaleTo(150);
   }

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -10,6 +10,7 @@
  - Fix `Parallax.load` with different loading times
  - Fix render order of components and add tests
  - `isHud` renamed to `respectCamera`
+ - Fix `HitboxCircle` when component is flipped
 
 ## [1.0.0-releasecandidate.18]
  - Forcing portrait and landscape mode is now supported on web

--- a/packages/flame/lib/src/geometry/circle.dart
+++ b/packages/flame/lib/src/geometry/circle.dart
@@ -43,7 +43,8 @@ class Circle extends Shape {
     _scaledSize
       ..setFrom(size)
       ..multiply(scale);
-    return (min(_scaledSize.x, _scaledSize.y) / 2) * normalizedRadius;
+    return (min(_scaledSize.x.abs(), _scaledSize.y.abs()) / 2) *
+        normalizedRadius;
   }
 
   /// This render method doesn't rotate the canvas according to angle since a


### PR DESCRIPTION
# Description

Since the `HitboxCircle` multiplies with the scale, when the component is flipped it can get a negative radius.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
