### PR TITLE
fix: Optimize AcceleratedParticle and MovingParticle

### DIFF
--- a/packages/flame/lib/src/particles/accelerated_particle.dart
+++ b/packages/flame/lib/src/particles/accelerated_particle.dart
@@ -41,26 +41,15 @@ class AcceleratedParticle extends CurvedParticle with SingleChildParticle {
   }
 
   /// Used to avoid creating new vectors in [update].
-  final _tmpVectors = [Vector2.zero(), Vector2.zero()];
+  static final _tmp1 = Vector2.zero();
+  static final _tmp2 = Vector2.zero();
 
   @override
   void update(double dt) {
-    speed.add(
-      _tmpVectors[0]
-        ..setFrom(acceleration)
-        ..scale(dt),
-    );
-    position.add(
-      _tmpVectors[0]
-        ..setFrom(speed)
-        ..scale(dt)
-        ..sub(
-          _tmpVectors[1]
-            ..setFrom(acceleration)
-            ..scale(dt * dt)
-            ..scale(0.5),
-        ),
-    );
+    speed.addScaled(acceleration, dt);
+    position
+      ..addScaled(speed, dt)
+      ..addScaled(acceleration, -dt*dt*0.5);
     super.update(dt);
   }
 }

--- a/packages/flame/lib/src/particles/accelerated_particle.dart
+++ b/packages/flame/lib/src/particles/accelerated_particle.dart
@@ -40,10 +40,6 @@ class AcceleratedParticle extends CurvedParticle with SingleChildParticle {
     canvas.restore();
   }
 
-  /// Used to avoid creating new vectors in [update].
-  static final _tmp1 = Vector2.zero();
-  static final _tmp2 = Vector2.zero();
-
   @override
   void update(double dt) {
     speed.addScaled(acceleration, dt);

--- a/packages/flame/lib/src/particles/accelerated_particle.dart
+++ b/packages/flame/lib/src/particles/accelerated_particle.dart
@@ -40,10 +40,27 @@ class AcceleratedParticle extends CurvedParticle with SingleChildParticle {
     canvas.restore();
   }
 
+  /// Used to avoid creating new vectors in [update].
+  final _tmpVectors = [Vector2.zero(), Vector2.zero()];
+
   @override
   void update(double dt) {
-    speed += acceleration * dt;
-    position += speed * dt - (acceleration * dt * dt) / 2;
+    speed.add(
+      _tmpVectors[0]
+        ..setFrom(acceleration)
+        ..scale(dt),
+    );
+    position.add(
+      _tmpVectors[0]
+        ..setFrom(speed)
+        ..scale(dt)
+        ..sub(
+          _tmpVectors[1]
+            ..setFrom(acceleration)
+            ..scale(dt * dt)
+            ..scale(0.5),
+        ),
+    );
     super.update(dt);
   }
 }

--- a/packages/flame/lib/src/particles/accelerated_particle.dart
+++ b/packages/flame/lib/src/particles/accelerated_particle.dart
@@ -45,7 +45,7 @@ class AcceleratedParticle extends CurvedParticle with SingleChildParticle {
     speed.addScaled(acceleration, dt);
     position
       ..addScaled(speed, dt)
-      ..addScaled(acceleration, -dt*dt*0.5);
+      ..addScaled(acceleration, -dt * dt * 0.5);
     super.update(dt);
   }
 }

--- a/packages/flame/lib/src/particles/moving_particle.dart
+++ b/packages/flame/lib/src/particles/moving_particle.dart
@@ -25,7 +25,7 @@ class MovingParticle extends CurvedParticle with SingleChildParticle {
         super(lifespan: lifespan, curve: curve);
 
   /// Used to avoid creating new [Vector2] objects in [update].
-  final _tmpVector = Vector2.zero();
+  static final _tmpVector = Vector2.zero();
 
   @override
   void render(Canvas c) {

--- a/packages/flame/lib/src/particles/moving_particle.dart
+++ b/packages/flame/lib/src/particles/moving_particle.dart
@@ -24,10 +24,15 @@ class MovingParticle extends CurvedParticle with SingleChildParticle {
   })  : from = from ?? Vector2.zero(),
         super(lifespan: lifespan, curve: curve);
 
+  /// Used to avoid creating new [Vector2] objects in [update].
+  final _tmpVector = Vector2.zero();
+
   @override
   void render(Canvas c) {
     c.save();
-    final current = from.clone()..lerp(to, progress);
+    final current = _tmpVector
+      ..setFrom(from)
+      ..lerp(to, progress);
     c.translateVector(current);
     super.render(c);
     c.restore();


### PR DESCRIPTION
# Description

Remove creation of new `Vector2` objects in `AcceleratedParticle` and `MovingParticle`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
