### PR TITLE
fix: `prepareComponent` should never run again on a prepared component

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -331,7 +331,7 @@ class Component with Loadable {
     final parentGame = findParent<FlameGame>();
     if (parentGame == null) {
       isPrepared = false;
-    } else {
+    } else if (!isPrepared) {
       assert(
         parentGame.hasLayout,
         '"prepare/add" called before the game is ready. '

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
@@ -14,7 +15,37 @@ class _RemoveComponent extends Component {
   }
 }
 
+class _PrepareGame extends FlameGame {
+  late final _ParentOnPrepareComponent prepareParent;
+
+  @override
+  Future<void> onLoad() async {
+    super.onLoad();
+    await add(prepareParent = _ParentOnPrepareComponent());
+  }
+
+  @override
+  void prepareComponent(Component c) {
+    super.prepareComponent(c);
+    (c as _OnPrepareComponent).prepareRuns++;
+  }
+}
+
+class _OnPrepareComponent extends Component {
+  int prepareRuns = 0;
+}
+
+class _ParentOnPrepareComponent extends _OnPrepareComponent {
+  @override
+  Future<void> onLoad() async {
+    super.onLoad();
+    await add(_OnPrepareComponent());
+  }
+}
+
 void main() {
+  final prepareGame = FlameTester(() => _PrepareGame());
+
   group('Component', () {
     test('get/set x/y or position', () {
       final PositionComponent c = SpriteComponent();
@@ -112,6 +143,16 @@ void main() {
         await game.ensureAdd(component);
         expect(component.removeCounter, 0);
         expect(game.children.length, 1);
+      },
+    );
+
+    prepareGame.test(
+      'adding children to a parent that is not yet added to a game should not '
+      'run double onPrepare',
+      (game) async {
+        final parent = game.prepareParent;
+        expect(parent.prepareRuns, 1);
+        expect((parent.children.first as _OnPrepareComponent).prepareRuns, 1);
       },
     );
 


### PR DESCRIPTION
# Description

Since `prepareComponent` can be called multiple times for non-root children we need to make sure that it is only called once.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `doc:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1235

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
