### PR TITLE
fix: HudMarginComponent positioning on zoom

### DIFF
--- a/packages/flame/lib/src/components/input/hud_margin_component.dart
+++ b/packages/flame/lib/src/components/input/hud_margin_component.dart
@@ -83,7 +83,9 @@ class HudMarginComponent<T extends FlameGame> extends PositionComponent
   }
 
   void _updateMargins() {
-    final screenSize = gameRef.size;
+    final screenSize = positionType == PositionType.viewport
+        ? gameRef.camera.viewport.effectiveSize
+        : gameRef.canvasSize;
     final margin = this.margin!;
     final x = margin.left != 0
         ? margin.left + scaledSize.x / 2

--- a/packages/flame/test/components/hud_margin_component_test.dart
+++ b/packages/flame/test/components/hud_margin_component_test.dart
@@ -29,5 +29,26 @@ void main() async {
         expectVector2(marginComponent.position, Vector2(960.0, 950.0));
       },
     );
+
+    flameGame.test(
+      'position is still correct after zooming and a game resize',
+      (game) async {
+        final marginComponent = HudMarginComponent(
+          margin: const EdgeInsets.only(right: 10, bottom: 20),
+          size: Vector2.all(20),
+        );
+        await game.ensureAdd(marginComponent);
+        // The position should be (470, 460) since the game size is (500, 500)
+        // and the component has its anchor in the top left corner (which then
+        // is were the margin will be calculated from).
+        // (500, 500) - size(20, 20) - position(10, 20) = (470, 460)
+        expectVector2(marginComponent.position, Vector2(470.0, 460.0));
+        game.update(0);
+        game.camera.zoom = 2.0;
+        game.onGameResize(Vector2.all(500));
+        game.update(0);
+        expectVector2(marginComponent.position, Vector2(470.0, 460.0));
+      },
+    );
   });
 }


### PR DESCRIPTION
# Description

This fixes so that the `HudMarginComponent` uses the size of the viewport instead of the zoomed size from the game.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
