### PR TITLE
feat: Deprecating Rect methods

### DIFF
--- a/doc/flame/other/util.md
+++ b/doc/flame/other/util.md
@@ -198,8 +198,8 @@ Methods:
  - `transform`: Transforms the `Rect` using a `Matrix4`.
 
 Factories:
- - `RectExtension.fromBounds`: Construct a `Rect` that represents the bounds of a list of `Vector2`s.
- - `RectExtension.fromVector2Center`: Construct a `Rect` from a center point.
+ - `RectExtension.getBounds`: Construct a `Rect` that represents the bounds of a list of `Vector2`s.
+ - `RectExtension.fromCenter`: Construct a `Rect` from a center point (using `Vector2`).
 
 ### math.Rectangle
 

--- a/packages/flame/lib/src/assets/images.dart
+++ b/packages/flame/lib/src/assets/images.dart
@@ -118,7 +118,7 @@ class Images {
   /// [runAsWeb] to `true`. Keep in mind that it is slightly slower than the
   /// native [ui.decodeImageFromPixels]. By default it is set to [kIsWeb].
   @Deprecated(
-    'Use Image.fromPixels() instead. This function will be removed in 1.1.0',
+    'Use Image.fromPixels() instead. This function will be removed in 1.2.0',
   )
   Future<Image> decodeImageFromPixels(
     Uint8List pixels,

--- a/packages/flame/lib/src/extensions/rect.dart
+++ b/packages/flame/lib/src/extensions/rect.dart
@@ -75,16 +75,27 @@ extension RectExtension on Rect {
   }
 
   /// Creates a [Rect] that represents the bounds of the list [pts].
-  static Rect fromBounds(List<Vector2> pts) {
-    final minX = pts.map((e) => e.x).reduce(min);
-    final maxX = pts.map((e) => e.x).reduce(max);
-    final minY = pts.map((e) => e.y).reduce(min);
-    final maxY = pts.map((e) => e.y).reduce(max);
+  static Rect getBounds(List<Vector2> pts) {
+    final xPoints = pts.map((e) => e.x);
+    final yPoints = pts.map((e) => e.y);
+
+    final minX = xPoints.reduce(min);
+    final maxX = xPoints.reduce(max);
+    final minY = yPoints.reduce(min);
+    final maxY = yPoints.reduce(max);
     return Rect.fromPoints(Offset(minX, minY), Offset(maxX, maxY));
   }
 
+  /// Creates a [Rect] that represents the bounds of the list [pts].
+  @Deprecated(
+    'Use RectExtension.getBounds() instead. This function will be removed in 1.2.0',
+  )
+  static Rect fromBounds(List<Vector2> pts) {
+    return getBounds(pts);
+  }
+
   /// Constructs a [Rect] with a [width] and [height] around the [center] point.
-  static Rect fromVector2Center({
+  static Rect fromCenter({
     required Vector2 center,
     required double width,
     required double height,
@@ -95,5 +106,17 @@ extension RectExtension on Rect {
       center.x + width / 2,
       center.y + height / 2,
     );
+  }
+
+  /// Constructs a [Rect] with a [width] and [height] around the [center] point.
+  @Deprecated(
+    'Use RectExtension.fromCenter() instead. This function will be removed in 1.2.0',
+  )
+  static Rect fromVector2Center({
+    required Vector2 center,
+    required double width,
+    required double height,
+  }) {
+    return fromCenter(center: center, width: width, height: height);
   }
 }

--- a/packages/flame/lib/src/extensions/rect.dart
+++ b/packages/flame/lib/src/extensions/rect.dart
@@ -88,7 +88,8 @@ extension RectExtension on Rect {
 
   /// Creates a [Rect] that represents the bounds of the list [pts].
   @Deprecated(
-    'Use RectExtension.getBounds() instead. This function will be removed in 1.2.0',
+    'Use RectExtension.getBounds() instead. This function will be removed'
+    ' in 1.2.0',
   )
   static Rect fromBounds(List<Vector2> pts) {
     return getBounds(pts);
@@ -110,7 +111,8 @@ extension RectExtension on Rect {
 
   /// Constructs a [Rect] with a [width] and [height] around the [center] point.
   @Deprecated(
-    'Use RectExtension.fromCenter() instead. This function will be removed in 1.2.0',
+    'Use RectExtension.fromCenter() instead. This function will be removed'
+    ' in 1.2.0',
   )
   static Rect fromVector2Center({
     required Vector2 center,


### PR DESCRIPTION
# Description

- Deprecating `fromBounds` in favor of better named `getBounds`.
- Deprecating `fromVector2Center` in favor of `fromCenter`, as it won't be blocking on the `Rect.fromCenter` constructor.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
