### PR TITLE
refactor: Simplify GameWidgetState.loaderFuture

### DIFF
--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -137,10 +137,12 @@ class _GameWidgetState<T extends Game> extends State<GameWidget<T>> {
 
   MouseCursor? _mouseCursor;
 
-  Future<void> get loaderFuture => _loaderFuture ??= (() {
+  Future<void> get loaderFuture => _loaderFuture ??= (() async {
         final onLoad = widget.game.onLoadCache;
-        final onMount = widget.game.onMount;
-        return (onLoad ?? Future<void>.value()).then((_) => onMount());
+        if (onLoad != null) {
+          await onLoad;
+        }
+        widget.game.onMount();
       })();
 
   Future<void>? _loaderFuture;


### PR DESCRIPTION
# Description

The code in `loaderFuture` can be simplified using `async`.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `doc:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
