### PR TITLE
fix: Component.propagateToChildren() order of traversal

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -331,25 +331,34 @@ class Component {
 
   /// Recursively enumerates all nested [children].
   ///
-  /// The search is depth-first, hence descendants are in postorder. In other
-  /// words, it explores the first child completely before visiting the next
-  /// sibling.
+  /// The search is depth-first in preorder. In other words, it explores the
+  /// first child completely before visiting the next sibling, and the root
+  /// component is visited before its children.
   ///
-  /// In order to filter descendants it is usually convenient to use [Iterable]
-  /// lazy methods, such as [Iterable.where].
-  Iterable<Component> descendants({bool includeSelf = false}) sync* {
-    if (includeSelf) {
+  /// This ordering of descendants is considered standard in Flame: it is the
+  /// same order in which the components will normally be updated and rendered
+  /// on every game cycle. The optional parameter [reversed] allows iterating
+  /// through the same set of descendants in reverse order.
+  ///
+  /// The [Iterable] produced by this method is "lazy", which means it will only
+  /// traverse the component tree when required. This allows efficient chaining
+  /// of various iterable methods, such as filtering, early stopping, folding,
+  /// and so on -- see the documentation of the [Iterable] class for details.
+  Iterable<Component> descendants({
+    bool includeSelf = false,
+    bool reversed = false,
+  }) sync* {
+    if (includeSelf && !reversed) {
       yield this;
     }
-    if (!hasChildren) {
-      return;
-    }
-
-    for (final component in children) {
-      yield component;
-      if (component.hasChildren) {
-        yield* component.descendants();
+    if (hasChildren) {
+      final childrenIterable = reversed ? children.reversed() : children;
+      for (final child in childrenIterable) {
+        yield* child.descendants(includeSelf: true, reversed: reversed);
       }
+    }
+    if (includeSelf && reversed) {
+      yield this;
     }
   }
 

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -565,27 +565,9 @@ class Component {
     bool Function(T) handler, {
     bool includeSelf = false,
   }) {
-    var shouldContinue = true;
-    if (includeSelf && this is T) {
-      shouldContinue = handler(this as T);
-      if (!shouldContinue) {
-        return false;
-      }
-    }
-    if (_children != null) {
-      for (final child in _children!.reversed()) {
-        shouldContinue = child.propagateToChildren(handler);
-        if (shouldContinue && child is T) {
-          shouldContinue = handler(child);
-        } else if (shouldContinue && child is FlameGame) {
-          shouldContinue = child.propagateToChildren<T>(handler);
-        }
-        if (!shouldContinue) {
-          break;
-        }
-      }
-    }
-    return shouldContinue;
+    return descendants(reversed: true, includeSelf: includeSelf)
+        .whereType<T>()
+        .every(handler);
   }
 
   /// Returns the closest parent further up the hierarchy that satisfies type=T,

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -120,13 +120,11 @@ class FlameGame extends Component with Game {
       // Give chance to other futures to execute first
       await Future<void>.delayed(const Duration());
       repeat = false;
-      propagateToChildren(
+      descendants(includeSelf: true).forEach(
         (Component child) {
           child.processPendingLifecycleEvents();
           repeat |= child.hasPendingLifecycleEvents;
-          return true;
         },
-        includeSelf: true,
       );
     }
   }

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -200,6 +200,38 @@ void main() {
       );
     });
 
+    testWithFlameGame(
+      'propagateToChildren visits children in the correct order',
+      (game) async {
+        final component1 = IntComponent()..addToParent(game);
+        final component2 = IntComponent()..addToParent(game);
+        final component3 = IntComponent()..addToParent(component2);
+        final component4 = IntComponent()..addToParent(component2);
+        await game.ready();
+
+        var order = 0;
+        game.propagateToChildren(
+          (component) {
+            order += 1;
+            if (component is IntComponent) {
+              expect(component.value, 0);
+              component.value = order;
+            } else {
+              expect(component, equals(game));
+              expect(order, 5);
+            }
+            return true;
+          },
+          includeSelf: true,
+        );
+        expect(component4.value, 1);
+        expect(component3.value, 2);
+        expect(component2.value, 3);
+        expect(component1.value, 4);
+        expect(order, 5);
+      },
+    );
+
     group('descendants', () {
       testWithFlameGame(
         'length must be 0 when it is called before being loaded',
@@ -337,4 +369,8 @@ class ComponentWithSizeHistory extends Component {
 
 class Visitor extends Component {
   bool visited = false;
+}
+
+class IntComponent extends Component {
+  int value = 0;
 }


### PR DESCRIPTION
# Description

* `propagateToChildren` is supposed to visit components in the order opposite of how they were rendered. However, there was a bug that when called with `includeSelf=true`, the root of the tree will be visited first instead of last.
* Also, there was a bug where, in case of a game-in-game structure, the children of the nested game would be traversed twice.
* Added flag `bool reversed = false` to the `descendants()` method.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
