### PR TITLE
fix: Don't use debug rendering by default in BodyComponent

### DIFF
--- a/packages/flame_forge2d/lib/body_component.dart
+++ b/packages/flame_forge2d/lib/body_component.dart
@@ -14,18 +14,17 @@ import 'sprite_body_component.dart';
 /// it is a good idea to turn on [debugMode] for it so that the bodies can be
 /// seen
 abstract class BodyComponent<T extends Forge2DGame> extends Component
-    with HasGameRef<T> {
+    with HasGameRef<T>, HasPaint {
   static const defaultColor = Color.fromARGB(255, 255, 255, 255);
   late Body body;
-  late Paint paint;
 
-  /// [debugMode] is true by default for body component since otherwise
-  /// nothing is rendered for it, if you render something on top of the
-  /// [BodyComponent], or doesn't want it to be seen, just set it to false.
+  /// [renderBody] is true by default for [BodyComponent], if set to false
+  /// the body wont be rendered. If you render something on top of the
+  /// [BodyComponent], or doesn't want it to be seen, you probably want to set
+  /// it to false.
   /// [SpriteBodyComponent] and [PositionBodyComponent] has it set to false by
   /// default.
-  @override
-  bool debugMode = true;
+  bool renderBody = true;
 
   BodyComponent({Paint? paint}) {
     this.paint = paint ?? (Paint()..color = defaultColor);
@@ -65,12 +64,19 @@ abstract class BodyComponent<T extends Forge2DGame> extends Component
     }
     canvas.save();
     canvas.transform(_transform.storage);
+    if (renderBody) {
+      _renderFixtures(canvas);
+    }
     super.renderTree(canvas);
     canvas.restore();
   }
 
   @override
   void renderDebugMode(Canvas canvas) {
+    _renderFixtures(canvas);
+  }
+
+  void _renderFixtures(Canvas canvas) {
     canvas.transform(_flipYTransform.storage);
 
     for (final fixture in body.fixtures) {

--- a/packages/flame_forge2d/lib/body_component.dart
+++ b/packages/flame_forge2d/lib/body_component.dart
@@ -77,8 +77,8 @@ abstract class BodyComponent<T extends Forge2DGame> extends Component
   }
 
   void _renderFixtures(Canvas canvas) {
+    canvas.save();
     canvas.transform(_flipYTransform.storage);
-
     for (final fixture in body.fixtures) {
       switch (fixture.type) {
         case ShapeType.chain:
@@ -95,6 +95,7 @@ abstract class BodyComponent<T extends Forge2DGame> extends Component
           break;
       }
     }
+    canvas.restore();
   }
 
   void _renderChain(Canvas canvas, Fixture fixture) {

--- a/packages/flame_forge2d/lib/position_body_component.dart
+++ b/packages/flame_forge2d/lib/position_body_component.dart
@@ -16,7 +16,7 @@ abstract class PositionBodyComponent<T extends Forge2DGame,
   Vector2 get size => _size!;
 
   @override
-  bool debugMode = false;
+  bool renderBody = false;
 
   /// Make sure that the [size] of the position component matches the bounding
   /// shape of the body that is create in createBody()


### PR DESCRIPTION
# Description

Since debug rendering now renders on top of everything (since ages), `BodyComponent` shouldn't hijack the debug render method for its normal rendering.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
