### PR TITLE
doc: Flutter-app directive can now also show the listings of code

### DIFF
--- a/doc/_sphinx/extensions/flutter_app.css
+++ b/doc/_sphinx/extensions/flutter_app.css
@@ -10,6 +10,7 @@ button.flutter-app-button {
   font-size: 1.1em;
   font-weight: bold;
   line-height: 1em;
+  margin-right: 1em;
   min-height: 26pt;
   min-width: 120pt;
 }
@@ -33,8 +34,45 @@ button.flutter-app-button:after {
   top: 1px;
 }
 
+.flutter-app-code {
+  display: none;
+}
+
+.flutter-app-code.active {
+  background: #282828;
+  box-shadow: 0 0 30px 0 #000;
+  box-sizing: border-box;
+  display: initial;
+  height: 80vh;
+  left: 50%;
+  overflow-y: scroll;
+  padding: 1em 2em;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 80vw;
+}
+
+.flutter-app-code .filename {
+  font-family: var(--font-mono);
+  font-size: 1.3em;
+  font-weight: bold;
+  margin: 1.5em 0 -0.5em 0;
+}
+
+.flutter-app-code div.highlight span.linenos {
+  color: #444;
+  margin-right: 8pt;
+}
+
 #flutter-app-overlay {
-  background: #00000050;
+  background: repeating-linear-gradient(
+    -45deg,
+    #000000bb 0px,
+    #000000bb 5px,
+    #000000aa 5px,
+    #000000aa 10px
+  );
   display: none;
   height: 100vh;
   left: 0;
@@ -49,8 +87,8 @@ button.flutter-app-button:after {
 }
 
 #flutter-app-overlay.active iframe {
-  border: none;
-  box-shadow: 0px 0px 30px 0px #ffffff26;
+  border: 1px solid #333;
+  box-shadow: 0px 0px 30px 0px #000;
   display: none;
   height: 80vh;
   left: 50%;

--- a/doc/_sphinx/extensions/flutter_app.js
+++ b/doc/_sphinx/extensions/flutter_app.js
@@ -4,13 +4,7 @@
 /// creates an (x) button to hide the overlay.
 function run_flutter_app(url) {
   let id = compute_iframe_id(url);
-  if (!$('#flutter-app-overlay').length) {
-    $('body').append($(`
-      <div id="flutter-app-overlay">
-        <button id="flutter-app-close-button" onclick="close_flutter_app()">✖</button>
-      </div>`
-    ));
-  }
+  create_overlay();
   if (!$('#' + id).length) {
     $('#flutter-app-overlay').append($(
       `<iframe id="${id}" class="flutter-app" src="${url}"></iframe>`
@@ -20,9 +14,29 @@ function run_flutter_app(url) {
   $('#' + id).addClass('active');
 }
 
+function open_code_listings(id) {
+  create_overlay();
+  if (!$('#flutter-app-overlay #' + id).length) {
+    $('#' + id).appendTo($('#flutter-app-overlay'));
+  }
+  $('#flutter-app-overlay').addClass('active');
+  $('#' + id).addClass('active');
+}
+
+function create_overlay() {
+  if (!$('#flutter-app-overlay').length) {
+    $('body').append($(`
+      <div id="flutter-app-overlay">
+        <button id="flutter-app-close-button" onclick="close_flutter_app()">✖</button>
+      </div>`
+    ));
+  }
+}
+
 /// Handler for the (x) close button on an app iframe.
 function close_flutter_app() {
-  $('#flutter-app-overlay iframe').removeClass('active');
+  $('#flutter-app-overlay > iframe').removeClass('active');
+  $('#flutter-app-overlay > div').removeClass('active');
   $('#flutter-app-overlay').removeClass('active');
 }
 

--- a/doc/_sphinx/extensions/flutter_app.py
+++ b/doc/_sphinx/extensions/flutter_app.py
@@ -47,7 +47,8 @@ class FlutterAppDirective(SphinxDirective):
         "popup", and "code". Each of these modes produces a different output:
           "widget" - an iframe shown directly inside the docs page;
           "popup" - a [Run] button which opens the app to (almost) fullscreen;
-          "code" - (NYI) opens a popup showing the code that was compiled.
+          "code" - a [Code] button which opens a popup with the code that was
+              compiled.
     """
     has_content = False
     required_arguments = 0

--- a/doc/tutorials/bare_flame_game.md
+++ b/doc/tutorials/bare_flame_game.md
@@ -1,7 +1,7 @@
 # Bare Flame game
 
-This tutorial assumes that you already have [Flutter], [git], and 
-[Android Studio] on your computer (all of these programs are free); and that 
+This tutorial assumes that you already have [Flutter], [git], and
+[Android Studio] on your computer (all of these programs are free); and that
 you have basic familiarity with using the command line. Android Studio is not
 a strict requirement, you can use other IDEs too, such as [Visual Studio Code].
 
@@ -22,7 +22,7 @@ $ flutter doctor
 ```
 
 Your output will be slightly different, but the important thing is to verify
-that no errors are reported, and that your Flutter version is **2.5.0** or 
+that no errors are reported, and that your Flutter version is **2.5.0** or
 above.
 
 
@@ -55,7 +55,7 @@ $ flutter create .
 
 You can verify that the project files were created successfully:
 ```console
-$ ls 
+$ ls
 README.md               android/   lib/           pubspec.yaml   test/
 analysis_options.yaml   ios/       pubspec.lock   syzygy.iml     web/
 ```
@@ -73,13 +73,13 @@ If you see only the `main.dart` file but not the side panel, then click the
 vertical `[Project]` button at the left edge of the window.
 
 Before we proceed, let's fix the view in the left panel. Locate the button
-in the top left corner that says `[Android]` in the screenshot. In this 
+in the top left corner that says `[Android]` in the screenshot. In this
 dropdown select the first option "Project". Your project window should now
 look like this:
 
 ![](../images/tutorials/android-studio-screenshot-2.webp)
 
-The important part is that you should be able to see all files in your 
+The important part is that you should be able to see all files in your
 project directory.
 
 
@@ -110,7 +110,7 @@ After that, press the `[Pub get]` button at the top of the window; or
 alternatively you could run command `flutter pub get` from the terminal. This
 will "apply" the changes in `pubspec` file to your project, in particular it
 will download the Flame library which we have declared as a dependency. In the
-future, you should run `flutter pub get` whenever you make changes to this 
+future, you should run `flutter pub get` whenever you make changes to this
 file.
 
 Now, open file `lib/main.dart` and replace its content with the following:
@@ -138,7 +138,7 @@ selected>`. In that dropdown choose `<Chrome (web)>` instead.
 After that open the `main.dart` file and press the green arrow next to the
 `void main()` function in line 4. Select `[Run main.dart]` from the menu.
 
-This should open a new Chrome window (which may take 10-30 seconds) and run 
+This should open a new Chrome window (which may take 10-30 seconds) and run
 your project in that window. For now it will simply show a black screen, which
 is expected because we created the game in its simplest blank configuration.
 
@@ -151,7 +151,7 @@ assumes that you already have a GitHub account.
 
 Log into your GitHub account, select `[Your repositories]` from your profile
 dropdown, and press the green `[New]` button. In the form enter repository
-name the same as your project name; select type "private"; and opt out of 
+name the same as your project name; select type "private"; and opt out of
 adding initial files like README, license and gitignore.
 
 Now go to your project's directory in the terminal and execute the following

--- a/doc/tutorials/klondike/step2.md
+++ b/doc/tutorials/klondike/step2.md
@@ -258,7 +258,7 @@ the card objects, which are the most important visual objects in this game.
 ```{flutter-app}
 :sources: ../tutorials/klondike/app
 :page: step2
-:show: popup
+:show: popup code
 ```
 
 [World]: ../../flame/camera_component.md#world


### PR DESCRIPTION
# Description

The `..flutter-app` directive now also supports the `"code"` mode, which produces button that will show code listing for all files in the compiled app.

Looks like this:
<img width="1752" alt="Screen Shot 2022-03-29 at 12 27 34 AM" src="https://user-images.githubusercontent.com/4231472/160557573-dc8ee1db-0df5-4551-ab8f-53f65def7ab5.png">


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.



<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
