### PR TITLE
perf: Allow components to have null children

### DIFF
--- a/packages/flame/lib/src/components/component_set.dart
+++ b/packages/flame/lib/src/components/component_set.dart
@@ -103,7 +103,7 @@ class ComponentSet extends QueryableOrderedSet<Component> {
     // Should run every time the component gets a new parent, including its
     // first parent.
     component.onMount();
-    if (component.children.isNotEmpty) {
+    if (component.hasChildren) {
       await component.reAddChildren();
     }
 


### PR DESCRIPTION
# Description

The `Component.children` property can now be null.

The reasoning is simple: most of the components in the game tree are leaf nodes, and don't have any children. For these components carrying around a `ComponentSet` object is wasteful.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `doc:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
