### PR TITLE
feat: Added AnchorToEffect and AnchorByEffect

### DIFF
--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -40,6 +40,7 @@ There are multiple effects provided by Flame, and you can also
 - [`ScaleEffect.to`](#scaleeffectto)
 - [`SizeEffect.by`](#sizeeffectby)
 - [`SizeEffect.to`](#sizeeffectto)
+- [`AnchorByEffect`](#anchorbyeffect)
 - [`AnchorToEffect`](#anchortoeffect)
 - [`OpacityEffect`](#opacityeffect)
 - [`ColorEffect`](#coloreffect)
@@ -211,9 +212,20 @@ final effect = SizeEffect.to(Vector2(120, 120), EffectController(duration: 1));
 ```
 
 
+### `AnchorByEffect`
+
+Changes the location of the target's anchor by the specified offset. This effect can also be created
+using `AnchorEffect.by()`.
+
+```dart
+final effect = AnchorByEffect(Vector2(0.1, 0.1), EffectController(speed: 1));
+```
+
+
 ### `AnchorToEffect`
 
-Changes the location of the target's anchor.
+Changes the location of the target's anchor. This effect can also be created using
+`AnchorEffect.to()`.
 
 ```dart
 final effect = AnchorToEffect(Anchor.center, EffectController(speed: 1));

--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -40,6 +40,7 @@ There are multiple effects provided by Flame, and you can also
 - [`ScaleEffect.to`](#scaleeffectto)
 - [`SizeEffect.by`](#sizeeffectby)
 - [`SizeEffect.to`](#sizeeffectto)
+- [`AnchorToEffect`](#anchortoeffect)
 - [`OpacityEffect`](#opacityeffect)
 - [`ColorEffect`](#coloreffect)
 - [`SequenceEffect`](#sequenceeffect)
@@ -207,6 +208,15 @@ Changes the size of the target component to the specified size. Target size cann
 
 ```dart
 final effect = SizeEffect.to(Vector2(120, 120), EffectController(duration: 1));
+```
+
+
+### `AnchorToEffect`
+
+Changes the location of the target's anchor.
+
+```dart
+final effect = AnchorToEffect(Anchor.center, EffectController(speed: 1));
 ```
 
 

--- a/packages/flame/lib/effects.dart
+++ b/packages/flame/lib/effects.dart
@@ -24,7 +24,7 @@ export 'src/effects/move_effect.dart';
 export 'src/effects/move_to_effect.dart';
 export 'src/effects/opacity_effect.dart';
 export 'src/effects/provider_interfaces.dart'
-    show PositionProvider, ScaleProvider, AngleProvider;
+    show AnchorProvider, AngleProvider, PositionProvider, ScaleProvider;
 export 'src/effects/remove_effect.dart';
 export 'src/effects/rotate_effect.dart';
 export 'src/effects/scale_effect.dart';

--- a/packages/flame/lib/effects.dart
+++ b/packages/flame/lib/effects.dart
@@ -1,3 +1,5 @@
+export 'src/effects/anchor_by_effect.dart' show AnchorByEffect;
+export 'src/effects/anchor_effect.dart' show AnchorEffect;
 export 'src/effects/anchor_to_effect.dart' show AnchorToEffect;
 export 'src/effects/color_effect.dart';
 export 'src/effects/component_effect.dart';

--- a/packages/flame/lib/effects.dart
+++ b/packages/flame/lib/effects.dart
@@ -1,3 +1,4 @@
+export 'src/effects/anchor_to_effect.dart' show AnchorToEffect;
 export 'src/effects/color_effect.dart';
 export 'src/effects/component_effect.dart';
 export 'src/effects/controllers/curved_effect_controller.dart';

--- a/packages/flame/lib/src/anchor.dart
+++ b/packages/flame/lib/src/anchor.dart
@@ -113,7 +113,7 @@ class Anchor {
 
   @override
   bool operator ==(Object other) {
-    return other is Anchor && x == other.x && y == other.y;
+    return other is Anchor && hashCode == other.hashCode;
   }
 
   @override

--- a/packages/flame/lib/src/anchor.dart
+++ b/packages/flame/lib/src/anchor.dart
@@ -113,7 +113,7 @@ class Anchor {
 
   @override
   bool operator ==(Object other) {
-    return other is Anchor && hashCode == other.hashCode;
+    return other is Anchor && x == other.x && y == other.y;
   }
 
   @override

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -59,7 +59,7 @@ import 'component.dart';
 /// do not specify the size of a PositionComponent, then it will be
 /// equal to zero and the component won't be able to respond to taps.
 class PositionComponent extends Component
-    implements AngleProvider, PositionProvider, ScaleProvider {
+    implements AnchorProvider, AngleProvider, PositionProvider, ScaleProvider {
   PositionComponent({
     Vector2? position,
     Vector2? size,
@@ -138,7 +138,9 @@ class PositionComponent extends Component
   /// which means that visually the component will shift on the screen
   /// so that its new anchor will be at the same screen coordinates as
   /// the old anchor was.
+  @override
   Anchor get anchor => _anchor;
+  @override
   set anchor(Anchor anchor) {
     _anchor = anchor;
     _onModifiedSizeOrAnchor();

--- a/packages/flame/lib/src/effects/anchor_by_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_by_effect.dart
@@ -1,0 +1,43 @@
+import 'package:vector_math/vector_math_64.dart';
+
+import '../anchor.dart';
+import 'anchor_effect.dart';
+import 'controllers/effect_controller.dart';
+import 'provider_interfaces.dart';
+
+/// An [AnchorEffect] that changes its target's anchor by the specified offset.
+///
+/// This effect will move the anchor in a straight line to a new position that
+/// is at an `offset` from the target's anchor at the start of the effect.
+///
+/// The `controller` can be used to change the timing of the movement: when the
+/// move starts, how fast it is, whether the motion is uniform or not, and so
+/// on. The [EffectController] can even be used to create oscillating or random
+/// motions.
+///
+/// This effect applies incremental changes to the target's position, which
+/// allows it to be combined with other [AnchorEffect]s. When several
+/// [AnchorByEffect]s are applied to the same target simultaneously, the anchor
+/// is moved by the vector sum of offsets from all effects.
+class AnchorByEffect extends AnchorEffect {
+  AnchorByEffect(
+    Vector2 offset,
+    EffectController controller, {
+    AnchorProvider? target,
+  })  : _offset = offset.clone(),
+        super(controller, target);
+
+  final Vector2 _offset;
+
+  @override
+  void apply(double progress) {
+    final dProgress = progress - previousProgress;
+    target.anchor = Anchor(
+      target.anchor.x + _offset.x * dProgress,
+      target.anchor.y + _offset.y * dProgress,
+    );
+  }
+
+  @override
+  double measure() => _offset.length;
+}

--- a/packages/flame/lib/src/effects/anchor_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_effect.dart
@@ -1,0 +1,40 @@
+import 'package:vector_math/vector_math_64.dart';
+
+import '../anchor.dart';
+// import 'anchor_by_effect.dart';
+import 'anchor_to_effect.dart';
+import 'controllers/effect_controller.dart';
+import 'effect.dart';
+import 'effect_target.dart';
+import 'measurable_effect.dart';
+import 'provider_interfaces.dart';
+
+/// Base class for effects that affect the `anchor` of their targets.
+///
+/// The main purpose of this class is for type reflection, for example to select
+/// all effects on the target that are of "anchor" type.
+///
+/// Factory constructors [AnchorEffect.by] and [AnchorEffect.to] are also
+/// provided for convenience.
+abstract class AnchorEffect extends Effect
+    with EffectTarget<AnchorProvider>
+    implements MeasurableEffect {
+  AnchorEffect(EffectController controller, AnchorProvider? target)
+      : super(controller) {
+    this.target = target;
+  }
+
+  // factory AnchorEffect.by(
+  //     Vector2 offset,
+  //     EffectController controller, {
+  //       AnchorProvider? target,
+  //     }) =>
+  //     AnchorByEffect(offset, controller, target: target);
+
+  factory AnchorEffect.to(
+      Anchor destination,
+      EffectController controller, {
+        AnchorProvider? target,
+      }) =>
+      AnchorToEffect(destination, controller, target: target);
+}

--- a/packages/flame/lib/src/effects/anchor_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_effect.dart
@@ -1,7 +1,7 @@
 import 'package:vector_math/vector_math_64.dart';
 
 import '../anchor.dart';
-// import 'anchor_by_effect.dart';
+import 'anchor_by_effect.dart';
 import 'anchor_to_effect.dart';
 import 'controllers/effect_controller.dart';
 import 'effect.dart';
@@ -24,17 +24,17 @@ abstract class AnchorEffect extends Effect
     this.target = target;
   }
 
-  // factory AnchorEffect.by(
-  //     Vector2 offset,
-  //     EffectController controller, {
-  //       AnchorProvider? target,
-  //     }) =>
-  //     AnchorByEffect(offset, controller, target: target);
+  factory AnchorEffect.by(
+    Vector2 offset,
+    EffectController controller, {
+    AnchorProvider? target,
+  }) =>
+      AnchorByEffect(offset, controller, target: target);
 
   factory AnchorEffect.to(
-      Anchor destination,
-      EffectController controller, {
-        AnchorProvider? target,
-      }) =>
+    Anchor destination,
+    EffectController controller, {
+    AnchorProvider? target,
+  }) =>
       AnchorToEffect(destination, controller, target: target);
 }

--- a/packages/flame/lib/src/effects/anchor_to_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_to_effect.dart
@@ -1,0 +1,43 @@
+import 'package:vector_math/vector_math_64.dart';
+
+import '../anchor.dart';
+import 'controllers/effect_controller.dart';
+import 'effect.dart';
+import 'effect_target.dart';
+import 'measurable_effect.dart';
+import 'provider_interfaces.dart';
+
+/// An effect that moves the target's anchor to the specified value.
+///
+/// The anchor will move in a straight line from the anchor's value at the start
+/// of the effect towards the provided target. The timing of the move is
+/// governed by the [controller].
+class AnchorToEffect extends Effect
+    with EffectTarget<AnchorProvider>
+    implements MeasurableEffect {
+  AnchorToEffect(Anchor destination, EffectController controller)
+      : _destination = destination,
+        _offset = Vector2.zero(),
+        super(controller);
+
+  final Anchor _destination;
+  final Vector2 _offset;
+
+  @override
+  void onStart() {
+    _offset.x = _destination.x - target.anchor.x;
+    _offset.y = _destination.y - target.anchor.y;
+  }
+
+  @override
+  void apply(double progress) {
+    final dProgress = progress - previousProgress;
+    target.anchor = Anchor(
+      target.anchor.x + _offset.x * dProgress,
+      target.anchor.y + _offset.y * dProgress,
+    );
+  }
+
+  @override
+  double measure() => _offset.length;
+}

--- a/packages/flame/lib/src/effects/anchor_to_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_to_effect.dart
@@ -15,9 +15,14 @@ import 'provider_interfaces.dart';
 class AnchorToEffect extends Effect
     with EffectTarget<AnchorProvider>
     implements MeasurableEffect {
-  AnchorToEffect(Anchor destination, EffectController controller)
-      : _destination = destination,
-        super(controller);
+  AnchorToEffect(
+    Anchor destination,
+    EffectController controller, {
+    AnchorProvider? target,
+  })  : _destination = destination,
+        super(controller) {
+    this.target = target;
+  }
 
   final Anchor _destination;
   late Vector2 _offset;

--- a/packages/flame/lib/src/effects/anchor_to_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_to_effect.dart
@@ -17,16 +17,14 @@ class AnchorToEffect extends Effect
     implements MeasurableEffect {
   AnchorToEffect(Anchor destination, EffectController controller)
       : _destination = destination,
-        _offset = Vector2.zero(),
         super(controller);
 
   final Anchor _destination;
-  final Vector2 _offset;
+  late Vector2 _offset;
 
   @override
   void onStart() {
-    _offset.x = _destination.x - target.anchor.x;
-    _offset.y = _destination.y - target.anchor.y;
+    _offset = _destination.toVector2() - target.anchor.toVector2();
   }
 
   @override

--- a/packages/flame/lib/src/effects/anchor_to_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_to_effect.dart
@@ -1,10 +1,8 @@
 import 'package:vector_math/vector_math_64.dart';
 
 import '../anchor.dart';
+import 'anchor_effect.dart';
 import 'controllers/effect_controller.dart';
-import 'effect.dart';
-import 'effect_target.dart';
-import 'measurable_effect.dart';
 import 'provider_interfaces.dart';
 
 /// An effect that moves the target's anchor to the specified value.
@@ -12,17 +10,13 @@ import 'provider_interfaces.dart';
 /// The anchor will move in a straight line from the anchor's value at the start
 /// of the effect towards the provided target. The timing of the move is
 /// governed by the [controller].
-class AnchorToEffect extends Effect
-    with EffectTarget<AnchorProvider>
-    implements MeasurableEffect {
+class AnchorToEffect extends AnchorEffect {
   AnchorToEffect(
     Anchor destination,
     EffectController controller, {
     AnchorProvider? target,
   })  : _destination = destination,
-        super(controller) {
-    this.target = target;
-  }
+        super(controller, target);
 
   final Anchor _destination;
   late Vector2 _offset;

--- a/packages/flame/lib/src/effects/provider_interfaces.dart
+++ b/packages/flame/lib/src/effects/provider_interfaces.dart
@@ -1,5 +1,7 @@
 import 'package:vector_math/vector_math_64.dart';
 
+import '../anchor.dart';
+
 /// Interface for a component that can be affected by move effects.
 abstract class PositionProvider {
   Vector2 get position;
@@ -16,4 +18,10 @@ abstract class ScaleProvider {
 abstract class AngleProvider {
   double get angle;
   set angle(double value);
+}
+
+/// Interface for a component that can be affected by anchor effects.
+abstract class AnchorProvider {
+  Anchor get anchor;
+  set anchor(Anchor value);
 }

--- a/packages/flame/lib/src/experimental/viewfinder.dart
+++ b/packages/flame/lib/src/experimental/viewfinder.dart
@@ -16,7 +16,7 @@ import 'camera_component.dart';
 /// "cross-hairs" of the viewport ([position]), the [zoom] level, and the
 /// [angle] of rotation of the camera.
 class Viewfinder extends Component
-    implements AngleProvider, PositionProvider, ScaleProvider {
+    implements AnchorProvider, AngleProvider, PositionProvider, ScaleProvider {
   /// Internal transform matrix used by the viewfinder.
   final Transform2D _transform = Transform2D();
 
@@ -62,8 +62,10 @@ class Viewfinder extends Component
   /// The "logical center" of the camera means the point within the viewport
   /// where the viewfinder's focus is located at. It is at this point within
   /// the viewport that the world's point [position] will be displayed.
+  @override
   Anchor get anchor => _anchor;
   Anchor _anchor = Anchor.center;
+  @override
   set anchor(Anchor value) {
     _anchor = value;
     onViewportResize();

--- a/packages/flame/test/effects/anchor_by_effect_test.dart
+++ b/packages/flame/test/effects/anchor_by_effect_test.dart
@@ -1,0 +1,46 @@
+import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AnchorByEffect', () {
+    testWithFlameGame('simple AnchorEffect.by', (game) async {
+      final component = PositionComponent(
+        size: Vector2(100, 40),
+        position: Vector2(12, 98),
+        anchor: Anchor.center,
+      );
+      game.add(component);
+      await game.ready();
+
+      component.add(
+        AnchorEffect.by(Vector2(0.3, 0.5), EffectController(duration: 1)),
+      );
+      for (var t = 0.0; t <= 1.0; t += 0.1) {
+        expect(component.anchor.x, closeTo(0.5 + 0.3 * t, 1e-15));
+        expect(component.anchor.y, closeTo(0.5 + 0.5 * t, 1e-15));
+        game.update(0.1);
+      }
+    });
+
+    testWithFlameGame('AnchorByEffect with explicit target', (game) async {
+      final component = PositionComponent(anchor: Anchor.topCenter);
+      game.add(component);
+      game.add(
+        AnchorByEffect(
+          Vector2(-0.2, 0.6),
+          EffectController(duration: 1),
+          target: component,
+        ),
+      );
+      await game.ready();
+
+      for (var t = 0.0; t <= 1.0; t += 0.1) {
+        expect(component.anchor.x, closeTo(0.5 - 0.2 * t, 1e-15));
+        expect(component.anchor.y, closeTo(0.0 + 0.6 * t, 1e-15));
+        game.update(0.1);
+      }
+    });
+  });
+}

--- a/packages/flame/test/effects/anchor_to_effect_test.dart
+++ b/packages/flame/test/effects/anchor_to_effect_test.dart
@@ -1,0 +1,45 @@
+import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
+import 'package:flame/experimental.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AnchorToEffect', () {
+    testWithFlameGame('simple anchor movement', (game) async {
+      final object = PositionComponent()
+        ..position = Vector2(3, 4)
+        ..anchor = Anchor.bottomRight;
+      game.add(object);
+      await game.ready();
+
+      object.add(
+        AnchorToEffect(Anchor.center, EffectController(duration: 1)),
+      );
+      game.update(0.5);
+      expect(object.position, Vector2(3, 4));
+      expect(object.anchor.x, closeTo(0.75, 1e-15));
+      expect(object.anchor.y, closeTo(0.75, 1e-15));
+
+      game.update(0.5);
+      expect(object.anchor.x, closeTo(0.5, 1e-15));
+      expect(object.anchor.y, closeTo(0.5, 1e-15));
+    });
+
+    testWithFlameGame('viewfinder move anchor', (game) async {
+      final world = World()..addToParent(game);
+      final camera = CameraComponent(world: world)..addToParent(game);
+      await game.ready();
+
+      expect(camera.viewfinder.anchor, Anchor.center);
+      camera.viewfinder.add(
+        AnchorToEffect(const Anchor(0.2, 0.6), EffectController(duration: 1)),
+      );
+      for (var t = 0.0; t <= 1.0; t += 0.1) {
+        expect(camera.viewfinder.anchor.x, closeTo(0.5 - 0.3 * t, 1e-15));
+        expect(camera.viewfinder.anchor.y, closeTo(0.5 + 0.1 * t, 1e-15));
+        game.update(0.1);
+      }
+    });
+  });
+}


### PR DESCRIPTION
# Description

- Added `AnchorProvider` interface, currently implemented by `PositionComponent` and `Viewfinder`.
- Added `AnchorToEffect` and `AnchorByEffect` that can be applied to a target which is an `AnchorProvider`.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
