### PR TITLE
fix: Game-in-Game now works correctly again

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -266,9 +266,7 @@ class Component {
     if (isMounted) {
       return Future.value();
     }
-
     _mountCompleter ??= Completer<void>();
-
     return _mountCompleter!.future;
   }
 
@@ -468,9 +466,10 @@ class Component {
   }
 
   Future<void>? _load() {
+    assert(_parent != null);
     assert(_state == LifecycleState.uninitialized);
     _state = LifecycleState.loading;
-    onGameResize(findGame()!.canvasSize);
+    onGameResize(_parent!.findGame()!.canvasSize);
     final onLoadFuture = onLoad();
     if (onLoadFuture == null) {
       _state = LifecycleState.loaded;

--- a/packages/flame/test/game/flame_game_test.dart
+++ b/packages/flame/test/game/flame_game_test.dart
@@ -18,6 +18,16 @@ void main() {
       },
     );
 
+    testWithFlameGame('Game in game', (game) async {
+      final innerGame = FlameGame();
+      game.add(innerGame);
+      await game.ready();
+
+      expect(innerGame.canvasSize, closeToVector(800, 600));
+      expect(innerGame.isLoaded, true);
+      expect(innerGame.isMounted, true);
+    });
+
     group('components', () {
       testWithFlameGame(
         'Add component',


### PR DESCRIPTION
# Description

Fix the case when a FlameGame is being added into another FlameGame.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Closes #1474 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
