### PR TITLE
fix: MouseJoint gets less and less reactive(#1558)

### DIFF
--- a/packages/flame_forge2d/example/lib/mouse_joint_sample.dart
+++ b/packages/flame_forge2d/example/lib/mouse_joint_sample.dart
@@ -36,8 +36,10 @@ class MouseJointSample extends Forge2DGame with MultiTouchDragDetector {
       ..bodyA = groundBody
       ..bodyB = ball.body;
 
-    mouseJoint ??= MouseJoint(mouseJointDef);
-    world.createJoint(mouseJoint!);
+    if (mouseJoint == null) {
+      mouseJoint = MouseJoint(mouseJointDef);
+      world.createJoint(mouseJoint!);
+    }
 
     mouseJoint?.setTarget(details.eventPosition.game);
     return false;


### PR DESCRIPTION
# Description
Found a functional bug in Forge2d samplecode: `mouse_joint_sample.dart`

## Breaking Change
- [ x] No, this is *not* a breaking change.

<!-- Links -->
https://stackoverflow.com/questions/71928016/mousejoint-gets-less-and-less-reactive/71938577#71938577