### PR TITLE
fix: Optimize the contact callback process.

### DIFF
--- a/packages/flame_forge2d/lib/contact_callbacks.dart
+++ b/packages/flame_forge2d/lib/contact_callbacks.dart
@@ -2,25 +2,9 @@ import 'package:forge2d/forge2d.dart';
 
 import 'body_component.dart';
 
-class ContactTypes<T1, T2> {
-  // If o1 is, or inherits from, T1 or T2
-  bool has(Object o1) => o1 is T1 || o1 is T2;
-  bool hasOne(Object o1, Object o2) => has(o1) || has(o2);
-
-  // Only makes sense to call with objects that you know is in [T1, T2]
-  bool inOrder(Object o1, Object o2) => o1 is T1 && o2 is T2;
-
-  // Remember that this is not symmetric, it checks if the types in `o1` and
-  // `o2` are the same or inherits from the types in `other`
-  bool match(Object o1, Object o2) =>
-      (o1 is T1 && o2 is T2) || (o2 is T1 && o1 is T2);
-}
-
-typedef ContactCallbackFun = void Function(Object a, Object b, Contact contact);
+typedef ContactCallbackFun = void Function(ContactCallback a, ContactCallback b, Contact contact);
 
 abstract class ContactCallback<Type1, Type2> {
-  ContactTypes<Type1, Type2> types = ContactTypes<Type1, Type2>();
-
   void begin(Type1 a, Type2 b, Contact contact);
   void end(Type1 a, Type2 b, Contact contact);
   void preSolve(Type1 a, Type2 b, Contact contact, Manifold oldManifold) {}
@@ -28,66 +12,52 @@ abstract class ContactCallback<Type1, Type2> {
 }
 
 class ContactCallbacks extends ContactListener {
-  final List<ContactCallback> _callbacks = [];
 
-  void register(ContactCallback callback) {
-    _callbacks.add(callback);
-  }
-
-  void deregister(ContactCallback callback) {
-    _callbacks.remove(callback);
-  }
-
-  void clear() {
-    _callbacks.clear();
-  }
-
-  void _maybeCallback(
-    Contact contact,
-    ContactCallback callback,
-    ContactCallbackFun f,
-  ) {
+  void _specificCallback(Contact contact, ContactCallbackFun f) {
     final a = contact.fixtureA.body.userData;
     final b = contact.fixtureB.body.userData;
-    final wanted = callback.types;
-
     if (a == null || b == null) {
       return;
     }
-
-    if (wanted.match(a, b) ||
-        (wanted.has(BodyComponent) && wanted.hasOne(a, b))) {
-      wanted.inOrder(a, b) ? f(a, b, contact) : f(b, a, contact);
+    if (!(a is ContactCallback) || !(b is ContactCallback)) {
+      return;
     }
+    f(a, b, contact);
   }
 
   @override
-  void beginContact(Contact contact) =>
-      _callbacks.forEach((c) => _maybeCallback(contact, c, c.begin));
+  void beginContact(Contact contact) {
+    ContactCallbackFun beginAux = (ContactCallback a, ContactCallback b, Contact contact) {
+      a.begin(a, b, contact);
+      b.begin(b, a, contact);
+    };
+    _specificCallback(contact, beginAux);
+  }
 
   @override
-  void endContact(Contact contact) =>
-      _callbacks.forEach((c) => _maybeCallback(contact, c, c.end));
+  void endContact(Contact contact) {
+    ContactCallbackFun endAux = (ContactCallback a, ContactCallback b, Contact contact) {
+      a.end(a, b, contact);
+      b.end(b, a, contact);
+    };
+    _specificCallback(contact, endAux);
+  }
 
   @override
   void preSolve(Contact contact, Manifold oldManifold) {
-    _callbacks.forEach((c) {
-      void preSolveAux(Object a, Object b, Contact contact) {
-        c.preSolve(a, b, contact, oldManifold);
-      }
-
-      _maybeCallback(contact, c, preSolveAux);
-    });
+    ContactCallbackFun preSolveAux = (ContactCallback a, ContactCallback b, Contact contact) {
+      a.preSolve(a, b, contact, oldManifold);
+      b.preSolve(b, a, contact, oldManifold);
+    };
+    _specificCallback(contact, preSolveAux);
   }
 
   @override
   void postSolve(Contact contact, ContactImpulse impulse) {
-    _callbacks.forEach((c) {
-      void postSolveAux(Object a, Object b, Contact contact) {
-        c.postSolve(a, b, contact, impulse);
-      }
-
-      _maybeCallback(contact, c, postSolveAux);
-    });
+    ContactCallbackFun postSolveAux = (ContactCallback a, ContactCallback b, Contact contact) {
+      a.postSolve(a, b, contact, impulse);
+      b.postSolve(b, a, contact, impulse);
+    };
+    _specificCallback(contact, postSolveAux);
   }
 }

--- a/packages/flame_forge2d/lib/forge2d_game.dart
+++ b/packages/flame_forge2d/lib/forge2d_game.dart
@@ -27,18 +27,6 @@ class Forge2DGame extends FlameGame {
     world.stepDt(dt);
   }
 
-  void addContactCallback(ContactCallback callback) {
-    _contactCallbacks.register(callback);
-  }
-
-  void removeContactCallback(ContactCallback callback) {
-    _contactCallbacks.deregister(callback);
-  }
-
-  void clearContactCallbacks() {
-    _contactCallbacks.clear();
-  }
-
   Vector2 worldToScreen(Vector2 position) {
     return projector.projectVector(position);
   }


### PR DESCRIPTION
Sorry for late. Yes, this is a breaking change, it's my mistake for description.

The original code may cause a bug when register more than one same class, such as I register two Football. Then the two class both will be selected in the functions of 'ContactTypes' and both will be callback. So maybe the two balls will both move if we don't do anything else to make the two Football different.

About "why there are no need to register the callbacks". Because the 'Contact' call back from the forge2d (beginContact, endContact) already tell us both the contacted objects. 'Contact' includes the two bodies and the two fixtures that contacted. And we also can get the contacted object using the 'userData' of 'BodyDef'.

Using my modified code, the listening callback can be like below:

class Football extends PositionBodyComponent with ContactCallback {
  ...
  @override
  void begin(a, b, Contact contact) {
    // Here a is the Football, b is another contacted object.
  }

  @override
  void end(a, b, Contact contact) {}
}

---------------- new above --- old below --------------

# Description

The callback process is no need to do 'register' and 'forEach' loop to fetch.
There will be a problem when two same class A in the listener list, because the forEach and _mayCallback will callback the both but only one is in the contact.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have did tests for ALL new/updated/fixed functionality.
- [/] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [/] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

YES, this is a breaking change.

## Related Issues

#1321
