### PR TITLE
feat: Add missing optional priority to SpriteBodyComponent

### DIFF
--- a/packages/flame_forge2d/lib/sprite_body_component.dart
+++ b/packages/flame_forge2d/lib/sprite_body_component.dart
@@ -11,7 +11,7 @@ abstract class SpriteBodyComponent<T extends Forge2DGame>
     Sprite sprite,
     Vector2 spriteSize, {
     int? priority,
-  },) : super(
+  }) : super(
           positionComponent: SpriteComponent(
             size: spriteSize,
             sprite: sprite,

--- a/packages/flame_forge2d/lib/sprite_body_component.dart
+++ b/packages/flame_forge2d/lib/sprite_body_component.dart
@@ -10,10 +10,13 @@ abstract class SpriteBodyComponent<T extends Forge2DGame>
   SpriteBodyComponent(
     Sprite sprite,
     Vector2 spriteSize, {
-    int priority = 0,
-  }) : super(
+    int? priority,
+  },) : super(
           positionComponent: SpriteComponent(
-              size: spriteSize, sprite: sprite, priority: priority),
+            size: spriteSize,
+            sprite: sprite,
+            priority: priority,
+          ),
           size: spriteSize,
         );
 }

--- a/packages/flame_forge2d/lib/sprite_body_component.dart
+++ b/packages/flame_forge2d/lib/sprite_body_component.dart
@@ -9,9 +9,11 @@ abstract class SpriteBodyComponent<T extends Forge2DGame>
   /// body that is create in createBody()
   SpriteBodyComponent(
     Sprite sprite,
-    Vector2 spriteSize,
-  ) : super(
-          positionComponent: SpriteComponent(size: spriteSize, sprite: sprite),
+    Vector2 spriteSize, {
+    int priority = 0,
+  }) : super(
+          positionComponent: SpriteComponent(
+              size: spriteSize, sprite: sprite, priority: priority),
           size: spriteSize,
         );
 }


### PR DESCRIPTION
Gives you the option to set the priority directly when creating the component.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.