### PR TITLE
fix: remove vector_math dependency

### DIFF
--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   meta: ^1.7.0
   collection: ^1.15.0
   ordered_set: ^5.0.0
-  vector_math: '>=2.1.0 <3.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
     sdk: flutter
   meta: ^1.7.0
   test: ^1.17.10
-  vector_math: '>=2.1.0 <3.0.0'
 
 dev_dependencies:
   dartdoc: ^4.1.0


### PR DESCRIPTION
# Description

Today, `package:flame` and `package:flame_test` depend on `vector_math`. However, the upstream Flutter SDK already depends on this package: https://github.com/flutter/flutter/blob/master/packages/flutter/pubspec.yaml#L15. Thus pub get will resolve both dependencies to a single package (and version solving fail if they are not compatible, which is why I suspect Flame uses such a wide version constraint).

This PR simplifies things by just removing the dependency from the pubspec's altogether. I ran `pub get` on both repos and there was no diff to the pubspec.lock, and the example app built and ran fine.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality. (no behavior change, existing tests should verify this)
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change. (Indicate it in the [Conventional Commit] prefix with a `!`,
  e.g. `feat!:`, `fix!:`).
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
