### PR TITLE
feat: Make ContactCallback begin end methods optional overrides

### DIFF
--- a/packages/flame_forge2d/example/lib/balls.dart
+++ b/packages/flame_forge2d/example/lib/balls.dart
@@ -81,9 +81,6 @@ class BallContactCallback extends ContactCallback<Ball, Ball> {
       ball2.paint = ball1.paint;
     }
   }
-
-  @override
-  void end(Ball ball1, Ball ball2, Contact contact) {}
 }
 
 class WhiteBallContactCallback extends ContactCallback<Ball, WhiteBall> {
@@ -91,9 +88,6 @@ class WhiteBallContactCallback extends ContactCallback<Ball, WhiteBall> {
   void begin(Ball ball, WhiteBall whiteBall, Contact contact) {
     ball.giveNudge = true;
   }
-
-  @override
-  void end(Ball ball, WhiteBall whiteBall, Contact contact) {}
 }
 
 class BallWallContactCallback extends ContactCallback<Ball, Wall> {
@@ -101,7 +95,4 @@ class BallWallContactCallback extends ContactCallback<Ball, Wall> {
   void begin(Ball ball, Wall wall, Contact contact) {
     wall.paint = ball.paint;
   }
-
-  @override
-  void end(Ball ball, Wall wall, Contact contact) {}
 }

--- a/packages/flame_forge2d/lib/contact_callbacks.dart
+++ b/packages/flame_forge2d/lib/contact_callbacks.dart
@@ -21,8 +21,8 @@ typedef ContactCallbackFun = void Function(Object a, Object b, Contact contact);
 abstract class ContactCallback<Type1, Type2> {
   ContactTypes<Type1, Type2> types = ContactTypes<Type1, Type2>();
 
-  void begin(Type1 a, Type2 b, Contact contact);
-  void end(Type1 a, Type2 b, Contact contact);
+  void begin(Type1 a, Type2 b, Contact contact) {}
+  void end(Type1 a, Type2 b, Contact contact) {}
   void preSolve(Type1 a, Type2 b, Contact contact, Manifold oldManifold) {}
   void postSolve(Type1 a, Type2 b, Contact contact, ContactImpulse impulse) {}
 }


### PR DESCRIPTION
# Description

Make begin and end methods optionally overridable when extending ContactCallback.

Also updates examples that were implementing empty methods.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->
Aims to resolve #1414.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
