### PR TITLE
feat: Expose priority for TiledComponent

### DIFF
--- a/packages/flame_tiled/lib/src/tiled_component.dart
+++ b/packages/flame_tiled/lib/src/tiled_component.dart
@@ -23,12 +23,11 @@ class TiledComponent extends Component {
   }
 
   /// Loads a [TiledComponent] from a file.
-  static Future<TiledComponent> load(
-    String fileName,
-    Vector2 destTileSize,
-  ) async {
+  static Future<TiledComponent> load(String fileName, Vector2 destTileSize,
+      {int? priority}) async {
     return TiledComponent(
       await RenderableTiledMap.fromFile(fileName, destTileSize),
+      priority: priority,
     );
   }
 }

--- a/packages/flame_tiled/lib/src/tiled_component.dart
+++ b/packages/flame_tiled/lib/src/tiled_component.dart
@@ -15,7 +15,7 @@ class TiledComponent extends Component {
   RenderableTiledMap tileMap;
 
   /// {@macro _tiled_component}
-  TiledComponent(this.tileMap);
+  TiledComponent(this.tileMap, {int? priority}) : super(priority: priority);
 
   @override
   void render(Canvas canvas) {

--- a/packages/flame_tiled/lib/src/tiled_component.dart
+++ b/packages/flame_tiled/lib/src/tiled_component.dart
@@ -23,8 +23,11 @@ class TiledComponent extends Component {
   }
 
   /// Loads a [TiledComponent] from a file.
-  static Future<TiledComponent> load(String fileName, Vector2 destTileSize,
-      {int? priority}) async {
+  static Future<TiledComponent> load(
+    String fileName,
+    Vector2 destTileSize, {
+    int? priority,
+  }) async {
     return TiledComponent(
       await RenderableTiledMap.fromFile(fileName, destTileSize),
       priority: priority,


### PR DESCRIPTION
# Description

There was no way to set priority of TiledComponent while construction. This change exposes that property.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- (NA) I have updated/added tests for ALL new/updated/fixed functionality.
- (NA) I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- (NA) I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

## Related Issues

NA

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
