### PR TITLE
feat: Add `FpsComponent` and `FpsTextComponent`

### DIFF
--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -141,7 +141,7 @@ class MyGame extends FlameGame {
         children: [
           HighScoreDisplay(),
           HitPointsDisplay(),
-          FpsCounter(),
+          FpsComponent(),
         ],
       ),
     );

--- a/doc/flame/other/debug.md
+++ b/doc/flame/other/debug.md
@@ -20,15 +20,15 @@ game is running in should be the FPS that we are reporting, since that is what o
 bound by.
 
 
-### FPSComponent
+### FpsComponent
 
-The `FPSComponent` can be added to anywhere in the component tree and will keep track of how many
+The `FpsComponent` can be added to anywhere in the component tree and will keep track of how many
 FPS that the game is currently rendering in. If you want to display this as text in the game, use
 the [](#fpstextcomponent).
 
 
-### FPSTextComponent
+### FpsTextComponent
 
-The `FPSTextComponent` is simply a [](../rendering/text.md#textcomponent) that wraps an
+The `FpsTextComponent` is simply a [](../rendering/text.md#textcomponent) that wraps an
 [](../rendering/text.md#textcomponent), since you most commonly want to show the current FPS
 somewhere when you the [](#fpscomponent) is used.

--- a/doc/flame/other/debug.md
+++ b/doc/flame/other/debug.md
@@ -1,6 +1,34 @@
 # Debug features
 
-## FPS counter
+## FlameGame features
+
+Flame provides some debugging features for the `FlameGame` class. These features are enabled when
+the `debugMode` property is set to `true` (or overridden to be `true`).
+When `debugMode` is enabled, each `PositionComponent` will be rendered with their bounding size, and
+have their positions written on the screen. This way, you can visually verify the components
+boundaries and positions.
+
+To see a working example of the debugging features of the `FlameGame`, check this
+[example](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/components/debug_example.dart).
+
+
+## FPS
+
+### FPSComponent
+
+The `FPSComponent` can be added to anywhere in the component tree and will keep track of how many
+FPS that the game is currently rendering with. If you want to display this as text in the game, use
+the [](#fpstextcomponent).
+
+
+### FPSTextComponent
+
+The `FPSTextComponent` is simply a [](../rendering/text.md#textcomponent) that wraps an
+[](../rendering/text.md#textcomponent), since you most commonly want to show the current FPS
+somewhere when you the [](#fpscomponent) is used.
+
+
+### FPS counter
 
 Flame provides the `FPSCounter` mixin for recording the fps; this mixin can be applied on any class
 that extends from `Game`. Once applied you can access the current fps by using the `fps` method,
@@ -18,14 +46,3 @@ class MyGame extends FlameGame with FPSCounter {
   }
 }
 ```
-
-## FlameGame features
-
-Flame provides some debugging features for the `FlameGame` class. These features are enabled when
-the `debugMode` property is set to `true` (or overridden to be `true`).
-When `debugMode` is enabled, each `PositionComponent` will be rendered with their bounding size, and
-have their positions written on the screen. This way, you can visually verify the components
-boundaries and positions.
-
-To see a working example of the debugging features of the `FlameGame`, check this
-[example](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/components/debug_example.dart).

--- a/doc/flame/other/debug.md
+++ b/doc/flame/other/debug.md
@@ -14,6 +14,12 @@ To see a working example of the debugging features of the `FlameGame`, check thi
 
 ## FPS
 
+The FPS reported from Flame might be a bit lower than what is reported from for example the Flutter
+DevTools, depending on which platform you are targeting. The source of truth for how many FPS your
+game is running in should be the FPS that we are reporting, since that is what our game loop is
+bound by.
+
+
 ### FPSComponent
 
 The `FPSComponent` can be added to anywhere in the component tree and will keep track of how many
@@ -26,23 +32,3 @@ the [](#fpstextcomponent).
 The `FPSTextComponent` is simply a [](../rendering/text.md#textcomponent) that wraps an
 [](../rendering/text.md#textcomponent), since you most commonly want to show the current FPS
 somewhere when you the [](#fpscomponent) is used.
-
-
-### FPS counter
-
-Flame provides the `FPSCounter` mixin for recording the fps; this mixin can be applied on any class
-that extends from `Game`. Once applied you can access the current fps by using the `fps` method,
-like shown in the example below.
-
-```dart
-class MyGame extends FlameGame with FPSCounter {
-  static final fpsTextConfig = TextConfig(color: BasicPalette.white.color);
-
-  @override
-  void render(Canvas canvas) {
-    super.render(canvas);
-    final fpsCount = fps(120); // The average FPS for the last 120 microseconds.
-    fpsTextConfig.render(canvas, fpsCount.toString(), Vector2(0, 50));
-  }
-}
-```

--- a/doc/flame/other/debug.md
+++ b/doc/flame/other/debug.md
@@ -23,7 +23,7 @@ bound by.
 ### FPSComponent
 
 The `FPSComponent` can be added to anywhere in the component tree and will keep track of how many
-FPS that the game is currently rendering with. If you want to display this as text in the game, use
+FPS that the game is currently rendering in. If you want to display this as text in the game, use
 the [](#fpstextcomponent).
 
 

--- a/examples/lib/stories/collision_detection/multiple_shapes_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes_example.dart
@@ -27,7 +27,7 @@ class MultipleShapesExample extends FlameGame
 
   @override
   Future<void> onLoad() async {
-    add(FPSTextComponent(position: Vector2(0, size.y - 24)));
+    add(FpsTextComponent(position: Vector2(0, size.y - 24)));
     final screenHitbox = ScreenHitbox();
     final snowman = CollidableSnowman(
       Vector2.all(150),

--- a/examples/lib/stories/collision_detection/multiple_shapes_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes_example.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart' hide Image, Draggable;
 enum Shapes { circle, rectangle, polygon }
 
 class MultipleShapesExample extends FlameGame
-    with HasCollisionDetection, HasDraggables, FPSCounter {
+    with HasCollisionDetection, HasDraggables {
   static const description = '''
     An example with many hitboxes that move around on the screen and during
     collisions they change color depending on what it is that they have collided
@@ -25,10 +25,9 @@ class MultipleShapesExample extends FlameGame
     any direction.
   ''';
 
-  final TextPaint fpsTextPaint = TextPaint();
-
   @override
   Future<void> onLoad() async {
+    add(FPSTextComponent(position: Vector2(0, size.y - 24)));
     final screenHitbox = ScreenHitbox();
     final snowman = CollidableSnowman(
       Vector2.all(150),
@@ -83,11 +82,6 @@ class MultipleShapesExample extends FlameGame
   @override
   void render(Canvas canvas) {
     super.render(canvas);
-    fpsTextPaint.render(
-      canvas,
-      '${fps(120).toStringAsFixed(2)}fps',
-      Vector2(0, size.y - 24),
-    );
   }
 }
 

--- a/examples/lib/stories/collision_detection/multiple_shapes_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes_example.dart
@@ -78,11 +78,6 @@ class MultipleShapesExample extends FlameGame
       rng: _rng,
     );
   }
-
-  @override
-  void render(Canvas canvas) {
-    super.render(canvas);
-  }
 }
 
 abstract class MyCollidable extends PositionComponent

--- a/examples/lib/stories/components/debug_example.dart
+++ b/examples/lib/stories/components/debug_example.dart
@@ -33,7 +33,7 @@ class DebugExample extends FlameGame {
     add(flame2);
     add(flame3);
 
-    add(FPSTextComponent(position: Vector2(0, size.y - 24)));
+    add(FpsTextComponent(position: Vector2(0, size.y - 24)));
   }
 }
 

--- a/examples/lib/stories/components/debug_example.dart
+++ b/examples/lib/stories/components/debug_example.dart
@@ -1,16 +1,12 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
-import 'package:flutter/material.dart';
 
-class DebugExample extends FlameGame with FPSCounter {
+class DebugExample extends FlameGame {
   static const String description = '''
-    In this example we show what you will see when setting `debugMode = true` on
-    your game. It is a non-interactive example.
+    In this example we show what you will see when setting `debugMode = true`
+    and add the `FPSTextComponent` to your game.
+    This is a non-interactive example.
   ''';
-
-  static final fpsTextPaint = TextPaint(
-    style: const TextStyle(color: Color(0xFFFFFFFF)),
-  );
 
   @override
   bool debugMode = true;
@@ -36,15 +32,8 @@ class DebugExample extends FlameGame with FPSCounter {
     add(flame1);
     add(flame2);
     add(flame3);
-  }
 
-  @override
-  void render(Canvas canvas) {
-    super.render(canvas);
-
-    if (debugMode) {
-      fpsTextPaint.render(canvas, fps(120).toString(), Vector2(0, 50));
-    }
+    add(FPSTextComponent(position: Vector2(0, size.y - 24)));
   }
 }
 

--- a/examples/lib/stories/rendering/particles_example.dart
+++ b/examples/lib/stories/rendering/particles_example.dart
@@ -8,7 +8,7 @@ import 'package:flame/sprite.dart';
 import 'package:flame/timer.dart' as flame_timer;
 import 'package:flutter/material.dart' hide Image;
 
-class ParticlesExample extends FlameGame with FPSCounter {
+class ParticlesExample extends FlameGame {
   static const String description = '''
     In this example we show how to render a lot of different particles.
   ''';
@@ -25,9 +25,6 @@ class ParticlesExample extends FlameGame with FPSCounter {
   Timer? spawnTimer;
   final StepTween steppedTween = StepTween(begin: 0, end: 5);
   final trafficLight = TrafficLightComponent();
-  final TextPaint fpsTextPaint = TextPaint(
-    style: const TextStyle(color: Colors.white),
-  );
 
   /// Defines the lifespan of all the particles in these examples
   final sceneDuration = const Duration(seconds: 1);
@@ -480,22 +477,6 @@ class ParticlesExample extends FlameGame with FPSCounter {
             .accelerated(acceleration: Vector2(-5, 5)..multiply(halfCellSize)),
       ],
     );
-  }
-
-  @override
-  bool debugMode = true;
-
-  @override
-  void render(Canvas canvas) {
-    super.render(canvas);
-
-    if (debugMode) {
-      fpsTextPaint.render(
-        canvas,
-        '${fps(120).toStringAsFixed(2)}fps',
-        Vector2(0, size.y - 24),
-      );
-    }
   }
 
   /// Returns random [Vector2] within a virtual grid cell

--- a/packages/flame/lib/components.dart
+++ b/packages/flame/lib/components.dart
@@ -6,6 +6,8 @@ export 'src/components/component.dart';
 export 'src/components/component_point_pair.dart';
 export 'src/components/component_set.dart';
 export 'src/components/custom_painter_component.dart';
+export 'src/components/fps_component.dart';
+export 'src/components/fps_text_component.dart';
 export 'src/components/input/joystick_component.dart';
 export 'src/components/isometric_tile_map_component.dart';
 export 'src/components/mixins/draggable.dart';

--- a/packages/flame/lib/src/components/fps_component.dart
+++ b/packages/flame/lib/src/components/fps_component.dart
@@ -12,22 +12,25 @@ class FPSComponent extends Component {
 
   /// The number of game ticks over which the fps measure will be averaged.
   final int windowSize;
-  /// The queue of the recent game tick durations. The length of this queue will not exceed [windowSize].
-  final Queue<double> _window = Queue();
-  /// The sum of all values in the [_window] queue.
+
+  /// The queue of the recent game tick durations.
+  /// The length of this queue will not exceed [windowSize].
+  final Queue<double> window = Queue();
+
+  /// The sum of all values in the [window] queue.
   double _sum = 0;
 
   @override
   void update(double dt) {
-    _window.addLast(dt);
+    window.addLast(dt);
     _sum += dt;
-    if (_window.length > windowSize) {
-      _sum -= _window.removeFirst();
+    if (window.length > windowSize) {
+      _sum -= window.removeFirst();
     }
   }
 
   /// Get the current average FPS over the last [windowSize] frames.
   double get fps {
-    return _window.isEmpty ? 0 : _window.length / _sum;
+    return window.isEmpty ? 0 : window.length / _sum;
   }
 }

--- a/packages/flame/lib/src/components/fps_component.dart
+++ b/packages/flame/lib/src/components/fps_component.dart
@@ -2,11 +2,11 @@ import 'dart:collection';
 
 import '../../components.dart';
 
-/// The [FPSComponent] is a non-visual component which you can get the current
+/// The [FpsComponent] is a non-visual component which you can get the current
 /// fps of the game with by calling [fps], once the component has been added to
 /// the component tree.
-class FPSComponent extends Component {
-  FPSComponent({
+class FpsComponent extends Component {
+  FpsComponent({
     this.windowSize = 60,
   });
 

--- a/packages/flame/lib/src/components/fps_component.dart
+++ b/packages/flame/lib/src/components/fps_component.dart
@@ -16,15 +16,16 @@ class FPSComponent extends Component {
 
   @override
   void update(double dt) {
-    _window.add(dt);
-    _sum += dt;
-    if (_window.length >= windowSize) {
+    final frameFps = 1 / dt;
+    _window.add(frameFps);
+    _sum += frameFps;
+    if (_window.length > windowSize) {
       _sum -= _window.removeFirst();
     }
   }
 
   /// Get the current average FPS over the last [windowSize] frames.
   double get fps {
-    return 1 / (_sum / _window.length);
+    return _window.isEmpty ? 0 : _sum / _window.length;
   }
 }

--- a/packages/flame/lib/src/components/fps_component.dart
+++ b/packages/flame/lib/src/components/fps_component.dart
@@ -10,6 +10,7 @@ class FPSComponent extends Component {
     this.windowSize = 60,
   });
 
+  /// The number of game ticks over which the fps measure will be averaged.
   final int windowSize;
   final Queue<double> _window = Queue();
   /// The sum of all values in the [_window] queue.

--- a/packages/flame/lib/src/components/fps_component.dart
+++ b/packages/flame/lib/src/components/fps_component.dart
@@ -12,6 +12,7 @@ class FPSComponent extends Component {
 
   /// The number of game ticks over which the fps measure will be averaged.
   final int windowSize;
+  /// The queue of the recent game tick durations. The length of this queue will not exceed [windowSize].
   final Queue<double> _window = Queue();
   /// The sum of all values in the [_window] queue.
   double _sum = 0;

--- a/packages/flame/lib/src/components/fps_component.dart
+++ b/packages/flame/lib/src/components/fps_component.dart
@@ -16,9 +16,8 @@ class FPSComponent extends Component {
 
   @override
   void update(double dt) {
-    final frameFps = 1 / dt;
-    _window.add(frameFps);
-    _sum += frameFps;
+    _window.addLast(dt);
+    _sum += dt;
     if (_window.length > windowSize) {
       _sum -= _window.removeFirst();
     }
@@ -26,6 +25,6 @@ class FPSComponent extends Component {
 
   /// Get the current average FPS over the last [windowSize] frames.
   double get fps {
-    return _window.isEmpty ? 0 : _sum / _window.length;
+    return _window.isEmpty ? 0 : _window.length / _sum;
   }
 }

--- a/packages/flame/lib/src/components/fps_component.dart
+++ b/packages/flame/lib/src/components/fps_component.dart
@@ -10,7 +10,8 @@ class FpsComponent extends Component {
     this.windowSize = 60,
   });
 
-  /// The number of game ticks over which the fps measure will be averaged.
+  /// The sliding window size, i.e. the number of game ticks over which the fps
+  /// measure will be averaged.
   final int windowSize;
 
   /// The queue of the recent game tick durations.

--- a/packages/flame/lib/src/components/fps_component.dart
+++ b/packages/flame/lib/src/components/fps_component.dart
@@ -1,0 +1,30 @@
+import 'dart:collection';
+
+import '../../components.dart';
+
+/// The [FPSComponent] is a non-visual component which you can get the current
+/// fps of the game with by calling [fps], once the component has been added to
+/// the component tree.
+class FPSComponent extends Component {
+  FPSComponent({
+    this.windowSize = 60,
+  });
+
+  final int windowSize;
+  final Queue<double> _window = Queue();
+  double _sum = 0;
+
+  @override
+  void update(double dt) {
+    _window.add(dt);
+    _sum += dt;
+    if (_window.length >= windowSize) {
+      _sum -= _window.removeFirst();
+    }
+  }
+
+  /// Get the current average FPS over the last [windowSize] frames.
+  double get fps {
+    return 1 / (_sum / _window.length);
+  }
+}

--- a/packages/flame/lib/src/components/fps_component.dart
+++ b/packages/flame/lib/src/components/fps_component.dart
@@ -12,6 +12,7 @@ class FPSComponent extends Component {
 
   final int windowSize;
   final Queue<double> _window = Queue();
+  /// The sum of all values in the [_window] queue.
   double _sum = 0;
 
   @override

--- a/packages/flame/lib/src/components/fps_text_component.dart
+++ b/packages/flame/lib/src/components/fps_text_component.dart
@@ -1,9 +1,9 @@
 import '../../components.dart';
 
-/// The [FPSTextComponent] is a [TextComponent] that writes out the current FPS.
-/// It has a [FPSComponent] as a child which does the actual calculations.
-class FPSTextComponent<T extends TextRenderer> extends TextComponent {
-  FPSTextComponent({
+/// The [FpsTextComponent] is a [TextComponent] that writes out the current FPS.
+/// It has a [FpsComponent] as a child which does the actual calculations.
+class FpsTextComponent<T extends TextRenderer> extends TextComponent {
+  FpsTextComponent({
     this.windowSize = 60,
     this.decimalPlaces = 0,
     T? textRenderer,
@@ -25,12 +25,12 @@ class FPSTextComponent<T extends TextRenderer> extends TextComponent {
 
   final int windowSize;
   final int decimalPlaces;
-  late final FPSComponent fpsComponent;
+  late final FpsComponent fpsComponent;
 
   @override
   Future<void> onLoad() async {
     positionType = PositionType.game;
-    add(fpsComponent = FPSComponent(windowSize: windowSize));
+    add(fpsComponent = FpsComponent(windowSize: windowSize));
   }
 
   @override

--- a/packages/flame/lib/src/components/fps_text_component.dart
+++ b/packages/flame/lib/src/components/fps_text_component.dart
@@ -35,6 +35,6 @@ class FPSTextComponent<T extends TextRenderer> extends TextComponent {
 
   @override
   void update(double dt) {
-    text = '${fpsComponent.fps.toStringAsFixed(decimalPlaces)}FPS';
+    text = '${fpsComponent.fps.toStringAsFixed(decimalPlaces)} FPS';
   }
 }

--- a/packages/flame/lib/src/components/fps_text_component.dart
+++ b/packages/flame/lib/src/components/fps_text_component.dart
@@ -4,7 +4,7 @@ import '../../components.dart';
 /// It has a [FpsComponent] as a child which does the actual calculations.
 class FpsTextComponent<T extends TextRenderer> extends TextComponent {
   FpsTextComponent({
-    this.windowSize = 60,
+    int windowSize = 60,
     this.decimalPlaces = 0,
     T? textRenderer,
     Vector2? position,
@@ -13,7 +13,8 @@ class FpsTextComponent<T extends TextRenderer> extends TextComponent {
     double? angle,
     Anchor? anchor,
     int? priority,
-  }) : super(
+  })  : fpsComponent = FpsComponent(windowSize: windowSize),
+        super(
           textRenderer: textRenderer,
           position: position,
           size: size,
@@ -21,17 +22,13 @@ class FpsTextComponent<T extends TextRenderer> extends TextComponent {
           angle: angle,
           anchor: anchor,
           priority: priority ?? double.maxFinite.toInt(),
-        );
-
-  final int windowSize;
-  final int decimalPlaces;
-  late final FpsComponent fpsComponent;
-
-  @override
-  Future<void> onLoad() async {
-    positionType = PositionType.game;
-    add(fpsComponent = FpsComponent(windowSize: windowSize));
+        ) {
+    positionType = PositionType.viewport;
+    add(fpsComponent);
   }
+
+  final int decimalPlaces;
+  final FpsComponent fpsComponent;
 
   @override
   void update(double dt) {

--- a/packages/flame/lib/src/components/fps_text_component.dart
+++ b/packages/flame/lib/src/components/fps_text_component.dart
@@ -1,0 +1,39 @@
+import '../../components.dart';
+
+/// The [FPSTextComponent] is a [TextComponent] that writes out the current FPS.
+/// It has a [FPSComponent] as a child which does the actual calculations.
+class FPSTextComponent<T extends TextRenderer> extends TextComponent {
+  FPSTextComponent({
+    this.windowSize = 60,
+    this.decimalPlaces = 0,
+    T? textRenderer,
+    Vector2? position,
+    Vector2? size,
+    Vector2? scale,
+    double? angle,
+    Anchor? anchor,
+    int? priority,
+  }) : super(
+          textRenderer: textRenderer,
+          position: position,
+          size: size,
+          scale: scale,
+          angle: angle,
+          anchor: anchor,
+          priority: priority,
+        );
+
+  final int windowSize;
+  final int decimalPlaces;
+  late final FPSComponent fpsComponent;
+
+  @override
+  Future<void> onLoad() async {
+    add(fpsComponent = FPSComponent(windowSize: windowSize));
+  }
+
+  @override
+  void update(double dt) {
+    text = '${fpsComponent.fps.toStringAsFixed(decimalPlaces)}FPS';
+  }
+}

--- a/packages/flame/lib/src/components/fps_text_component.dart
+++ b/packages/flame/lib/src/components/fps_text_component.dart
@@ -20,7 +20,7 @@ class FPSTextComponent<T extends TextRenderer> extends TextComponent {
           scale: scale,
           angle: angle,
           anchor: anchor,
-          priority: priority,
+          priority: priority ?? double.maxFinite.toInt(),
         );
 
   final int windowSize;
@@ -29,6 +29,7 @@ class FPSTextComponent<T extends TextRenderer> extends TextComponent {
 
   @override
   Future<void> onLoad() async {
+    positionType = PositionType.game;
     add(fpsComponent = FPSComponent(windowSize: windowSize));
   }
 

--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -10,6 +10,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   GameLoop? gameLoop;
 
   GameRenderBox(this.buildContext, this.game) {
+    //ignore: deprecated_member_use_from_same_package
     WidgetsBinding.instance!.addTimingsCallback(game.onTimingsCallback);
   }
 

--- a/packages/flame/lib/src/game/mixins/fps_counter.dart
+++ b/packages/flame/lib/src/game/mixins/fps_counter.dart
@@ -6,6 +6,10 @@ const _maxFrames = 60;
 const frameInterval =
     Duration(microseconds: Duration.microsecondsPerSecond ~/ _maxFrames);
 
+@Deprecated(
+  'Use FPSComponent or FPSTextComponent instead. '
+  'FPSCounter will be removed in v1.3.0',
+)
 mixin FPSCounter on Game {
   List<FrameTiming> _previousTimings = [];
 

--- a/packages/flame/lib/src/game/mixins/game.dart
+++ b/packages/flame/lib/src/game/mixins/game.dart
@@ -98,6 +98,7 @@ mixin Game {
   void lifecycleStateChange(AppLifecycleState state) {}
 
   /// Use for calculating the FPS.
+  @Deprecated('Use FPSComponent instead, will be removed in v1.3.0')
   void onTimingsCallback(List<FrameTiming> timings) {}
 
   /// Method to perform late initialization of the [Game] class.

--- a/packages/flame/test/components/fps_component_test.dart
+++ b/packages/flame/test/components/fps_component_test.dart
@@ -3,6 +3,8 @@ import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 void main() {
+  const _diff = 0.0000000000001;
+
   group('FPSComponent', () {
     testWithFlameGame('reports correct FPS for 1 frames', (game) async {
       final fpsComponent = FPSComponent();
@@ -10,7 +12,7 @@ void main() {
       expect(fpsComponent.fps, 0);
       game.update(1 / 60);
 
-      expect(fpsComponent.fps, 60.0);
+      expect(fpsComponent.fps, closeTo(60, _diff));
     });
 
     testWithFlameGame('reports correct FPS with full window', (game) async {
@@ -21,7 +23,7 @@ void main() {
         game.update(1 / 60);
       }
 
-      expect(fpsComponent.fps, 60.0);
+      expect(fpsComponent.fps, closeTo(60, _diff));
     });
 
     testWithFlameGame('reports correct FPS with slided window', (game) async {
@@ -32,7 +34,7 @@ void main() {
         game.update(1 / 60);
       }
 
-      expect(fpsComponent.fps, 60.0);
+      expect(fpsComponent.fps, closeTo(60, _diff));
     });
 
     testWithFlameGame('reports correct FPS with varying dt', (game) async {
@@ -44,7 +46,7 @@ void main() {
         game.update(dt);
       }
 
-      expect(fpsComponent.fps, closeTo(100 / 1.5, 0.00000000001));
+      expect(fpsComponent.fps, closeTo(100 / 1.5, _diff));
     });
   });
 }

--- a/packages/flame/test/components/fps_component_test.dart
+++ b/packages/flame/test/components/fps_component_test.dart
@@ -7,6 +7,7 @@ void main() {
     testWithFlameGame('reports correct FPS for 1 frames', (game) async {
       final fpsComponent = FPSComponent();
       await game.ensureAdd(fpsComponent);
+      expect(fpsComponent.fps, 0);
       game.update(1 / 60);
 
       expect(fpsComponent.fps, 60.0);
@@ -40,7 +41,7 @@ void main() {
       await game.ensureAdd(fpsComponent);
       for (var i = 0; i < 1.5 * windowSize; i++) {
         // Alternating between 50 and 100 FPS
-        final dt = 1 / (100 / (1 + i % 2));
+        final dt = i.isEven? 1/100 : 1/50;
         game.update(dt);
       }
 

--- a/packages/flame/test/components/fps_component_test.dart
+++ b/packages/flame/test/components/fps_component_test.dart
@@ -7,7 +7,7 @@ void main() {
 
   group('FPSComponent', () {
     testWithFlameGame('reports correct FPS for 1 frames', (game) async {
-      final fpsComponent = FPSComponent();
+      final fpsComponent = FpsComponent();
       await game.ensureAdd(fpsComponent);
       expect(fpsComponent.fps, 0);
       game.update(1 / 60);
@@ -17,7 +17,7 @@ void main() {
 
     testWithFlameGame('reports correct FPS with full window', (game) async {
       const windowSize = 30;
-      final fpsComponent = FPSComponent(windowSize: windowSize);
+      final fpsComponent = FpsComponent(windowSize: windowSize);
       await game.ensureAdd(fpsComponent);
       for (var i = 0; i < windowSize; i++) {
         game.update(1 / 60);
@@ -28,7 +28,7 @@ void main() {
 
     testWithFlameGame('reports correct FPS with slided window', (game) async {
       const windowSize = 30;
-      final fpsComponent = FPSComponent(windowSize: windowSize);
+      final fpsComponent = FpsComponent(windowSize: windowSize);
       await game.ensureAdd(fpsComponent);
       for (var i = 0; i < 2 * windowSize; i++) {
         game.update(1 / 60);
@@ -38,7 +38,7 @@ void main() {
     });
 
     testWithFlameGame('reports correct FPS with varying dt', (game) async {
-      final fpsComponent = FPSComponent();
+      final fpsComponent = FpsComponent();
       await game.ensureAdd(fpsComponent);
       for (var i = 0; i < fpsComponent.windowSize; i++) {
         // Alternating between 50 and 100 FPS

--- a/packages/flame/test/components/fps_component_test.dart
+++ b/packages/flame/test/components/fps_component_test.dart
@@ -36,16 +36,15 @@ void main() {
     });
 
     testWithFlameGame('reports correct FPS with varying dt', (game) async {
-      const windowSize = 40;
-      final fpsComponent = FPSComponent(windowSize: windowSize);
+      final fpsComponent = FPSComponent();
       await game.ensureAdd(fpsComponent);
-      for (var i = 0; i < 1.5 * windowSize; i++) {
+      for (var i = 0; i < fpsComponent.windowSize; i++) {
         // Alternating between 50 and 100 FPS
-        final dt = i.isEven? 1/100 : 1/50;
+        final dt = i.isEven ? 1 / 100 : 1 / 50;
         game.update(dt);
       }
 
-      expect(fpsComponent.fps, 75.0);
+      expect(fpsComponent.fps, closeTo(100 / 1.5, 0.00000000001));
     });
   });
 }

--- a/packages/flame/test/components/fps_component_test.dart
+++ b/packages/flame/test/components/fps_component_test.dart
@@ -1,0 +1,50 @@
+import 'package:flame/components.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FPSComponent', () {
+    testWithFlameGame('reports correct FPS for 1 frames', (game) async {
+      final fpsComponent = FPSComponent();
+      await game.ensureAdd(fpsComponent);
+      game.update(1 / 60);
+
+      expect(fpsComponent.fps, 60.0);
+    });
+
+    testWithFlameGame('reports correct FPS with full window', (game) async {
+      const windowSize = 30;
+      final fpsComponent = FPSComponent(windowSize: windowSize);
+      await game.ensureAdd(fpsComponent);
+      for (var i = 0; i < windowSize; i++) {
+        game.update(1 / 60);
+      }
+
+      expect(fpsComponent.fps, 60.0);
+    });
+
+    testWithFlameGame('reports correct FPS with slided window', (game) async {
+      const windowSize = 30;
+      final fpsComponent = FPSComponent(windowSize: windowSize);
+      await game.ensureAdd(fpsComponent);
+      for (var i = 0; i < 2 * windowSize; i++) {
+        game.update(1 / 60);
+      }
+
+      expect(fpsComponent.fps, 60.0);
+    });
+
+    testWithFlameGame('reports correct FPS with varying dt', (game) async {
+      const windowSize = 40;
+      final fpsComponent = FPSComponent(windowSize: windowSize);
+      await game.ensureAdd(fpsComponent);
+      for (var i = 0; i < 1.5 * windowSize; i++) {
+        // Alternating between 50 and 100 FPS
+        final dt = 1 / (100 / (1 + i % 2));
+        game.update(dt);
+      }
+
+      expect(fpsComponent.fps, 75.0);
+    });
+  });
+}

--- a/packages/flame_oxygen/example/lib/main.dart
+++ b/packages/flame_oxygen/example/lib/main.dart
@@ -16,7 +16,7 @@ void main() {
   runApp(GameWidget(game: ExampleGame()));
 }
 
-class ExampleGame extends OxygenGame with FPSCounter {
+class ExampleGame extends OxygenGame {
   @override
   Future<void> init() async {
     if (kDebugMode) {

--- a/packages/flame_oxygen/example/lib/system/debug_system.dart
+++ b/packages/flame_oxygen/example/lib/system/debug_system.dart
@@ -24,7 +24,6 @@ class DebugSystem extends BaseSystem {
     statusPainter.render(
       canvas,
       [
-        'FPS: ${(world!.game as FPSCounter).fps()}',
         'Entities: ${world!.entities.length}',
       ].join('\n'),
       Vector2.zero(),


### PR DESCRIPTION
# Description

This PR adds two components:
- `FpsComponent` which calculates the current FPS within a window.
- `FpsTextComponent` which renders the current FPS on the screen using a `TextComponent`.

Will add docs and tests if you think it looks like a good idea.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] No, this is *not* a breaking change.

## Related Issues

Related to #1582 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
