### PR TITLE
fix: Clone input vector before projecting it

### DIFF
--- a/packages/flame_forge2d/lib/forge2d_camera.dart
+++ b/packages/flame_forge2d/lib/forge2d_camera.dart
@@ -10,7 +10,7 @@ class Forge2DCamera extends Camera {
 
   @override
   Vector2 projectVector(Vector2 worldCoordinates) {
-    return ((worldCoordinates..y *= -1) - position)..scale(zoom);
+    return ((worldCoordinates.clone()..y *= -1) - position)..scale(zoom);
   }
 
   @override

--- a/packages/flame_forge2d/test/position_test.dart
+++ b/packages/flame_forge2d/test/position_test.dart
@@ -15,4 +15,14 @@ void main() {
       });
     },
   );
+  group(
+    'Test input vector does not get modified while function call',
+    () {
+      test('Camera should not modify the input vector while projecting it', () {
+        final vec = Vector2(5, 6);
+        TestGame().camera.projectVector(vec);
+        expect(vec, Vector2(5, 6));
+      });
+    },
+  );
 }


### PR DESCRIPTION
# Description

While projecting world coordinates, Forge2DCamera was modifying the original input vector. This change makes sure that the input vector is cloned before modifying it.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- (NA) I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- (NA) I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1254 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
