### PR TITLE
feat: allowing changing of the images prefix and allowing empty prefixes

### DIFF
--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -11,16 +11,20 @@ import '../flame.dart';
 
 class Images {
   Images({String prefix = 'assets/images/'})
-      : assert(prefix.endsWith('/')),
+      : assert(prefix.isEmpty || prefix.endsWith('/'), _assertMessage),
         _prefix = prefix;
 
   String _prefix;
   final Map<String, _ImageAssetLoader> _loadedFiles = {};
 
+  static const _assertMessage = 'Prefix must be empty or end with a "/"';
+
   set prefix(String value) {
-    assert(value.endsWith('/'));
+    assert(prefix.isEmpty || value.endsWith('/'), _assertMessage);
     _prefix = value;
   }
+
+  String get prefix => _prefix;
 
   /// Adds an [image] into the cache under the key [name].
   void add(String name, Image image) {

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -10,11 +10,17 @@ import 'package:flutter/services.dart';
 import '../flame.dart';
 
 class Images {
-  Images({this.prefix = 'assets/images/'})
-      : assert(prefix.isEmpty || prefix.endsWith('/'));
+  Images({String prefix = 'assets/images/'})
+      : assert(prefix.endsWith('/')),
+        _prefix = prefix;
 
-  final String prefix;
+  String _prefix;
   final Map<String, _ImageAssetLoader> _loadedFiles = {};
+
+  set prefix(String value) {
+    assert(value.endsWith('/'));
+    _prefix = value;
+  }
 
   /// Adds an [image] into the cache under the key [name].
   void add(String name, Image image) {
@@ -82,8 +88,8 @@ class Images {
     final manifestContent = await rootBundle.loadString('AssetManifest.json');
     final manifestMap = json.decode(manifestContent) as Map<String, dynamic>;
     final imagePaths = manifestMap.keys.where((path) {
-      return path.startsWith(prefix) && path.toLowerCase().contains(pattern);
-    }).map((path) => path.replaceFirst(prefix, ''));
+      return path.startsWith(_prefix) && path.toLowerCase().contains(pattern);
+    }).map((path) => path.replaceFirst(_prefix, ''));
     return loadAll(imagePaths.toList());
   }
 
@@ -130,7 +136,7 @@ class Images {
   }
 
   Future<Image> _fetchToMemory(String name) async {
-    final data = await Flame.bundle.load('$prefix$name');
+    final data = await Flame.bundle.load('$_prefix$name');
     final bytes = Uint8List.view(data.buffer);
     return _loadBytes(bytes);
   }

--- a/packages/flame/test/assets/images_test.dart
+++ b/packages/flame/test/assets/images_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flame/assets.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -41,7 +42,10 @@ void main() {
     test('throws when setting an invalid prefix', () {
       final images = Images();
 
-      expect(() => images.prefix = 'adasd', throwsAssertionError);
+      expect(
+        () => images.prefix = 'adasd',
+        failsAssert('Prefix must be empty or end with a "/"'),
+      );
     });
   });
 }

--- a/packages/flame/test/assets/images_test.dart
+++ b/packages/flame/test/assets/images_test.dart
@@ -1,8 +1,8 @@
 import 'dart:ui';
 
 import 'package:flame/assets.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:test/test.dart';
 
 class MockImage extends Mock implements Image {
   int disposedCount = 0;
@@ -36,6 +36,12 @@ void main() {
         images.fold<int>(0, (agg, image) => agg + image.disposedCount),
         images.length,
       );
+    });
+
+    test('throws when setting an invalid prefix', () {
+      final images = Images();
+
+      expect(() => images.prefix = 'adasd', throwsAssertionError);
     });
   });
 }


### PR DESCRIPTION
# Description

Solves #1429 

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
