### PR TITLE
refactor: Add a few more rules to flame_lint, including use_key_in_widget_constructors

### DIFF
--- a/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
@@ -56,7 +56,7 @@ void addCameraAndViewportStories(Dashbook dashbook) {
     )
     ..add(
       'Coordinate Systems',
-      (context) => CoordinateSystemsWidget(),
+      (context) => const CoordinateSystemsWidget(),
       codeLink: baseLink('camera_and_viewport/coordinate_systems_example.dart'),
       info: CoordinateSystemsExample.description,
     );

--- a/examples/lib/stories/camera_and_viewport/coordinate_systems_example.dart
+++ b/examples/lib/stories/camera_and_viewport/coordinate_systems_example.dart
@@ -165,6 +165,8 @@ class CoordinateSystemsExample extends FlameGame
 /// on each direction (top, bottom, left and right) and allow adding
 /// or removing containers.
 class CoordinateSystemsWidget extends StatefulWidget {
+  const CoordinateSystemsWidget({Key? key}) : super(key: key);
+
   @override
   State<StatefulWidget> createState() {
     return _CoordinateSystemsState();

--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -32,7 +32,9 @@ class SpriteAnimationWidget extends StatelessWidget {
     this.anchor = Anchor.topLeft,
     this.errorBuilder,
     this.loadingBuilder,
-  }) : _animationFuture = (() => Future.value(animation));
+    Key? key,
+  })  : _animationFuture = (() => Future.value(animation)),
+        super(key: key);
 
   SpriteAnimationWidget.asset({
     required String path,
@@ -42,8 +44,13 @@ class SpriteAnimationWidget extends StatelessWidget {
     this.anchor = Anchor.topLeft,
     this.errorBuilder,
     this.loadingBuilder,
-  }) : _animationFuture =
-            (() => SpriteAnimation.load(path, data, images: images));
+    Key? key,
+  })  : _animationFuture = (() => SpriteAnimation.load(
+              path,
+              data,
+              images: images,
+            )),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flame/lib/src/widgets/base_future_builder.dart
+++ b/packages/flame/lib/src/widgets/base_future_builder.dart
@@ -11,7 +11,8 @@ class BaseFutureBuilder<T> extends StatefulWidget {
     required this.builder,
     this.loadingBuilder,
     this.errorBuilder,
-  });
+    Key? key,
+  }) : super(key: key);
 
   @override
   State<StatefulWidget> createState() {

--- a/packages/flame/lib/src/widgets/nine_tile_box.dart
+++ b/packages/flame/lib/src/widgets/nine_tile_box.dart
@@ -153,7 +153,9 @@ class NineTileBox extends StatelessWidget {
     this.child,
     this.errorBuilder,
     this.loadingBuilder,
-  }) : _imageFuture = (() => Future.value(image));
+    Key? key,
+  })  : _imageFuture = (() => Future.value(image)),
+        super(key: key);
 
   NineTileBox.asset({
     required String path,
@@ -165,7 +167,9 @@ class NineTileBox extends StatelessWidget {
     this.child,
     this.errorBuilder,
     this.loadingBuilder,
-  }) : _imageFuture = (() => (images ?? Flame.images).load(path));
+    Key? key,
+  })  : _imageFuture = (() => (images ?? Flame.images).load(path)),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -52,10 +52,12 @@ class SpriteButton extends StatelessWidget {
     this.pressedSrcSize,
     this.errorBuilder,
     this.loadingBuilder,
-  }) : _buttonsFuture = (() => Future.wait([
+    Key? key,
+  })  : _buttonsFuture = (() => Future.wait([
               Future.value(sprite),
               Future.value(pressedSprite),
-            ]));
+            ])),
+        super(key: key);
 
   SpriteButton.asset({
     required String path,
@@ -71,7 +73,8 @@ class SpriteButton extends StatelessWidget {
     this.pressedSrcSize,
     this.errorBuilder,
     this.loadingBuilder,
-  }) : _buttonsFuture = (() => Future.wait([
+    Key? key,
+  })  : _buttonsFuture = (() => Future.wait([
               Sprite.load(
                 path,
                 srcSize: srcSize,
@@ -84,7 +87,8 @@ class SpriteButton extends StatelessWidget {
                 srcPosition: pressedSrcPosition,
                 images: images,
               ),
-            ]));
+            ])),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -40,7 +40,9 @@ class SpriteWidget extends StatelessWidget {
     this.srcSize,
     this.errorBuilder,
     this.loadingBuilder,
-  }) : _spriteFuture = (() => Future.value(sprite));
+    Key? key,
+  })  : _spriteFuture = (() => Future.value(sprite)),
+        super(key: key);
 
   SpriteWidget.asset({
     required String path,
@@ -51,12 +53,14 @@ class SpriteWidget extends StatelessWidget {
     this.srcSize,
     this.errorBuilder,
     this.loadingBuilder,
-  }) : _spriteFuture = (() => Sprite.load(
+    Key? key,
+  })  : _spriteFuture = (() => Sprite.load(
               path,
               srcSize: srcSize,
               srcPosition: srcPosition,
               images: images,
-            ));
+            )),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flame_forge2d/example/lib/main.dart
+++ b/packages/flame_forge2d/example/lib/main.dart
@@ -87,7 +87,7 @@ void main() async {
     )
     ..add(
       'Widget sample',
-      (DashbookContext ctx) => BodyWidgetSample(),
+      (DashbookContext ctx) => const BodyWidgetSample(),
       info: widgetSampleDescription,
       codeLink: link('widget_sample.dart'),
     );

--- a/packages/flame_forge2d/example/lib/widget_sample.dart
+++ b/packages/flame_forge2d/example/lib/widget_sample.dart
@@ -61,6 +61,8 @@ class WidgetSample extends Forge2DGame with TapDetector {
 }
 
 class BodyWidgetSample extends StatelessWidget {
+  const BodyWidgetSample({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return GameWidget<WidgetSample>(
@@ -82,7 +84,11 @@ class BodyButtonWidget extends StatefulWidget {
   final WidgetSample _game;
   final int _bodyId;
 
-  const BodyButtonWidget(this._game, this._bodyId);
+  const BodyButtonWidget(
+    this._game,
+    this._bodyId, {
+    Key? key,
+  }) : super(key: key);
 
   @override
   State<StatefulWidget> createState() {

--- a/packages/flame_lint/lib/analysis_options.yaml
+++ b/packages/flame_lint/lib/analysis_options.yaml
@@ -5,6 +5,8 @@ analyzer:
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+  exclude:
+    - "**/*.g.dart"
 
 linter:
   rules:
@@ -132,7 +134,9 @@ linter:
     - unsafe_html
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
+    - use_if_null_to_convert_nulls_to_bools
     - use_is_even_rather_than_modulo
+    - use_key_in_widget_constructors
     - use_rethrow_when_possible
     - use_test_throws_matchers
     - valid_regexps

--- a/packages/flame_test/example/lib/game.dart
+++ b/packages/flame_test/example/lib/game.dart
@@ -3,6 +3,8 @@ import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 
 class MyGameWidget extends StatelessWidget {
+  const MyGameWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return GameWidget(game: MyGame());


### PR DESCRIPTION
# Description
This:

- Add new rule `use_if_null_to_convert_nulls_to_bools` to `flame_lint` (no violations)
- Add new rule `use_key_in_widget_constructors` (several violations)
- Fix violations
- Exclude generated files from flame_lint (we don't have any on this repo but when using on games often there are)

I believe this is *not* a breaking change because it just adds optional arguments to constructors, but if it is, we can reconsider this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
