### PR TITLE
fix: Properly dispose images when cache is cleared

### DIFF
--- a/doc/images.md
+++ b/doc/images.md
@@ -29,6 +29,12 @@ They return a `Future` for the loaded Image.
 To synchronously retrieve a previously cached image, the `fromCache` method can be used. If an image
 with that key was not previously loaded, it will throw an exception.
 
+To add an already loaded image to the cache, the `add` method can be used and you can set the key
+that the image should have in the cache.
+
+For `clear` and `clearCache`, do note that `dispose` is called for each removed image from the
+cache, so make sure that you don't use the image afterwards.
+
 ### Standalone usage
 
 It can manually be used by instantiating it:

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -17,11 +17,14 @@ class Images {
 
   /// Remove the image with the specified [fileName] from the cache.
   void clear(String fileName) {
-    _loadedFiles.remove(fileName);
+    _loadedFiles.remove(fileName)?.loadedImage?.dispose();
   }
 
   /// Clear all cached images.
   void clearCache() {
+    _loadedFiles.forEach((_, imageAssetLoader) {
+      imageAssetLoader.loadedImage?.dispose();
+    });
     _loadedFiles.clear();
   }
 

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -15,9 +15,16 @@ class Images {
 
   Images({this.prefix = 'assets/images/'});
 
-  /// Remove the image with the specified [fileName] from the cache.
-  void clear(String fileName) {
-    _loadedFiles.remove(fileName)?.loadedImage?.dispose();
+  /// Adds an [image] to the cache that can be fetched with with the specified
+  /// [name].
+  void add(String name, Image image) {
+    _loadedFiles[name] = _ImageAssetLoader(Future.value(image))
+      ..loadedImage = image;
+  }
+
+  /// Remove the image with the specified [name] from the cache.
+  void clear(String name) {
+    _loadedFiles.remove(name)?.loadedImage?.dispose();
   }
 
   /// Clear all cached images.
@@ -28,12 +35,12 @@ class Images {
     _loadedFiles.clear();
   }
 
-  /// Gets the specified image with [fileName] from the cache.
-  Image fromCache(String fileName) {
-    final image = _loadedFiles[fileName];
+  /// Gets the specified image with [name] from the cache.
+  Image fromCache(String name) {
+    final image = _loadedFiles[name];
     assert(
       image?.loadedImage != null,
-      'Tried to access an inexistent entry on cache "$fileName", make sure to '
+      'Tried to access an inexistent entry on cache "$name", make sure to '
       'use the load method before accessing a file on the cache',
     );
     return image!.loadedImage!;

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -23,11 +23,16 @@ class Images {
   }
 
   /// Remove the image with the specified [name] from the cache.
+  /// This calls [Image.dispose], so make sure that you don't use the previously
+  /// cached image once it is cleared (removed) from the cache.
   void clear(String name) {
     _loadedFiles.remove(name)?.loadedImage?.dispose();
   }
 
   /// Clear all cached images.
+  /// This calls [Image.dispose] for all images in the cache, so make sure that
+  /// you don't use any of the previously cached images once [clearCache] has
+  /// been called.
   void clearCache() {
     _loadedFiles.forEach((_, imageAssetLoader) {
       imageAssetLoader.loadedImage?.dispose();

--- a/packages/flame/test/images_cache_test.dart
+++ b/packages/flame/test/images_cache_test.dart
@@ -1,0 +1,41 @@
+import 'dart:ui';
+
+import 'package:flame/assets.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockImage extends Mock implements Image {
+  int disposedCount = 0;
+
+  @override
+  void dispose() {
+    disposedCount++;
+  }
+}
+
+void main() {
+  group('ImagesCache', () {
+    test('clear', () {
+      final cache = Images();
+      final image = MockImage();
+      cache.add('test', image);
+      expect(image.disposedCount, 0);
+      cache.clear('test');
+      expect(image.disposedCount, 1);
+    });
+
+    test('clearCache', () {
+      final cache = Images();
+      final images = List.generate(10, (_) => MockImage());
+      for (var i = 0; i < images.length; i++) {
+        cache.add(i.toString(), images[i]);
+      }
+      expect(images.fold<int>(0, (agg, image) => agg + image.disposedCount), 0);
+      cache.clearCache();
+      expect(
+        images.fold<int>(0, (agg, image) => agg + image.disposedCount),
+        images.length,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

Disposes the images when they are removed or when the image cache is cleared.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

## Related Issues

Closes #1309

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
