### PR TITLE
feat: Add setter for CircleComponent.radius

### DIFF
--- a/packages/flame/lib/src/geometry/circle_component.dart
+++ b/packages/flame/lib/src/geometry/circle_component.dart
@@ -46,6 +46,11 @@ class CircleComponent extends ShapeComponent {
     return min(size.x, size.y) / 2;
   }
 
+  /// Set the radius of the circle (and therefore the [size]).
+  set radius(double value) {
+    size.setValues(value * 2, value * 2);
+  }
+
   // Used to not create new Vector2 objects every time radius is called.
   final Vector2 _scaledSize = Vector2.zero();
 


### PR DESCRIPTION
# Description

Adds the possibility to set the `radius` in a `CircleComponent`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
