### PR TITLE
fix: onGameResize callback #1305

### DIFF
--- a/packages/flame/lib/src/components/component_set.dart
+++ b/packages/flame/lib/src/components/component_set.dart
@@ -187,6 +187,10 @@ class ComponentSet extends QueryableOrderedSet<Component> {
     _addLater.forEach((c) {
       super.add(c);
       c.isMounted = true;
+      final parentGame = c.findParent<FlameGame>();
+      if (parentGame != null) {
+        c.onGameResize(parentGame.size);
+      }
     });
     _addLater.clear();
   }

--- a/packages/flame/lib/src/components/component_set.dart
+++ b/packages/flame/lib/src/components/component_set.dart
@@ -188,7 +188,9 @@ class ComponentSet extends QueryableOrderedSet<Component> {
       super.add(c);
       c.isMounted = true;
       final parentGame = c.findParent<FlameGame>();
-      if (parentGame != null) {
+      if (c is PositionComponent &&
+          parentGame != null &&
+          parentGame.size != c.size) {
         c.onGameResize(parentGame.size);
       }
     });


### PR DESCRIPTION
# Description

This pull request fixes #1305.
It calls onGameResize callback when component added in _actuallyAdd method

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

## Related Issues

#1305 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
