### PR TITLE
feat: Turn off `strictMode` for children

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -91,10 +91,15 @@ class GameOverPanel extends PositionComponent with HasGameRef<MyGame> {
 
 ### Querying child components
 
-The children that have been added to a component live in the `QueryableOrderedSet` called
-`components`. To query for a specific type of components in the set, a query first has to be
-registered on the set, and then the `query` function can be run efficiently at any later point. The
-register call is usually done in `onLoad`.
+The children that have been added to a component live in a `QueryableOrderedSet` called
+`children`. To query for a specific type of components in the set, the `query<T>()` function can be
+used. By default `strictMode` is `false` in the children set, but if you set it to true, then the
+queries will have to be registered with `children.register` before a query can be used.
+
+If you know in compile time that you will later will run a query of a specific type it is
+recommended to register the query no matter if the `strictMode` is set to `true` or `false`, since
+there are some performance benefits to gain from it. The `register` call is usually done in
+`onLoad`.
 
 Example:
 

--- a/doc/components.md
+++ b/doc/components.md
@@ -96,10 +96,9 @@ The children that have been added to a component live in a `QueryableOrderedSet`
 used. By default `strictMode` is `false` in the children set, but if you set it to true, then the
 queries will have to be registered with `children.register` before a query can be used.
 
-If you know in compile time that you will later will run a query of a specific type it is
-recommended to register the query no matter if the `strictMode` is set to `true` or `false`, since
-there are some performance benefits to gain from it. The `register` call is usually done in
-`onLoad`.
+If you know in compile time that you later will run a query of a specific type it is recommended to
+register the query, no matter if the `strictMode` is set to `true` or `false`, since there are some
+performance benefits to gain from it. The `register` call is usually done in `onLoad`.
 
 Example:
 

--- a/packages/flame/lib/src/components/component_set.dart
+++ b/packages/flame/lib/src/components/component_set.dart
@@ -44,7 +44,7 @@ class ComponentSet extends QueryableOrderedSet<Component> {
   ComponentSet(
     int Function(Component e1, Component e2)? comparator,
     this.parent, {
-    bool strictMode = true,
+    bool strictMode = false,
   }) : super(comparator: comparator, strictMode: strictMode);
 
   /// Prepares and registers one component to be added on the next game tick.


### PR DESCRIPTION
# Description

In some situations where you don't know whether you need to use `children.query` or not it will be a performance hit to be forced to `register` the query, since when `children.register` is called the set is initialized, even though the children set might never be used.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
