### PR TITLE
feat: Add setter to priority

### DIFF
--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -10,7 +10,7 @@ This diagram might look intimidating, but don't worry, it is not as complex as i
 All components inherit from the abstract class `Component`.
 
 If you want to skip reading about abstract classes you can jump directly to
-[](#positioncomponent).
+[](#PositionComponent).
 
 Every `Component` has a few methods that you can optionally implement, which are used by the
 `FlameGame` class. If you are not using `FlameGame`, you can use these methods on your own game loop
@@ -62,13 +62,7 @@ class MyGame extends FlameGame {
 ```
 
 To update the priority of a component you have to either just set it to a new value, like 
-`component.priority = 2`, or call `parent?.children.changePriorities` if you want to change the
-priorities of many child components at the same time.
-
-The `changePriorities` method is useful due to the fact that rebalancing the component list is a
-fairly computationally expensive operation if there are a lot of components, so you would rather
-reorder the list once after all the priorities have been changed and not once for each priority
-change, if you have several changes.
+`component.priority = 2`, and it will be updated in the next tick.
 
 Example:
 

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -10,7 +10,7 @@ This diagram might look intimidating, but don't worry, it is not as complex as i
 All components inherit from the abstract class `Component`.
 
 If you want to skip reading about abstract classes you can jump directly to
-[](#PositionComponent).
+[](#positioncomponent).
 
 Every `Component` has a few methods that you can optionally implement, which are used by the
 `FlameGame` class. If you are not using `FlameGame`, you can use these methods on your own game loop
@@ -54,6 +54,7 @@ Example:
 
 ```dart
 class MyGame extends FlameGame {
+  @override
   Future<void> onLoad() {
     final myComponent = PositionComponent(priority: 5);
     add(myComponent);
@@ -70,7 +71,8 @@ Example:
 class MyComponent extends PositionComponent with Tappable {
   
   MyComponent() : super(priority: 1);
-  
+
+  @override
   void onTap() {
     priority = 2;
   }

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -37,14 +37,54 @@ If the parent is not mounted yet, then this method will wait in a queue (this wi
 on the rest of the game engine). 
 
 
-## Component
-Usually if you are going to make your own component you want to extend `PositionComponent`, but if
-you want to be able to handle effects and child components but handle the positioning differently
-you can extend the `Component` directly.
+### Priority
 
-`Component` is used by `SpriteBodyComponent`, `PositionBodyComponent`, and `BodyComponent` in
-`flame_forge2d` since those components doesn't have their position in relation to the screen, but in
-relation to the Forge2D world.
+In Flame the order components are rendered (and updated) in is called `priority`, this is sometimes
+referred to as `z-index` in other languages and frameworks. The higher the `priority` is set to, the
+closer the component will appear on the screen, since it will be rendered on top of any components
+with lower priority that were rendered before it.
+
+If you add two components and set one of them to priority 1 for example, then that component will be
+rendered on top of the other component (if they overlap), because the default priority is 0.
+
+All components take in `priority` as a named argument, so if you know the priority that you want
+your component at compile time, then you can pass it in to the constructor.
+
+Example:
+
+```dart
+class MyGame extends FlameGame {
+  Future<void> onLoad() {
+    final myComponent = PositionComponent(priority: 5);
+    add(myComponent);
+  }
+}
+```
+
+To update the priority of a component you have to either just set it to a new value, like 
+`component.priority = 2`, or call `parent?.children.changePriorities` if you want to change the
+priorities of many child components at the same time.
+
+The `changePriorities` method is useful due to the fact that rebalancing the component list is a
+fairly computationally expensive operation if there are a lot of components, so you would rather
+reorder the list once after all the priorities have been changed and not once for each priority
+change, if you have several changes.
+
+Example:
+
+```dart
+class MyComponent extends PositionComponent with Tappable {
+  
+  MyComponent() : super(priority: 1);
+  
+  void onTap() {
+    priority = 2;
+  }
+}
+```
+
+In the example above we first initialize the component with priority 1, and then when the user taps
+the component we change the priority to 2.
 
 
 ### Composability of components

--- a/doc/flame/game.md
+++ b/doc/flame/game.md
@@ -65,6 +65,7 @@ want to remove a list of components.
 Any component on which the `remove()` method has been called will also be removed. You can do this
 simply by doing `yourComponent.remove();`.
 
+
 ## Lifecycle
 
 ![Game Lifecycle Diagram](../images/component_lifecycle.png)
@@ -75,18 +76,6 @@ in order: `onGameResize`, `onLoad` and `onMount`. After that it goes on to call 
 Once the `GameWidget` is removed from the tree, `onRemove` is called, just like when a normal
 component is removed from the component tree.
 
-## Changing component priorities (render/update order)
-
-To update a component with a new priority you have to call either `FlameGame.changePriority`, or
-`FlameGame.changePriorities` if you want to change the priorities of many components at once.
-This design is due to the fact that the components doesn't always have access to the component list and
-because rebalancing the component list is a fairly computationally expensive operation, so you
-would rather reorder the list once after all the priorities have been changed and not once for each
-priority change, if you have several changes.
-
-The higher a priority is the later it is rendered and updated, which will make it appear closer on
-the screen since it will be rendered on top of any components with lower priority that were rendered
-before it.
 
 ## Debug mode
 
@@ -159,6 +148,7 @@ main() {
 }
 ```
 
+
 ## Game Loop
 
 The `GameLoop` module is a simple abstraction over the game loop concept. Basically most games are
@@ -170,6 +160,7 @@ built upon two methods:
 
 The `GameLoop` is used by all of Flame's `Game` implementations.
 
+
 ## Pause/Resuming game execution
 
 A Flame `Game` can be paused and resumed in two ways:
@@ -179,6 +170,7 @@ A Flame `Game` can be paused and resumed in two ways:
 
 When pausing a Flame `Game`, the `GameLoop` is effectively paused, meaning that no updates or new
 renders will happen until it is resumed.
+
 
 ## Flutter Widgets and Game instances
 

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -77,7 +77,7 @@ class Component {
     if (parent == null) {
       _priority = newPriority;
     } else {
-      parent?.children.changePriority(this, newPriority);
+      parent!.children.changePriority(this, newPriority);
     }
   }
 

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -73,6 +73,14 @@ class Component {
   /// If two components share the same priority, they will probably be drawn in
   /// the order they were added.
   int get priority => _priority;
+  set priority(int newPriority) {
+    if (parent == null) {
+      _priority = newPriority;
+    } else {
+      parent?.children.changePriority(this, newPriority);
+    }
+  }
+
   int _priority;
 
   /// Whether this component should be removed or not.

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -72,6 +72,10 @@ class Component {
   /// It can be any integer (negative, zero, or positive).
   /// If two components share the same priority, they will probably be drawn in
   /// the order they were added.
+  ///
+  /// Note that this operation is relatively expensive if the component is
+  /// already added to a component tree since all siblings have to be re-added
+  /// to the parent.
   int get priority => _priority;
   set priority(int newPriority) {
     if (parent == null) {

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -73,7 +73,7 @@ class Component {
   /// If two components share the same priority, they will probably be drawn in
   /// the order they were added.
   ///
-  /// Note that this operation is relatively expensive if the component is
+  /// Note that setting the priority is relatively expensive if the component is
   /// already added to a component tree since all siblings have to be re-added
   /// to the parent.
   int get priority => _priority;

--- a/packages/flame/test/components/priority_test.dart
+++ b/packages/flame/test/components/priority_test.dart
@@ -44,18 +44,36 @@ void main() {
     flameGame.test(
       'changing priority should reorder component list',
       (game) async {
-        final firstCompopnent = _PriorityComponent(-1);
+        final firstComponent = _PriorityComponent(-1);
         final priorityComponents =
             List.generate(10, (i) => _PriorityComponent(i))
-              ..add(firstCompopnent);
+              ..add(firstComponent);
         priorityComponents.shuffle();
         final components = game.children;
         await game.ensureAddAll(priorityComponents);
         componentsSorted(components);
-        expect(components.first, firstCompopnent);
-        game.children.changePriority(firstCompopnent, 11);
+        expect(components.first, firstComponent);
+        game.children.changePriority(firstComponent, 11);
         game.update(0);
-        expect(components.last, firstCompopnent);
+        expect(components.last, firstComponent);
+      },
+    );
+
+    flameGame.test(
+      'changing priority with the priority setter should reorder the list',
+      (game) async {
+        final firstComponent = _PriorityComponent(-1);
+        final priorityComponents =
+            List.generate(10, (i) => _PriorityComponent(i))
+              ..add(firstComponent);
+        priorityComponents.shuffle();
+        final components = game.children;
+        await game.ensureAddAll(priorityComponents);
+        componentsSorted(components);
+        expect(components.first, firstComponent);
+        firstComponent.priority = 11;
+        game.update(0);
+        expect(components.last, firstComponent);
       },
     );
 


### PR DESCRIPTION
# Description

Allows setting the priority directly by having a setter that checks whether the component has a parent or not.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
