### PR TITLE
fix: `@mustCallSuper` missing on components

### DIFF
--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -85,6 +85,7 @@ class SpriteAnimationComponent extends PositionComponent with HasPaint {
         );
   }
 
+  @mustCallSuper
   @override
   void update(double dt) {
     if (playing) {

--- a/packages/flame/lib/src/components/sprite_animation_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_group_component.dart
@@ -93,6 +93,7 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent with HasPaint {
         );
   }
 
+  @mustCallSuper
   @override
   void update(double dt) {
     animation?.update(dt);

--- a/packages/flame/lib/src/components/sprite_batch_component.dart
+++ b/packages/flame/lib/src/components/sprite_batch_component.dart
@@ -28,6 +28,7 @@ class SpriteBatchComponent extends Component {
     );
   }
 
+  @mustCallSuper
   @override
   void render(Canvas canvas) {
     spriteBatch?.render(


### PR DESCRIPTION
# Description

Added the missing @mustCallSuper tags in 3 sprite components to provide proper linting.  PR request per this thread: https://discordapp.com/channels/509714518008528896/516639688581316629/952199344679964742

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

None
