### PR TITLE
fix: Use strokeWidth=0 in debug mode

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -119,7 +119,7 @@ class Component {
     if (!_debugPaintCache.isCacheValid([debugColor])) {
       final paint = Paint()
         ..color = debugColor
-        ..strokeWidth = 1
+        ..strokeWidth = 0 // hairline-width
         ..style = PaintingStyle.stroke;
       _debugPaintCache.updateCache(paint, [debugColor]);
     }


### PR DESCRIPTION
# Description

Currently, `Component.debugPaint` uses `strokeWidth = 1`. However, this "1" is not 1 pixel, but rather 1 unit of the game coordinate system. So, if the game uses large zoom level by default, the wireframes will become too thick; and if the game uses small zoom, the wireframes will be barely visible. Setting `strokWidth = 0` produces "hairline width" rectangles of consistent appearance regardless of the zoom level.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.



<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
