### PR TITLE
chore: Ensure unique names for all flame sub-packages

### DIFF
--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -1,5 +1,5 @@
-name: flame_example
-description: A set of small game examples showcasing each feature provided by the Flame Engine.
+name: examples
+description: A set of small examples showcasing each feature provided by the Flame Engine.
 homepage: https://github.com/flame-engine/flame/tree/main/examples
 publish_to: 'none'
 

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -1,5 +1,5 @@
-name: position_component
-description: A new Flutter project.
+name: flame_example
+description: Simple example of a Flame game
 
 publish_to: 'none'
 

--- a/packages/flame_audio/example/pubspec.yaml
+++ b/packages/flame_audio/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: flame_audio_example
 description: Simple project to showcase the usage of flame_audio
 
 publish_to: 'none'

--- a/packages/flame_bloc/example/pubspec.yaml
+++ b/packages/flame_bloc/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: flame_bloc_example
 description: Example game using the flame_bloc package
 
 publish_to: 'none'

--- a/packages/flame_fire_atlas/example/pubspec.yaml
+++ b/packages/flame_fire_atlas/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: flame_fire_atlas_example
 description: Example app to showcase flame fire atlas package
 
 publish_to: 'none'

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: forge2d_samples
+name: flame_forge2d_example
 description: Flame Forge2D (box2d) samples
 
 publish_to: 'none'

--- a/packages/flame_oxygen/example/pubspec.yaml
+++ b/packages/flame_oxygen/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: flame_oxygen_example
 description: Flame Oxygen example
 
 publish_to: 'none'

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: flame_rive_example
 description: A testbed for flame_rive
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: flame_svg_example
 description: Example app of how to use the flame_svg package
 
 publish_to: 'none'

--- a/packages/flame_test/example/pubspec.yaml
+++ b/packages/flame_test/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: flame_test_example
 description: Example of how to test with the flame_test package
 
 publish_to: 'none'

--- a/packages/flame_test/example/test/flame_test_test.dart
+++ b/packages/flame_test/example/test/flame_test_test.dart
@@ -1,5 +1,5 @@
-import 'package:example/game.dart';
 import 'package:flame_test/flame_test.dart';
+import 'package:flame_test_example/game.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 final myGame = FlameTester(() => MyGame());

--- a/packages/flame_test/example/test/main_test.dart
+++ b/packages/flame_test/example/test/main_test.dart
@@ -1,6 +1,6 @@
-import 'package:example/main.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_test/flame_test.dart';
+import 'package:flame_test_example/main.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/flame_tiled/example/pubspec.yaml
+++ b/packages/flame_tiled/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: flame_tiled_example
 description: Simple project to showcase the usage of flame_tiled
 publish_to: 'none'
 version: 1.0.0+1

--- a/tutorials/space_shooter/pubspec.yaml
+++ b/tutorials/space_shooter/pubspec.yaml
@@ -1,4 +1,4 @@
-name: tutorial
+name: tutorials_space_shooter
 description: Flame Space Shooter Tutorial
 
 publish_to: 'none'


### PR DESCRIPTION
# Description

This PR renames some of the internal (non-published) packages within Flame, ensuring that they all have unique and predictable names. The reason for this change is that when melos runs its action across all packages, and then reports a problem in one of the packages, it uses the name of the package in the report. Thus, if the name is non-unique like `example`, it is impossible to tell where the problem was.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
