### PR TITLE
refactor: Loadable no longer declares onGameResize

### DIFF
--- a/examples/lib/stories/system/without_flamegame_example.dart
+++ b/examples/lib/stories/system/without_flamegame_example.dart
@@ -8,7 +8,7 @@ class NoFlameGameExample with Loadable, Game, KeyboardEvents {
   static const String description = '''
     This example showcases how to create a game without the FlameGame.
     It also briefly showcases how to act on keyboard events.
-    Usage: Use A S D F to steer the rectangle.
+    Usage: Use A W S D to steer the rectangle.
   ''';
 
   static final Paint white = BasicPalette.white.paint();

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -119,6 +119,15 @@ class Component with Loadable {
 
   //#region Component lifecycle methods
 
+  /// Called whenever the size of the top-level Canvas changes.
+  ///
+  /// In addition, this method will be invoked once after the component is
+  /// attached to the game tree, and before [onLoad] is called.
+  @mustCallSuper
+  void onGameResize(Vector2 gameSize) {
+    _children?.forEach((child) => child.onGameResize(gameSize));
+  }
+
   /// Called after the component has finished running its [onLoad] method and
   /// when the component is added to its new parent.
   ///
@@ -202,16 +211,6 @@ class Component with Loadable {
       yield current;
       current = current.parent;
     }
-  }
-
-  /// It receives the new game size.
-  /// Executed right after the component is attached to a game and right before
-  /// [onLoad] is called.
-  @override
-  @mustCallSuper
-  void onGameResize(Vector2 gameSize) {
-    super.onGameResize(gameSize);
-    _children?.forEach((child) => child.onGameResize(gameSize));
   }
 
   /// Called right before the component is removed from the game.

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -106,7 +106,11 @@ class FlameGame extends Component with Game {
   @mustCallSuper
   void onGameResize(Vector2 canvasSize) {
     camera.handleResize(canvasSize);
-    super.onGameResize(canvasSize);
+    super.onGameResize(canvasSize); // Game.onGameResize
+    // [onGameResize] is declared both in [Component] and in [Game]. Since
+    // there is no way to explicitly call the [Component]'s implementation,
+    // we propagate the event to [FlameGame]'s children manually.
+    children.forEach((child) => child.onGameResize(canvasSize));
   }
 
   /// Whether a point is within the boundaries of the visible part of the game.

--- a/packages/flame/lib/src/game/mixins/game.dart
+++ b/packages/flame/lib/src/game/mixins/game.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -69,10 +68,8 @@ mixin Game on Loadable {
   /// is called.
   ///
   /// The default implementation just sets the new size on the size field
-  @override
   @mustCallSuper
   void onGameResize(Vector2 size) {
-    super.onGameResize(size);
     _size = (_size ?? Vector2.zero())..setFrom(size);
   }
 

--- a/packages/flame/lib/src/game/mixins/loadable.dart
+++ b/packages/flame/lib/src/game/mixins/loadable.dart
@@ -9,10 +9,6 @@ import '../../../game.dart';
 /// component/class can be certain that [onLoad] only runs once which then gives
 /// the possibility to do late initializations in [onLoad].
 mixin Loadable {
-  /// This receives the new bounding size from its parent, which could be for
-  /// example a [GameWidget] or a `Component`.
-  void onGameResize(Vector2 size) {}
-
   /// Whenever [onLoad] returns something, the parent will wait for the [Future]
   /// to be resolved before adding it.
   /// If `null` is returned, the class is added right away.


### PR DESCRIPTION
# Description

Mixin `Loadable` no longer declares method `onGameResize()`. Instead, this method is now defined by classes `Component` and `Game` separately (which they were already doing before).

Resizing has nothing to do with loading, so it is not proper to declare this method inside `Loadable`. I presume it existed there by accident. 


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- (NA) I have updated/added tests for ALL new/updated/fixed functionality.
- (NA) I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- (NA) I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
