### PR TITLE
fix: Add missing `priority` argument for `JoystickComponent`

### DIFF
--- a/packages/flame/lib/src/components/input/joystick_component.dart
+++ b/packages/flame/lib/src/components/input/joystick_component.dart
@@ -52,6 +52,7 @@ class JoystickComponent extends HudMarginComponent with Draggable {
     double? size,
     double? knobRadius,
     Anchor anchor = Anchor.center,
+    int? priority,
   })  : assert(
           size != null || background != null,
           'Either size or background must be defined',
@@ -66,6 +67,7 @@ class JoystickComponent extends HudMarginComponent with Draggable {
           position: position,
           size: background?.size ?? Vector2.all(size ?? 0),
           anchor: anchor,
+          priority: priority,
         ) {
     this.knobRadius = knobRadius ?? this.size.x / 2;
   }


### PR DESCRIPTION
# Description

Apparently the priority was missing from the `JoystickComponent`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors and are passing (See [Contributor Guide]).
- [x] My PR does not decrease the code coverage, or I have __a very special case__ and explained on the PR description why this PR decreases the coverage.
- [x] I updated/added relevant documentation (doc comments with `///`) and updated/added examples in `doc/examples`.
- [x] I have formatted my code with `flutter format` and the `flutter analyze` does not report any problems.
- [x] I read and followed the [Flame Style Guide].
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I removed the `Draft` status, by clicking on the `Ready for review` button in this PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1226

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
