### PR TITLE
docs: Fix typo in flame_bloc readme

### DIFF
--- a/packages/flame_bloc/README.md
+++ b/packages/flame_bloc/README.md
@@ -18,7 +18,7 @@ BlocProvider<ExampleGame>(
 To access the bloc from inside your game, the `read` method can be used.
 
 ```dart
-class ExampleGame example FlameBlocGame {
+class ExampleGame extends FlameBlocGame {
   void selectWeapon() {
     read<InventoryBloc>.add(WeaponSelected('axe'));
   }


### PR DESCRIPTION
the example should be 

```dart
class ExampleGame extends FlameBlocGame {
  void selectWeapon() {
    read<InventoryBloc>.add(WeaponSelected('axe'));
  }
}
```

not

```dart
class ExampleGame example FlameBlocGame {
  void selectWeapon() {
    read<InventoryBloc>.add(WeaponSelected('axe'));
  }
}
```

# Description

*Replace this paragraph with a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [ ] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
