### PR TITLE
fix: CameraComponent's behavior under zoom

### DIFF
--- a/packages/flame/lib/src/experimental/viewfinder.dart
+++ b/packages/flame/lib/src/experimental/viewfinder.dart
@@ -21,8 +21,8 @@ class Viewfinder extends Component {
 
   /// The game coordinates of a point that is to be positioned at the center
   /// of the viewport.
-  Vector2 get position => -_transform.position;
-  set position(Vector2 value) => _transform.position = -value;
+  Vector2 get position => -_transform.offset;
+  set position(Vector2 value) => _transform.offset = -value;
 
   /// Zoom level of the game.
   ///

--- a/packages/flame/test/experimental/viewfinder_test.dart
+++ b/packages/flame/test/experimental/viewfinder_test.dart
@@ -1,0 +1,122 @@
+import 'dart:ui';
+
+import 'package:canvas_test/canvas_test.dart';
+import 'package:flame/components.dart';
+import 'package:flame/experimental.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Viewfinder', () {
+    testWithFlameGame(
+      'default camera centers the view in canvas',
+      (game) async {
+        final world = World()..addToParent(game);
+        final camera = CameraComponent(world: world)..addToParent(game);
+        world.add(_Rect());
+        await game.ready();
+        expect(game.canvasSize, closeToVector(800, 600));
+        expect(camera.viewfinder.position, closeToVector(0, 0));
+        expect(camera.viewfinder.zoom, 1);
+
+        // By default, the camera uses anchor=center, and places the world's
+        // point (0,0) there. This means the camera applies default translation
+        // of (400,300).
+        final canvas = MockCanvas();
+        game.render(canvas);
+        expect(
+          canvas,
+          MockCanvas()
+            ..translate(400, 300)
+            ..drawRect(const Rect.fromLTWH(0, 0, 80, 60))
+            ..translate(0, 0),
+        );
+      },
+    );
+
+    testWithFlameGame(
+      'default camera centers on a given point',
+      (game) async {
+        final world = World()..addToParent(game);
+        final camera = CameraComponent(world: world)
+          ..viewfinder.position = Vector2(100, -50)
+          ..addToParent(game);
+        world.add(_Rect());
+        await game.ready();
+        expect(camera.viewfinder.position, closeToVector(100, -50));
+
+        final canvas = MockCanvas();
+        game.render(canvas);
+        expect(
+          canvas,
+          MockCanvas()
+            ..translate(300, 350) // (800,600)/2 - (100,-50)
+            ..drawRect(const Rect.fromLTWH(0, 0, 80, 60))
+            ..translate(0, 0),
+        );
+      },
+    );
+
+    testWithFlameGame(
+      'default camera apply zoom > 1',
+      (game) async {
+        final world = World()..addToParent(game);
+        final camera = CameraComponent(world: world)
+          ..viewfinder.zoom = 2
+          ..addToParent(game);
+        world.add(_Rect()..position = Vector2(20, 10));
+        await game.ready();
+        expect(camera.viewfinder.zoom, 2);
+
+        final canvas = MockCanvas();
+        game.render(canvas);
+        expect(
+          canvas,
+          MockCanvas()
+            ..translate(400, 300) // viewfinder translate
+            ..scale(2)
+            ..translate(20, 10) // rectangle translate
+            ..drawRect(const Rect.fromLTWH(0, 0, 80, 60))
+            ..translate(0, 0),
+        );
+      },
+    );
+
+    testWithFlameGame(
+      'default camera with zoom > 1 and shifted center',
+      (game) async {
+        final world = World()..addToParent(game);
+        final camera = CameraComponent(world: world)
+          ..viewfinder.zoom = 5
+          ..viewfinder.position = Vector2(60, 40)
+          ..addToParent(game);
+        world.add(_Rect()..position = Vector2(20, 10));
+        await game.ready();
+        expect(camera.viewfinder.zoom, 5);
+
+        final canvas = MockCanvas();
+        game.render(canvas);
+        expect(
+          canvas,
+          MockCanvas()
+            ..translate(400, 300) // canvas center
+            ..scale(5)
+            ..translate(-60, -40) // viewfinder translate
+            ..translate(20, 10) // rectangle translate
+            ..drawRect(const Rect.fromLTWH(0, 0, 80, 60))
+            ..translate(0, 0),
+        );
+      },
+    );
+  });
+}
+
+/// Simple rectangle with default size 80x60.
+class _Rect extends PositionComponent {
+  _Rect() : super(size: Vector2(80, 60));
+
+  @override
+  void render(Canvas canvas) {
+    canvas.drawRect(size.toRect(), Paint());
+  }
+}


### PR DESCRIPTION
# Description

Camera's aim was incorrect in games with zoom≠1.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
