### PR TITLE
feat: MoveAlongPathEffect can now be applied to any PositionProvider

### DIFF
--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -128,7 +128,7 @@ position.
 
 ```dart
 final effect = MoveAlongPathEffect(
-  Path() ..quadraticBezierTo(100, 0, 50, -50),
+  Path()..quadraticBezierTo(100, 0, 50, -50),
   EffectController(duration: 1.5),
 );
 ```

--- a/packages/flame/lib/src/effects/move_along_path_effect.dart
+++ b/packages/flame/lib/src/effects/move_along_path_effect.dart
@@ -21,7 +21,9 @@ import 'provider_interfaces.dart';
 /// The `oriented` flag controls the direction of the target as it follows the
 /// path. If this flag is false (default), the target keeps its original
 /// orientation. If the flag is true, the target is automatically rotated as it
-/// follows the path so that it is always oriented tangent to the path.
+/// follows the path so that it is always oriented tangent to the path. When
+/// using this flag, make sure that the effect is applied to a target that
+/// actually supports rotations.
 class MoveAlongPathEffect extends MoveEffect {
   MoveAlongPathEffect(
     Path path,

--- a/packages/flame/lib/src/effects/move_along_path_effect.dart
+++ b/packages/flame/lib/src/effects/move_along_path_effect.dart
@@ -3,8 +3,8 @@ import 'dart:ui';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'controllers/effect_controller.dart';
-import 'measurable_effect.dart';
-import 'transform2d_effect.dart';
+import 'move_effect.dart';
+import 'provider_interfaces.dart';
 
 /// This effect will move the target along the specified path, which may
 /// contain curved segments, but must be simply-connected.
@@ -22,16 +22,16 @@ import 'transform2d_effect.dart';
 /// path. If this flag is false (default), the target keeps its original
 /// orientation. If the flag is true, the target is automatically rotated as it
 /// follows the path so that it is always oriented tangent to the path.
-class MoveAlongPathEffect extends Transform2DEffect
-    implements MeasurableEffect {
+class MoveAlongPathEffect extends MoveEffect {
   MoveAlongPathEffect(
     Path path,
     EffectController controller, {
     bool absolute = false,
     bool oriented = false,
+    PositionProvider? target,
   })  : _isAbsolute = absolute,
         _followDirection = oriented,
-        super(controller) {
+        super(controller, target) {
     final metrics = path.computeMetrics().toList();
     if (metrics.length != 1) {
       throw ArgumentError(
@@ -72,12 +72,19 @@ class MoveAlongPathEffect extends Transform2DEffect
   void onStart() {
     _lastOffset = Vector2.zero();
     _lastAngle = 0;
+    if (_followDirection) {
+      assert(
+        target is AngleProvider,
+        'An `oriented` MoveAlongPathEffect cannot be applied to a target that '
+        'does not support rotation',
+      );
+    }
     if (_isAbsolute) {
       final start = _pathMetric.getTangentForOffset(0)!;
       target.position.x = _lastOffset.x = start.position.dx;
       target.position.y = _lastOffset.y = start.position.dy;
       if (_followDirection) {
-        target.angle = _lastAngle = -start.angle;
+        (target as AngleProvider).angle = _lastAngle = -start.angle;
       }
     }
   }
@@ -92,7 +99,7 @@ class MoveAlongPathEffect extends Transform2DEffect
     _lastOffset.x = offset.dx;
     _lastOffset.y = offset.dy;
     if (_followDirection) {
-      target.angle += -tangent.angle - _lastAngle;
+      (target as AngleProvider).angle += -tangent.angle - _lastAngle;
       _lastAngle = -tangent.angle;
     }
   }

--- a/packages/flame/test/effects/move_along_path_effect_test.dart
+++ b/packages/flame/test/effects/move_along_path_effect_test.dart
@@ -3,7 +3,9 @@ import 'dart:ui';
 
 import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
+import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -99,6 +101,29 @@ void main() {
         game.update(0.1);
       }
     });
+
+    testWithFlameGame(
+      'oriented effect applied to non-orientable target',
+      (game) async {
+        final world = World()..addToParent(game);
+        final camera = CameraComponent(world: world)..addToParent(game);
+        await game.ready();
+        await camera.viewport.add(
+          MoveAlongPathEffect(
+            Path()..lineTo(10, 10),
+            EffectController(duration: 1),
+            oriented: true,
+          ),
+        );
+        expect(
+          () => game.update(0),
+          failsAssert(
+            'An `oriented` MoveAlongPathEffect cannot be applied to a target '
+            'that does not support rotation',
+          ),
+        );
+      },
+    );
 
     test('errors', () {
       final controller = LinearEffectController(0);


### PR DESCRIPTION
# Description

- The `MoveAlongPathEffect` is now derived from the `MoveEffect` base class, and can be given an explicit `target`.
- The effect can now be applied to any `PositionProvider`.
- An exception will be thrown if `oriented: true` flag is given, but the target is not an `AngleProvider`.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
