### PR TITLE
feat: included `completed` to `SpriteAnimation`

### DIFF
--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -367,7 +367,7 @@ animation object needs to be ticked to move the frames.
 To listen when the animation is done (when it reaches its last frame and is not looping) you can
 use `animation.completed`.
 
-For example, you can:
+Example:
 
 ```dart
 await animation.completed; 

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -367,6 +367,17 @@ animation object needs to be ticked to move the frames.
 To listen when the animation is done (when it reaches its last frame and is not looping) you can
 use `animation.completed`.
 
+For example, you can:
+
+```dart
+await animation.completed; 
+doSomething();
+
+// or alternatively
+
+animation.completed.whenCompleted(doSomething);
+```
+
 
 ## SpriteAnimationGroup
 

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -364,7 +364,7 @@ this.player = SpriteAnimationComponent.fromFrameData(
 If you are not using `FlameGame`, don't forget this component needs to be updated, because the
 animation object needs to be ticked to move the frames.
 
-To listen when the animation is done (when it reaches its last frame and is not looping) you can
+To listen when the animation is done (when it reaches the last frame and is not looping) you can
 use `animation.completed`.
 
 Example:

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -375,7 +375,7 @@ doSomething();
 
 // or alternatively
 
-animation.completed.whenCompleted(doSomething);
+animation.completed.whenComplete(doSomething);
 ```
 
 

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -364,6 +364,9 @@ this.player = SpriteAnimationComponent.fromFrameData(
 If you are not using `FlameGame`, don't forget this component needs to be updated, because the
 animation object needs to be ticked to move the frames.
 
+To listen when the animation is done (when it reaches its last frame and is not looping) you can
+use `animation.completed`.
+
 
 ## SpriteAnimationGroup
 

--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'assets/images.dart';
@@ -233,6 +234,8 @@ class SpriteAnimation {
   /// Registered method to be triggered when the animation complete.
   void Function()? onComplete;
 
+  Completer<void>? _completeCompleter;
+
   /// The current frame that should be displayed.
   SpriteAnimationFrame get currentFrame => frames[currentIndex];
 
@@ -242,6 +245,17 @@ class SpriteAnimation {
   /// Returns whether the animation has only a single frame (and is, thus, a
   /// still image).
   bool get isSingleFrame => frames.length == 1;
+
+  /// A future that will complete when the animation reaches [isLastFrame].
+  Future<void> get completed {
+    if (isLastFrame) {
+      return Future.value();
+    }
+
+    _completeCompleter ??= Completer<void>();
+
+    return _completeCompleter!.future;
+  }
 
   /// Sets a different step time to each frame.
   /// The sizes of the arrays must match.
@@ -307,6 +321,7 @@ class SpriteAnimation {
         } else {
           _done = true;
           onComplete?.call();
+          _completeCompleter?.complete();
           return;
         }
       } else {

--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -251,7 +251,7 @@ class SpriteAnimation {
   /// An animation is considered to be completed if it reaches its [isLastFrame]
   /// and is not [loop]ing.
   Future<void> get completed {
-    if (isLastFrame) {
+    if (_done) {
       return Future.value();
     }
 

--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -246,7 +246,10 @@ class SpriteAnimation {
   /// still image).
   bool get isSingleFrame => frames.length == 1;
 
-  /// A future that will complete when the animation reaches [isLastFrame].
+  /// A future that will complete when the animation completes.
+  ///
+  /// An animation is considered to be completed if it reaches its [isLastFrame]
+  /// and is not [loop]ing.
   Future<void> get completed {
     if (isLastFrame) {
       return Future.value();

--- a/packages/flame/test/sprite_animation_test.dart
+++ b/packages/flame/test/sprite_animation_test.dart
@@ -73,7 +73,7 @@ void main() {
     });
 
     test(
-      'completed completes when animation has alrady completed',
+      'completed completes when the animation has already completed',
       () async {
         final sprite = MockSprite();
         final animation = SpriteAnimation.spriteList(

--- a/packages/flame/test/sprite_animation_test.dart
+++ b/packages/flame/test/sprite_animation_test.dart
@@ -55,6 +55,30 @@ void main() {
       animation.update(1);
       expect(counter, 1);
     });
+
+    test('completed completes', () {
+      final sprite = MockSprite();
+      final animation =
+          SpriteAnimation.spriteList([sprite], stepTime: 1, loop: false);
+
+      expectLater(animation.completed, completes);
+
+      animation.update(1);
+    });
+
+    test(
+      'completed completes when '
+      'animation has alrady completed',
+      () async {
+        final sprite = MockSprite();
+        final animation =
+            SpriteAnimation.spriteList([sprite], stepTime: 1, loop: false);
+
+        animation.update(1);
+
+        expectLater(animation.completed, completes);
+      },
+    );
   });
 }
 

--- a/packages/flame/test/sprite_animation_test.dart
+++ b/packages/flame/test/sprite_animation_test.dart
@@ -113,7 +113,7 @@ void main() {
     );
 
     test(
-      "completed doesn't completes when animation is looping and on last frame",
+      "completed doesn't complete when animation is looping and on last frame",
       () async {
         final sprite = MockSprite();
         final animation = SpriteAnimation.spriteList([sprite], stepTime: 1);

--- a/packages/flame/test/sprite_animation_test.dart
+++ b/packages/flame/test/sprite_animation_test.dart
@@ -44,9 +44,12 @@ void main() {
     test('onComplete called for single-frame animation', () {
       var counter = 0;
       final sprite = MockSprite();
-      final animation =
-          SpriteAnimation.spriteList([sprite], stepTime: 1, loop: false)
-            ..onComplete = () => counter++;
+      final animation = SpriteAnimation.spriteList(
+        [sprite],
+        stepTime: 1,
+        loop: false,
+      )..onComplete = () => counter++;
+
       expect(counter, 0);
       animation.update(0.5);
       expect(counter, 0);
@@ -58,8 +61,11 @@ void main() {
 
     test('completed completes', () {
       final sprite = MockSprite();
-      final animation =
-          SpriteAnimation.spriteList([sprite], stepTime: 1, loop: false);
+      final animation = SpriteAnimation.spriteList(
+        [sprite],
+        stepTime: 1,
+        loop: false,
+      );
 
       expectLater(animation.completed, completes);
 
@@ -67,16 +73,54 @@ void main() {
     });
 
     test(
-      'completed completes when '
-      'animation has alrady completed',
+      'completed completes when animation has alrady completed',
       () async {
         final sprite = MockSprite();
-        final animation =
-            SpriteAnimation.spriteList([sprite], stepTime: 1, loop: false);
+        final animation = SpriteAnimation.spriteList(
+          [sprite],
+          stepTime: 1,
+          loop: false,
+        );
 
         animation.update(1);
 
         expectLater(animation.completed, completes);
+      },
+    );
+
+    test(
+      "completed doesn't completes when animation is yet to complete",
+      () async {
+        final sprite = MockSprite();
+        final animation = SpriteAnimation.spriteList(
+          [sprite],
+          stepTime: 1,
+          loop: false,
+        );
+
+        expectLater(animation.completed, doesNotComplete);
+      },
+    );
+
+    test(
+      "completed doesn't complete when animation is looping",
+      () async {
+        final sprite = MockSprite();
+        final animation = SpriteAnimation.spriteList([sprite], stepTime: 1);
+
+        expectLater(animation.completed, doesNotComplete);
+      },
+    );
+
+    test(
+      "completed doesn't completes when animation is looping and on last frame",
+      () async {
+        final sprite = MockSprite();
+        final animation = SpriteAnimation.spriteList([sprite], stepTime: 1);
+
+        animation.update(1);
+
+        expectLater(animation.completed, doesNotComplete);
       },
     );
   });

--- a/packages/flame/test/sprite_animation_test.dart
+++ b/packages/flame/test/sprite_animation_test.dart
@@ -89,7 +89,7 @@ void main() {
     );
 
     test(
-      "completed doesn't completes when animation is yet to complete",
+      "completed doesn't complete when the animation is yet to complete",
       () async {
         final sprite = MockSprite();
         final animation = SpriteAnimation.spriteList(


### PR DESCRIPTION
# Description

Adds `completed` future that completes whenever the animation completes.

Similar to how we have `loaded` and `mounted` on `Component`.

Reasoning:
- The `onCompleted` can be overridden whereas with `completed` you can add multiple "callbacks"
(that overriding issue is what raised the issue on the widget in the first place)
- In some scenarios, the API `completed` is easier to test and read over `onCompleted`

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X]  I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

#1543 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
