### PR TITLE
refactor: Resize logic in GameRenderBox

### DIFF
--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -19,10 +19,10 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   bool get isRepaintBoundary => true;
 
   @override
-  void performResize() {
-    super.performResize();
-    game.onGameResize(constraints.biggest.toVector2());
-  }
+  bool get sizedByParent => true;
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => constraints.biggest;
 
   @override
   void attach(PipelineOwner owner) {
@@ -59,11 +59,6 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   }
 
   @override
-  void performLayout() {
-    size = constraints.biggest;
-  }
-
-  @override
   void paint(PaintingContext context, Offset offset) {
     context.canvas.save();
     context.canvas.translate(offset.dx, offset.dy);
@@ -83,7 +78,4 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     game.lifecycleStateChange(state);
   }
-
-  @override
-  Size computeDryLayout(BoxConstraints constraints) => constraints.biggest;
 }

--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart' hide WidgetBuilder;
 
-import '../extensions/size.dart';
 import 'game_loop.dart';
 import 'mixins/game.dart';
 


### PR DESCRIPTION
# Description

The documentation of `RenderBox` says the following:
```dart
/// When implementing a [RenderBox] subclass, one must make a choice. Does it
/// size itself exclusively based on the constraints, or does it use any other
/// information in sizing itself? An example of sizing purely based on the
/// constraints would be growing to fit the parent.
///
/// Sizing purely based on the constraints allows the system to make some
/// significant optimizations. Classes that use this approach should override
/// [sizedByParent] to return true, and then override [computeDryLayout] to
/// compute the [Size] using nothing but the constraints, e.g.:
```
This PR changes `GameRenderBox` to adhere to this advice and set `sizedByParent` to true. 

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- (NA) I have updated/added tests for ALL new/updated/fixed functionality.
- (NA) I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- (NA) I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

Maybe helps with #1293 ?

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
