### PR TITLE
fix: Remove generics from ancestors

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -321,12 +321,10 @@ class Component {
   /// An iterator producing this component's parent, then its parent's parent,
   /// then the great-grand-parent, and so on, until it reaches a component
   /// without a parent.
-  Iterable<T> ancestors<T extends Component>({bool includeSelf = false}) sync* {
+  Iterable<Component> ancestors({bool includeSelf = false}) sync* {
     var current = includeSelf ? this : parent;
     while (current != null) {
-      if (current is T) {
-        yield current;
-      }
+      yield current;
       current = current.parent;
     }
   }

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -178,17 +178,18 @@ class PositionComponent extends Component {
   /// has been applied.
   double get absoluteAngle {
     // TODO(spydon): take scale into consideration
-    return ancestors<PositionComponent>()
+    return ancestors()
+        .whereType<PositionComponent>()
         .fold<double>(angle, (totalAngle, c) => totalAngle + c.angle);
   }
 
   /// The resulting scale after all the ancestors and the components own scale
   /// has been applied.
   Vector2 get absoluteScale {
-    return ancestors<PositionComponent>().fold<Vector2>(
-      scale.clone(),
-      (totalScale, c) => totalScale..multiply(c.scale),
-    );
+    return ancestors().whereType<PositionComponent>().fold<Vector2>(
+          scale.clone(),
+          (totalScale, c) => totalScale..multiply(c.scale),
+        );
   }
 
   /// Measure the distance (in parent's coordinate space) between this


### PR DESCRIPTION
# Description

Since `whereType` can be used just as efficiently on `ancestors` and since `descendants` didn't implement generics, it should be removed from `ancestors`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

Since it wasn't released yet it's not a breaking change.

- [x] No, this is *not* a breaking change.


## Related Issues

#1456 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
