### PR TITLE
feat: Add onReleased callback for HudButtonComponent

### DIFF
--- a/doc/other-inputs.md
+++ b/doc/other-inputs.md
@@ -113,9 +113,9 @@ As the name suggests this button is a hud by default, which means that it will b
 screen even if the camera for the game moves around. You can also use this component as a non-hud by
 setting `hudButtonComponent.respectCamera = true;`.
 
-If you want to act upon the button being pressed (which would be the common thing to do) you can either pass in
-a callback function as the `onPressed` argument, or you extend the component and override
-`onTapDown`, `onTapUp` and/or `onTapCancel` and implement your logic there.
+If you want to act upon the button being pressed (which would be the common thing to do) and released,
+you can either pass in callback functions as the `onPressed` and `onReleased` arguments, or you can
+extend the component and override `onTapDown`, `onTapUp` and/or `onTapCancel` and implement your logic there.
 
 ## SpriteButtonComponent
 

--- a/packages/flame/lib/src/components/input/hud_button_component.dart
+++ b/packages/flame/lib/src/components/input/hud_button_component.dart
@@ -14,15 +14,17 @@ class HudButtonComponent extends HudMarginComponent with Tappable {
   late final PositionComponent? buttonDown;
 
   /// Callback for what should happen when the button is pressed.
-  /// If you want to interact with [onTapUp] or [onTapCancel] it is recommended
-  /// to extend [HudButtonComponent].
   void Function()? onPressed;
+
+  /// Callback for what should happen when the button is released.
+  void Function()? onReleased;
 
   HudButtonComponent({
     this.button,
     this.buttonDown,
     EdgeInsets? margin,
     this.onPressed,
+    this.onReleased,
     Vector2? position,
     Vector2? size,
     Vector2? scale,
@@ -81,6 +83,7 @@ class HudButtonComponent extends HudMarginComponent with Tappable {
         add(button!);
       }
     }
+    onReleased?.call();
     return false;
   }
 }

--- a/packages/flame/lib/src/components/input/hud_button_component.dart
+++ b/packages/flame/lib/src/components/input/hud_button_component.dart
@@ -14,9 +14,13 @@ class HudButtonComponent extends HudMarginComponent with Tappable {
   late final PositionComponent? buttonDown;
 
   /// Callback for what should happen when the button is pressed.
+  /// If you want to directly interact with [onTapUp], [onTapDown] or
+  /// [onTapCancel] it is recommended to extend [HudButtonComponent].
   void Function()? onPressed;
 
   /// Callback for what should happen when the button is released.
+  /// If you want to directly interact with [onTapUp], [onTapDown] or
+  /// [onTapCancel] it is recommended to extend [HudButtonComponent].
   void Function()? onReleased;
 
   HudButtonComponent({
@@ -71,6 +75,7 @@ class HudButtonComponent extends HudMarginComponent with Tappable {
   @mustCallSuper
   bool onTapUp(TapUpInfo info) {
     onTapCancel();
+    onReleased?.call();
     return true;
   }
 
@@ -83,7 +88,6 @@ class HudButtonComponent extends HudMarginComponent with Tappable {
         add(button!);
       }
     }
-    onReleased?.call();
     return false;
   }
 }


### PR DESCRIPTION
# Description

This PR adds an `onReleased` callback to HudButtonComponent which will be called when button is released.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- (NA) I have updated/added tests for ALL new/updated/fixed functionality.
- (NA) I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1290 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
