### PR TITLE
doc: Take PUBLISH_PATH into account when building docs

### DIFF
--- a/doc/_sphinx/extensions/flutter_app.py
+++ b/doc/_sphinx/extensions/flutter_app.py
@@ -81,7 +81,7 @@ class FlutterAppDirective(SphinxDirective):
         self._ensure_compiled()
 
         page = self.options.get('page', '')
-        iframe_url = '/' + self.html_dir + '/index.html?' + page
+        iframe_url = _doc_root() + self.html_dir + '/index.html?' + page
         result = []
         if 'popup' in self.modes:
             result.append(Button(
@@ -172,11 +172,20 @@ class FlutterAppDirective(SphinxDirective):
         with open(target_file, 'wt') as out:
             out.write('<!DOCTYPE html>\n')
             out.write('<html>\n<head>\n')
-            out.write('<base href="/%s/">\n' % self.html_dir)
+            out.write('<base href="%s%s/">\n' % (_doc_root(), self.html_dir))
             out.write('<title>%s</title>\n' % self.app_name)
             out.write('</head>\n<body>\n')
             out.write('<script src="main.dart.js"></script>\n')
             out.write('</body>\n</html>\n')
+
+
+def _doc_root():
+    root = os.environ.get('PUBLISH_PATH', '')
+    if not root.startswith('/'):
+        root = '/' + root
+    if not root.endswith('/'):
+        root = root + '/'
+    return root
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

The `..flutter-app` directive in the documentation system now takes into account the `PUBLISH_PATH` environment variable, which can be used to specify that the documentation will reside at a path different from the root.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
