### PR TITLE
chore: Add coverage script to melos.yaml

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -23,15 +23,26 @@ scripts:
       melos exec -c 10 -- \
         flutter analyze . --fatal-infos
     description: Run `flutter analyze` for all packages.
+
   format:
     run: melos exec flutter format .
     description: Run `flutter format` for all packages.
+
   test:select:
     run: melos exec -- flutter test
     select-package:
       dir-exists:
         - test
     description: Run `flutter test` for selected packages.
+
   test:
     run: melos run test:select --no-select
     description: Run all Flutter tests in this project.
+
+  coverage:
+    run: |
+      melos exec -- flutter test --coverage &&
+      melos exec -- genhtml coverage/lcov.info --output-directory=coverage/
+    select-package:
+      dir-exists: test
+    description: Generate coverage for the selected package.


### PR DESCRIPTION
# Description

Added new command `melos run coverage` to generate the standard test coverage report.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `doc:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
