### PR TITLE
docs: Fix various dartdoc warnings

### DIFF
--- a/packages/flame/lib/components.dart
+++ b/packages/flame/lib/components.dart
@@ -1,3 +1,5 @@
+/// {@canonicalFor anchor.Anchor}
+
 export 'src/anchor.dart';
 export 'src/components/component.dart';
 export 'src/components/component_set.dart';

--- a/packages/flame/lib/game.dart
+++ b/packages/flame/lib/game.dart
@@ -1,3 +1,6 @@
+/// {@canonicalFor text.TextPaint}
+/// {@canonicalFor text.TextRenderer}
+
 export 'src/extensions/vector2.dart';
 export 'src/game/camera/camera.dart';
 export 'src/game/camera/viewport.dart';

--- a/packages/flame/lib/input.dart
+++ b/packages/flame/lib/input.dart
@@ -1,3 +1,6 @@
+/// {@canonicalFor joystick_component.JoystickComponent}
+/// {@canonicalFor joystick_component.JoystickDirection}
+
 export 'src/components/input/button_component.dart';
 export 'src/components/input/hud_button_component.dart';
 export 'src/components/input/hud_margin_component.dart';

--- a/packages/flame/lib/sprite.dart
+++ b/packages/flame/lib/sprite.dart
@@ -1,3 +1,8 @@
+/// {@canonicalFor sprite_animation.SpriteAnimation}
+/// {@canonicalFor sprite_animation.SpriteAnimationData}
+/// {@canonicalFor sprite_animation.SpriteAnimationFrame}
+/// {@canonicalFor sprite_animation.SpriteAnimationFrameData}
+
 export 'src/sprite.dart';
 export 'src/sprite_animation.dart';
 export 'src/sprite_batch.dart';

--- a/packages/flame/lib/src/components/input/joystick_component.dart
+++ b/packages/flame/lib/src/components/input/joystick_component.dart
@@ -23,7 +23,7 @@ class JoystickComponent extends HudMarginComponent with Draggable {
   late final PositionComponent? knob;
   late final PositionComponent? background;
 
-  /// The percentage [0.0, 1.0] the knob is dragged from the center to the edge.
+  /// The percentage (0.0, 1.0) the knob is dragged from the center to the edge.
   double intensity = 0.0;
 
   /// The amount the knob is dragged from the center, scaled to fit inside the

--- a/packages/flame/lib/src/components/input/joystick_component.dart
+++ b/packages/flame/lib/src/components/input/joystick_component.dart
@@ -23,7 +23,8 @@ class JoystickComponent extends HudMarginComponent with Draggable {
   late final PositionComponent? knob;
   late final PositionComponent? background;
 
-  /// The percentage (0.0, 1.0) the knob is dragged from the center to the edge.
+  /// The percentage `[0.0, 1.0]` the knob is dragged from the center to the
+  /// edge.
   double intensity = 0.0;
 
   /// The amount the knob is dragged from the center, scaled to fit inside the

--- a/packages/flame/lib/src/components/parallax_component.dart
+++ b/packages/flame/lib/src/components/parallax_component.dart
@@ -120,8 +120,8 @@ class ParallaxComponent<T extends FlameGame> extends PositionComponent
   /// Optionally arguments for the [baseVelocity] and [velocityMultiplierDelta]
   /// can be passed in, [baseVelocity] defines what the base velocity of the
   /// layers should be and [velocityMultiplierDelta] defines how the velocity
-  /// should change the closer the layer is ([velocityMultiplierDelta ^ n],
-  /// where n is the layer index).
+  /// should change the closer the layer is (`velocityMultiplierDelta ^ n`,
+  /// where `n` is the layer index).
   /// Arguments for how all the images should repeat ([repeat]),
   /// which edge it should align with ([alignment]), which axis it should fill
   /// the image on ([fill]) and [images] which is the image cache that should be

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -104,7 +104,7 @@ class RectangleComponent extends ShapeComponent {
 
 class PolygonComponent extends ShapeComponent {
   /// The [normalizedVertices] should be a list of points that range between
-  /// [-1.0, 1.0] which defines the relation of the vertices in the polygon
+  /// (-1.0, 1.0) which defines the relation of the vertices in the polygon
   /// from the center of the component to the size of the component.
   PolygonComponent({
     required List<Vector2> normalizedVertices,

--- a/packages/flame/lib/src/components/shape_component.dart
+++ b/packages/flame/lib/src/components/shape_component.dart
@@ -104,7 +104,7 @@ class RectangleComponent extends ShapeComponent {
 
 class PolygonComponent extends ShapeComponent {
   /// The [normalizedVertices] should be a list of points that range between
-  /// (-1.0, 1.0) which defines the relation of the vertices in the polygon
+  /// `[-1.0, 1.0]` which defines the relation of the vertices in the polygon
   /// from the center of the component to the size of the component.
   PolygonComponent({
     required List<Vector2> normalizedVertices,

--- a/packages/flame/lib/src/effects/controllers/effect_controller.dart
+++ b/packages/flame/lib/src/effects/controllers/effect_controller.dart
@@ -32,7 +32,7 @@ import 'speed_effect_controller.dart';
 ///   - the progress may change over a finite or infinite period of time;
 ///   - the value of 0 corresponds to the logical start of an animation;
 ///   - the value of 1 is either the end or the "peak" of an animation;
-///   - the progress may briefly attain values outside of [0; 1] range (for
+///   - the progress may briefly attain values outside of `[0; 1]` range (for
 ///     example if a "bouncy" easing curve is applied).
 ///
 /// An [EffectController] can be made to run forward in time (`advance()`), or

--- a/packages/flame/lib/src/extensions/color.dart
+++ b/packages/flame/lib/src/extensions/color.dart
@@ -107,7 +107,7 @@ extension ColorExtension on Color {
   /// You can pass in a random number generator [rng], if omitted the function
   /// will create a new [Random] object without a seed and use that.
   /// [base] can be used to get the random colors in only a lighter spectrum, it
-  /// should be between [0-256].
+  /// should be between 0 and 256.
   static Color random({
     double withAlpha = 1.0,
     int base = 0,
@@ -115,13 +115,13 @@ extension ColorExtension on Color {
   }) {
     assert(
       base >= 0 && base <= 256,
-      'The base argument should be between 0-256',
+      'The base argument should be in the range 0..256',
     );
     rng ??= Random();
     return Color.fromRGBO(
-      base + (base == 256 ? 0 : rng.nextInt(256 - base)),
-      base + (base == 256 ? 0 : rng.nextInt(256 - base)),
-      base + (base == 256 ? 0 : rng.nextInt(256 - base)),
+      base + (base >= 255 ? 0 : rng.nextInt(256 - base)),
+      base + (base >= 255 ? 0 : rng.nextInt(256 - base)),
+      base + (base >= 255 ? 0 : rng.nextInt(256 - base)),
       withAlpha,
     );
   }

--- a/packages/flame/lib/src/extensions/paint.dart
+++ b/packages/flame/lib/src/extensions/paint.dart
@@ -65,7 +65,7 @@ extension PaintExtension on Paint {
   /// You can pass in a random number generator [rng], if omitted the function
   /// will create a new [Random] object without a seed and use that.
   /// [base] can be used to get the random colors in only a lighter spectrum, it
-  /// should be between [0-256].
+  /// should be between 0 and 256.
   static Paint random({
     double withAlpha = 1.0,
     int base = 0,

--- a/packages/flame/lib/src/extensions/rect.dart
+++ b/packages/flame/lib/src/extensions/rect.dart
@@ -13,7 +13,7 @@ extension RectExtension on Rect {
   /// Creates an [Offset] from this [Rect]
   Offset toOffset() => Offset(width, height);
 
-  /// Creates a [Vector2] starting in top left and going to [width, height].
+  /// Creates a [Vector2] starting in top left and going to (width, height).
   Vector2 toVector2() => Vector2(width, height);
 
   /// Converts this [Rect] into a [math.Rectangle].

--- a/packages/flame/lib/src/extensions/vector2.dart
+++ b/packages/flame/lib/src/extensions/vector2.dart
@@ -22,7 +22,7 @@ extension Vector2Extension on Vector2 {
   /// to the origin, and whose size is the right-hand-side operand.
   Rect operator &(Vector2 size) => toPositionedRect(size);
 
-  /// Creates a [Rect] starting from [x, y] and having the size of the
+  /// Creates a [Rect] starting from (x, y) and having the size of the
   /// argument [Vector2]
   Rect toPositionedRect(Vector2 size) => Rect.fromLTWH(x, y, size.x, size.y);
 

--- a/packages/flame/lib/src/game/camera/viewport.dart
+++ b/packages/flame/lib/src/game/camera/viewport.dart
@@ -19,7 +19,8 @@ import '../../../game.dart';
 ///
 /// When using a viewport, [resize] should be called by the engine with
 /// the raw canvas size (on startup and subsequent resizes) and that will
-/// configure [getEffectiveSize()] and [getCanvasSize()].
+/// configure [effectiveSize] and [canvasSize].
+///
 /// The Viewport can also apply an offset to render and clip the canvas adding
 /// borders (clipping) when necessary.
 /// When rendering, call [render] and put all your rendering inside the lambda

--- a/packages/flame/lib/src/geometry/circle.dart
+++ b/packages/flame/lib/src/geometry/circle.dart
@@ -24,8 +24,9 @@ class Circle extends Shape {
         );
 
   /// This constructor is used by [HitboxCircle]
-  /// [relation] is the relation [0.0, 1.0] of the shortest edge of [size] that
-  /// the circle should fill.
+  ///
+  /// [relation] is the relation `[0.0, 1.0]` of the shortest edge of [size]
+  /// that the circle should fill.
   Circle.fromDefinition({
     double? relation,
     Vector2? position,

--- a/packages/flame/lib/src/geometry/polygon.dart
+++ b/packages/flame/lib/src/geometry/polygon.dart
@@ -55,7 +55,8 @@ class Polygon extends Shape {
 
   /// With this constructor you define the [Polygon] from the center of and with
   /// percentages of the size of the shape.
-  /// Example: [[1.0, 0.0], [0.0, -1.0], [-1.0, 0.0], [0.0, 1.0]]
+  ///
+  /// Example: `[[1.0, 0.0], [0.0, -1.0], [-1.0, 0.0], [0.0, 1.0]]`
   /// This will form a diamond shape within the bounding size box.
   /// NOTE: Always define your shape in a counter-clockwise fashion (in the
   /// screen coordinate system).

--- a/packages/flame/lib/src/parallax.dart
+++ b/packages/flame/lib/src/parallax.dart
@@ -478,8 +478,8 @@ class Parallax {
   /// Optionally arguments for the [baseVelocity] and [velocityMultiplierDelta]
   /// can be passed in, [baseVelocity] defines what the base velocity of the
   /// layers should be and [velocityMultiplierDelta] defines how the velocity
-  /// should change the closer the layer is ([velocityMultiplierDelta ^ n],
-  /// where n is the layer index).
+  /// should change the closer the layer is (`velocityMultiplierDelta ^ n`,
+  /// where `n` is the layer index).
   /// Arguments for how all the images should repeat ([repeat]),
   /// which edge it should align with ([alignment]), which axis it should fill
   /// the image on ([fill]) and [images] which is the image cache that should be

--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -102,8 +102,6 @@ class SpriteAnimationFrame {
   SpriteAnimationFrame(this.sprite, this.stepTime);
 }
 
-typedef OnCompleteSpriteAnimation = void Function();
-
 /// Represents a sprite animation, that is, a list of sprites that change with
 /// time.
 class SpriteAnimation {
@@ -127,7 +125,7 @@ class SpriteAnimation {
   bool loop = true;
 
   /// Registered method to be triggered when the animation complete.
-  OnCompleteSpriteAnimation? onComplete;
+  void Function()? onComplete;
 
   /// Creates an animation given a list of frames.
   SpriteAnimation(this.frames, {this.loop = true});

--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -170,8 +170,8 @@ class SpriteAnimation {
   /// Automatically creates an Animation Object using animation data provided by
   /// the json file provided by Aseprite.
   ///
-  /// [imagePath]: Source of the sprite sheet animation.
-  /// [dataPath]: Animation's exported data in json format.
+  /// [image]: sprite sheet animation image.
+  /// [jsonData]: animation's data in json format.
   SpriteAnimation.fromAsepriteData(
     Image image,
     Map<String, dynamic> jsonData,

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -19,8 +19,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.17.10
-  dartdoc: ^0.42.0
-  mocktail: ^0.1.4
+  dartdoc: ^4.1.0
+  mocktail: ^0.2.0
   canvas_test: ^0.2.0
   flame_test:
     path: ../flame_test

--- a/packages/flame/test/effects/color_effect_test.dart
+++ b/packages/flame/test/effects/color_effect_test.dart
@@ -11,7 +11,7 @@ void main() {
     flameGame.test('applies the correct color filter', (game) {
       final component = _PaintComponent();
       game.ensureAdd(component);
-      final color = Colors.red;
+      const color = Colors.red;
 
       component.add(
         ColorEffect(color, const Offset(0, 1), EffectController(duration: 1)),
@@ -39,7 +39,7 @@ void main() {
 
       final originalColorFilter = component.paint.colorFilter;
 
-      final color = Colors.red;
+      const color = Colors.red;
 
       final effect = ColorEffect(
         color,

--- a/packages/flame/test/extensions/color_test.dart
+++ b/packages/flame/test/extensions/color_test.dart
@@ -1,16 +1,17 @@
 import 'package:flame/extensions.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Color test', () {
-    test('test parse short RGB', () {
+  group('ColorExtension', () {
+    test('parse short RGB', () {
       expect(ColorExtension.fromRGBHexString('#234'), const Color(0xFF223344));
       expect(ColorExtension.fromRGBHexString('1f0'), const Color(0xFF11FF00));
       expect(ColorExtension.fromRGBHexString('#ccc'), const Color(0xFFCCCCCC));
       expect(ColorExtension.fromRGBHexString('b1f'), const Color(0xFFBB11FF));
     });
 
-    test('test parse long RGB', () {
+    test('parse long RGB', () {
       expect(
         ColorExtension.fromRGBHexString('#121314'),
         const Color(0xFF121314),
@@ -24,19 +25,19 @@ void main() {
         const Color(0xFFCCCCCC),
       );
       expect(
-        ColorExtension.fromRGBHexString('b210af'),
-        const Color(0xFFB210AF),
+        ColorExtension.fromRGBHexString('decade'),
+        const Color(0xFFDECADE),
       );
     });
 
-    test('test parse short ARGB', () {
+    test('parse short ARGB', () {
       expect(
         ColorExtension.fromARGBHexString('#fccc'),
         const Color(0xFFCCCCCC),
       );
       expect(
-        ColorExtension.fromARGBHexString('fccc'),
-        const Color(0xFFCCCCCC),
+        ColorExtension.fromARGBHexString('dead'),
+        const Color(0xDDEEAADD),
       );
       expect(
         ColorExtension.fromARGBHexString('#8cc0'),
@@ -48,14 +49,14 @@ void main() {
       );
     });
 
-    test('test parse long ARGB', () {
+    test('parse long ARGB', () {
       expect(
         ColorExtension.fromARGBHexString('#ffcc1050'),
         const Color(0xFFCC1050),
       );
       expect(
-        ColorExtension.fromARGBHexString('ffccbbaa'),
-        const Color(0xFFCCBBAA),
+        ColorExtension.fromARGBHexString('0defaced'),
+        const Color(0x0DEFACED),
       );
       expect(
         ColorExtension.fromARGBHexString('#80cccc00'),
@@ -64,6 +65,17 @@ void main() {
       expect(
         ColorExtension.fromARGBHexString('01234567'),
         const Color(0x01234567),
+      );
+    });
+
+    test('random: errors', () {
+      expect(
+        () => ColorExtension.random(base: -1),
+        failsAssert('The base argument should be in the range 0..256'),
+      );
+      expect(
+        () => ColorExtension.random(base: 257),
+        failsAssert('The base argument should be in the range 0..256'),
       );
     });
   });

--- a/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
@@ -15,12 +15,13 @@ class _MyGame extends FlameGame {
   }
 
   @override
-  Future<void> onLoad() async {
+  Future<void>? onLoad() {
     events.add('onLoad');
+    return null;
   }
 
   @override
-  Future<void>? onMount() {
+  void onMount() {
     events.add('onMount');
   }
 

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0
   flutter_test:
     sdk: flutter
   test: ^1.9.4

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -15,10 +15,10 @@ dependencies:
   flutter_bloc: ^8.0.1
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.0
   flame_test: ^1.1.0
-  mocktail: ^0.1.4
+  mocktail: ^0.2.0
   flame_lint: ^0.0.1

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -21,6 +21,4 @@ dev_dependencies:
   flame_lint:
     path: ../flame_lint
   mocktail: ^0.1.2
-  dartdoc: ^0.42.0
-
-flutter:
+  dartdoc: ^4.1.0

--- a/packages/flame_flare/pubspec.yaml
+++ b/packages/flame_flare/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0
   flutter_test:
     sdk: flutter
   test: ^1.9.4

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -20,7 +20,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.16.0
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0
   flame_lint:
     path: ../flame_lint
-

--- a/packages/flame_lint/pubspec.yaml
+++ b/packages/flame_lint/pubspec.yaml
@@ -8,4 +8,4 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -15,10 +15,9 @@ dependencies:
   oxygen: ^0.2.0
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0
   flutter_test:
     sdk: flutter
   test: ^1.9.4
   flame_lint:
     path: ../flame_lint
-

--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -85,7 +85,7 @@ class RiveArtboardRenderer {
   }
 
   void _paint(Canvas canvas, AABB bounds, ui.Size size) {
-    final position = Offset.zero;
+    const position = Offset.zero;
 
     final contentWidth = bounds[2] - bounds[0];
     final contentHeight = bounds[3] - bounds[1];

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0
   flutter_test:
     sdk: flutter
-  dart_code_metrics: ^3.2.2
+  dart_code_metrics: ^4.1.0
   flame_lint:
     path: ../flame_lint

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0
   flame_lint:
     path: ../flame_lint

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   vector_math: '>=2.1.0 <3.0.0'
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0
   flutter_lints: ^1.0.0
   flame_lint: ^0.0.1
-

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^4.1.0
   flutter_test:
     sdk: flutter
   test: ^1.9.4


### PR DESCRIPTION
# Description

Currently, dartdoc is emitting ~60 different warnings on our codebase. This PR fixes all of them, except the "broken link" warnings, which stem from the README file that contains links to other .md documents.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- (NA) I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- (NA) I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
