### PR TITLE
fix: Add missing paint argument to `SpriteComponent.fromImage`

### DIFF
--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -43,6 +43,7 @@ class SpriteComponent extends PositionComponent with HasPaint {
     Image image, {
     Vector2? srcPosition,
     Vector2? srcSize,
+    Paint? paint,
     Vector2? position,
     Vector2? size,
     Vector2? scale,
@@ -55,6 +56,7 @@ class SpriteComponent extends PositionComponent with HasPaint {
             srcPosition: srcPosition,
             srcSize: srcSize,
           ),
+          paint: paint,
           position: position,
           size: size ?? srcSize ?? image.size,
           scale: scale,


### PR DESCRIPTION
# Description

Adding the paint argument which exists in the normal `SpriteComponent` constructor to the named `SpriteComponent.fromImage` constructor.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
