### PR TITLE
MoveAlongPathEffect

### DIFF
--- a/examples/lib/stories/effects/move_effect_example.dart
+++ b/examples/lib/stories/effects/move_effect_example.dart
@@ -90,7 +90,7 @@ class MoveEffectExample extends FlameGame {
       add(
         CircleComponent(radius: 5)
           ..add(
-            MoveEffect.along(
+            MoveAlongPathEffect(
               path1,
               EffectController(
                 duration: 10,
@@ -108,7 +108,7 @@ class MoveEffectExample extends FlameGame {
         RectangleComponent.square(size: 10)
           ..paint = (Paint()..color = Colors.tealAccent)
           ..add(
-            MoveEffect.along(
+            MoveAlongPathEffect(
               path2,
               EffectController(
                 duration: 6,

--- a/examples/lib/stories/effects/move_effect_example.dart
+++ b/examples/lib/stories/effects/move_effect_example.dart
@@ -117,6 +117,7 @@ class MoveEffectExample extends FlameGame {
                 startDelay: i * 0.3,
                 infinite: true,
               ),
+              oriented: true,
             ),
           ),
       );

--- a/examples/lib/stories/effects/move_effect_example.dart
+++ b/examples/lib/stories/effects/move_effect_example.dart
@@ -89,6 +89,7 @@ class MoveEffectExample extends FlameGame {
     for (var i = 0; i < 40; i++) {
       add(
         CircleComponent(radius: 5)
+          ..position = Vector2(0, -1000)
           ..add(
             MoveAlongPathEffect(
               path1,
@@ -97,6 +98,7 @@ class MoveEffectExample extends FlameGame {
                 startDelay: i * 0.2,
                 infinite: true,
               ),
+              absolute: true,
             ),
           ),
       );

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -11,6 +11,7 @@
  - Fix render order of components and add tests
  - `isHud` renamed to `respectCamera`
  - Fix `HitboxCircle` when component is flipped
+ - `MoveAlongPathEffect` can now be absolute, and can auto-orient the object along the path
 
 ## [1.0.0-releasecandidate.18]
  - Forcing portrait and landscape mode is now supported on web

--- a/packages/flame/lib/effects.dart
+++ b/packages/flame/lib/effects.dart
@@ -11,6 +11,7 @@ export 'src/effects/controllers/reverse_curved_effect_controller.dart';
 export 'src/effects/controllers/reverse_linear_effect_controller.dart';
 export 'src/effects/controllers/sequence_effect_controller.dart';
 export 'src/effects/effect.dart';
+export 'src/effects/move_along_path_effect.dart';
 export 'src/effects/move_effect.dart';
 export 'src/effects/opacity_effect.dart';
 export 'src/effects/remove_effect.dart';

--- a/packages/flame/lib/src/effects/move_along_path_effect.dart
+++ b/packages/flame/lib/src/effects/move_along_path_effect.dart
@@ -1,0 +1,46 @@
+import 'dart:ui';
+
+import 'package:vector_math/vector_math_64.dart';
+
+import 'controllers/effect_controller.dart';
+import 'transform2d_effect.dart';
+
+/// This effect will move the target along the specified path, which may
+/// contain curved segments, but must be simply-connected. The `path` argument
+/// is taken as relative to the target's position at the start of the effect.
+class MoveAlongPathEffect extends Transform2DEffect {
+  MoveAlongPathEffect(Path path, EffectController controller)
+      : _lastPosition = Vector2.zero(),
+        super(controller) {
+    final metrics = path.computeMetrics().toList();
+    if (metrics.length != 1) {
+      throw ArgumentError(
+        'Only single-contour paths are allowed in MoveAlongPathEffect',
+      );
+    }
+    _pathMetric = metrics[0];
+    _pathLength = _pathMetric.length;
+    assert(_pathLength > 0);
+  }
+
+  late final PathMetric _pathMetric;
+  late final double _pathLength;
+  late Vector2 _lastPosition;
+
+  @override
+  void apply(double progress) {
+    final distance = progress * _pathLength;
+    final tangent = _pathMetric.getTangentForOffset(distance)!;
+    final offset = tangent.position;
+    target.position.x += offset.dx - _lastPosition.x;
+    target.position.y += offset.dy - _lastPosition.y;
+    _lastPosition.setValues(offset.dx, offset.dy);
+    super.apply(progress);
+  }
+
+  @override
+  void reset() {
+    super.reset();
+    _lastPosition = Vector2.zero();
+  }
+}

--- a/packages/flame/lib/src/effects/move_along_path_effect.dart
+++ b/packages/flame/lib/src/effects/move_along_path_effect.dart
@@ -58,8 +58,10 @@ class MoveAlongPathEffect extends Transform2DEffect {
       final pathStart = _pathMetric.getTangentForOffset(0)!.position;
       target.position.x = pathStart.dx;
       target.position.y = pathStart.dy;
+      _lastOffset = Vector2(pathStart.dx, pathStart.dy);
+    } else {
+      _lastOffset = Vector2.zero();
     }
-    _lastOffset = Vector2.zero();
   }
 
   @override

--- a/packages/flame/lib/src/effects/move_along_path_effect.dart
+++ b/packages/flame/lib/src/effects/move_along_path_effect.dart
@@ -10,8 +10,7 @@ import 'transform2d_effect.dart';
 /// is taken as relative to the target's position at the start of the effect.
 class MoveAlongPathEffect extends Transform2DEffect {
   MoveAlongPathEffect(Path path, EffectController controller)
-      : _lastPosition = Vector2.zero(),
-        super(controller) {
+      : super(controller) {
     final metrics = path.computeMetrics().toList();
     if (metrics.length != 1) {
       throw ArgumentError(
@@ -25,22 +24,22 @@ class MoveAlongPathEffect extends Transform2DEffect {
 
   late final PathMetric _pathMetric;
   late final double _pathLength;
-  late Vector2 _lastPosition;
+  late Vector2 _lastOffset;
+
+  @override
+  void onStart() {
+    _lastOffset = Vector2.zero();
+  }
 
   @override
   void apply(double progress) {
     final distance = progress * _pathLength;
     final tangent = _pathMetric.getTangentForOffset(distance)!;
     final offset = tangent.position;
-    target.position.x += offset.dx - _lastPosition.x;
-    target.position.y += offset.dy - _lastPosition.y;
-    _lastPosition.setValues(offset.dx, offset.dy);
+    target.position.x += offset.dx - _lastOffset.x;
+    target.position.y += offset.dy - _lastOffset.y;
+    _lastOffset.x = offset.dx;
+    _lastOffset.y = offset.dy;
     super.apply(progress);
-  }
-
-  @override
-  void reset() {
-    super.reset();
-    _lastPosition = Vector2.zero();
   }
 }

--- a/packages/flame/lib/src/effects/move_effect.dart
+++ b/packages/flame/lib/src/effects/move_effect.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:vector_math/vector_math_64.dart';
 
 import 'controllers/effect_controller.dart';
@@ -16,11 +14,6 @@ import 'transform2d_effect.dart';
 ///   - [MoveEffect.to] will move the target in a straight line to the specified
 ///     coordinates;
 ///
-///   - [MoveEffect.along] will move the target along the specified path, which
-///     may contain curved segments, but must be simply-connected. The `path`
-///     argument is taken as relative to the target's position at the start of
-///     the effect.
-///
 /// This effect applies incremental changes to the component's position, and
 /// requires that any other effect or update logic applied to the same component
 /// also used incremental updates.
@@ -31,9 +24,6 @@ class MoveEffect extends Transform2DEffect {
 
   factory MoveEffect.to(Vector2 destination, EffectController controller) =>
       _MoveToEffect(destination, controller);
-
-  factory MoveEffect.along(Path path, EffectController controller) =>
-      _MoveAlongPathEffect(path, controller);
 
   Vector2 _offset;
 
@@ -56,43 +46,5 @@ class _MoveToEffect extends MoveEffect {
   @override
   void onStart() {
     _offset = _destination - target.position;
-  }
-}
-
-/// Implementation class for [MoveEffect.along].
-class _MoveAlongPathEffect extends MoveEffect {
-  _MoveAlongPathEffect(Path path, EffectController controller)
-      : _lastPosition = Vector2.zero(),
-        super.by(Vector2.zero(), controller) {
-    final metrics = path.computeMetrics().toList();
-    if (metrics.length != 1) {
-      throw ArgumentError(
-        'Only single-contour paths are allowed in MoveEffect.along',
-      );
-    }
-    _pathMetric = metrics[0];
-    _pathLength = _pathMetric.length;
-    assert(_pathLength > 0);
-  }
-
-  late final PathMetric _pathMetric;
-  late final double _pathLength;
-  late Vector2 _lastPosition;
-
-  @override
-  void apply(double progress) {
-    final distance = progress * _pathLength;
-    final tangent = _pathMetric.getTangentForOffset(distance)!;
-    final offset = tangent.position;
-    target.position.x += offset.dx - _lastPosition.x;
-    target.position.y += offset.dy - _lastPosition.y;
-    _lastPosition.setValues(offset.dx, offset.dy);
-    super.apply(progress);
-  }
-
-  @override
-  void reset() {
-    super.reset();
-    _lastPosition = Vector2.zero();
   }
 }

--- a/packages/flame/test/effects/move_along_path_effect_test.dart
+++ b/packages/flame/test/effects/move_along_path_effect_test.dart
@@ -38,22 +38,64 @@ void main() {
     });
 
     test('absolute path', () {
-      final game = FlameGame() ..onGameResize(Vector2(100, 100));
-      final component = PositionComponent() ..position = Vector2(17, -5);
+      final game = FlameGame()..onGameResize(Vector2(100, 100));
+      final component = PositionComponent()..position = Vector2(17, -5);
       game.add(component);
       game.update(0);
 
       component.add(
         MoveAlongPathEffect(
-          Path() ..moveTo(1000, 300) ..lineTo(1200, 500),
+          Path()
+            ..moveTo(1000, 300)
+            ..lineTo(1200, 500),
           EffectController(duration: 1),
           absolute: true,
         ),
       );
       game.update(0);
       for (var i = 0; i < 10; i++) {
-        expect(component.position.x, closeTo(1000 + 200*(i/10), 1e-10));
-        expect(component.position.y, closeTo(300 + 200*(i/10), 1e-10));
+        expect(component.position.x, closeTo(1000 + 200 * (i / 10), 1e-10));
+        expect(component.position.y, closeTo(300 + 200 * (i / 10), 1e-10));
+        game.update(0.1);
+      }
+    });
+
+    test('absolute oriented path', () {
+      final game = FlameGame()..onGameResize(Vector2(100, 100));
+      final component = PositionComponent(
+        position: Vector2(17, -5),
+        angle: -30.5,
+      );
+      game.add(component);
+      game.update(0);
+
+      component.add(
+        MoveAlongPathEffect(
+          Path() // pythagorean triangle, perimeter=600
+            ..moveTo(200, 200)
+            ..lineTo(290, 80)
+            ..lineTo(450, 200)
+            ..lineTo(200, 200),
+          EffectController(duration: 6),
+          absolute: true,
+          oriented: true,
+        ),
+      );
+      game.update(0);
+      for (var i = 0; i < 60; i++) {
+        if (i <= 15) {
+          expect(component.position.x, closeTo(200 + 6 * i, 1e-10));
+          expect(component.position.y, closeTo(200 - 8 * i, 1e-10));
+          expect(component.angle, closeTo(-asin(0.8), 1e-7));
+        } else if (i <= 35) {
+          expect(component.position.x, closeTo(290 + 8 * (i - 15), 1e-10));
+          expect(component.position.y, closeTo(80 + 6 * (i - 15), 1e-10));
+          expect(component.angle, closeTo(asin(0.6), 1e-7));
+        } else {
+          expect(component.position.x, closeTo(450 - 10 * (i - 35), 1e-10));
+          expect(component.position.y, closeTo(200, 1e-10));
+          expect(component.angle, closeTo(pi, 1e-7));
+        }
         game.update(0.1);
       }
     });

--- a/packages/flame/test/effects/move_along_path_effect_test.dart
+++ b/packages/flame/test/effects/move_along_path_effect_test.dart
@@ -1,0 +1,63 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame/src/effects/controllers/linear_effect_controller.dart';
+import 'package:flame/src/effects/move_along_path_effect.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MoveAlongPathEffect', () {
+    test('normal', () {
+      const tau = Transform2D.tau;
+      final game = FlameGame();
+      game.onGameResize(Vector2(100, 100));
+      final object = PositionComponent()..position = Vector2(3, 4);
+      game.add(object);
+      game.update(0);
+
+      object.add(
+        MoveAlongPathEffect(
+          Path()
+            ..addOval(Rect.fromCircle(center: const Offset(6, 10), radius: 50)),
+          LinearEffectController(1),
+        ),
+      );
+      game.update(0);
+      for (var i = 0; i < 100; i++) {
+        final a = tau * i / 100;
+        // Apparently, in Flutter circle paths are not truly circles, but only
+        // appear circle-ish to an unsuspecting observer. Which is why the
+        // precision in `closeTo()` is so low: only 0.1 pixels.
+        expect(object.position.x, closeTo(3 + 6 + 50 * cos(a), 0.1));
+        expect(object.position.y, closeTo(4 + 10 + 50 * sin(a), 0.1));
+        game.update(0.01);
+      }
+    });
+
+    test('errors', () {
+      final controller = LinearEffectController(0);
+      expect(
+        () => MoveAlongPathEffect(Path(), controller),
+        throwsArgumentError,
+      );
+
+      final path2 = Path()
+        ..moveTo(10, 10)
+        ..lineTo(10, 10);
+      expect(
+        () => MoveAlongPathEffect(path2, controller),
+        throwsArgumentError,
+      );
+
+      final path3 = Path()
+        ..addOval(const Rect.fromLTWH(0, 0, 1, 1))
+        ..addOval(const Rect.fromLTWH(2, 2, 1, 1));
+      expect(
+        () => MoveAlongPathEffect(path3, controller),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/flame/test/effects/move_along_path_effect_test.dart
+++ b/packages/flame/test/effects/move_along_path_effect_test.dart
@@ -2,18 +2,19 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
 import 'package:flame/game.dart';
-import 'package:flame/src/effects/controllers/linear_effect_controller.dart';
-import 'package:flame/src/effects/move_along_path_effect.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('MoveAlongPathEffect', () {
-    test('normal', () {
+    test('relative path', () {
       const tau = Transform2D.tau;
+      const x0 = 32.5;
+      const y0 = 14.88;
       final game = FlameGame();
       game.onGameResize(Vector2(100, 100));
-      final object = PositionComponent()..position = Vector2(3, 4);
+      final object = PositionComponent()..position = Vector2(x0, y0);
       game.add(object);
       game.update(0);
 
@@ -30,9 +31,30 @@ void main() {
         // Apparently, in Flutter circle paths are not truly circles, but only
         // appear circle-ish to an unsuspecting observer. Which is why the
         // precision in `closeTo()` is so low: only 0.1 pixels.
-        expect(object.position.x, closeTo(3 + 6 + 50 * cos(a), 0.1));
-        expect(object.position.y, closeTo(4 + 10 + 50 * sin(a), 0.1));
+        expect(object.position.x, closeTo(x0 + 6 + 50 * cos(a), 0.1));
+        expect(object.position.y, closeTo(y0 + 10 + 50 * sin(a), 0.1));
         game.update(0.01);
+      }
+    });
+
+    test('absolute path', () {
+      final game = FlameGame() ..onGameResize(Vector2(100, 100));
+      final component = PositionComponent() ..position = Vector2(17, -5);
+      game.add(component);
+      game.update(0);
+
+      component.add(
+        MoveAlongPathEffect(
+          Path() ..moveTo(1000, 300) ..lineTo(1200, 500),
+          EffectController(duration: 1),
+          absolute: true,
+        ),
+      );
+      game.update(0);
+      for (var i = 0; i < 10; i++) {
+        expect(component.position.x, closeTo(1000 + 200*(i/10), 1e-10));
+        expect(component.position.y, closeTo(300 + 200*(i/10), 1e-10));
+        game.update(0.1);
       }
     });
 

--- a/packages/flame/test/effects/move_effect_test.dart
+++ b/packages/flame/test/effects/move_effect_test.dart
@@ -1,6 +1,3 @@
-import 'dart:math';
-import 'dart:ui';
-
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame/src/effects/controllers/linear_effect_controller.dart';
@@ -43,57 +40,6 @@ void main() {
       game.update(0.5);
       expect(object.position.x, closeTo(5, 1e-15));
       expect(object.position.y, closeTo(-1, 1e-15));
-    });
-
-    test('#along', () {
-      const tau = Transform2D.tau;
-      final game = FlameGame();
-      game.onGameResize(Vector2(100, 100));
-      final object = PositionComponent()..position = Vector2(3, 4);
-      game.add(object);
-      game.update(0);
-
-      object.add(
-        MoveEffect.along(
-          Path()
-            ..addOval(Rect.fromCircle(center: const Offset(6, 10), radius: 50)),
-          LinearEffectController(1),
-        ),
-      );
-      game.update(0);
-      for (var i = 0; i < 100; i++) {
-        final a = tau * i / 100;
-        // Apparently, in Flutter circle paths are not truly circles, but only
-        // appear circle-ish to an unsuspecting observer. Which is why the
-        // precision in `closeTo()` is so low: only 0.1 pixels.
-        expect(object.position.x, closeTo(3 + 6 + 50 * cos(a), 0.1));
-        expect(object.position.y, closeTo(4 + 10 + 50 * sin(a), 0.1));
-        game.update(0.01);
-      }
-    });
-
-    test('#along wrong arguments', () {
-      final controller = LinearEffectController(0);
-      expect(
-        () => MoveEffect.along(Path(), controller),
-        throwsArgumentError,
-      );
-
-      final path2 = Path()
-        ..moveTo(10, 10)
-        ..lineTo(10, 10);
-      expect(
-        () => MoveEffect.along(path2, controller),
-        throwsArgumentError,
-      );
-
-      final path3 = Path()
-        ..addOval(const Rect.fromLTWH(0, 0, 1, 1))
-        ..addOval(const Rect.fromLTWH(2, 2, 1, 1));
-      expect(
-        () => MoveEffect.along(path3, controller),
-        throwsArgumentError,
-      );
     });
   });
 }


### PR DESCRIPTION
# Description

- `MoveEffect.along` converted into a separate class `MoveAlongPathEffect`
- Added flag `absolute`, to create an effect that moves the target along an absolutely positioned path
- Added flag `oriented` to allow the target to keep its orientation aligned with the direction of the path
- The example updated to use oriented path

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
