### PR TITLE
fix: Setting images.prefix to empty string

### DIFF
--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -35,6 +35,7 @@ class Images {
     );
     _prefix = value;
   }
+
   late String _prefix;
 
   /// Adds an [image] into the cache under the key [name].

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -10,21 +10,32 @@ import 'package:flutter/services.dart';
 import '../flame.dart';
 
 class Images {
-  Images({String prefix = 'assets/images/'})
-      : assert(prefix.isEmpty || prefix.endsWith('/'), _assertMessage),
-        _prefix = prefix;
-
-  String _prefix;
-  final Map<String, _ImageAssetLoader> _loadedFiles = {};
-
-  static const _assertMessage = 'Prefix must be empty or end with a "/"';
-
-  set prefix(String value) {
-    assert(prefix.isEmpty || value.endsWith('/'), _assertMessage);
-    _prefix = value;
+  Images({String prefix = 'assets/images/'}) {
+    this.prefix = prefix;
   }
 
+  final Map<String, _ImageAssetLoader> _loadedFiles = {};
+
+  /// Path prefix to the project's directory with images.
+  ///
+  /// This path is relative to the project's root, and the default prefix is
+  /// "assets/images/". If necessary, you may change this prefix at any time.
+  /// A prefix must be a valid directory name and end with "/" (empty prefix is
+  /// also allowed).
+  ///
+  /// The prefix is **not** part of the keys of the images stored in this cache.
+  /// For example, if you load image `player.png`, then it will be searched at
+  /// location `prefix + "player.png"` but stored in the cache under the key
+  /// `"player.png"`.
   String get prefix => _prefix;
+  set prefix(String value) {
+    assert(
+      value.isEmpty || value.endsWith('/'),
+      'Prefix must be empty or end with a "/"',
+    );
+    _prefix = value;
+  }
+  late String _prefix;
 
   /// Adds an [image] into the cache under the key [name].
   void add(String name, Image image) {

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -28,6 +28,7 @@ class Images {
   /// location `prefix + "player.png"` but stored in the cache under the key
   /// `"player.png"`.
   String get prefix => _prefix;
+  late String _prefix;
   set prefix(String value) {
     assert(
       value.isEmpty || value.endsWith('/'),
@@ -35,8 +36,6 @@ class Images {
     );
     _prefix = value;
   }
-
-  late String _prefix;
 
   /// Adds an [image] into the cache under the key [name].
   void add(String name, Image image) {

--- a/packages/flame/test/assets/images_test.dart
+++ b/packages/flame/test/assets/images_test.dart
@@ -39,6 +39,17 @@ void main() {
       );
     });
 
+    testWithFlameGame(
+      'prefix on game.images can be changed',
+      (game) async {
+        expect(game.images.prefix, 'assets/images/');
+        game.images.prefix = 'assets/pictures/';
+        expect(game.images.prefix, 'assets/pictures/');
+        game.images.prefix = '';
+        expect(game.images.prefix, '');
+      },
+    );
+
     test('throws when setting an invalid prefix', () {
       final images = Images();
 


### PR DESCRIPTION
# Description

- Setter for `Images.prefix` now allows to set to an empty string.
- Added doc-string for the `.prefix` property.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
