### PR TITLE
fix: TextBoxComponent did not redraw when changing text to another string with the same length

### DIFF
--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -83,6 +83,15 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
         );
 
   @override
+  set text(String value) {
+    if (text != value) {
+      super.text = value;
+      // This ensures that the component will redraw on next update
+      _previousChar = -1;
+    }
+  }
+
+  @override
   @mustCallSuper
   Future<void> onLoad() async {
     await super.onLoad();


### PR DESCRIPTION
# Description

TextBoxComponent used to decide whether to redraw text or not based on whether the text length is different from the `_previousChar` value. Thus, when replacing text with another text that has the same length, the component failed to update its cached image.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- (NA) I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- (NA) I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1277

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
