### PR TITLE
Fixing tests with multiple futures finishing abruptly

### DIFF
--- a/packages/flame_test/CHANGELOG.md
+++ b/packages/flame_test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [Next]
+ - Fix tests with multiples futures finishing abruptly
+
 ## [1.0.0-releasecandidate.15]
  - Add `pumpWidget` to flame widget test
 

--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -30,7 +30,7 @@ extension FlameGameExtension on Component {
 }
 
 typedef GameCreateFunction<T extends Game> = T Function();
-typedef VerifyFunction<T extends Game> = void Function(T);
+typedef VerifyFunction<T extends Game> = dynamic Function(T);
 
 typedef GameWidgetCreateFunction<T extends Game> = GameWidget<T> Function(
   T game,
@@ -94,7 +94,7 @@ class GameTester<T extends Game> {
   ) {
     flutter_test.test(description, () async {
       final game = await initializeGame();
-      verify(game);
+      await verify(game);
     });
   }
 

--- a/packages/flame_test/test/flame_async_test.dart
+++ b/packages/flame_test/test/flame_async_test.dart
@@ -1,0 +1,35 @@
+import 'package:flame/components.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  var instructions = 0;
+
+  tearDown(() {
+    assert(instructions == 9);
+  });
+  flameGame.test(
+    'runs all the async tests',
+    (game) async {
+      await game.ensureAdd(Component());
+      instructions++;
+      await game.ensureAdd(Component());
+      instructions++;
+      await game.ensureAdd(Component());
+      instructions++;
+      await game.ensureAdd(Component());
+      instructions++;
+      await game.ensureAdd(Component());
+      instructions++;
+      await game.ensureAdd(Component());
+      instructions++;
+      await game.ensureAdd(Component());
+      instructions++;
+      await game.ensureAdd(Component());
+      instructions++;
+
+      expect(game.children.length, equals(8));
+      instructions++;
+    },
+  );
+}


### PR DESCRIPTION
# Description

Fixes an issue where our test framework sometimes finished abruptly, without running the whole test when there were too many futures on it.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [ ] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
