### PR TITLE
fix: `debugMode` should be inherited from parent when mounted

### DIFF
--- a/examples/lib/stories/collision_detection/multiple_shapes_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes_example.dart
@@ -42,9 +42,8 @@ class MultipleShapesExample extends FlameGame
     var totalAdded = 1;
     while (totalAdded < 100) {
       lastToAdd = nextRandomCollidable(lastToAdd, screenHitbox);
-      final lastBottomRight =
-          lastToAdd.toAbsoluteRect().bottomRight.toVector2();
-      if (lastBottomRight.x < size.x && lastBottomRight.y < size.y) {
+      final lastBottomRight = lastToAdd.toAbsoluteRect().bottomRight;
+      if (lastBottomRight.dx < size.x && lastBottomRight.dy < size.y) {
         add(lastToAdd);
         totalAdded++;
       } else {
@@ -143,7 +142,7 @@ abstract class MyCollidable extends PositionComponent
   @override
   void render(Canvas canvas) {
     if (isDragged) {
-      final localCenter = (scaledSize / 2).toOffset();
+      final localCenter = scaledSize.toOffset() / 2;
       canvas.drawCircle(localCenter, 5, _dragIndicatorPaint);
     }
   }

--- a/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:meta/meta.dart';
 
 import '../../../collisions.dart';
@@ -13,9 +11,6 @@ import '../../geometry/shape_intersections.dart' as intersection_system;
 mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   @override
   CollisionType collisionType = CollisionType.active;
-
-  @override
-  Paint get paint => debugPaint;
 
   /// Whether the hitbox is allowed to collide with another hitbox that is
   /// added to the same parent.
@@ -48,10 +43,7 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   final Matrix3 _rotationMatrix = Matrix3.zero();
 
   @override
-  bool get renderShape => _renderShape || debugMode;
-  @override
-  set renderShape(bool shouldRender) => _renderShape = shouldRender;
-  bool _renderShape = false;
+  bool renderShape = false;
 
   @protected
   late PositionComponent hitboxParent;

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -390,7 +390,6 @@ class Component {
           _state == LifecycleState.removed,
     );
     _parent = parent;
-    debugMode |= parent.debugMode;
     parent.lifecycle._children.add(this);
 
     if (!isLoaded) {
@@ -455,6 +454,7 @@ class Component {
     }
     _mountCompleter?.complete();
     _mountCompleter = null;
+    debugMode |= _parent!.debugMode;
     onMount();
     _state = LifecycleState.mounted;
     if (!existingChild) {

--- a/packages/flame/lib/src/geometry/circle_component.dart
+++ b/packages/flame/lib/src/geometry/circle_component.dart
@@ -57,13 +57,17 @@ class CircleComponent extends ShapeComponent {
     return min(_scaledSize.x, _scaledSize.y) / 2;
   }
 
-  /// This render method doesn't rotate the canvas according to angle since a
-  /// circle will look the same rotated as not rotated.
   @override
   void render(Canvas canvas) {
     if (renderShape) {
       canvas.drawCircle((size / 2).toOffset(), radius, paint);
     }
+  }
+
+  @override
+  void renderDebugMode(Canvas canvas) {
+    super.renderDebugMode(canvas);
+    canvas.drawCircle((size / 2).toOffset(), radius, debugPaint);
   }
 
   /// Checks whether the represented circle contains the [point].

--- a/packages/flame/lib/src/geometry/polygon_component.dart
+++ b/packages/flame/lib/src/geometry/polygon_component.dart
@@ -189,6 +189,12 @@ class PolygonComponent extends ShapeComponent {
     }
   }
 
+  @override
+  void renderDebugMode(Canvas canvas) {
+    super.renderDebugMode(canvas);
+    canvas.drawPath(_path, debugPaint);
+  }
+
   /// Checks whether the polygon contains the [point].
   /// Note: The polygon needs to be convex for this to work.
   @override

--- a/packages/flame/test/components/composed_component_test.dart
+++ b/packages/flame/test/components/composed_component_test.dart
@@ -39,7 +39,7 @@ class _MyTap extends PositionComponent with Tappable {
   }
 }
 
-class _MyAsyncChild extends _MyTap {
+class _MyAsyncChild extends PositionComponent {
   @override
   Future<void> onLoad() async {
     await super.onLoad();
@@ -52,7 +52,7 @@ void main() {
   final withTappables = FlameTester(() => _HasTappablesGame());
 
   group('Composability', () {
-    withTappables.test(
+    testWithFlameGame(
       'child is not added until the component is prepared',
       (game) async {
         final child = Component();
@@ -71,7 +71,7 @@ void main() {
       },
     );
 
-    withTappables.test('removes the child from the component', (game) async {
+    testWithFlameGame('removes the child from the component', (game) async {
       final child = Component();
       final wrapper = Component();
       await game.ensureAdd(wrapper);
@@ -88,7 +88,7 @@ void main() {
       expect(wrapper.contains(child), false);
     });
 
-    withTappables.test(
+    testWithFlameGame(
       'when child is async loading, the child is added to the component after '
       'loading',
       (game) async {
@@ -119,8 +119,8 @@ void main() {
       expect(child.tapped, true);
     });
 
-    withTappables.test('add multiple children with addAll', (game) async {
-      final children = List.generate(10, (_) => _MyTap());
+    testWithFlameGame('add multiple children with addAll', (game) async {
+      final children = List.generate(10, (_) => _MyAsyncChild());
       final wrapper = Component();
       await wrapper.addAll(children);
 
@@ -191,7 +191,7 @@ void main() {
       expect(child.rendered, true);
     });
 
-    withTappables.test('initially same debugMode as parent', (game) async {
+    testWithFlameGame('initially same debugMode as parent', (game) async {
       final child = Component();
       final wrapper = Component();
       wrapper.debugMode = true;
@@ -203,5 +203,23 @@ void main() {
       wrapper.debugMode = false;
       expect(child.debugMode, true);
     });
+
+    testWithFlameGame(
+      'debugMode propagates to descendants onMount',
+      (game) async {
+        final child = Component();
+        final parent = Component();
+        final grandParent = Component();
+        parent.add(child);
+        grandParent.add(parent);
+        grandParent.debugMode = true;
+
+        await game.ensureAdd(grandParent);
+
+        expect(child.debugMode, true);
+        expect(parent.debugMode, true);
+        expect(grandParent.debugMode, true);
+      },
+    );
   });
 }


### PR DESCRIPTION
# Description

`debugMode` wasn't propagating properly from the parent component to it's descendants.
If you for example added a component `a` to a component `b` first, and then added `b` to `c` which had `debugMode = true`, `a` would not have `debugMode = true`. But if `a` was added to `b` after it was added to `c`, then `a` would have `debugMode = true`.

This also fixes the `debugMode` for `HitboxShape`s.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
