### PR TITLE
docs: Add `backgroundColor()` docs

### DIFF
--- a/doc/flame/game.md
+++ b/doc/flame/game.md
@@ -87,6 +87,24 @@ if you change the `debugMode` at runtime, it will not affect already added compo
 To read more about the `debugMode` on Flame, please refer to the [Debug Docs](other/debug.md)
 
 
+# Change background color
+
+To change the background color of your `FlameGame` you have to override `backgroundColor()`.
+
+In the following example the background color is set to be fully transparent, so that you can see
+the widgets that are behind the `GameWidget`. The default it opaque black.
+
+```dart
+class MyGame extends FlameGame {
+  @override
+  Color backgroundColor() => const Color(0x00000000);
+}
+```
+
+Note that the background color can't change dynamically while the game is running, but you could
+just draw a background that covers the whole canvas if you would want it to change dynamically.
+
+
 ## SingleGameInstance mixin
 
 An optional mixin `SingleGameInstance` can be applied to your game if you are making a single-game


### PR DESCRIPTION
# Description

We were missing docs about `backgroundColor`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
