### PR TITLE
feat: Effect.onComplete callback as an alternative to onFinish()

### DIFF
--- a/doc/effects.md
+++ b/doc/effects.md
@@ -80,7 +80,7 @@ functionality inherited by all other effects. This includes:
     removed from the game tree and garbage-collected once the effect completes. Set this to false
     if you plan to reuse the effect after it is finished.
 
-  - Optional user-provided `onComplete` callback, which will be invoked when the effect has just
+  - Optional user-provided `onFinishCallback`, which will be invoked when the effect has just
     completed its execution but before it is removed from the game.
 
   - The `reset()` method reverts the effect to its original state, allowing it to run once again.
@@ -248,7 +248,7 @@ final effect = ColorEffect(
 The `Offset` argument will determine "how much" of the color that will be applied to the component,
 in this example the effect will start with 0% and will go up to 80%.
 
-__Note :__Due to how this effect is implemented, and how Flutter's `ColorFilter` class works, this
+__Note:__ Due to how this effect is implemented, and how Flutter's `ColorFilter` class works, this
 effect can't be mixed with other `ColorEffect`s, when more than one is added to the component, only
 the last one will have effect.
 

--- a/doc/effects.md
+++ b/doc/effects.md
@@ -79,6 +79,9 @@ functionality inherited by all other effects. This includes:
     removed from the game tree and garbage-collected once the effect completes. Set this to false
     if you plan to reuse the effect after it is finished.
 
+  - Optional user-provided `onFinish` callback, which will be invoked when the effect has just
+    completed its execution but before it is removed from the game.
+
   - The `reset()` method reverts the effect to its original state, allowing it to run once again.
 
 

--- a/doc/effects.md
+++ b/doc/effects.md
@@ -79,7 +79,7 @@ functionality inherited by all other effects. This includes:
     removed from the game tree and garbage-collected once the effect completes. Set this to false
     if you plan to reuse the effect after it is finished.
 
-  - Optional user-provided `onFinish` callback, which will be invoked when the effect has just
+  - Optional user-provided `onComplete` callback, which will be invoked when the effect has just
     completed its execution but before it is removed from the game.
 
   - The `reset()` method reverts the effect to its original state, allowing it to run once again.

--- a/packages/flame/lib/src/effects/effect.dart
+++ b/packages/flame/lib/src/effects/effect.dart
@@ -44,14 +44,8 @@ abstract class Effect extends Component {
   /// in order to make it run once again.
   bool removeOnFinish;
 
-  /// This method is called once when the effect is about to finish, but before
-  /// it is removed from its parent. The notion of "about to finish" is defined
-  /// by the [controller]: this method is called when `controller.completed`
-  /// property first becomes true.
-  ///
-  /// If the effect is reset, its [onFinish] method will be called again after
-  /// the effect has finished again.
-  void Function()? onFinish;
+  /// Optional callback function to be invoked once the effect completes.
+  void Function()? onComplete;
 
   /// Boolean indicators of the effect's state, their purpose is to ensure that
   /// the `onStart()` and `onFinish()` callbacks are called exactly once.
@@ -124,7 +118,7 @@ abstract class Effect extends Component {
     }
     if (!_finished && controller.completed) {
       _finished = true;
-      onFinish?.call();
+      onFinish();
       if (removeOnFinish) {
         removeFromParent();
       }
@@ -150,6 +144,18 @@ abstract class Effect extends Component {
   ///
   /// This is a main method that MUST be implemented in every derived class.
   void apply(double progress);
+
+  /// This method is called once when the effect is about to finish, but before
+  /// it is removed from its parent. The notion of "about to finish" is defined
+  /// by the [controller]: this method is called when `controller.completed`
+  /// property first becomes true.
+  ///
+  /// If the effect is reset, its [onFinish] method will be called again after
+  /// the effect has finished again.
+  @mustCallSuper
+  void onFinish() {
+    onComplete?.call();
+  }
 
   //#endregion
 }

--- a/packages/flame/lib/src/effects/effect.dart
+++ b/packages/flame/lib/src/effects/effect.dart
@@ -136,15 +136,6 @@ abstract class Effect extends Component {
   /// the effect is about to start.
   void onStart() {}
 
-  /// Apply the given [progress] level to the effect's target.
-  ///
-  /// Here [progress] is a variable that is typically in the range from 0 to 1,
-  /// with 0 being the initial state, and 1 the final state of the effect. See
-  /// [EffectController] for details.
-  ///
-  /// This is a main method that MUST be implemented in every derived class.
-  void apply(double progress);
-
   /// This method is called once when the effect is about to finish, but before
   /// it is removed from its parent. The notion of "about to finish" is defined
   /// by the [controller]: this method is called when `controller.completed`
@@ -156,6 +147,15 @@ abstract class Effect extends Component {
   void onFinish() {
     onComplete?.call();
   }
+
+  /// Apply the given [progress] level to the effect's target.
+  ///
+  /// Here [progress] is a variable that is typically in the range from 0 to 1,
+  /// with 0 being the initial state, and 1 the final state of the effect. See
+  /// [EffectController] for details.
+  ///
+  /// This is a main method that MUST be implemented in every derived class.
+  void apply(double progress);
 
   //#endregion
 }

--- a/packages/flame/lib/src/effects/effect.dart
+++ b/packages/flame/lib/src/effects/effect.dart
@@ -45,7 +45,7 @@ abstract class Effect extends Component {
   bool removeOnFinish;
 
   /// Optional callback function to be invoked once the effect completes.
-  void Function()? onComplete;
+  void Function()? onFinishCallback;
 
   /// Boolean indicators of the effect's state, their purpose is to ensure that
   /// the `onStart()` and `onFinish()` callbacks are called exactly once.
@@ -145,7 +145,7 @@ abstract class Effect extends Component {
   /// the effect has finished again.
   @mustCallSuper
   void onFinish() {
-    onComplete?.call();
+    onFinishCallback?.call();
   }
 
   /// Apply the given [progress] level to the effect's target.

--- a/packages/flame/lib/src/effects/effect.dart
+++ b/packages/flame/lib/src/effects/effect.dart
@@ -45,8 +45,8 @@ abstract class Effect extends Component {
   bool removeOnFinish;
 
   /// This method is called once when the effect is about to finish, but before
-  /// it is removed from parent. The notion of "about to finish" is defined by
-  /// the [controller]: this method is called when `controller.completed`
+  /// it is removed from its parent. The notion of "about to finish" is defined
+  /// by the [controller]: this method is called when `controller.completed`
   /// property first becomes true.
   ///
   /// If the effect is reset, its [onFinish] method will be called again after

--- a/packages/flame/lib/src/effects/effect.dart
+++ b/packages/flame/lib/src/effects/effect.dart
@@ -44,6 +44,15 @@ abstract class Effect extends Component {
   /// in order to make it run once again.
   bool removeOnFinish;
 
+  /// This method is called once when the effect is about to finish, but before
+  /// it is removed from parent. The notion of "about to finish" is defined by
+  /// the [controller]: this method is called when `controller.completed`
+  /// property first becomes true.
+  ///
+  /// If the effect is reset, its [onFinish] method will be called again after
+  /// the effect has finished again.
+  void Function()? onFinish;
+
   /// Boolean indicators of the effect's state, their purpose is to ensure that
   /// the `onStart()` and `onFinish()` callbacks are called exactly once.
   bool _started;
@@ -115,7 +124,7 @@ abstract class Effect extends Component {
     }
     if (!_finished && controller.completed) {
       _finished = true;
-      onFinish();
+      onFinish?.call();
       if (removeOnFinish) {
         removeFromParent();
       }
@@ -132,15 +141,6 @@ abstract class Effect extends Component {
   /// If the effect is reset, its `onStart()` method will be called again when
   /// the effect is about to start.
   void onStart() {}
-
-  /// This method is called once when the effect is about to finish, but before
-  /// it is removed from parent. The notion of "about to finish" is defined by
-  /// the [controller]: this method is called when `controller.completed`
-  /// property first becomes true.
-  ///
-  /// If the effect is reset, its `onFinish()` method will be called again after
-  /// the effect has finished again.
-  void onFinish() {}
 
   /// Apply the given [progress] level to the effect's target.
   ///

--- a/packages/flame/test/effects/effect_test.dart
+++ b/packages/flame/test/effects/effect_test.dart
@@ -27,12 +27,6 @@ class _MyEffect extends Effect {
     super.onStart();
     onStartCallback?.call();
   }
-
-  @override
-  void onFinish() {
-    super.onFinish();
-    onFinishCallback?.call();
-  }
 }
 
 void main() {
@@ -150,7 +144,7 @@ void main() {
         ..onStartCallback = () {
           nStarted++;
         }
-        ..onFinishCallback = () {
+        ..onFinish = () {
           nFinished++;
         };
 

--- a/packages/flame/test/effects/effect_test.dart
+++ b/packages/flame/test/effects/effect_test.dart
@@ -144,7 +144,7 @@ void main() {
         ..onStartCallback = () {
           nStarted++;
         }
-        ..onFinish = () {
+        ..onComplete = () {
           nFinished++;
         };
 

--- a/packages/flame/test/effects/effect_test.dart
+++ b/packages/flame/test/effects/effect_test.dart
@@ -9,7 +9,6 @@ class _MyEffect extends Effect {
 
   double x = -1;
   Function()? onStartCallback;
-  Function()? onFinishCallback;
 
   @override
   void apply(double progress) {
@@ -144,7 +143,7 @@ void main() {
         ..onStartCallback = () {
           nStarted++;
         }
-        ..onComplete = () {
+        ..onFinishCallback = () {
           nFinished++;
         };
 


### PR DESCRIPTION
# Description

`Effect.onFinish` is now a property that can be directly set by the user. This allows an alternative way to chain multiple effects, and to perform some special action when an effect completes.

Previously, `Effect.onFinish()` was a method, and the only way to use it was to subclass a particular effect and create an overridden `.onFinish` method -- which is very cumbersome.

Note the asymmetry between `onStart()` and `onFinish()`: the first still remains an overridable method. This is because there are many effects that are interested in performing a custom action at start, and for them using a callback function would be more difficult. At the same time, there doesn't appear to be a clear use case when the user would want to provide a custom action at the start of an event.