### PR TITLE
fix: Fix width setter in Oxygen's SizeComponent

### DIFF
--- a/packages/flame_oxygen/lib/src/component/size_component.dart
+++ b/packages/flame_oxygen/lib/src/component/size_component.dart
@@ -8,7 +8,7 @@ class SizeComponent extends Component<Vector2> {
   set size(Vector2 position) => _size.setFrom(position);
 
   double get width => _size.x;
-  set width(double x) => _size.x = width;
+  set width(double width) => _size.x = width;
 
   double get height => _size.y;
   set height(double height) => _size.y = height;


### PR DESCRIPTION
# Description

The width setter in Oxygen's SizeComponent is obviously incorrect.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues