### PR TITLE
feat: Added .anchor property to CameraComponent.Viewfinder

### DIFF
--- a/doc/flame/camera_component.md
+++ b/doc/flame/camera_component.md
@@ -90,6 +90,13 @@ This part of the camera is responsible for knowing which location in the
 underlying game world we are currently looking at. The `Viewfinder` also
 controls the zoom level, and the rotation angle of the view.
 
+The `anchor` property of the viewfinder allows you to designate which point
+inside the viewport serves as a "logical center" of the camera. For example,
+in side-scrolling action games it is common to have the camera focused on the
+main character who is displayed not in the center of the screen but closer to
+the lower-left corner. This off-center position would be the "logical center"
+of the camera, controlled by the viewfinder's `anchor`.
+
 Components added to the `Viewfinder` as children will be rendered as if they
 were part of the world (but on top). It is more useful to add behavioral
 components to the viewfinder, for example [](effects.md) or other controllers.
@@ -109,6 +116,6 @@ Pros:
   - (NYI) Effects can be applied either to the viewport, or to the viewfinder;
   - (NYI) More flexible camera controllers.
 
-Cons (we are planning to address these in the near future):
+Cons (we are planning to eliminate these in the near future):
   - Camera controls are not yet implemented;
   - Events propagation may not always work correctly.

--- a/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
@@ -1,4 +1,5 @@
 import 'package:dashbook/dashbook.dart';
+import 'package:examples/stories/camera_and_viewport/camera_component_properties_example.dart';
 import 'package:flame/game.dart';
 
 import '../../commons/commons.dart';
@@ -66,5 +67,13 @@ void addCameraAndViewportStories(Dashbook dashbook) {
       (context) => GameWidget(game: CameraComponentExample()),
       codeLink: baseLink('camera_and_viewport/camera_component_example.dart'),
       info: CameraComponentExample.description,
+    )
+    ..add(
+      'CameraComponent properties',
+      (context) => GameWidget(game: CameraComponentPropertiesExample()),
+      codeLink: baseLink(
+        'camera_and_viewport/camera_component_properties_example.dart',
+      ),
+      info: CameraComponentPropertiesExample.description,
     );
 }

--- a/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
@@ -1,9 +1,9 @@
 import 'package:dashbook/dashbook.dart';
-import 'package:examples/stories/camera_and_viewport/camera_component_properties_example.dart';
 import 'package:flame/game.dart';
 
 import '../../commons/commons.dart';
 import 'camera_component_example.dart';
+import 'camera_component_properties_example.dart';
 import 'coordinate_systems_example.dart';
 import 'fixed_resolution_example.dart';
 import 'follow_component_example.dart';

--- a/examples/lib/stories/camera_and_viewport/camera_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_component_example.dart
@@ -66,12 +66,14 @@ class CameraComponentExample extends FlameGame with PanDetector {
   }
 
   void _updateMagnifyingGlassPosition(Vector2 point) {
-    // shifts the original [point] by 1.4142*radius, which happens to be in the
-    // middle of a handle
+    // [point] is in the canvas coordinate system.
+    // This shifts the original [point] by 1.4142*radius, which happens to be
+    // in the middle of the magnifying glass' handle.
     final handlePoint = point - Vector2.all(radius);
-    magnifyingGlass.viewport.position = handlePoint;
-    magnifyingGlass.viewfinder.position =
-        (handlePoint - canvasSize / 2 + center) * zoom;
+    magnifyingGlass
+      ..viewport.position = handlePoint
+      ..viewfinder.position = handlePoint - canvasSize / 2 + center;
+    // print('position = ${magnifyingGlass.viewfinder.position}');
   }
 }
 

--- a/examples/lib/stories/camera_and_viewport/camera_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_component_example.dart
@@ -73,7 +73,6 @@ class CameraComponentExample extends FlameGame with PanDetector {
     magnifyingGlass
       ..viewport.position = handlePoint
       ..viewfinder.position = handlePoint - canvasSize / 2 + center;
-    // print('position = ${magnifyingGlass.viewfinder.position}');
   }
 }
 

--- a/examples/lib/stories/camera_and_viewport/camera_component_properties_example.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_component_properties_example.dart
@@ -1,0 +1,88 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/experimental.dart';
+import 'package:flame/game.dart' hide Viewport;
+
+class CameraComponentPropertiesExample extends FlameGame {
+  static const description = '''
+    This example uses FixedSizeViewport which is dynamically sized and 
+    positioned based on the size of the game widget.
+    
+    The underlying world is represented as a simple coordinate plane, with
+    green dot being the origin. The viewfinder uses custom anchor in order to
+    declare its "center" half-way between the bottom left corner and the true
+    center.
+  ''';
+
+  CameraComponent? _camera;
+
+  @override
+  Color backgroundColor() => const Color(0xff333333);
+
+  @override
+  Future<void> onLoad() async {
+    final world = World();
+    world.add(Background());
+    _camera = CameraComponent(
+      world: world,
+      viewport: FixedSizeViewport(200, 200)..add(ViewportFrame()),
+    )
+      ..viewfinder.zoom = 5
+      ..viewfinder.anchor = const Anchor(0.25, 0.75);
+    await add(world);
+    await add(_camera!);
+    onGameResize(canvasSize);
+  }
+
+  @override
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    _camera?.viewport.size = size * 0.7;
+    _camera?.viewport.position = size * 0.6;
+  }
+}
+
+class ViewportFrame extends Component {
+  final paint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 3
+    ..color = const Color(0xff87c4e2);
+
+  @override
+  void render(Canvas canvas) {
+    final size = (parent! as Viewport).size;
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromLTWH(-size.x / 2, -size.y / 2, size.x, size.y),
+        const Radius.circular(5),
+      ),
+      paint,
+    );
+  }
+}
+
+class Background extends Component {
+  final bgPaint = Paint()..color = const Color(0xffff0000);
+  final originPaint = Paint()..color = const Color(0xff2f8750);
+  final axisPaint = Paint()
+    ..strokeWidth = 1
+    ..style = PaintingStyle.stroke
+    ..color = const Color(0xff878787);
+  final gridPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 0
+    ..color = const Color(0xff555555);
+
+  @override
+  void render(Canvas canvas) {
+    canvas.drawColor(const Color(0xff000000), BlendMode.src);
+    for (var i = -100.0; i <= 100.0; i += 10) {
+      canvas.drawLine(Offset(i, -100), Offset(i, 100), gridPaint);
+      canvas.drawLine(Offset(-100, i), Offset(100, i), gridPaint);
+    }
+    canvas.drawLine(Offset.zero, const Offset(0, 10), axisPaint);
+    canvas.drawLine(Offset.zero, const Offset(10, 0), axisPaint);
+    canvas.drawCircle(Offset.zero, 1.0, originPaint);
+  }
+}

--- a/packages/flame/lib/src/experimental/fixed_size_viewport.dart
+++ b/packages/flame/lib/src/experimental/fixed_size_viewport.dart
@@ -11,9 +11,10 @@ import 'viewport.dart';
 class FixedSizeViewport extends Viewport {
   FixedSizeViewport(double width, double height) {
     size = Vector2(width, height);
+    onViewportResize();
   }
 
-  Rect _clipRect = Rect.zero;
+  late Rect _clipRect;
 
   @override
   void clip(Canvas canvas) => canvas.clipRect(_clipRect, doAntiAlias: false);

--- a/packages/flame/lib/src/experimental/viewfinder.dart
+++ b/packages/flame/lib/src/experimental/viewfinder.dart
@@ -20,6 +20,9 @@ class Viewfinder extends Component {
   /// Internal transform matrix used by the viewfinder.
   final Transform2D _transform = Transform2D();
 
+  @internal
+  Matrix4 get transformMatrix => _transform.transformMatrix;
+
   /// The game coordinates of a point that is to be positioned at the center
   /// of the viewport.
   Vector2 get position => -_transform.offset;
@@ -120,28 +123,5 @@ class Viewfinder extends Component {
     );
     _initZoom();
     onViewportResize();
-  }
-
-  @override
-  void renderTree(Canvas canvas) {}
-
-  /// Internal rendering method called by the [Viewport] (regular rendering is
-  /// disabled). This ensures that the viewfinder performs its rendering only
-  /// after the viewport applied the necessary transforms / clip mask.
-  @internal
-  void renderFromViewport(Canvas canvas) {
-    final world = camera.world;
-    if (world.isMounted &&
-        CameraComponent.currentCameras.length <
-            CameraComponent.maxCamerasDepth) {
-      try {
-        CameraComponent.currentCameras.add(camera);
-        canvas.transform(_transform.transformMatrix.storage);
-        world.renderFromCamera(canvas);
-        super.renderTree(canvas);
-      } finally {
-        CameraComponent.currentCameras.removeLast();
-      }
-    }
   }
 }

--- a/packages/flame/lib/src/experimental/viewfinder.dart
+++ b/packages/flame/lib/src/experimental/viewfinder.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import '../anchor.dart';
 import '../components/component.dart';
 import '../game/transform2d.dart';
 import 'camera_component.dart';
@@ -44,6 +45,13 @@ class Viewfinder extends Component {
   /// The rotation is around the axis that is perpendicular to the screen.
   double get angle => -_transform.angle;
   set angle(double value) => _transform.angle = -value;
+
+  Anchor get anchor => _anchor;
+  Anchor _anchor = Anchor.center;
+  set anchor(Anchor value) {
+    _anchor = value;
+    onViewportResize();
+  }
 
   /// Reference to the parent camera.
   CameraComponent get camera => parent! as CameraComponent;
@@ -95,12 +103,18 @@ class Viewfinder extends Component {
     _initZoom();
   }
 
+  void onViewportResize() {
+    final viewportSize = camera.viewport.size;
+    _transform.position.x = viewportSize.x * (_anchor.x - 0.5);
+    _transform.position.y = viewportSize.y * (_anchor.y - 0.5);
+  }
+
   @mustCallSuper
   @override
   void onMount() {
     assert(
       parent! is CameraComponent,
-      'Viewfinder can only be mounted to a Camera2',
+      'Viewfinder can only be mounted to a CameraComponent',
     );
     _initZoom();
   }

--- a/packages/flame/lib/src/experimental/viewfinder.dart
+++ b/packages/flame/lib/src/experimental/viewfinder.dart
@@ -104,9 +104,11 @@ class Viewfinder extends Component {
   }
 
   void onViewportResize() {
-    final viewportSize = camera.viewport.size;
-    _transform.position.x = viewportSize.x * (_anchor.x - 0.5);
-    _transform.position.y = viewportSize.y * (_anchor.y - 0.5);
+    if (parent != null) {
+      final viewportSize = camera.viewport.size;
+      _transform.position.x = viewportSize.x * (_anchor.x - 0.5);
+      _transform.position.y = viewportSize.y * (_anchor.y - 0.5);
+    }
   }
 
   @mustCallSuper
@@ -117,6 +119,7 @@ class Viewfinder extends Component {
       'Viewfinder can only be mounted to a CameraComponent',
     );
     _initZoom();
+    onViewportResize();
   }
 
   @override

--- a/packages/flame/lib/src/experimental/viewfinder.dart
+++ b/packages/flame/lib/src/experimental/viewfinder.dart
@@ -49,6 +49,15 @@ class Viewfinder extends Component {
   double get angle => -_transform.angle;
   set angle(double value) => _transform.angle = -value;
 
+  /// The point within the viewport that is considered the "logical center" of
+  /// the camera.
+  ///
+  /// This anchor is relative to the viewport's bounding rect, and by default
+  /// is at the center of the viewport.
+  ///
+  /// The "logical center" of the camera means the point within the viewport
+  /// where the viewfinder's focus is located at. It is at this point within
+  /// the viewport that the world's point [position] will be displayed.
   Anchor get anchor => _anchor;
   Anchor _anchor = Anchor.center;
   set anchor(Anchor value) {
@@ -106,6 +115,8 @@ class Viewfinder extends Component {
     _initZoom();
   }
 
+  /// Called by the viewport when its size changes.
+  @internal
   void onViewportResize() {
     if (parent != null) {
       final viewportSize = camera.viewport.size;

--- a/packages/flame/lib/src/experimental/viewfinder.dart
+++ b/packages/flame/lib/src/experimental/viewfinder.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -8,7 +7,6 @@ import '../anchor.dart';
 import '../components/component.dart';
 import '../game/transform2d.dart';
 import 'camera_component.dart';
-import 'viewport.dart';
 
 /// [Viewfinder] is a part of a [CameraComponent] system that controls which
 /// part of the game world is currently visible through a viewport.

--- a/packages/flame/lib/src/experimental/viewport.dart
+++ b/packages/flame/lib/src/experimental/viewport.dart
@@ -45,8 +45,8 @@ abstract class Viewport extends Component {
     _size.setFrom(value);
     if (isMounted) {
       camera.viewfinder.onViewportResize();
-      onViewportResize();
     }
+    onViewportResize();
   }
 
   /// Reference to the parent camera.

--- a/packages/flame/lib/src/experimental/viewport.dart
+++ b/packages/flame/lib/src/experimental/viewport.dart
@@ -59,7 +59,6 @@ abstract class Viewport extends Component {
   /// clip mask's shape must match the [size] of the viewport.
   ///
   /// This API must be implemented by all viewports.
-  @protected
   void clip(Canvas canvas);
 
   /// Override in order to perform a custom action upon resize.
@@ -76,18 +75,5 @@ abstract class Viewport extends Component {
       parent! is CameraComponent,
       'A Viewport may only be attached to a CameraComponent',
     );
-  }
-
-  @override
-  void renderTree(Canvas canvas) {
-    canvas.save();
-    canvas.translate(_position.x, _position.y);
-    canvas.save();
-    clip(canvas);
-    camera.viewfinder.renderFromViewport(canvas);
-    canvas.restore();
-    // Render viewport's children
-    super.renderTree(canvas);
-    canvas.restore();
   }
 }

--- a/packages/flame/lib/src/experimental/viewport.dart
+++ b/packages/flame/lib/src/experimental/viewport.dart
@@ -43,8 +43,14 @@ abstract class Viewport extends Component {
       "Viewport's size cannot be negative: $value",
     );
     _size.setFrom(value);
-    onViewportResize();
+    if (isMounted) {
+      camera.viewfinder.onViewportResize();
+      onViewportResize();
+    }
   }
+
+  /// Reference to the parent camera.
+  CameraComponent get camera => parent! as CameraComponent;
 
   /// Apply clip mask to the [canvas].
   ///
@@ -68,13 +74,12 @@ abstract class Viewport extends Component {
   void onMount() {
     assert(
       parent! is CameraComponent,
-      'A Viewport may only be attached to a Camera2',
+      'A Viewport may only be attached to a CameraComponent',
     );
   }
 
   @override
   void renderTree(Canvas canvas) {
-    final camera = parent! as CameraComponent;
     canvas.save();
     canvas.translate(_position.x, _position.y);
     canvas.save();

--- a/packages/flame/test/experimental/viewfinder_test.dart
+++ b/packages/flame/test/experimental/viewfinder_test.dart
@@ -35,7 +35,7 @@ void main() {
     );
 
     testWithFlameGame(
-      'default camera centers on a given point',
+      'default camera centers on a given world point',
       (game) async {
         final world = World()..addToParent(game);
         final camera = CameraComponent(world: world)
@@ -83,7 +83,7 @@ void main() {
     );
 
     testWithFlameGame(
-      'default camera with zoom > 1 and shifted center',
+      'default camera with zoom > 1 and non-zero position',
       (game) async {
         final world = World()..addToParent(game);
         final camera = CameraComponent(world: world)
@@ -102,6 +102,32 @@ void main() {
             ..translate(400, 300) // canvas center
             ..scale(5)
             ..translate(-60, -40) // viewfinder translate
+            ..translate(20, 10) // rectangle translate
+            ..drawRect(const Rect.fromLTWH(0, 0, 80, 60))
+            ..translate(0, 0),
+        );
+      },
+    );
+
+    testWithFlameGame(
+      'default camera with non-central anchor and zoom',
+      (game) async {
+        final world = World()
+          ..add(_Rect()..position = Vector2(20, 10))
+          ..addToParent(game);
+        CameraComponent(world: world)
+          ..viewfinder.zoom = 2
+          ..viewfinder.anchor = const Anchor(0.1, 0.7)
+          ..addToParent(game);
+        await game.ready();
+
+        final canvas = MockCanvas();
+        game.render(canvas);
+        expect(
+          canvas,
+          MockCanvas()
+            ..translate(800 * 0.1, 600 * 0.7) // viewfinder logical center
+            ..scale(2) // zoom
             ..translate(20, 10) // rectangle translate
             ..drawRect(const Rect.fromLTWH(0, 0, 80, 60))
             ..translate(0, 0),


### PR DESCRIPTION
# Description

The `.anchor` property allows to designate a specific point within the viewport as being the "logical center" of the viewport -- this is the point where the viewfinder's focus will be placed at. This is similar to the `relativeOffset` property of the old `Camera`.

Also: slightly simplified the rendering logic of `CameraComponent` by merging the multiple rendering methods.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
