### PR TITLE
feat: adding default constructor on SvgComponent

### DIFF
--- a/packages/flame_svg/example/lib/main.dart
+++ b/packages/flame_svg/example/lib/main.dart
@@ -19,8 +19,8 @@ class MyGame extends FlameGame {
   Future<void> onLoad() async {
     await super.onLoad();
     svgInstance = await loadSvg('android.svg');
-    final android = SvgComponent.fromSvg(
-      svgInstance,
+    final android = SvgComponent(
+      svg: svgInstance,
       position: Vector2.all(100),
       size: Vector2.all(100),
     );

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -11,8 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flame:
-    path: ../../flame
+  flame: ^1.0.0
   flame_svg:
     path: ../
 

--- a/packages/flame_svg/lib/svg_component.dart
+++ b/packages/flame_svg/lib/svg_component.dart
@@ -7,18 +7,26 @@ import './svg.dart';
 /// Wraps [Svg] in a Flame component.
 class SvgComponent extends PositionComponent {
   /// The wrapped instance of [Svg].
-  Svg svg;
+  final Svg? svg;
 
-  /// Creates an [SvgComponent] from an [Svg] instance.
-  SvgComponent.fromSvg(
-    this.svg, {
+  /// Creates an [SvgComponent]
+  SvgComponent({
+    this.svg,
     Vector2? position,
     Vector2? size,
     int? priority,
   }) : super(position: position, size: size, priority: priority);
 
+  /// Creates an [SvgComponent] from an [Svg] instance.
+  SvgComponent.fromSvg(
+    Svg svg, {
+    Vector2? position,
+    Vector2? size,
+    int? priority,
+  }) : this(svg: svg, position: position, size: size, priority: priority);
+
   @override
   void render(Canvas canvas) {
-    svg.render(canvas, size);
+    svg?.render(canvas, size);
   }
 }

--- a/packages/flame_svg/lib/svg_component.dart
+++ b/packages/flame_svg/lib/svg_component.dart
@@ -7,7 +7,7 @@ import './svg.dart';
 /// Wraps [Svg] in a Flame component.
 class SvgComponent extends PositionComponent {
   /// The wrapped instance of [Svg].
-  final Svg? svg;
+  Svg? svg;
 
   /// Creates an [SvgComponent]
   SvgComponent({

--- a/packages/flame_svg/lib/svg_component.dart
+++ b/packages/flame_svg/lib/svg_component.dart
@@ -14,16 +14,41 @@ class SvgComponent extends PositionComponent {
     this.svg,
     Vector2? position,
     Vector2? size,
+    Vector2? scale,
+    double? angle,
+    Anchor? anchor,
     int? priority,
-  }) : super(position: position, size: size, priority: priority);
+  }) : super(
+          position: position,
+          size: size,
+          scale: scale,
+          angle: angle,
+          anchor: anchor,
+          priority: priority,
+        );
 
   /// Creates an [SvgComponent] from an [Svg] instance.
+  @Deprecated(
+    'Will be removed on future versions, use the default '
+    'constructor instead',
+  )
   SvgComponent.fromSvg(
     Svg svg, {
     Vector2? position,
     Vector2? size,
+    Vector2? scale,
+    double? angle,
+    Anchor? anchor,
     int? priority,
-  }) : this(svg: svg, position: position, size: size, priority: priority);
+  }) : this(
+          svg: svg,
+          position: position,
+          size: size,
+          scale: scale,
+          angle: angle,
+          anchor: anchor,
+          priority: priority,
+        );
 
   @override
   void render(Canvas canvas) {

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -9,8 +9,7 @@ environment:
   flutter: ">=2.5.0"
 
 dependencies:
-  flame:
-    path: ../flame
+  flame: ^1.0.0
   flutter_svg: ^0.22.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
# Description

SvgComponent lacked a default constructor and had a non nullable instance of the svg, which didn't allowed it to be lazy loaded on the `onLoad` method and was not consistent with the rest of Flame components. This PRs simply add the default constructor to address that.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx*

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
