### PR TITLE
fix: Menu dropdown in the docs

### DIFF
--- a/doc/_sphinx/scripts/versions.js
+++ b/doc/_sphinx/scripts/versions.js
@@ -48,8 +48,11 @@ function buildVersionsMenu(data) {
       </div>
     </div>
   `);
-  $("#versions-menu").on("click blur", function() {
+  $("#versions-menu").on("click", function() {
     $(this).toggleClass("active");
+  }).on("blur", function() {
+    // A timeout ensures that `click` can propagate to child <A/> elements.
+    setTimeout(() => $(this).removeClass("active"), 200);
   });
 }
 

--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -174,6 +174,7 @@ div.top-bar #menu-button {
   position: absolute;
   right: 0;
   top: calc(var(--top-menu-height) - 4px);
+  white-space: nowrap;
 }
 
 #versions-menu.active > .dropdown-buttons .header {


### PR DESCRIPTION
# Description

- Prevent version entries in the menu dropdown from wrapping to 2 lines.
- Stop blur event from interfering with the click events in the menu.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- (NA) I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- (NA) I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
