### PR TITLE
fix: Isometric tile map component uses scale when getting block from position

### DIFF
--- a/packages/flame/lib/src/components/isometric_tile_map_component.dart
+++ b/packages/flame/lib/src/components/isometric_tile_map_component.dart
@@ -154,7 +154,7 @@ class IsometricTileMapComponent extends PositionComponent {
   /// This can be used to handle clicks or hovers.
   /// This is the opposite of [getBlockCenterPosition].
   Block getBlock(Vector2 p) {
-    final halfTile = effectiveTileSize / 2;
+    final halfTile = (effectiveTileSize / 2)..multiply(scale);
     final multiplier = 1 - halfTile.y / (2 * effectiveTileHeight);
     final delta = halfTile.clone()..multiply(Vector2(1, multiplier));
     final cart = isoToCart(p - position + delta);

--- a/packages/flame/lib/src/components/isometric_tile_map_component.dart
+++ b/packages/flame/lib/src/components/isometric_tile_map_component.dart
@@ -132,7 +132,8 @@ class IsometricTileMapComponent extends PositionComponent {
   Vector2 getBlockCenterPosition(Block block) {
     final tile = effectiveTileSize;
     final result = getBlockRenderPosition(block) +
-        (Vector2(tile.x / 2, tile.y - effectiveTileHeight - tile.y / 4)..multiply(scale));
+        (Vector2(tile.x / 2, tile.y - effectiveTileHeight - tile.y / 4)
+          ..multiply(scale));
     return result;
   }
 
@@ -170,7 +171,9 @@ class IsometricTileMapComponent extends PositionComponent {
   Block getBlockRenderedAt(Vector2 p) {
     final tile = effectiveTileSize;
     return getBlock(
-      p + (Vector2(tile.x / 2, tile.y - effectiveTileHeight - tile.y / 4)..multiply(scale)),
+      p +
+          (Vector2(tile.x / 2, tile.y - effectiveTileHeight - tile.y / 4)
+            ..multiply(scale)),
     );
   }
 

--- a/packages/flame/lib/src/components/isometric_tile_map_component.dart
+++ b/packages/flame/lib/src/components/isometric_tile_map_component.dart
@@ -120,7 +120,7 @@ class IsometricTileMapComponent extends PositionComponent {
     final halfTile = Vector2(
       effectiveTileSize.x / 2,
       (effectiveTileSize.y / 2) / scalingFactor,
-    );
+    )..multiply(scale);
     final pos = Vector2(i.toDouble(), j.toDouble())..multiply(halfTile);
     return cartToIso(pos) - halfTile;
   }
@@ -131,8 +131,9 @@ class IsometricTileMapComponent extends PositionComponent {
   /// This is the opposite of [getBlock].
   Vector2 getBlockCenterPosition(Block block) {
     final tile = effectiveTileSize;
-    return getBlockRenderPosition(block) +
-        Vector2(tile.x / 2, tile.y - effectiveTileHeight - tile.y / 4);
+    final result = getBlockRenderPosition(block) +
+        (Vector2(tile.x / 2, tile.y - effectiveTileHeight - tile.y / 4)..multiply(scale));
+    return result;
   }
 
   /// Converts a coordinate from the isometric space to the cartesian space.
@@ -155,7 +156,7 @@ class IsometricTileMapComponent extends PositionComponent {
   /// This is the opposite of [getBlockCenterPosition].
   Block getBlock(Vector2 p) {
     final halfTile = (effectiveTileSize / 2)..multiply(scale);
-    final multiplier = 1 - halfTile.y / (2 * effectiveTileHeight);
+    final multiplier = 1 - halfTile.y / (2 * effectiveTileHeight * scale.x);
     final delta = halfTile.clone()..multiply(Vector2(1, multiplier));
     final cart = isoToCart(p - position + delta);
     final px = (cart.x / halfTile.x - 1).ceil();
@@ -169,7 +170,7 @@ class IsometricTileMapComponent extends PositionComponent {
   Block getBlockRenderedAt(Vector2 p) {
     final tile = effectiveTileSize;
     return getBlock(
-      p + Vector2(tile.x / 2, tile.y - effectiveTileHeight - tile.y / 4),
+      p + (Vector2(tile.x / 2, tile.y - effectiveTileHeight - tile.y / 4)..multiply(scale)),
     );
   }
 

--- a/packages/flame/test/components/isometric_tile_map_component_test.dart
+++ b/packages/flame/test/components/isometric_tile_map_component_test.dart
@@ -10,8 +10,10 @@ class MockImage extends Mock implements Image {
   MockImage(this.size);
 
   final Vector2 size;
+
   @override
   int get width => size.x.toInt();
+
   @override
   int get height => size.y.toInt();
 }
@@ -20,6 +22,7 @@ class _MockSpriteSheet extends Mock implements SpriteSheet {
   _MockSpriteSheet(this.tileSize);
 
   final Vector2 tileSize;
+
   @override
   Image get image => MockImage(tileSize);
 }
@@ -40,10 +43,14 @@ void main() {
         tileHeight: 8.0,
       );
 
+      final scales = [Vector2.all(0.1), Vector2.all(1), Vector2.all(2.0)];
       const blocks = [Block(0, 0), Block(1, 1), Block(-1, 0), Block(2, -10)];
-      for (final block in blocks) {
-        expect(c.getBlockRenderedAt(c.getBlockRenderPosition(block)), block);
-        expect(c.getBlock(c.getBlockCenterPosition(block)), block);
+      for (final scale in scales) {
+        c.scale = scale;
+        for (final block in blocks) {
+          expect(c.getBlockRenderedAt(c.getBlockRenderPosition(block)), block);
+          expect(c.getBlock(c.getBlockCenterPosition(block)), block);
+        }
       }
     });
 


### PR DESCRIPTION
# Description

Taking scale in consideration when getting a block from IsometricTileMapComponent. This will allow for scaled maps to return the correct block. 

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
