### PR TITLE
docs: Widget overlay documentation is out of date

### DIFF
--- a/doc/flame/game.md
+++ b/doc/flame/game.md
@@ -219,7 +219,7 @@ Widget build(BuildContext context) {
   return GameWidget(
     game: game,
     overlayBuilderMap: {
-      'PauseMenu': (ctx) {
+      'PauseMenu': (BuildContext context, MyGame game) {
         return Text('A pause menu');
       },
     },
@@ -227,9 +227,8 @@ Widget build(BuildContext context) {
 }
 ```
 
-The order in which the overlays are declared in the `overlayBuilderMap` defines which order the
-overlays will be rendered.
+The order of rendering for an overlay is determined by the order of the keys in the 
+`overlayBuilderMap`. 
 
-Here you can see a
-[working example](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/system/overlays_example.dart)
-of this feature.
+An example of feature can be found 
+[here](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/system/overlays_example.dart).


### PR DESCRIPTION
# Description

The Widget Overlay docs was out of date and was missing the `Game` argument.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
