### PR TITLE
fix: Make string input a named parameter in example code

### DIFF
--- a/doc/text.md
+++ b/doc/text.md
@@ -79,7 +79,7 @@ final regular = TextPaint(style: style);
 class MyGame extends FlameGame {
   @override
   Future<void> onLoad() async {
-    add(TextComponent('Hello, Flame', textRenderer: regular)
+    add(TextComponent(text: 'Hello, Flame', textRenderer: regular)
       ..anchor = Anchor.topCenter
       ..x = size.width / 2 // size is a property from game
       ..y = 32.0);
@@ -101,7 +101,7 @@ Example usage:
 
 ```dart
 class MyTextBox extends TextBoxComponent {
-  MyTextBox(String text) : super(text, textRenderer: tiny, boxConfig: TextBoxConfig(timePerChar: 0.05));
+  MyTextBox(String text) : super(text: text, textRenderer: tiny, boxConfig: TextBoxConfig(timePerChar: 0.05));
 
   @override
   void drawBackground(Canvas c) {


### PR DESCRIPTION
# Description

Usage examples were out of sync with `TextComponent` and `TextBoxComponent`. Input string is now a named parameters for both these components. This PR fixes that.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.
- (NA) My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- (NA) I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- (NA) I have added a description of the change under `[next]` in `CHANGELOG.md`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

NA

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
