### PR TITLE
feat: Camera's Viewfinder can now be affected by rotation effects

### DIFF
--- a/packages/flame/lib/effects.dart
+++ b/packages/flame/lib/effects.dart
@@ -22,7 +22,7 @@ export 'src/effects/move_along_path_effect.dart';
 export 'src/effects/move_effect.dart';
 export 'src/effects/opacity_effect.dart';
 export 'src/effects/provider_interfaces.dart'
-    show PositionProvider, ScaleProvider;
+    show PositionProvider, ScaleProvider, AngleProvider;
 export 'src/effects/remove_effect.dart';
 export 'src/effects/rotate_effect.dart';
 export 'src/effects/scale_effect.dart';

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -59,7 +59,7 @@ import 'component.dart';
 /// do not specify the size of a PositionComponent, then it will be
 /// equal to zero and the component won't be able to respond to taps.
 class PositionComponent extends Component
-    implements PositionProvider, ScaleProvider {
+    implements PositionProvider, ScaleProvider, AngleProvider {
   PositionComponent({
     Vector2? position,
     Vector2? size,
@@ -110,7 +110,9 @@ class PositionComponent extends Component
   /// Rotation angle (in radians) of the component. The component will be
   /// rotated around its anchor point in the clockwise direction if the
   /// angle is positive, or counterclockwise if the angle is negative.
+  @override
   double get angle => transform.angle;
+  @override
   set angle(double a) => transform.angle = a;
 
   /// The scale factor of this component. The scale can be different along

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -59,7 +59,7 @@ import 'component.dart';
 /// do not specify the size of a PositionComponent, then it will be
 /// equal to zero and the component won't be able to respond to taps.
 class PositionComponent extends Component
-    implements PositionProvider, ScaleProvider, AngleProvider {
+    implements AngleProvider, PositionProvider, ScaleProvider {
   PositionComponent({
     Vector2? position,
     Vector2? size,

--- a/packages/flame/lib/src/effects/provider_interfaces.dart
+++ b/packages/flame/lib/src/effects/provider_interfaces.dart
@@ -11,3 +11,9 @@ abstract class ScaleProvider {
   Vector2 get scale;
   set scale(Vector2 value);
 }
+
+/// Interface for a component that can be affected by rotation effects.
+abstract class AngleProvider {
+  double get angle;
+  set angle(double value);
+}

--- a/packages/flame/lib/src/effects/rotate_effect.dart
+++ b/packages/flame/lib/src/effects/rotate_effect.dart
@@ -1,6 +1,8 @@
 import 'controllers/effect_controller.dart';
+import 'effect.dart';
+import 'effect_target.dart';
 import 'measurable_effect.dart';
-import 'transform2d_effect.dart';
+import 'provider_interfaces.dart';
 
 /// Rotate a component around its anchor.
 ///
@@ -16,7 +18,9 @@ import 'transform2d_effect.dart';
 /// This effect applies incremental changes to the component's angle, and
 /// requires that any other effect or update logic applied to the same component
 /// also used incremental updates.
-class RotateEffect extends Transform2DEffect implements MeasurableEffect {
+class RotateEffect extends Effect
+    with EffectTarget<AngleProvider>
+    implements MeasurableEffect {
   RotateEffect.by(double angle, EffectController controller)
       : _angle = angle,
         super(controller);

--- a/packages/flame/lib/src/experimental/viewfinder.dart
+++ b/packages/flame/lib/src/experimental/viewfinder.dart
@@ -15,7 +15,8 @@ import 'camera_component.dart';
 /// The viewfinder contains the game point that is currently at the
 /// "cross-hairs" of the viewport ([position]), the [zoom] level, and the
 /// [angle] of rotation of the camera.
-class Viewfinder extends Component implements PositionProvider, ScaleProvider {
+class Viewfinder extends Component
+    implements AngleProvider, PositionProvider, ScaleProvider {
   /// Internal transform matrix used by the viewfinder.
   final Transform2D _transform = Transform2D();
 
@@ -47,7 +48,9 @@ class Viewfinder extends Component implements PositionProvider, ScaleProvider {
   /// Rotation angle of the game world, in radians.
   ///
   /// The rotation is around the axis that is perpendicular to the screen.
+  @override
   double get angle => -_transform.angle;
+  @override
   set angle(double value) => _transform.angle = -value;
 
   /// The point within the viewport that is considered the "logical center" of

--- a/packages/flame/test/experimental/viewfinder_test.dart
+++ b/packages/flame/test/experimental/viewfinder_test.dart
@@ -179,6 +179,23 @@ void main() {
         }
       },
     );
+
+    testWithFlameGame(
+      'camera rotate effect',
+      (game) async {
+        final world = World()..addToParent(game);
+        final camera = CameraComponent(world: world)..addToParent(game);
+        camera.viewfinder.add(
+          RotateEffect.by(1, EffectController(duration: 1)),
+        );
+        await game.ready();
+
+        for (var t = 0.0; t < 1.0; t += 0.1) {
+          expect(camera.viewfinder.angle, closeTo(t, 1e-15));
+          game.update(0.1);
+        }
+      },
+    );
   });
 }
 


### PR DESCRIPTION
# Description

- Added interface `AngleProvider`, which is currently implemented by `PositionComponent` and `Viewfinder`;
- The `RotateEffect`s are now targeting any component with an `AngleProvider`.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
