### PR TITLE
feat: adding blueprint

### DIFF
--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -154,6 +154,48 @@ void update(double dt) {
 ```
 
 
+### Blueprints
+
+Flame also offers a virtual approach for grouping components which allows the developer to keep
+their components grouped "code wise", but the components (or other things, like a
+`ContactCallback` for Forge2d Games) are individually added to the game and there isn't a parent
+component.
+
+This is useful when you have a complex feature that will require different components, but they
+all need to be on the same rendering level of different faatures, a simple example for this is
+a top down view game, we would like to play with the rendering order of things so we can give the
+player the impression of depth, so if the player character goes behind a house, its roofs is
+rendered "above" the player, to be able to achieve that we would need to split our building
+component into more components, for example: `HouseBase`, `HouseSecondFloor` and `HouseRoof`.
+
+So to avoid leaving these components "floating" around, we could create a `Blueprint` to group
+them:
+
+```dart
+class House extends Blueprint {
+  @override
+  void build() {
+    addAll([
+      HouseBase(),
+      HouseSecondFloor(),
+      HouseRoof(),
+    ]);
+  }
+}
+```
+
+And then just add it to the game, quite similar to how simple components would be added:
+
+```dart
+class MyGame extends FlameGame {
+  @override
+  Future<void> onLoad() async {
+    addFromBlueprint(House());
+  }
+}
+```
+
+
 ### PositionType
 If you want to create a HUD (Head-up display) or another component that isn't positioned in relation
 to the game coordinates, you can change the `PositionType` of the component.

--- a/packages/flame/lib/components.dart
+++ b/packages/flame/lib/components.dart
@@ -2,6 +2,7 @@
 export 'src/anchor.dart';
 export 'src/collisions/has_collision_detection.dart';
 export 'src/collisions/hitboxes/screen_hitbox.dart';
+export 'src/components/blueprint.dart';
 export 'src/components/component.dart';
 export 'src/components/component_set.dart';
 export 'src/components/custom_painter_component.dart';

--- a/packages/flame/lib/src/components/blueprint.dart
+++ b/packages/flame/lib/src/components/blueprint.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/foundation.dart';
+
+import '../../components.dart';
+import '../game/flame_game.dart';
+
+const _attachedErrorMessage = "Can't add to attached Blueprints";
+
+// so we can experiment with the idea, but this is a
+// potential upstream change on Flame.
+
+/// A [Blueprint] is a virtual way of grouping [Component]s
+/// that are related, but they need to be added directly on
+/// the [FlameGame] level.
+abstract class Blueprint {
+  final List<Component> _components = [];
+  bool _isAttached = false;
+
+  /// Called before the the [Component]s managed
+  /// by this blueprint is added to the [FlameGame]
+  void build();
+
+  /// Attach the [Component]s built on [build] to the [game]
+  /// instance
+  @mustCallSuper
+  Future<void> attach(FlameGame game) async {
+    build();
+    await game.addAll(_components);
+    _isAttached = true;
+  }
+
+  /// Adds a list of [Component]s to this blueprint.
+  void addAll(List<Component> components) {
+    assert(!_isAttached, _attachedErrorMessage);
+    _components.addAll(components);
+  }
+
+  /// Adds a single [Component] to this blueprint.
+  void add(Component component) {
+    assert(!_isAttached, _attachedErrorMessage);
+    _components.add(component);
+  }
+
+  /// Returns a copy of the components built by this blueprint
+  List<Component> get components => List.unmodifiable(_components);
+
+  /// [bool] that indicates if this [Blueprint] instance is already
+  /// attached to a [FlameGame], attached [Blueprint]s can't have
+  /// more additions to it.
+  bool get isAttached => _isAttached;
+}

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:meta/meta.dart';
 
+import '../components/blueprint.dart';
 import '../components/component.dart';
 import '../extensions/vector2.dart';
 import 'camera/camera.dart';
@@ -150,4 +151,10 @@ class FlameGame extends Component with Game {
 
   @override
   Projector get projector => camera.combinedProjector;
+
+  /// Shortcut to attach a [Blueprint] instance to this game
+  /// equivalent to `MyBluepinrt().attach(game)`
+  Future<void> addFromBlueprint(Blueprint blueprint) async {
+    await blueprint.attach(this);
+  }
 }

--- a/packages/flame/test/components/blueprint_test.dart
+++ b/packages/flame/test/components/blueprint_test.dart
@@ -1,0 +1,45 @@
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockGame extends Mock implements FlameGame {}
+
+class MyBlueprint extends Blueprint {
+  @override
+  void build() {
+    add(Component());
+    addAll([Component(), Component()]);
+  }
+}
+
+void main() {
+  group('Blueprint', () {
+    test('components can be added to it', () {
+      final blueprint = MyBlueprint()..build();
+
+      expect(blueprint.components.length, equals(3));
+    });
+
+    test('adds the components to a game on attach', () {
+      final mockGame = MockGame();
+      when(() => mockGame.addAll(any())).thenAnswer((_) async {});
+      MyBlueprint().attach(mockGame);
+
+      verify(() => mockGame.addAll(any())).called(1);
+    });
+
+    test(
+      'throws assertion error when adding to an already attached blueprint',
+      () async {
+        final mockGame = MockGame();
+        when(() => mockGame.addAll(any())).thenAnswer((_) async {});
+        final blueprint = MyBlueprint();
+        await blueprint.attach(mockGame);
+
+        expect(() => blueprint.add(Component()), throwsAssertionError);
+        expect(() => blueprint.addAll([Component()]), throwsAssertionError);
+      },
+    );
+  });
+}

--- a/packages/flame_forge2d/lib/blueprint.dart
+++ b/packages/flame_forge2d/lib/blueprint.dart
@@ -1,0 +1,38 @@
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+
+import 'contact_callbacks.dart';
+import 'forge2d_game.dart';
+
+const _attachedErrorMessage = "Can't add callbacks to attached Blueprints";
+
+
+/// A [Blueprint] that provides additional
+/// structures specific to flame_forge2d
+abstract class Forge2DBlueprint extends Blueprint {
+  final List<ContactCallback> _callbacks = [];
+
+  /// Adds a single [ContactCallback] to this blueprint
+  void addContactCallback(ContactCallback callback) {
+    assert(!isAttached, _attachedErrorMessage);
+    _callbacks.add(callback);
+  }
+
+  /// Adds a collection of [ContactCallback]s to this blueprint
+  void addAllContactCallback(List<ContactCallback> callbacks) {
+    assert(!isAttached, _attachedErrorMessage);
+    _callbacks.addAll(callbacks);
+  }
+
+  @override
+  Future<void> attach(FlameGame game) async {
+    await super.attach(game);
+
+    assert(game is Forge2DGame, 'Forge2DBlueprint used outside a Forge2DGame');
+
+    callbacks.forEach((game as Forge2DGame).addContactCallback);
+  }
+
+  /// Returns a copy of the callbacks built by this blueprint
+  List<ContactCallback> get callbacks => List.unmodifiable(_callbacks);
+}

--- a/packages/flame_forge2d/lib/flame_forge2d.dart
+++ b/packages/flame_forge2d/lib/flame_forge2d.dart
@@ -2,6 +2,7 @@ library flame_forge2d;
 
 export 'package:forge2d/forge2d.dart';
 
+export 'blueprint.dart';
 export 'body_component.dart';
 export 'contact_callbacks.dart';
 export 'forge2d_camera.dart';

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -17,4 +17,5 @@ dependencies:
 dev_dependencies:
   dartdoc: ^4.1.0
   flame_lint: ^0.0.1
+  mocktail: ^0.3.0
   test: any

--- a/packages/flame_forge2d/test/blueprint_test.dart
+++ b/packages/flame_forge2d/test/blueprint_test.dart
@@ -1,0 +1,69 @@
+import 'package:flame/game.dart';
+import 'package:flame_forge2d/flame_forge2d.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockForge2dGame extends Mock implements Forge2DGame {}
+
+class MockContactCallback extends Mock
+    implements ContactCallback<Object, Object> {}
+
+class FakeContactCallback extends ContactCallback<Object, Object> {}
+
+class MyForge2dBlueprint extends Forge2DBlueprint {
+  @override
+  void build() {
+    addContactCallback(MockContactCallback());
+    addAllContactCallback([MockContactCallback(), MockContactCallback()]);
+  }
+}
+
+void main() {
+  group('Forge2DBlueprint', () {
+    setUpAll(() {
+      registerFallbackValue(FakeContactCallback());
+    });
+
+    test('callbacks can be added to it', () {
+      final blueprint = MyForge2dBlueprint()..build();
+
+      expect(blueprint.callbacks.length, equals(3));
+    });
+
+    test('adds the callbacks to a game on attach', () async {
+      final mockGame = MockForge2dGame();
+      when(() => mockGame.addAll(any())).thenAnswer((_) async {});
+      when(() => mockGame.addContactCallback(any())).thenAnswer((_) async {});
+      await MyForge2dBlueprint().attach(mockGame);
+
+      verify(() => mockGame.addContactCallback(any())).called(3);
+    });
+
+    test(
+      'throws assertion error when adding to an already attached blueprint',
+      () async {
+        final mockGame = MockForge2dGame();
+        when(() => mockGame.addAll(any())).thenAnswer((_) async {});
+        when(() => mockGame.addContactCallback(any())).thenAnswer((_) async {});
+        final blueprint = MyForge2dBlueprint();
+        await blueprint.attach(mockGame);
+
+        expect(
+          () => blueprint.addContactCallback(MockContactCallback()),
+          throwsAssertionError,
+        );
+        expect(
+          () => blueprint.addAllContactCallback([MockContactCallback()]),
+          throwsAssertionError,
+        );
+      },
+    );
+
+    test('throws assertion error when used on a non Forge2dGame', () {
+      expect(
+        () => MyForge2dBlueprint().attach(FlameGame()),
+        throwsAssertionError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

Adds a new way of grouping flame components that will be added directly on the game level and does not introduces a component who only purposes is to group other components.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
