### PR TITLE
fix: Clip canvas when rendering Game

### DIFF
--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -10,6 +10,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   BuildContext buildContext;
   Game game;
   GameLoop? gameLoop;
+  Rect? _clipRect;
 
   GameRenderBox(this.buildContext, this.game) {
     WidgetsBinding.instance!.addTimingsCallback(game.onTimingsCallback);
@@ -61,13 +62,14 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   @override
   void performLayout() {
     size = constraints.biggest;
+    _clipRect = Rect.fromLTWH(0, 0, size.width, size.height);
   }
 
   @override
   void paint(PaintingContext context, Offset offset) {
     context.canvas.save();
     context.canvas.translate(offset.dx, offset.dy);
-    context.canvas.clipRect(Rect.fromLTWH(0, 0, size.width, size.height));
+    context.canvas.clipRect(_clipRect!, doAntiAlias: false);
     game.render(context.canvas);
     context.canvas.restore();
   }

--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -67,6 +67,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   void paint(PaintingContext context, Offset offset) {
     context.canvas.save();
     context.canvas.translate(offset.dx, offset.dy);
+    context.canvas.clipRect(Rect.fromLTWH(0, 0, size.width, size.height));
     game.render(context.canvas);
     context.canvas.restore();
   }

--- a/packages/flame/test/game/flame_game_test.dart
+++ b/packages/flame/test/game/flame_game_test.dart
@@ -128,6 +128,7 @@ void main() {
         renderBox.attach(PipelineOwner());
         renderBox.gameLoopCallback(1.0);
         expect(component.isUpdateCalled, true);
+        renderBox.layout(BoxConstraints.tight(const Size.square(1000)));
         renderBox.paint(
           PaintingContext(ContainerLayer(), Rect.zero),
           Offset.zero,


### PR DESCRIPTION
# Description

Ensure that game canvas is clipped, allowing it to be used in situations where the game was not fullscreen. See https://github.com/bluefireteam/dashbook/issues/68 for an example of this bug.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

Fixes https://github.com/bluefireteam/dashbook/issues/68

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
