### PR TITLE
Fix propagation order

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -281,7 +281,7 @@ class Component with Loadable {
     bool Function(T) handler,
   ) {
     var shouldContinue = true;
-    for (final child in children) {
+    for (final child in children.reversed()) {
       if (child is Component) {
         shouldContinue = child.propagateToChildren(handler);
       }

--- a/packages/flame/lib/src/components/mixins/draggable.dart
+++ b/packages/flame/lib/src/components/mixins/draggable.dart
@@ -79,33 +79,25 @@ mixin Draggable on Component {
 mixin HasDraggables on FlameGame {
   @mustCallSuper
   void onDragStart(int pointerId, DragStartInfo info) {
-    _onGenericEventReceived((c) => c.handleDragStart(pointerId, info));
+    propagateToChildren<Draggable>((c) => c.handleDragStart(pointerId, info));
   }
 
   @mustCallSuper
   void onDragUpdate(int pointerId, DragUpdateInfo details) {
-    _onGenericEventReceived((c) => c.handleDragUpdated(pointerId, details));
+    propagateToChildren<Draggable>(
+      (c) => c.handleDragUpdated(pointerId, details),
+    );
   }
 
   @mustCallSuper
   void onDragEnd(int pointerId, DragEndInfo details) {
-    _onGenericEventReceived((c) => c.handleDragEnded(pointerId, details));
+    propagateToChildren<Draggable>(
+      (c) => c.handleDragEnded(pointerId, details),
+    );
   }
 
   @mustCallSuper
   void onDragCancel(int pointerId) {
-    _onGenericEventReceived((c) => c.handleDragCanceled(pointerId));
-  }
-
-  void _onGenericEventReceived(bool Function(Draggable) handler) {
-    for (final c in children.reversed()) {
-      var shouldContinue = c.propagateToChildren<Draggable>(handler);
-      if (c is Draggable && shouldContinue) {
-        shouldContinue = handler(c);
-      }
-      if (!shouldContinue) {
-        break;
-      }
-    }
+    propagateToChildren<Draggable>((c) => c.handleDragCanceled(pointerId));
   }
 }

--- a/packages/flame/lib/src/components/mixins/hoverable.dart
+++ b/packages/flame/lib/src/components/mixins/hoverable.dart
@@ -50,18 +50,6 @@ mixin Hoverable on Component {
 mixin HasHoverables on FlameGame {
   @mustCallSuper
   void onMouseMove(PointerHoverInfo info) {
-    bool _mouseMoveHandler(Hoverable c) {
-      return c.handleMouseMovement(info);
-    }
-
-    for (final c in children.reversed()) {
-      var shouldContinue = c.propagateToChildren<Hoverable>(_mouseMoveHandler);
-      if (c is Hoverable && shouldContinue) {
-        shouldContinue = _mouseMoveHandler(c);
-      }
-      if (!shouldContinue) {
-        break;
-      }
-    }
+    propagateToChildren<Hoverable>((c) => c.handleMouseMovement(info));
   }
 }

--- a/packages/flame/lib/src/components/mixins/tappable.dart
+++ b/packages/flame/lib/src/components/mixins/tappable.dart
@@ -62,30 +62,20 @@ mixin Tappable on Component {
 }
 
 mixin HasTappables on FlameGame {
-  void _handleTapEvent(bool Function(Tappable child) tapEventHandler) {
-    for (final c in children.reversed()) {
-      var shouldContinue = c.propagateToChildren<Tappable>(tapEventHandler);
-      if (c is Tappable && shouldContinue) {
-        shouldContinue = tapEventHandler(c);
-      }
-      if (!shouldContinue) {
-        break;
-      }
-    }
-  }
-
   @mustCallSuper
   void onTapCancel(int pointerId) {
-    _handleTapEvent((Tappable child) => child.handleTapCancel(pointerId));
+    propagateToChildren((Tappable child) => child.handleTapCancel(pointerId));
   }
 
   @mustCallSuper
   void onTapDown(int pointerId, TapDownInfo info) {
-    _handleTapEvent((Tappable child) => child.handleTapDown(pointerId, info));
+    propagateToChildren(
+      (Tappable child) => child.handleTapDown(pointerId, info),
+    );
   }
 
   @mustCallSuper
   void onTapUp(int pointerId, TapUpInfo info) {
-    _handleTapEvent((Tappable child) => child.handleTapUp(pointerId, info));
+    propagateToChildren((Tappable child) => child.handleTapUp(pointerId, info));
   }
 }

--- a/packages/flame/lib/src/game/mixins/keyboard.dart
+++ b/packages/flame/lib/src/game/mixins/keyboard.dart
@@ -23,32 +23,13 @@ mixin KeyboardHandler on Component {
 /// Attention: should not be used alongside [KeyboardEvents] in a game subclass.
 /// Using this mixin remove the necessity of [KeyboardEvents].
 mixin HasKeyboardHandlerComponents on FlameGame implements KeyboardEvents {
-  bool _handleKeyboardEvent(
-    bool Function(KeyboardHandler child) keyboardEventHandler,
-  ) {
-    var shouldContinue = true;
-    for (final c in children.toList().reversed) {
-      shouldContinue = c.propagateToChildren<KeyboardHandler>(
-        keyboardEventHandler,
-      );
-      if (c is KeyboardHandler && shouldContinue) {
-        shouldContinue = keyboardEventHandler(c);
-      }
-      if (!shouldContinue) {
-        break;
-      }
-    }
-
-    return shouldContinue;
-  }
-
   @override
   @mustCallSuper
   KeyEventResult onKeyEvent(
     RawKeyEvent event,
     Set<LogicalKeyboardKey> keysPressed,
   ) {
-    final blockedPropagation = !_handleKeyboardEvent(
+    final blockedPropagation = !propagateToChildren<KeyboardHandler>(
       (KeyboardHandler child) => child.onKeyEvent(event, keysPressed),
     );
 

--- a/packages/flame/test/components/composed_component_test.dart
+++ b/packages/flame/test/components/composed_component_test.dart
@@ -167,10 +167,10 @@ void main() {
           ),
         );
 
-        expect(child2.tapped, true);
-        expect(child2.tapTimes, 1);
-        expect(child1.tapped, false);
-        expect(child1.tapTimes, 0);
+        expect(child2.tapped, isTrue);
+        expect(child2.tapTimes, equals(1));
+        expect(child1.tapped, isFalse);
+        expect(child1.tapTimes, equals(0));
       },
     );
 

--- a/packages/flame/test/components/composed_component_test.dart
+++ b/packages/flame/test/components/composed_component_test.dart
@@ -35,7 +35,7 @@ class _MyTap extends PositionComponent with Tappable {
   @override
   bool onTapDown(_) {
     ++tapTimes;
-    return true;
+    return false;
   }
 }
 
@@ -147,6 +147,32 @@ void main() {
       expect(child.tapped, true);
       expect(child.tapTimes, 1);
     });
+
+    withTappables.test(
+      'tap on child on top of child without propagation',
+      (game) async {
+        final child1 = _MyTap()..size.setFrom(Vector2.all(100));
+        final child2 = _MyTap()..size.setFrom(Vector2.all(100));
+        final parent = PositionComponent()..size.setFrom(Vector2.all(300));
+
+        game.onGameResize(size);
+        await game.ensureAdd(parent);
+        await parent.ensureAdd(child1);
+        await parent.ensureAdd(child2);
+        game.onTapDown(
+          1,
+          createTapDownEvent(
+            game,
+            globalPosition: const Offset(50, 50),
+          ),
+        );
+
+        expect(child2.tapped, true);
+        expect(child2.tapTimes, 1);
+        expect(child1.tapped, false);
+        expect(child1.tapTimes, 0);
+      },
+    );
 
     withTappables.test('updates and renders children', (game) async {
       final child = _MyTap();


### PR DESCRIPTION
# Description

Since the children weren't reversed in `propagateToChildren` the events were not first passed to the last added component.
In `OrderedSet` we now cache the reversed set, so it is a slightly less impact than it should have been to have reversed here than before.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1175
Closes #949 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
