### PR TITLE
!fix: fix multiple external tilesets

### DIFF
--- a/packages/flame_tiled/lib/src/flame_tsx_provider.dart
+++ b/packages/flame_tiled/lib/src/flame_tsx_provider.dart
@@ -9,7 +9,7 @@ class FlameTsxProvider implements TsxProvider {
   /// Parsed data for this tsx file.
   final String data;
 
-  // Stored filename for corresponding tsx file.
+  /// Stored filename for corresponding tsx file.
   final String _filename;
 
   FlameTsxProvider._(this.data, this._filename);

--- a/packages/flame_tiled/lib/src/flame_tsx_provider.dart
+++ b/packages/flame_tiled/lib/src/flame_tsx_provider.dart
@@ -6,15 +6,36 @@ import 'package:xml/xml.dart';
 ///
 /// It uses [Flame.bundle] and has a built-in cache for the file read.
 class FlameTsxProvider implements TsxProvider {
+  /// Parsed data for this tsx file.
+  final String data;
+
+  // Stored filename for corresponding tsx file.
+  final String _filename;
+
+  FlameTsxProvider._(this.data, this._filename);
+
+  @override
+  String get filename => _filename;
+
   @override
   Parser getSource(String key) {
-    throw UnimplementedError();
+    final node = XmlDocument.parse(data).rootElement;
+    return XmlParser(node);
   }
 
   @override
-  Future<Parser> loadSource(String filename) async {
-    final data = await Flame.bundle.loadString('assets/tiles/$filename');
-    final node = XmlDocument.parse(data).rootElement;
-    return XmlParser(node);
+  Parser? getChachedSource() {
+    if (data.isEmpty) {
+      return null;
+    }
+    return getSource('');
+  }
+
+  /// Parses a file returning a [FlameTsxProvider].
+  ///
+  /// NOTE: this method looks for files under the path "assets/tiles/".
+  static Future<FlameTsxProvider> parse(String key) async {
+    final data = await Flame.bundle.loadString('assets/tiles/$key');
+    return FlameTsxProvider._(data, key);
   }
 }

--- a/packages/flame_tiled/lib/src/flame_tsx_provider.dart
+++ b/packages/flame_tiled/lib/src/flame_tsx_provider.dart
@@ -6,22 +6,15 @@ import 'package:xml/xml.dart';
 ///
 /// It uses [Flame.bundle] and has a built-in cache for the file read.
 class FlameTsxProvider implements TsxProvider {
-  /// Parsed data for this tsx file.
-  final String data;
-
-  FlameTsxProvider._(this.data);
-
   @override
   Parser getSource(String key) {
-    final node = XmlDocument.parse(data).rootElement;
-    return XmlParser(node);
+    throw UnimplementedError();
   }
 
-  /// Parses a file returning a [FlameTsxProvider].
-  ///
-  /// NOTE: this method looks for files under the path "assets/tiles/".
-  static Future<FlameTsxProvider> parse(String key) async {
-    final data = await Flame.bundle.loadString('assets/tiles/$key');
-    return FlameTsxProvider._(data);
+  @override
+  Future<Parser> loadSource(String filename) async {
+    final data = await Flame.bundle.loadString('assets/tiles/$filename');
+    final node = XmlDocument.parse(data).rootElement;
+    return XmlParser(node);
   }
 }

--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -127,7 +127,7 @@ class RenderableTiledMap {
 
     TsxProvider? tsxProvider;
     if (tsxSourcePath != null) {
-      tsxProvider = await FlameTsxProvider.parse(tsxSourcePath);
+      tsxProvider = FlameTsxProvider();
     } else {
       tsxProvider = null;
     }

--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -118,20 +118,23 @@ class RenderableTiledMap {
   }
 
   static Future<TiledMap> _loadMap(String contents) async {
-    final tsxSourcePath = XmlDocument.parse(contents)
+    final tsxSourcePaths = XmlDocument.parse(contents)
         .rootElement
         .children
         .whereType<XmlElement>()
-        .firstWhere((element) => element.name.local == 'tileset')
-        .getAttribute('source');
+        .where((element) => element.name.local == 'tileset')
+        .map((e) => e.getAttribute('source'));
 
-    TsxProvider? tsxProvider;
-    if (tsxSourcePath != null) {
-      tsxProvider = FlameTsxProvider();
-    } else {
-      tsxProvider = null;
-    }
-    return TileMapParser.parseTmx(contents, tsx: tsxProvider);
+    final tsxProviders = await Future.wait(
+      tsxSourcePaths
+          .where((key) => key != null)
+          .map((key) async => FlameTsxProvider.parse(key!)),
+    );
+
+    return TileMapParser.parseTmx(
+      contents,
+      tsx: tsxProviders.isEmpty ? null : tsxProviders,
+    );
   }
 
   static Future<Map<String, SpriteBatch>> _loadImages(TiledMap map) async {

--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -133,7 +133,7 @@ class RenderableTiledMap {
 
     return TileMapParser.parseTmx(
       contents,
-      tsx: tsxProviders.isEmpty ? null : tsxProviders,
+      tsxList: tsxProviders.isEmpty ? null : tsxProviders,
     );
   }
 

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -9,7 +9,11 @@ environment:
 
 dependencies:
   flame: ^1.0.0
-  tiled: ^0.7.2
+  #tiled: ^0.7.2
+  tiled: 
+    git:
+      url: https://github.com/lfraker/tiled.dart
+      ref: lfraker.fix-multiple-external-tilesets
   xml: ^5.3.0
   meta: ^1.7.0
   collection: ^1.15.0

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -9,11 +9,7 @@ environment:
 
 dependencies:
   flame: ^1.0.0
-  #tiled: ^0.7.2
-  tiled: 
-    git:
-      url: https://github.com/lfraker/tiled.dart
-      ref: lfraker.fix-multiple-external-tilesets
+  tiled: ^0.8.0
   xml: ^5.3.0
   meta: ^1.7.0
   collection: ^1.15.0

--- a/packages/flame_tiled/test/assets/tiles/external_tileset_1.tsx
+++ b/packages/flame_tiled/test/assets/tiles/external_tileset_1.tsx
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.2" tiledversion="2018.11.29" name="level1" tilewidth="16" tileheight="16" tilecount="136" columns="17">
+<image source="../images/map-level1.png" width="272" height="128"/>
+  <tile id="64">
+   <properties>
+    <property name="type" value="sky"/>
+   </properties>
+  </tile>
+  <tile id="65">
+   <properties>
+    <property name="type" value="xpto"/>
+   </properties>
+  </tile>
+</tileset>

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -19,6 +19,15 @@ void main() {
     expect(tiled.tileMap.batchesByLayer.length == 1, true);
   });
 
+  test('correctly loads external tileset', () async {
+    final externalTileset =
+        await FlameTsxProvider().loadSource('external_tileset_1.tsx');
+    expect(
+      externalTileset.getSingleChild('tileset').getString('name') == 'level1',
+      true,
+    );
+  });
+
   group('Layered tiles render correctly with layered sprite batch', () {
     late Uint8List canvasPixelData;
     late RenderableTiledMap overlapMap;

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -20,10 +20,20 @@ void main() {
   });
 
   test('correctly loads external tileset', () async {
-    final externalTileset =
-        await FlameTsxProvider().loadSource('external_tileset_1.tsx');
+    final tsxProvider = await FlameTsxProvider.parse('external_tileset_1.tsx');
+
+    expect(tsxProvider.getChachedSource() != null, true);
     expect(
-      externalTileset.getSingleChild('tileset').getString('name') == 'level1',
+      tsxProvider
+              .getChachedSource()!
+              .getSingleChild('tileset')
+              .getString('name') ==
+          'level1',
+      true,
+    );
+
+    expect(
+      tsxProvider.filename == 'external_tileset_1.tsx',
       true,
     );
   });


### PR DESCRIPTION
# Description

This is an update to adhere to the new TiledMap.parseTmx contract that will be introduced with: https://github.com/flame-engine/tiled.dart/pull/37/files. The contract update was made to fix the issue raised in https://github.com/flame-engine/tiled.dart/issues/35.

The parser was updated to take a list of external tileset TsxProviders. The parser now expects a list of loaded external tileset data for each external tileset. See other PR for more details on the fix in the tiled repo.

To adhere to this new contract, this fix pre-loads each external tileset referenced in the .tmx file and passes in a list of the corresponding TsxProviders.

While not technically a breaking change, if anyone is subclassing FlameTsxProvider or using directly, the logic is changing when parsing Tilesets, and this will cause issues for them.

Also, please note that I'm currently referencing the corresponding GitHub branch in the pubspec file so that I'm able to run tests. Per the discussion in the issue, this reference should be swapped back to the tiled package once the corresponding fix is released there. This causes melos analyze to fail.

Please note, there was another issue with a deprecated call, unrelated to my changes, when running melos analyze: https://github.com/flame-engine/flame/blob/main/packages/flame_test/lib/src/mock_image.dart#L14 decodeImageFromPixels is deprecated, but the recommended replacement method did not appear to be available.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [X] No, this is *not* a breaking change.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx*

Fixes https://github.com/flame-engine/tiled.dart/issues/35

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
