### PR TITLE
docs: `Rect` extension docs is out of date

### DIFF
--- a/doc/flame/other/util.md
+++ b/doc/flame/other/util.md
@@ -195,6 +195,11 @@ Methods:
  - `toVertices`: Turns the four corners of the `Rect` into a list of `Vector2`.
  - `toMathRectangle`: Converts this `Rect` into a `math.Rectangle`.
  - `toGeometryRectangle`: Converts this `Rect` into a `Rectangle` from flame-geom.
+ - `transform`: Transforms the `Rect` using a `Matrix4`.
+
+Factories:
+ - `fromBounds`: Construct a `Rect` that represents the bounds of a list of `Vector2`s.
+ - `fromVector2Center`: Construct a `Rect` from a center point.
 
 ### math.Rectangle
 

--- a/packages/flame/lib/src/extensions/rect.dart
+++ b/packages/flame/lib/src/extensions/rect.dart
@@ -74,7 +74,7 @@ extension RectExtension on Rect {
     );
   }
 
-  /// Creates bounds in from of a [Rect] from a list of [Vector2]
+  /// Creates a [Rect] that represents the bounds of the list [pts].
   static Rect fromBounds(List<Vector2> pts) {
     final minX = pts.map((e) => e.x).reduce(min);
     final maxX = pts.map((e) => e.x).reduce(max);
@@ -83,8 +83,7 @@ extension RectExtension on Rect {
     return Rect.fromPoints(Offset(minX, minY), Offset(maxX, maxY));
   }
 
-  /// Constructs a rectangle from its center point (specified as a Vector2),
-  /// width and height.
+  /// Constructs a [Rect] with a [width] and [height] around the [center] point.
   static Rect fromVector2Center({
     required Vector2 center,
     required double width,


### PR DESCRIPTION
# Description

The `Rect` extension docs is out of date, and the factory methods were confusing to read, they were not explaining themselves easily so I have updated them as well.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
