### PR TITLE
style: Prevent docs side menu from changing size

### DIFF
--- a/doc/_sphinx/styles/custom.css
+++ b/doc/_sphinx/styles/custom.css
@@ -55,7 +55,7 @@ main.bd-content > #main-content > div {
 	overflow: hidden;
 }
 #site-navigation:hover {
-	overflow-y: auto;
+	overflow-y: scroll;
 	padding-right: 7px;
 }
 #site-navigation::-webkit-scrollbar {


### PR DESCRIPTION
# Description

Noted by @spydon, our docs' side menu was changing its size on hover when viewed within a browser window large enough that there was no scrollbar. This PR fixes the problem.
