### PR TITLE
fix: Components in uninitialized state can now be safely removed

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -459,7 +459,9 @@ class Component {
   }
 
   /// Removes a component from the component tree, calling [onRemove] for it and
-  /// its children.
+  /// its children. The [onRemove] handler will only be called if there was an
+  /// [onMount] call previously, i.e. when removing components that are properly
+  /// mounted.
   void remove(Component component) {
     assert(
       component._parent != null,
@@ -473,8 +475,7 @@ class Component {
     if (component._state == LifecycleState.uninitialized) {
       lifecycle._children.remove(component);
       component._parent = null;
-    } else if (component._state == LifecycleState.loading) {
-      component._state = LifecycleState.removing;
+      // TODO(st-pasha): properly handle removal in other states too
     } else if (component._state != LifecycleState.removing) {
       lifecycle._removals.add(component);
       component._state = LifecycleState.removing;

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -172,6 +172,75 @@ void main() {
       },
     );
 
+    testWithFlameGame(
+      'remove a component before it was ever added',
+      (game) async {
+        expect(
+          () => game.remove(Component()),
+          failsAssert(
+            "Trying to remove a component that doesn't belong to any parent",
+          ),
+        );
+      },
+    );
+
+    testWithFlameGame(
+      'remove a component from a wrong parent',
+      (game) async {
+        final badParent = Component()..addToParent(game);
+        final child = Component()..addToParent(game);
+        await game.ready();
+        expect(
+          () => badParent.remove(child),
+          failsAssert(
+            'Trying to remove a component that belongs to a different parent: '
+            "this = Instance of 'Component', component's parent = Instance of "
+            "'FlameGame'",
+          ),
+        );
+      },
+    );
+
+    testWithFlameGame(
+      'remove an uninitialized component',
+      (game) async {
+        final parent = Component();
+        final child = Component()..addToParent(parent);
+        expect(child.lifecycleState, LifecycleState.uninitialized);
+        child.removeFromParent();
+
+        game.add(parent);
+        await game.ready();
+
+        expect(child.lifecycleState, LifecycleState.uninitialized);
+        expect(parent.lifecycleState, LifecycleState.mounted);
+        expect(parent.children.length, 0);
+        expect(child.parent, isNull);
+      },
+    );
+
+    testWithFlameGame(
+      'remove and re-add uninitialized component with non-trivial onLoad',
+      (game) async {
+        final parent = Component();
+        final component = _ComponentWithOnLoad();
+        parent.add(component);
+        expect(component.lifecycleState, LifecycleState.uninitialized);
+        parent.remove(component);
+        expect(component.lifecycleState, LifecycleState.uninitialized);
+        expect(component.onLoadCalledCount, 0);
+
+        final newParent = Component()..addToParent(game);
+        newParent.add(component);
+        expect(component.lifecycleState, LifecycleState.loading);
+        expect(component.onLoadCalledCount, 1);
+        await game.ready();
+        expect(component.lifecycleState, LifecycleState.mounted);
+        expect(newParent.children.length, 1);
+        expect(newParent.children.first, component);
+      },
+    );
+
     prepareGame.test(
       'adding children to a parent that is not yet added to a game should not '
       'run double onPrepare',
@@ -470,5 +539,15 @@ class TwoChildrenComponent extends Component {
     child2 = Component();
     add(child1);
     add(child2);
+  }
+}
+
+class _ComponentWithOnLoad extends Component {
+  int onLoadCalledCount = 0;
+
+  @override
+  Future<void> onLoad() async {
+    onLoadCalledCount++;
+    await null;
   }
 }


### PR DESCRIPTION
# Description

Correctly handle removal of components that are still in uninitialized state (which can happen when a component is added to a detached parent). Added assertion checks to guard against component tree corruption when removing a component from the wrong parent.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

WIP for #1549

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
