### PR TITLE
fix: `ParallaxComponent` should have static `positionType`

### DIFF
--- a/packages/flame/lib/src/components/parallax_component.dart
+++ b/packages/flame/lib/src/components/parallax_component.dart
@@ -46,6 +46,9 @@ extension ParallaxComponentExtension on FlameGame {
 /// layer moves with different velocities to give an effect of depth.
 class ParallaxComponent<T extends FlameGame> extends PositionComponent
     with HasGameRef<T> {
+  @override
+  PositionType positionType = PositionType.viewport;
+
   bool isFullscreen = true;
   Parallax? _parallax;
 


### PR DESCRIPTION
# Description

I think we forgot to set this back to this after we changed from the `isHud` logic.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

(It kind of is a breaking change, but the current way is not what was intended so this is more of a bug fix).

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
