### PR TITLE
docs: Replace renderFlip properties with flipxxx methods

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -206,10 +206,13 @@ If you want to know where on the screen the bounding box of the component is you
 `toRect` method.
 
 In the event that you want to change the direction of your components rendering, you can also use
-`flipHorizontally()` and `flipVertically()` to flip anything drawn to canvas during `render(Canvas canvas)`.
-This is available on all `PositionComponent` objects, and is especially useful on `SpriteComponent`
-and `SpriteAnimationComponent`. For example call `component.flipHorizontally()` to mirror the
-horizontal rendering.
+`flipHorizontally()` and `flipVertically()` to flip anything drawn to canvas during `render(Canvas canvas)`,
+about the anchor point. These methods are available on all `PositionComponent` objects, and are especially
+useful on `SpriteComponent` and `SpriteAnimationComponent`. For example call `component.flipHorizontally()`
+to mirror the horizontal rendering.
+
+In case you want to flip a component about its center without having to change the anchor to `Anchor.center`,
+you can use `flipHorizontallyAroundCenter()` and `flipVerticallyAroundCenter()`.
 
 ## SpriteComponent
 

--- a/doc/components.md
+++ b/doc/components.md
@@ -211,8 +211,7 @@ If you want to know where on the screen the bounding box of the component is you
 In the event that you want to change the direction of your components rendering, you can also use
 `flipHorizontally()` and `flipVertically()` to flip anything drawn to canvas during `render(Canvas canvas)`,
 around the anchor point. These methods are available on all `PositionComponent` objects, and are especially
-useful on `SpriteComponent` and `SpriteAnimationComponent`. For example call `component.flipHorizontally()`
-to mirror the horizontal rendering.
+useful on `SpriteComponent` and `SpriteAnimationComponent`.
 
 In case you want to flip a component around its center without having to change the anchor to `Anchor.center`,
 you can use `flipHorizontallyAroundCenter()` and `flipVerticallyAroundCenter()`.

--- a/doc/components.md
+++ b/doc/components.md
@@ -207,11 +207,11 @@ If you want to know where on the screen the bounding box of the component is you
 
 In the event that you want to change the direction of your components rendering, you can also use
 `flipHorizontally()` and `flipVertically()` to flip anything drawn to canvas during `render(Canvas canvas)`,
-about the anchor point. These methods are available on all `PositionComponent` objects, and are especially
+around the anchor point. These methods are available on all `PositionComponent` objects, and are especially
 useful on `SpriteComponent` and `SpriteAnimationComponent`. For example call `component.flipHorizontally()`
 to mirror the horizontal rendering.
 
-In case you want to flip a component about its center without having to change the anchor to `Anchor.center`,
+In case you want to flip a component around its center without having to change the anchor to `Anchor.center`,
 you can use `flipHorizontallyAroundCenter()` and `flipVerticallyAroundCenter()`.
 
 ## SpriteComponent

--- a/doc/components.md
+++ b/doc/components.md
@@ -206,12 +206,13 @@ If you want to know where on the screen the bounding box of the component is you
 `toRect` method.
 
 In the event that you want to change the direction of your components rendering, you can also use
-`renderFlipX` and `renderFlipY` to flip anything drawn to canvas during `render(Canvas canvas)`.
+`flipHorizontally()` and `flipVertically()` to flip anything drawn to canvas during `render(Canvas canvas)`.
 This is available on all `PositionComponent` objects, and is especially useful on `SpriteComponent`
-and `SpriteAnimationComponent`. For example set `component.renderFlipX = true` to mirror the
+and `SpriteAnimationComponent`. For example call `component.flipHorizontally()` to mirror the
 horizontal rendering.
 
 ## SpriteComponent
+
 The most commonly used implementation of `PositionComponent` is `SpriteComponent`, and it can be
 created with a `Sprite`:
 


### PR DESCRIPTION
# Description

Updated the docs to use `flipHorizontally()` and `flipVertically()` instead of `renderFlipX` and `renderFlipY`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- (NA) I have updated/added relevant examples in `examples`.
- (NA) I have updated/added tests for ALL new/updated/fixed functionality.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1303 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
