### PR TITLE
feat: Add RandomEffectController

### DIFF
--- a/doc/effects.md
+++ b/doc/effects.md
@@ -31,7 +31,6 @@ the final value is provided by the user explicitly, and progression over time is
 
 There are multiple effects provided by Flame, and you can also
 [create your own](#creating-new-effects). The following effects are included:
-- [`ColorEffect`](#coloreffect)
 - [`MoveEffect.by`](#moveeffectby)
 - [`MoveEffect.to`](#moveeffectto)
 - [`MoveAlongPathEffect`](#movealongpatheffect)
@@ -42,6 +41,7 @@ There are multiple effects provided by Flame, and you can also
 - [`SizeEffect.by`](#sizeeffectby)
 - [`SizeEffect.to`](#sizeeffectto)
 - [`OpacityEffect`](#opacityeffect)
+- [`ColorEffect`](#coloreffect)
 - [`RemoveEffect`](#removeeffect)
 
 An `EffectController` is an object that describes how the effect should evolve over time. If you
@@ -60,6 +60,7 @@ There are multiple effect controllers provided by the Flame framework as well:
 - [`InfiniteEffectController`](#infiniteeffectcontroller)
 - [`SequenceEffectController`](#sequenceeffectcontroller)
 - [`DelayedEffectController`](#delayedeffectcontroller)
+- [`RandomEffectController`](#randomeffectcontroller)
 
 
 ## Built-in effects
@@ -234,12 +235,10 @@ the provided color between a provided range.
 Usage example:
 
 ```dart
-myComponent.add(
-  ColorEffect(
-    const Color(0xFF00FF00),
-    const Offset(0.0, 0.8),
-    EffectController(duration: 1.5),
-  ),
+final effect = ColorEffect(
+  const Color(0xFF00FF00),
+  const Offset(0.0, 0.8),
+  EffectController(duration: 1.5),
 );
 ```
 
@@ -249,6 +248,7 @@ in this example the effect will start with 0% and will go up to 80%.
 __Note :__Due to how this effect is implemented, and how Flutter's `ColorFilter` class works, this
 effect can't be mixed with other `ColorEffect`s, when more than one is added to the component, only
 the last one will have effect.
+
 
 ## Creating new effects
 
@@ -457,6 +457,25 @@ controller is executing the "delay" stage, the effect will be considered "not st
 ```dart
 final ec = DelayedEffectController(LinearEffectController(1), delay: 5);
 ```
+
+
+### `RandomEffectController`
+
+This controller wraps another controller and makes its duration random. The actual value for the
+duration is re-generated upon each reset, which makes this controller particularly useful within
+repeated contexts, such as [](#repeatedeffectcontroller) or [](#infiniteeffectcontroller).
+
+```dart
+final effect = RandomEffectController.uniform(
+  LinearEffectController(0),  // duration here is irrelevant
+  min: 0.5,
+  max: 1.5,
+);
+```
+
+The user has the ability to control which `Random` source to use, as well as the exact distribution
+of the produced random durations. Two distributions -- `.uniform` and `.exponential` are included,
+any other can be implemented by the user.
 
 
 ## See also

--- a/examples/lib/stories/effects/scale_effect_example.dart
+++ b/examples/lib/stories/effects/scale_effect_example.dart
@@ -34,21 +34,23 @@ class ScaleEffectExample extends FlameGame with TapDetector {
     add(square);
 
     add(
-        Star()
-          ..position=Vector2(200, 100)
-          ..add(ScaleEffect.to(
-              Vector2.all(1.2),
-              InfiniteEffectController(
-                SequenceEffectController([
-                  LinearEffectController(0.1),
-                  ReverseLinearEffectController(0.1),
-                  RandomEffectController.exponential(
-                    PauseEffectController(1, progress: 0),
-                    beta: 1,
-                  ),
-                ]),
-              ),
-          )),
+      Star()
+        ..position = Vector2(200, 100)
+        ..add(
+          ScaleEffect.to(
+            Vector2.all(1.2),
+            InfiniteEffectController(
+              SequenceEffectController([
+                LinearEffectController(0.1),
+                ReverseLinearEffectController(0.1),
+                RandomEffectController.exponential(
+                  PauseEffectController(1, progress: 0),
+                  beta: 1,
+                ),
+              ]),
+            ),
+          ),
+        ),
     );
   }
 
@@ -74,17 +76,18 @@ class Star extends PositionComponent {
   Star() {
     const smallR = 15.0;
     const bigR = 30.0;
-    shape = Path() ..moveTo(bigR, 0);
+    const tau = 2 * pi;
+    shape = Path()..moveTo(bigR, 0);
     for (var i = 1; i < 10; i++) {
-      final r = i.isEven? bigR : smallR;
-      final a = i / 10 * Transform2D.tau;
+      final r = i.isEven ? bigR : smallR;
+      final a = i / 10 * tau;
       shape.lineTo(r * cos(a), r * sin(a));
     }
     shape.close();
   }
 
   late final Path shape;
-  late final Paint paint = Paint() ..color=const Color(0xFFFFF127);
+  late final Paint paint = Paint()..color = const Color(0xFFFFF127);
 
   @override
   void render(Canvas canvas) {

--- a/examples/lib/stories/effects/scale_effect_example.dart
+++ b/examples/lib/stories/effects/scale_effect_example.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
 import 'package:flame/game.dart';
@@ -7,10 +9,10 @@ import 'package:flutter/material.dart';
 
 class ScaleEffectExample extends FlameGame with TapDetector {
   static const String description = '''
-    The `ScaleEffect` scales up the canvas before drawing the components and its
-    children.
     In this example you can tap the screen and the component will scale up or
     down, depending on its current state.
+    
+    The star pulsates randomly using a RandomEffectController.
   ''';
 
   late RectangleComponent square;
@@ -30,6 +32,24 @@ class ScaleEffectExample extends FlameGame with TapDetector {
     );
     square.add(childSquare);
     add(square);
+
+    add(
+        Star()
+          ..position=Vector2(200, 100)
+          ..add(ScaleEffect.to(
+              Vector2.all(1.2),
+              InfiniteEffectController(
+                SequenceEffectController([
+                  LinearEffectController(0.1),
+                  ReverseLinearEffectController(0.1),
+                  RandomEffectController.exponential(
+                    PauseEffectController(1, progress: 0),
+                    beta: 1,
+                  ),
+                ]),
+              ),
+          )),
+    );
   }
 
   @override
@@ -47,5 +67,27 @@ class ScaleEffectExample extends FlameGame with TapDetector {
         ),
       ),
     );
+  }
+}
+
+class Star extends PositionComponent {
+  Star() {
+    const smallR = 15.0;
+    const bigR = 30.0;
+    shape = Path() ..moveTo(bigR, 0);
+    for (var i = 1; i < 10; i++) {
+      final r = i.isEven? bigR : smallR;
+      final a = i / 10 * Transform2D.tau;
+      shape.lineTo(r * cos(a), r * sin(a));
+    }
+    shape.close();
+  }
+
+  late final Path shape;
+  late final Paint paint = Paint() ..color=const Color(0xFFFFF127);
+
+  @override
+  void render(Canvas canvas) {
+    canvas.drawPath(shape, paint);
   }
 }

--- a/packages/flame/lib/effects.dart
+++ b/packages/flame/lib/effects.dart
@@ -7,6 +7,7 @@ export 'src/effects/controllers/effect_controller.dart';
 export 'src/effects/controllers/infinite_effect_controller.dart';
 export 'src/effects/controllers/linear_effect_controller.dart';
 export 'src/effects/controllers/pause_effect_controller.dart';
+export 'src/effects/controllers/random_effect_controller.dart';
 export 'src/effects/controllers/repeated_effect_controller.dart';
 export 'src/effects/controllers/reverse_curved_effect_controller.dart';
 export 'src/effects/controllers/reverse_linear_effect_controller.dart';

--- a/packages/flame/lib/src/effects/controllers/effect_controller.dart
+++ b/packages/flame/lib/src/effects/controllers/effect_controller.dart
@@ -123,8 +123,8 @@ abstract class EffectController {
   /// Is the effect's duration random or fixed?
   bool get isRandom => false;
 
-  /// Total duration of the effect. If the effect is either infinite or random,
-  /// this will return `null`.
+  /// Total duration of the effect. If the duration cannot be determined, this
+  /// will return `null`.
   double? get duration;
 
   /// Has the effect started running? Some effects use a "delay" parameter to

--- a/packages/flame/lib/src/effects/controllers/infinite_effect_controller.dart
+++ b/packages/flame/lib/src/effects/controllers/infinite_effect_controller.dart
@@ -14,7 +14,7 @@ class InfiniteEffectController extends EffectController {
   bool get completed => false;
 
   @override
-  double? get duration => double.infinity;
+  double? get duration => null;
 
   @override
   double get progress => child.progress;

--- a/packages/flame/lib/src/effects/controllers/infinite_effect_controller.dart
+++ b/packages/flame/lib/src/effects/controllers/infinite_effect_controller.dart
@@ -14,7 +14,7 @@ class InfiniteEffectController extends EffectController {
   bool get completed => false;
 
   @override
-  double? get duration => null;
+  double? get duration => double.infinity;
 
   @override
   double get progress => child.progress;

--- a/packages/flame/lib/src/effects/controllers/random_effect_controller.dart
+++ b/packages/flame/lib/src/effects/controllers/random_effect_controller.dart
@@ -1,0 +1,132 @@
+import 'dart:math';
+
+import 'duration_effect_controller.dart';
+import 'effect_controller.dart';
+
+/// An [EffectController] that wraps another effect controller [child] and
+/// randomizes its duration after each reset.
+///
+/// This effect controller works best in contexts were it has a chance to be
+/// executed multiple times, such as within a `RepeatedEffectController`, or
+/// `InfiniteEffectController`, etc.
+///
+/// The child's duration is randomized first at construction, and then at each
+/// reset (`setToStart`). Thus, the child has a concrete well-defined duration
+/// at any point in time.
+class RandomEffectController extends EffectController {
+  RandomEffectController(this.child, this.randomGenerator)
+      : assert(!child.isInfinite, 'Child cannot be infinite'),
+        super.empty() {
+    _initializeDuration();
+  }
+
+  /// Factory constructor that uses a random variable uniformly distributed on
+  /// `[min, max)`.
+  factory RandomEffectController.uniform(
+    DurationEffectController child, {
+    required double min,
+    required double max,
+    Random? random,
+  }) {
+    assert(min >= 0, 'Min value cannot be negative: $min');
+    assert(min < max, 'Max value must exceed min: max=$max, min=$min');
+    return RandomEffectController(
+      child,
+      _UniformRandomVariable(min, max, random),
+    );
+  }
+
+  /// Factory constructor that employs a random variable distributed
+  /// exponentially with rate parameter `beta`. The produced random values will
+  /// have the average duration of `beta`.
+  factory RandomEffectController.exponential(
+    DurationEffectController child, {
+    required double beta,
+    Random? random,
+  }) {
+    assert(beta > 0, 'Beta must be positive: $beta');
+    return RandomEffectController(
+        child,
+      _ExponentialRandomVariable(beta, random),
+    );
+  }
+
+  final DurationEffectController child;
+  final RandomVariable randomGenerator;
+
+  @override
+  bool get isInfinite => false;
+
+  @override
+  bool get isRandom => true;
+
+  @override
+  bool get completed => child.completed;
+
+  @override
+  double? get duration => child.duration;
+
+  @override
+  double get progress => child.progress;
+
+  @override
+  double advance(double dt) => child.advance(dt);
+
+  @override
+  double recede(double dt) => child.recede(dt);
+
+  @override
+  void setToEnd() => child.setToEnd();
+
+  @override
+  void setToStart() {
+    child.setToStart();
+    _initializeDuration();
+  }
+
+  void _initializeDuration() {
+    final duration = randomGenerator.nextValue();
+    assert(
+      duration >= 0,
+      'Random generator produced a negative value: $duration',
+    );
+    child.duration = duration;
+  }
+}
+
+/// [RandomVariable] is an object capable of producing random values with the
+/// prescribed distribution function. Each distribution is implemented within
+/// its own derived class.
+abstract class RandomVariable {
+  RandomVariable(Random? random) : _random = random ?? _defaultRandom;
+
+  /// Internal random number generator.
+  final Random _random;
+  static final Random _defaultRandom = Random();
+
+  /// Produces the next value for this random variable.
+  double nextValue();
+}
+
+/// Random variable distributed uniformly between [min] and [max].
+class _UniformRandomVariable extends RandomVariable {
+  _UniformRandomVariable(this.min, this.max, Random? random) : super(random);
+
+  final double min;
+  final double max;
+
+  @override
+  double nextValue() => _random.nextDouble() * (max - min) + min;
+}
+
+/// Exponentially distributed random variable with rate parameter [beta].
+class _ExponentialRandomVariable extends RandomVariable {
+  _ExponentialRandomVariable(this.beta, Random? random) : super(random);
+
+  /// Rate parameter of the exponential distribution. This will be the average
+  /// of all returned values
+  final double beta;
+
+  @override
+  double nextValue() => -log(1 - _random.nextDouble()) * beta;
+}

--- a/packages/flame/lib/src/effects/controllers/random_effect_controller.dart
+++ b/packages/flame/lib/src/effects/controllers/random_effect_controller.dart
@@ -46,7 +46,7 @@ class RandomEffectController extends EffectController {
   }) {
     assert(beta > 0, 'Beta must be positive: $beta');
     return RandomEffectController(
-        child,
+      child,
       _ExponentialRandomVariable(beta, random),
     );
   }

--- a/packages/flame/test/effects/controllers/random_effect_controller_test.dart
+++ b/packages/flame/test/effects/controllers/random_effect_controller_test.dart
@@ -49,10 +49,10 @@ void main() {
     test('.uniform', () {
       final random = MyRandom();
       final ec = RandomEffectController.uniform(
-          LinearEffectController(1000),
-          min: 0,
-          max: 10,
-          random: random,
+        LinearEffectController(1000),
+        min: 0,
+        max: 10,
+        random: random,
       );
       expect(random.nextDouble(), 0.5);
       expect(ec.duration, 5);
@@ -74,12 +74,12 @@ void main() {
       );
       var sum = 0.0;
       for (var i = 0; i < n; i++) {
-        random.value = i/n;
+        random.value = i / n;
         ec.setToStart();
         expect(ec.duration! >= 0, true);
         sum += ec.duration!;
       }
-      expect(sum/n, closeTo(42, 400/n));
+      expect(sum / n, closeTo(42, 400 / n));
     });
   });
 }

--- a/packages/flame/test/effects/controllers/random_effect_controller_test.dart
+++ b/packages/flame/test/effects/controllers/random_effect_controller_test.dart
@@ -1,0 +1,85 @@
+import 'dart:math';
+
+import 'package:flame/effects.dart';
+import 'package:test/test.dart';
+
+class MyRandom implements Random {
+  double value = 0.5;
+
+  @override
+  double nextDouble() => value;
+
+  @override
+  bool nextBool() => true;
+
+  @override
+  int nextInt(int max) => 1;
+}
+
+class MyRandomVariable extends RandomVariable {
+  MyRandomVariable() : super(null);
+  double value = 1.23;
+
+  @override
+  double nextValue() => value;
+}
+
+void main() {
+  group('RandomEffectController', () {
+    test('custom random', () {
+      final randomVariable = MyRandomVariable();
+      final ec = RandomEffectController(
+        LinearEffectController(1000),
+        randomVariable,
+      );
+
+      expect(ec.duration, 1.23);
+      expect(ec.isRandom, true);
+      expect(ec.isInfinite, false);
+      expect(ec.progress, 0);
+      expect(ec.started, true);
+      expect(ec.completed, false);
+      expect(ec.advance(1), 0);
+      expect(ec.advance(0.23), 0);
+      expect(ec.completed, true);
+      expect(ec.advance(1), 1);
+      expect(ec.duration, 1.23);
+    });
+
+    test('.uniform', () {
+      final random = MyRandom();
+      final ec = RandomEffectController.uniform(
+          LinearEffectController(1000),
+          min: 0,
+          max: 10,
+          random: random,
+      );
+      expect(random.nextDouble(), 0.5);
+      expect(ec.duration, 5);
+      random.value = 0;
+      ec.setToStart();
+      expect(ec.duration, 0);
+      random.value = 1;
+      ec.setToStart();
+      expect(ec.duration, 10);
+    });
+
+    test('.exponential', () {
+      const n = 1000;
+      final random = MyRandom();
+      final ec = RandomEffectController.exponential(
+        LinearEffectController(1e6),
+        beta: 42,
+        random: random,
+      );
+      var sum = 0.0;
+      for (var i = 0; i < n; i++) {
+        random.value = i/n;
+        ec.setToStart();
+        expect(ec.duration! >= 0, true);
+        sum += ec.duration!;
+      }
+      expect(sum/n, closeTo(42, 400/n));
+    });
+  });
+}


### PR DESCRIPTION
# Description

Add `RandomEffectController` -- a controller that makes the duration of some other effect controller random. This could be useful if the user wants to inject some amount of unpredictability into the effect.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
