### PR TITLE
fix: correctly calculating frame length

### DIFF
--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -84,17 +84,17 @@ class SpriteAnimationData {
     this.loop = true,
   })  : assert(amountPerRow == null || amount >= amountPerRow),
         assert(start <= end && start >= 0 && end <= amount),
-        assert(stepTimes.length == end - start) {
+        assert(stepTimes.length >= end - start + 1) {
     amountPerRow ??= amount;
     texturePosition ??= Vector2.zero();
-    frames = List<SpriteAnimationFrameData>.generate(end - start, (index) {
+    frames = List<SpriteAnimationFrameData>.generate(end - start + 1, (index) {
       final i = index + start;
       final position = Vector2(
         texturePosition!.x + (i % amountPerRow!) * textureSize.x,
         texturePosition.y + (i ~/ amountPerRow) * textureSize.y,
       );
       return SpriteAnimationFrameData(
-        stepTime: stepTimes[i],
+        stepTime: stepTimes[index],
         srcPosition: position,
         srcSize: textureSize,
       );


### PR DESCRIPTION
Sorry I didn't double check this error in yesterday's pr due to my oversight, because the index starts from 0, and the calculated length should be incremented by 1。