### PR TITLE
fix: removed redundant null check operator

### DIFF
--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -10,7 +10,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   GameLoop? gameLoop;
 
   GameRenderBox(this.buildContext, this.game) {
-    WidgetsBinding.instance!.addTimingsCallback(game.onTimingsCallback);
+    WidgetsBinding.instance.addTimingsCallback(game.onTimingsCallback);
   }
 
   @override
@@ -65,11 +65,11 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   }
 
   void _bindLifecycleListener() {
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   void _unbindLifecycleListener() {
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
   }
 
   @override


### PR DESCRIPTION
# Description

Removes using null check operator `!` where receiver can't be null.

This is currently triggering warnings:

<details>

<summary> Warning logs </summary>

```cmd
: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
lib/…/game/game_render_box.dart:13
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../../../../flutter/packages/flutter/lib/src/widgets/binding.dart').
package:flutter/…/widgets/binding.dart:1
    WidgetsBinding.instance!.addTimingsCallback(game.onTimingsCallback);
                   ^

: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
lib/…/game/game_render_box.dart:68
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../../../../flutter/packages/flutter/lib/src/widgets/binding.dart').
package:flutter/…/widgets/binding.dart:1
    WidgetsBinding.instance!.addObserver(this);
                   ^
: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
lib/…/game/game_render_box.dart:72
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../../../../flutter/packages/flutter/lib/src/widgets/binding.dart').
package:flutter/…/widgets/binding.dart:1
    WidgetsBinding.instance!.removeObserver(this);
                   ^
```

</details>


<details>

<summary> Flutter doctor </summary>

```
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel master, 2.11.0-0.0.pre.616, on macOS 12.2 21D49 darwin-arm, locale en-GB)
[✓] Android toolchain - develop for Android devices (Android SDK version 30.0.3)
[✓] Xcode - develop for iOS and macOS (Xcode 13.2.1)
[✓] Chrome - develop for the web
[✓] Android Studio (version 4.2)
[✓] VS Code (version 1.66.1)
[✓] Connected device (1 available)
[✓] HTTP Host Availability

• No issues found!
```

</details>

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
