### PR TITLE
feat(flame_bloc): add FlameBlocListenerComponent

### DIFF
--- a/packages/flame_bloc/example/lib/src/game.dart
+++ b/packages/flame_bloc/example/lib/src/game.dart
@@ -16,42 +16,45 @@ class GamePage extends StatelessWidget {
     return Scaffold(
       body: MultiBlocProvider(
         providers: [
-          BlocProvider<GameStatsBloc>(
-            create: (_) => GameStatsBloc(),
-          ),
-          BlocProvider<InventoryBloc>(
-            create: (_) => InventoryBloc(),
-          ),
+          BlocProvider<GameStatsBloc>(create: (_) => GameStatsBloc()),
+          BlocProvider<InventoryBloc>(create: (_) => InventoryBloc()),
         ],
-        child: Builder(
-          builder: (context) {
-            return Column(
-              children: [
-                const GameStat(),
-                Expanded(
-                  child: Stack(
-                    children: [
-                      Positioned.fill(
-                        child: GameWidget(
-                          game: SpaceShooterGame(
-                            statsBloc: BlocProvider.of<GameStatsBloc>(context),
-                            inventoryBloc:
-                                BlocProvider.of<InventoryBloc>(context),
-                          ),
-                        ),
-                      ),
-                      const Positioned(
-                        top: 50,
-                        right: 10,
-                        child: Inventory(),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            );
-          },
+        child: const GameView(),
+      ),
+    );
+  }
+}
+
+class GameView extends StatelessWidget {
+  const GameView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const GameStat(),
+        Expanded(
+          child: Stack(
+            children: const [
+              Positioned.fill(child: Game()),
+              Positioned(top: 50, right: 10, child: Inventory()),
+            ],
+          ),
         ),
+      ],
+    );
+  }
+}
+
+class Game extends StatelessWidget {
+  const Game({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GameWidget(
+      game: SpaceShooterGame(
+        statsBloc: context.read<GameStatsBloc>(),
+        inventoryBloc: context.read<InventoryBloc>(),
       ),
     );
   }

--- a/packages/flame_bloc/example/lib/src/game/components/player.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/player.dart
@@ -24,7 +24,7 @@ class PlayerController extends Component
     if (state.status == GameStatus.respawn ||
         state.status == GameStatus.initial) {
       gameRef.statsBloc.add(const PlayerRespawned());
-      gameRef.add(gameRef.player = PlayerComponent());
+      parent?.add(gameRef.player = PlayerComponent());
     }
   }
 }

--- a/packages/flame_bloc/example/lib/src/game/components/player.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/player.dart
@@ -15,8 +15,8 @@ class PlayerController extends Component
         HasGameRef<SpaceShooterGame>,
         FlameBlocListener<GameStatsBloc, GameStatsState> {
   @override
-  bool listenWhen(GameStatsState? previousState, GameStatsState newState) {
-    return previousState?.status != newState.status;
+  bool listenWhen(GameStatsState previousState, GameStatsState newState) {
+    return previousState.status != newState.status;
   }
 
   @override

--- a/packages/flame_bloc/example/lib/src/game/game.dart
+++ b/packages/flame_bloc/example/lib/src/game/game.dart
@@ -15,7 +15,7 @@ class GameStatsController extends Component with HasGameRef<SpaceShooterGame> {
     add(
       FlameBlocListenerComponent<GameStatsBloc, GameStatsState>(
         listenWhen: (previousState, newState) {
-          return previousState?.status != newState.status &&
+          return previousState.status != newState.status &&
               newState.status == GameStatus.initial;
         },
         onNewState: (state) {

--- a/packages/flame_bloc/example/lib/src/game/game.dart
+++ b/packages/flame_bloc/example/lib/src/game/game.dart
@@ -43,17 +43,19 @@ class SpaceShooterGame extends FlameGame
     await super.onLoad();
 
     await add(
-      FlameBlocProvider<InventoryBloc, InventoryState>.value(
-        value: inventoryBloc,
-        children: [
+      FlameMultiBlocProvider(
+        providers: [
+          FlameBlocProvider<InventoryBloc, InventoryState>.value(
+            value: inventoryBloc,
+          ),
           FlameBlocProvider<GameStatsBloc, GameStatsState>.value(
             value: statsBloc,
-            children: [
-              player = PlayerComponent(),
-              PlayerController(),
-              GameStatsController(),
-            ],
           ),
+        ],
+        children: [
+          player = PlayerComponent(),
+          PlayerController(),
+          GameStatsController(),
         ],
       ),
     );

--- a/packages/flame_bloc/example/lib/src/game/game.dart
+++ b/packages/flame_bloc/example/lib/src/game/game.dart
@@ -9,19 +9,20 @@ import './components/player.dart';
 import '../game_stats/bloc/game_stats_bloc.dart';
 import '../inventory/bloc/inventory_bloc.dart';
 
-class GameStatsController extends Component
-    with
-        HasGameRef<SpaceShooterGame>,
-        FlameBlocListener<GameStatsBloc, GameStatsState> {
+class GameStatsController extends Component with HasGameRef<SpaceShooterGame> {
   @override
-  bool listenWhen(GameStatsState? previousState, GameStatsState newState) {
-    return previousState?.status != newState.status &&
-        newState.status == GameStatus.initial;
-  }
-
-  @override
-  void onNewState(GameStatsState state) {
-    gameRef.children.removeWhere((element) => element is EnemyComponent);
+  Future<void>? onLoad() async {
+    add(
+      FlameBlocListenerComponent<GameStatsBloc, GameStatsState>(
+        listenWhen: (previousState, newState) {
+          return previousState?.status != newState.status &&
+              newState.status == GameStatus.initial;
+        },
+        onNewState: (state) {
+          gameRef.children.removeWhere((element) => element is EnemyComponent);
+        },
+      ),
+    );
   }
 }
 

--- a/packages/flame_bloc/lib/flame_bloc.dart
+++ b/packages/flame_bloc/lib/flame_bloc.dart
@@ -1,6 +1,7 @@
 export 'src/flame_bloc_game.dart';
 
 export 'src/flame_bloc_listener.dart';
+export 'src/flame_bloc_listener_component.dart';
 export 'src/flame_bloc_provider.dart';
 export 'src/flame_bloc_reader.dart';
 export 'src/flame_multi_bloc_provider.dart';

--- a/packages/flame_bloc/lib/src/flame_bloc_listener.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listener.dart
@@ -6,6 +6,30 @@ import 'package:flutter/material.dart';
 
 import '../flame_bloc.dart';
 
+/// {@template flame_bloc_listener_component}
+/// A [Component] which exposes the ability to listen to changes in a [Bloc] state.
+/// {@endtemplate}
+class FlameBlocListenerComponent<B extends BlocBase<S>, S> extends Component
+    with FlameBlocListener<B, S> {
+  /// {@macro flame_bloc_listener_component}
+  FlameBlocListenerComponent({
+    required void Function(S state) onNewState,
+    bool Function(S? previousState, S newState)? listenWhen,
+  })  : _onNewState = onNewState,
+        _listenWhen = listenWhen;
+
+  final void Function(S state) _onNewState;
+  final bool Function(S? previousState, S newState)? _listenWhen;
+
+  @override
+  void onNewState(S state) => _onNewState(state);
+
+  @override
+  bool listenWhen(S? previousState, S newState) {
+    return _listenWhen?.call(previousState, newState) ?? true;
+  }
+}
+
 /// Adds [Bloc] access and listening to a [Component]
 mixin FlameBlocListener<B extends BlocBase<S>, S> on Component {
   late S _state;

--- a/packages/flame_bloc/lib/src/flame_bloc_listener.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listener.dart
@@ -6,30 +6,6 @@ import 'package:flutter/material.dart';
 
 import '../flame_bloc.dart';
 
-/// {@template flame_bloc_listener_component}
-/// A [Component] which exposes the ability to listen to changes in a [Bloc] state.
-/// {@endtemplate}
-class FlameBlocListenerComponent<B extends BlocBase<S>, S> extends Component
-    with FlameBlocListener<B, S> {
-  /// {@macro flame_bloc_listener_component}
-  FlameBlocListenerComponent({
-    required void Function(S state) onNewState,
-    bool Function(S? previousState, S newState)? listenWhen,
-  })  : _onNewState = onNewState,
-        _listenWhen = listenWhen;
-
-  final void Function(S state) _onNewState;
-  final bool Function(S? previousState, S newState)? _listenWhen;
-
-  @override
-  void onNewState(S state) => _onNewState(state);
-
-  @override
-  bool listenWhen(S? previousState, S newState) {
-    return _listenWhen?.call(previousState, newState) ?? true;
-  }
-}
-
 /// Adds [Bloc] access and listening to a [Component]
 mixin FlameBlocListener<B extends BlocBase<S>, S> on Component {
   late S _state;
@@ -66,7 +42,7 @@ mixin FlameBlocListener<B extends BlocBase<S>, S> on Component {
   /// a certain state change happens.
   ///
   /// Default implementation returns true.
-  bool listenWhen(S? previousState, S newState) => true;
+  bool listenWhen(S previousState, S newState) => true;
 
   /// Listener called everytime a new state is emitted to this component.
   ///

--- a/packages/flame_bloc/lib/src/flame_bloc_listener.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listener.dart
@@ -10,8 +10,7 @@ import '../flame_bloc.dart';
 mixin FlameBlocListener<B extends BlocBase<S>, S> on Component {
   late S _state;
   late B _bloc;
-  @visibleForTesting
-  late StreamSubscription<S> subscription;
+  late StreamSubscription<S> _subscription;
 
   @override
   @mustCallSuper
@@ -26,7 +25,7 @@ mixin FlameBlocListener<B extends BlocBase<S>, S> on Component {
     _bloc = provider.bloc;
     _state = _bloc.state;
 
-    subscription = _bloc.stream.listen((newState) {
+    _subscription = _bloc.stream.listen((newState) {
       if (_state != newState) {
         final _callNewState = listenWhen(_state, newState);
         _state = newState;
@@ -53,6 +52,6 @@ mixin FlameBlocListener<B extends BlocBase<S>, S> on Component {
   @mustCallSuper
   void onRemove() {
     super.onRemove();
-    subscription.cancel();
+    _subscription.cancel();
   }
 }

--- a/packages/flame_bloc/lib/src/flame_bloc_listener_component.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listener_component.dart
@@ -4,7 +4,7 @@ import 'package:flame/components.dart';
 import '../flame_bloc.dart';
 
 /// {@template flame_bloc_listener_component}
-/// A [Component] which exposes the ability to listen to changes in a [Bloc] state.
+/// A [Component] which can listen to changes in a [Bloc] state.
 /// {@endtemplate}
 class FlameBlocListenerComponent<B extends BlocBase<S>, S> extends Component
     with FlameBlocListener<B, S> {

--- a/packages/flame_bloc/lib/src/flame_bloc_listener_component.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listener_component.dart
@@ -1,0 +1,28 @@
+import 'package:bloc/bloc.dart';
+import 'package:flame/components.dart';
+
+import '../flame_bloc.dart';
+
+/// {@template flame_bloc_listener_component}
+/// A [Component] which exposes the ability to listen to changes in a [Bloc] state.
+/// {@endtemplate}
+class FlameBlocListenerComponent<B extends BlocBase<S>, S> extends Component
+    with FlameBlocListener<B, S> {
+  /// {@macro flame_bloc_listener_component}
+  FlameBlocListenerComponent({
+    required void Function(S state) onNewState,
+    bool Function(S previousState, S newState)? listenWhen,
+  })  : _onNewState = onNewState,
+        _listenWhen = listenWhen;
+
+  final void Function(S state) _onNewState;
+  final bool Function(S previousState, S newState)? _listenWhen;
+
+  @override
+  void onNewState(S state) => _onNewState(state);
+
+  @override
+  bool listenWhen(S previousState, S newState) {
+    return _listenWhen?.call(previousState, newState) ?? true;
+  }
+}

--- a/packages/flame_bloc/test/flame_bloc_game_test.dart
+++ b/packages/flame_bloc/test/flame_bloc_game_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:flame/components.dart';
 import 'package:flame_bloc/flame_bloc.dart';
 import 'package:flame_test/flame_test.dart';

--- a/packages/flame_bloc/test/src/flame_bloc_listener_component_test.dart
+++ b/packages/flame_bloc/test/src/flame_bloc_listener_component_test.dart
@@ -1,0 +1,72 @@
+import 'package:flame/components.dart';
+import 'package:flame_bloc/flame_bloc.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../player_cubit.dart';
+
+class TestPlayerListener extends Component {
+  TestPlayerListener({
+    required void Function(PlayerState state) onNewState,
+    bool Function(PlayerState? previous, PlayerState? current)? listenWhen,
+  })  : _onNewState = onNewState,
+        _listenWhen = listenWhen;
+
+  final void Function(PlayerState state) _onNewState;
+  final bool Function(PlayerState previous, PlayerState current)? _listenWhen;
+
+  @override
+  Future<void>? onLoad() async {
+    add(
+      FlameBlocListenerComponent<PlayerCubit, PlayerState>(
+        listenWhen: _listenWhen ?? (_, __) => true,
+        onNewState: _onNewState,
+      ),
+    );
+  }
+}
+
+void main() {
+  group('FlameBlocListenerComponent', () {
+    testWithFlameGame(
+      'onNewsState is called when state changes',
+      (game) async {
+        final bloc = PlayerCubit();
+        final provider = FlameBlocProvider<PlayerCubit, PlayerState>.value(
+          value: bloc,
+        );
+        final states = <PlayerState>[];
+        await game.ensureAdd(provider);
+
+        final component = TestPlayerListener(onNewState: states.add);
+        await provider.ensureAdd(component);
+
+        bloc.kill();
+        await Future.microtask(() {});
+        expect(states, equals([PlayerState.dead]));
+      },
+    );
+
+    testWithFlameGame(
+      'onNewsState is not called when listenWhen returns false',
+      (game) async {
+        final bloc = PlayerCubit();
+        final provider = FlameBlocProvider<PlayerCubit, PlayerState>.value(
+          value: bloc,
+        );
+        final states = <PlayerState>[];
+        await game.ensureAdd(provider);
+
+        final component = TestPlayerListener(
+          onNewState: states.add,
+          listenWhen: (_, __) => false,
+        );
+        await provider.ensureAdd(component);
+
+        bloc.kill();
+        await Future.microtask(() {});
+        expect(states, isEmpty);
+      },
+    );
+  });
+}

--- a/packages/flame_bloc/test/src/flame_bloc_listener_component_test.dart
+++ b/packages/flame_bloc/test/src/flame_bloc_listener_component_test.dart
@@ -1,30 +1,8 @@
-import 'package:flame/components.dart';
 import 'package:flame_bloc/flame_bloc.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../player_cubit.dart';
-
-class TestPlayerListener extends Component {
-  TestPlayerListener({
-    required void Function(PlayerState state) onNewState,
-    bool Function(PlayerState? previous, PlayerState? current)? listenWhen,
-  })  : _onNewState = onNewState,
-        _listenWhen = listenWhen;
-
-  final void Function(PlayerState state) _onNewState;
-  final bool Function(PlayerState previous, PlayerState current)? _listenWhen;
-
-  @override
-  Future<void>? onLoad() async {
-    add(
-      FlameBlocListenerComponent<PlayerCubit, PlayerState>(
-        listenWhen: _listenWhen ?? (_, __) => true,
-        onNewState: _onNewState,
-      ),
-    );
-  }
-}
 
 void main() {
   group('FlameBlocListenerComponent', () {
@@ -38,7 +16,9 @@ void main() {
         final states = <PlayerState>[];
         await game.ensureAdd(provider);
 
-        final component = TestPlayerListener(onNewState: states.add);
+        final component = FlameBlocListenerComponent<PlayerCubit, PlayerState>(
+          onNewState: states.add,
+        );
         await provider.ensureAdd(component);
 
         bloc.kill();
@@ -57,7 +37,7 @@ void main() {
         final states = <PlayerState>[];
         await game.ensureAdd(provider);
 
-        final component = TestPlayerListener(
+        final component = FlameBlocListenerComponent<PlayerCubit, PlayerState>(
           onNewState: states.add,
           listenWhen: (_, __) => false,
         );

--- a/packages/flame_bloc/test/src/flame_bloc_listener_test.dart
+++ b/packages/flame_bloc/test/src/flame_bloc_listener_test.dart
@@ -22,7 +22,7 @@ class SadPlayerListener extends Component
   PlayerState? last;
 
   @override
-  bool listenWhen(PlayerState? previousState, PlayerState newState) {
+  bool listenWhen(PlayerState previousState, PlayerState newState) {
     return newState == PlayerState.sad;
   }
 


### PR DESCRIPTION
# Description

<!-- Provide a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->

- feat(flame_bloc): add FlameBlocListenerComponent

This change allows developers to have components which can listen to multiple blocs and also aligns more closely with other components like the FlameBlocProvider. We can still keep the FlameBlocListener mixin if you'd like but if we decide to remove the mixin we can rename this to just `FlameBlocListener`.

### Previous Usage

```dart
class GameStatsController extends Component
    with
        HasGameRef<SpaceShooterGame>,
        FlameBlocListener<GameStatsBloc, GameStatsState> {
  @override
  bool listenWhen(GameStatsState? previousState, GameStatsState newState) {
    return previousState?.status != newState.status &&
        newState.status == GameStatus.initial;
  }
  @override
  void onNewState(GameStatsState state) {
    gameRef.children.removeWhere((element) => element is EnemyComponent);
  }
}
```

### Current Usage

```dart
class GameStatsController extends Component with HasGameRef<SpaceShooterGame> {
  @override
  Future<void>? onLoad() async {
    add(
      FlameBlocListenerComponent<GameStatsBloc, GameStatsState>(
        listenWhen: (previousState, newState) {
          return previousState?.status != newState.status &&
              newState.status == GameStatus.initial;
        },
        onNewState: (state) {
          gameRef.children.removeWhere((element) => element is EnemyComponent);
        },
      ),
    );
  }
}
```

cc @erickzanardo @wolfenrain @alestiago

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
