### PR TITLE
fix: Typo in handleDragCanceled() callback

### DIFF
--- a/packages/flame/lib/src/components/mixins/draggable.dart
+++ b/packages/flame/lib/src/components/mixins/draggable.dart
@@ -56,7 +56,7 @@ mixin Draggable on Component {
     if (_checkPointerId(pointerId)) {
       _isDragged = false;
       _currentPointerIds.remove(pointerId);
-      return handleDragCanceled(pointerId);
+      return onDragCancel(pointerId);
     }
     return true;
   }

--- a/packages/flame/test/components/draggable_test.dart
+++ b/packages/flame/test/components/draggable_test.dart
@@ -9,10 +9,17 @@ class _GameHasDraggables extends FlameGame with HasDraggables {}
 
 class _DraggableComponent extends PositionComponent with Draggable {
   bool hasStartedDragging = false;
+  bool hasCanceledDragging = false;
 
   @override
   bool onDragStart(int pointerId, DragStartInfo info) {
     hasStartedDragging = true;
+    return true;
+  }
+
+  @override
+  bool onDragCancel(int pointerId) {
+    hasCanceledDragging = true;
     return true;
   }
 }
@@ -154,7 +161,9 @@ void main() {
       ),
     );
     expect(component.isDragged, true);
+    expect(component.hasCanceledDragging, false);
     game.onDragCancel(1);
     expect(component.isDragged, false);
+    expect(component.hasCanceledDragging, true);
   });
 }


### PR DESCRIPTION
# Description

A typo in `handleDragCanceled` caused the proper event handler `onDragCancel` to never be called.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [NA] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [NA] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1276 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
