### PR TITLE
feat: `onCollisionStart` for `Collidable` and `HitboxShape`

### DIFF
--- a/doc/collision_detection.md
+++ b/doc/collision_detection.md
@@ -107,8 +107,12 @@ In this example it can be seen how the Dart `is` keyword is used to check which 
 that your component collided with. The set of points is where the edges of the hitboxes collided.
 Note that the `onCollision` method will be called on both collidable components if they
 have both implemented the `onCollision` method, and also on both shapes if they have that method
-implemented. The same goes for the `onCollisionEnd` method, which is called when two components or
-shapes that were previously colliding no longer colliding with each other.
+implemented. The same goes for the `onCollisionStart` and `onCollisionEnd` methods, which are
+called when two components or shapes starts or stops colliding with each other.
+
+When a `Collidable` (or `HitboxShape`) starts to collide with another `Collidable` both
+`onCollisionStart` and `onCollision` are called, so if you don't need to do something specific when
+a collision starts you only need to override `onCollision`, and vice versa.
 
 If you want to check collisions with the screen edges, as we do in the example above, you can use
 the predefined [ScreenCollidable](#screencollidable) class and since that one also is a `Collidable`

--- a/packages/flame/lib/src/components/mixins/collidable.dart
+++ b/packages/flame/lib/src/components/mixins/collidable.dart
@@ -21,6 +21,7 @@ mixin Collidable on HasHitboxes {
   CollidableType collidableType = CollidableType.active;
 
   void onCollision(Set<Vector2> intersectionPoints, Collidable other) {}
+  void onCollisionStart(Set<Vector2> intersectionPoints, Collidable other) {}
   void onCollisionEnd(Collidable other) {}
 
   @override

--- a/packages/flame/lib/src/geometry/collision_detection.dart
+++ b/packages/flame/lib/src/geometry/collision_detection.dart
@@ -27,10 +27,13 @@ void collisionDetection(List<Collidable> collidables) {
 
       final intersectionPoints = intersections(collidableX, collidableY);
       if (intersectionPoints.isNotEmpty) {
+        final collisionHash = _combinedHash(collidableX, collidableY);
+        if (_collidableHashes.add(collisionHash)) {
+          collidableX.onCollisionStart(intersectionPoints, collidableY);
+          collidableY.onCollisionStart(intersectionPoints, collidableX);
+        }
         collidableX.onCollision(intersectionPoints, collidableY);
         collidableY.onCollision(intersectionPoints, collidableX);
-        final collisionHash = _combinedHash(collidableX, collidableY);
-        _collidableHashes.add(collisionHash);
       } else {
         _handleCollisionEnd(collidableX, collidableY);
       }
@@ -92,10 +95,13 @@ Set<Vector2> intersections(
       if (currentResult.isNotEmpty) {
         result.addAll(currentResult);
         // Do callbacks to the involved shapes
+        if (_shapeHashes.add(_combinedHash(shapeA, shapeB))) {
+          shapeA.onCollisionStart(currentResult, shapeB);
+          shapeB.onCollisionStart(currentResult, shapeA);
+        }
         shapeA.onCollision(currentResult, shapeB);
         shapeB.onCollision(currentResult, shapeA);
         currentResult.clear();
-        _shapeHashes.add(_combinedHash(shapeA, shapeB));
       } else {
         _handleShapeCollisionEnd(shapeA, shapeB);
       }

--- a/packages/flame/lib/src/geometry/shape.dart
+++ b/packages/flame/lib/src/geometry/shape.dart
@@ -150,11 +150,15 @@ mixin HitboxShape on Shape {
   Vector2 get position => component.absoluteCenter;
 
   /// Assign your own [CollisionCallback] if you want a callback when this
-  /// shape collides with another [HitboxShape]
+  /// shape collides with another [HitboxShape].
   CollisionCallback onCollision = emptyCollisionCallback;
 
+  /// Assign your own [CollisionCallback] if you want a callback when this
+  /// shape starts to collide with another [HitboxShape].
+  CollisionCallback onCollisionStart = emptyCollisionCallback;
+
   /// Assign your own [CollisionEndCallback] if you want a callback when this
-  /// shape stops colliding with another [HitboxShape]
+  /// shape stops colliding with another [HitboxShape].
   CollisionEndCallback onCollisionEnd = emptyCollisionEndCallback;
 }
 

--- a/packages/flame/test/components/collision_callback_test.dart
+++ b/packages/flame/test/components/collision_callback_test.dart
@@ -8,10 +8,19 @@ class _HasCollidablesGame extends FlameGame with HasCollidables {}
 
 class _TestHitbox extends HitboxRectangle {
   final Set<HitboxShape> collisions = {};
+  int startCounter = 0;
+  int onCollisionCounter = 0;
   int endCounter = 0;
 
   _TestHitbox() {
-    onCollision = (_, shape) => collisions.add(shape);
+    onCollision = (_, shape) {
+      onCollisionCounter++;
+      collisions.add(shape);
+    };
+    onCollisionStart = (_, shape) {
+      startCounter++;
+      collisions.add(shape);
+    };
     onCollisionEnd = (shape) {
       endCounter++;
       collisions.remove(shape);
@@ -81,15 +90,15 @@ void main() {
       expect(blockB.collisions.length, 1);
       expect(blockA.startCounter, 1);
       expect(blockB.startCounter, 1);
-      expect(blockA.onCollisionCounter, 0);
-      expect(blockB.onCollisionCounter, 0);
+      expect(blockA.onCollisionCounter, 1);
+      expect(blockB.onCollisionCounter, 1);
       game.update(0);
       expect(blockA.collisions.length, 1);
       expect(blockB.collisions.length, 1);
       expect(blockA.startCounter, 1);
       expect(blockB.startCounter, 1);
-      expect(blockA.onCollisionCounter, 1);
-      expect(blockB.onCollisionCounter, 1);
+      expect(blockA.onCollisionCounter, 2);
+      expect(blockB.onCollisionCounter, 2);
       blockB.position = Vector2.all(21);
       expect(blockA.endCounter, 0);
       expect(blockB.endCounter, 0);
@@ -120,6 +129,15 @@ void main() {
       expect(hitboxB.hasCollisionWith(hitboxA), true);
       expect(hitboxA.collisions.length, 1);
       expect(hitboxB.collisions.length, 1);
+      expect(hitboxA.startCounter, 1);
+      expect(hitboxB.startCounter, 1);
+      expect(hitboxA.onCollisionCounter, 1);
+      expect(hitboxB.onCollisionCounter, 1);
+      game.update(0);
+      expect(hitboxA.startCounter, 1);
+      expect(hitboxB.startCounter, 1);
+      expect(hitboxA.onCollisionCounter, 2);
+      expect(hitboxB.onCollisionCounter, 2);
       blockB.position = Vector2.all(21);
       expect(hitboxA.endCounter, 0);
       expect(hitboxB.endCounter, 0);
@@ -128,7 +146,6 @@ void main() {
       expect(hitboxB.hasCollisionWith(hitboxA), false);
       expect(hitboxA.collisions.length, 0);
       expect(hitboxB.collisions.length, 0);
-      game.update(0);
       expect(hitboxA.endCounter, 1);
       expect(hitboxB.endCounter, 1);
     });

--- a/packages/flame/test/components/collision_callback_test.dart
+++ b/packages/flame/test/components/collision_callback_test.dart
@@ -26,6 +26,8 @@ class _TestHitbox extends HitboxRectangle {
 class _TestBlock extends PositionComponent with HasHitboxes, Collidable {
   final Set<Collidable> collisions = {};
   final hitbox = _TestHitbox();
+  int startCounter = 0;
+  int onCollisionCounter = 0;
   int endCounter = 0;
 
   _TestBlock(Vector2 position, Vector2 size)
@@ -41,8 +43,14 @@ class _TestBlock extends PositionComponent with HasHitboxes, Collidable {
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, Collidable other) {
+  void onCollisionStart(Set<Vector2> intersectionPoints, Collidable other) {
     collisions.add(other);
+    startCounter++;
+  }
+
+  @override
+  void onCollision(Set<Vector2> intersectionPoints, Collidable other) {
+    onCollisionCounter++;
   }
 
   @override
@@ -71,6 +79,17 @@ void main() {
       expect(blockB.hasCollisionWith(blockA), true);
       expect(blockA.collisions.length, 1);
       expect(blockB.collisions.length, 1);
+      expect(blockA.startCounter, 1);
+      expect(blockB.startCounter, 1);
+      expect(blockA.onCollisionCounter, 0);
+      expect(blockB.onCollisionCounter, 0);
+      game.update(0);
+      expect(blockA.collisions.length, 1);
+      expect(blockB.collisions.length, 1);
+      expect(blockA.startCounter, 1);
+      expect(blockB.startCounter, 1);
+      expect(blockA.onCollisionCounter, 1);
+      expect(blockB.onCollisionCounter, 1);
       blockB.position = Vector2.all(21);
       expect(blockA.endCounter, 0);
       expect(blockB.endCounter, 0);


### PR DESCRIPTION
# Description

Introduces `onCollsionStart` for `Collidable` and `HitboxShape`, which is called only once when the collision starts.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
