### PR TITLE
feat: Added flame_test function closeToAabb()

### DIFF
--- a/packages/flame_test/lib/flame_test.dart
+++ b/packages/flame_test/lib/flame_test.dart
@@ -1,3 +1,4 @@
+export 'src/close_to_aabb.dart' show closeToAabb;
 export 'src/close_to_vector.dart';
 export 'src/expect_double.dart';
 export 'src/expect_vector2.dart';

--- a/packages/flame_test/lib/src/close_to_aabb.dart
+++ b/packages/flame_test/lib/src/close_to_aabb.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+/// Returns a matcher which checks if the argument is an axis-aligned bounding
+/// box sufficiently close (within distance [epsilon]) to [expected]. Example
+/// of usage:
+/// ```dart
+/// expect(
+///   component.aabb,
+///   closeToAabb(Aabb2.minMax(Vector2.zero(), Vector2.all(1)), 1e-5),
+/// );
+/// ```
+Matcher closeToAabb(Aabb2 expected, [double epsilon = 1e-15]) {
+  return _IsCloseToAabb(expected, epsilon);
+}
+
+class _IsCloseToAabb extends Matcher {
+  const _IsCloseToAabb(this._expected, this._epsilon);
+
+  final Aabb2 _expected;
+  final double _epsilon;
+
+  @override
+  bool matches(dynamic item, Map matchState) {
+    return (item is Aabb2) &&
+        (item.min - _expected.min).length <= _epsilon &&
+        (item.max - _expected.max).length <= _epsilon;
+  }
+
+  @override
+  Description describe(Description description) {
+    return description.add(
+      'an Aabb2 object within $_epsilon of Aabb2([${_expected.min.x}, '
+      '${_expected.min.y}]..[${_expected.max.x}, ${_expected.max.y}])',
+    );
+  }
+
+  @override
+  Description describeMismatch(
+    dynamic item,
+    Description mismatchDescription,
+    Map matchState,
+    bool verbose,
+  ) {
+    if (item is! Aabb2) {
+      return mismatchDescription.add('is not an instance of Aabb2');
+    }
+    final minDiff = (item.min - _expected.min).length;
+    final maxDiff = (item.max - _expected.max).length;
+    if (minDiff > _epsilon) {
+      mismatchDescription.add('min corner is at distance $minDiff\n');
+    }
+    if (maxDiff > _epsilon) {
+      mismatchDescription.add('max corner is at distance $maxDiff\n');
+    }
+    return mismatchDescription.add(
+      'Aabb2([${item.min.x}, ${item.min.y}]..[${item.max.x}, ${item.max.y}])',
+    );
+  }
+}

--- a/packages/flame_test/test/close_to_aabb_test.dart
+++ b/packages/flame_test/test/close_to_aabb_test.dart
@@ -1,0 +1,61 @@
+import 'package:flame_test/src/close_to_aabb.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+void main() {
+  group('closeToAabb', () {
+    test('zero aabb', () {
+      expect(Aabb2(), closeToAabb(Aabb2()));
+      expect(
+        Aabb2(),
+        closeToAabb(Aabb2.minMax(Vector2.all(1e-5), Vector2.all(1e-4)), 1e-3),
+      );
+    });
+
+    test('matches normally', () {
+      final aabb = Aabb2.minMax(Vector2.zero(), Vector2.all(1));
+      expect(aabb, closeToAabb(aabb));
+      expect(aabb, closeToAabb(Aabb2(), 2));
+      expect(
+        aabb,
+        closeToAabb(Aabb2.minMax(Vector2.all(1e-16), Vector2.all(1))),
+      );
+    });
+
+    test('fails on type mismatch', () {
+      try {
+        expect(3.14, closeToAabb(Aabb2()));
+      } on TestFailure catch (e) {
+        expect(
+          e.message,
+          contains(
+            'Expected: an Aabb2 object within 1e-15 of '
+            'Aabb2([0.0, 0.0]..[0.0, 0.0])',
+          ),
+        );
+        expect(e.message, contains('Actual: <3.14>'));
+        expect(e.message, contains('Which: is not an instance of Aabb2'));
+      }
+    });
+
+    test('fails on value mismatch', () {
+      try {
+        expect(
+          Aabb2.minMax(Vector2.zero(), Vector2.all(1)),
+          closeToAabb(Aabb2(), 0.01),
+        );
+      } on TestFailure catch (e) {
+        expect(
+          e.message,
+          contains(
+            'Expected: an Aabb2 object within 0.01 of '
+            'Aabb2([0.0, 0.0]..[0.0, 0.0])',
+          ),
+        );
+        expect(e.message, contains("Actual: <Instance of 'Aabb2'>"));
+        expect(e.message, contains('Which: max corner is at distance 1.4142'));
+        expect(e.message, contains('Aabb2([0.0, 0.0]..[1.0, 1.0])'));
+      }
+    });
+  });
+}


### PR DESCRIPTION
# Description

A convenience function for testing that an Aabb is close to the value that you'd expect.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
