### PR TITLE
feat: adding Component.lastChild and Component.firstChild

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -45,6 +45,9 @@ class Component {
   Component? _parent;
 
   /// Returns the first child that matches the given type [T].
+  ///
+  /// As opposed to `children.whereType<T>().first`, this method returns null
+  /// instead of a [StateError] when no matching children are found.
   T? firstChild<T extends Component>() {
     final match = children.whereType<T>();
 

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -49,7 +49,7 @@ class Component {
     final match = children.whereType<T>();
 
     final it = match.iterator;
-    return it.moveNext()? it.current : null;
+    return it.moveNext() ? it.current : null;
   }
 
   /// The children of the current component.

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -44,6 +44,17 @@ class Component {
   Component? get parent => _parent;
   Component? _parent;
 
+  /// Returns the first child that matches the given type [T].
+  T? child<T extends Component>() {
+     final match = children.whereType<T>();
+
+     if (match.isNotEmpty) {
+       return match.first;
+     }
+
+     return match.first;
+  }
+
   /// The children of the current component.
   ///
   /// This getter will automatically create the [ComponentSet] container within

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -49,9 +49,7 @@ class Component {
   /// As opposed to `children.whereType<T>().first`, this method returns null
   /// instead of a [StateError] when no matching children are found.
   T? firstChild<T extends Component>() {
-    final match = children.whereType<T>();
-
-    final it = match.iterator;
+    final it = children.whereType<T>().iterator;
     return it.moveNext() ? it.current : null;
   }
 

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -55,13 +55,8 @@ class Component {
 
   /// Returns the last child that matches the given type [T].
   T? lastChild<T extends Component>() {
-    final match = children.whereType<T>();
-
-    if (match.isNotEmpty) {
-      return match.last;
-    }
-
-    return null;
+    final it = children.reversed().whereType<T>().iterator;
+    return it.moveNext() ? it.current : null;
   }
 
   /// The children of the current component.

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -48,11 +48,8 @@ class Component {
   T? child<T extends Component>() {
     final match = children.whereType<T>();
 
-    if (match.isNotEmpty) {
-      return match.first;
-    }
-
-    return match.first;
+    final it = match.iterator;
+    return it.moveNext()? it.current : null;
   }
 
   /// The children of the current component.

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -46,13 +46,13 @@ class Component {
 
   /// Returns the first child that matches the given type [T].
   T? child<T extends Component>() {
-     final match = children.whereType<T>();
+    final match = children.whereType<T>();
 
-     if (match.isNotEmpty) {
-       return match.first;
-     }
+    if (match.isNotEmpty) {
+      return match.first;
+    }
 
-     return match.first;
+    return match.first;
   }
 
   /// The children of the current component.

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -45,11 +45,22 @@ class Component {
   Component? _parent;
 
   /// Returns the first child that matches the given type [T].
-  T? child<T extends Component>() {
+  T? firstChild<T extends Component>() {
     final match = children.whereType<T>();
 
     final it = match.iterator;
     return it.moveNext() ? it.current : null;
+  }
+
+  /// Returns the last child that matches the given type [T].
+  T? lastChild<T extends Component>() {
+    final match = children.whereType<T>();
+
+    if (match.isNotEmpty) {
+      return match.last;
+    }
+
+    return null;
   }
 
   /// The children of the current component.

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -397,7 +397,7 @@ void main() {
           expect(childB, isNotNull);
           expect(childB, equals(lastB));
 
-          final nonExistentChild = game.firstChild<SpriteComponent>();
+          final nonExistentChild = game.lastChild<SpriteComponent>();
           expect(nonExistentChild, isNull);
         },
       );

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -355,20 +355,49 @@ void main() {
       });
 
       testWithFlameGame(
-        'child returns the first child on the matching type',
+        'firstChild returns the first child on the matching type',
         (game) async {
+          final firstA = ComponentA();
+          final firstB = ComponentB();
+
+          await game.ensureAdd(firstA);
           await game.ensureAdd(ComponentA());
+          await game.ensureAdd(firstB);
           await game.ensureAdd(ComponentB());
 
-          final childA = game.child<ComponentA>();
+          final childA = game.firstChild<ComponentA>();
           expect(childA, isNotNull);
-          expect(childA, isA<ComponentA>());
+          expect(childA, equals(firstA));
 
-          final childB = game.child<ComponentB>();
+          final childB = game.firstChild<ComponentB>();
           expect(childB, isNotNull);
-          expect(childB, isA<ComponentB>());
+          expect(childB, equals(firstB));
 
-          final nonExistentChild = game.child<SpriteComponent>();
+          final nonExistentChild = game.firstChild<SpriteComponent>();
+          expect(nonExistentChild, isNull);
+        },
+      );
+
+      testWithFlameGame(
+        'lastChild returns the last child on the matching type',
+        (game) async {
+          final lastA = ComponentA();
+          final lastB = ComponentB();
+
+          await game.ensureAdd(ComponentA());
+          await game.ensureAdd(lastA);
+          await game.ensureAdd(ComponentB());
+          await game.ensureAdd(lastB);
+
+          final childA = game.lastChild<ComponentA>();
+          expect(childA, isNotNull);
+          expect(childA, equals(lastA));
+
+          final childB = game.lastChild<ComponentB>();
+          expect(childB, isNotNull);
+          expect(childB, equals(lastB));
+
+          final nonExistentChild = game.firstChild<SpriteComponent>();
           expect(nonExistentChild, isNull);
         },
       );

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -353,9 +353,32 @@ void main() {
         expect(componentD.visited, false);
         expect(componentE.visited, false);
       });
+
+      testWithFlameGame(
+        'child returns the first child on the matching type',
+        (game) async {
+          await game.ensureAdd(ComponentA());
+          await game.ensureAdd(ComponentB());
+
+          final childA = game.child<ComponentA>();
+          expect(childA, isNotNull);
+          expect(childA, isA<ComponentA>());
+
+          final childB = game.child<ComponentB>();
+          expect(childB, isNotNull);
+          expect(childB, isA<ComponentB>());
+
+          final nonExistentChild = game.child<SpriteComponent>();
+          expect(nonExistentChild, isNull);
+        },
+      );
     });
   });
 }
+
+class ComponentA extends Component {}
+
+class ComponentB extends Component {}
 
 class ComponentWithSizeHistory extends Component {
   List<Vector2> history = [];


### PR DESCRIPTION
# Description

Adds a simple new method on `Component` to enable easy and safe way to recover the first child of a given type, basically a convenience method for `children.whereType<T>.first`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
