### PR TITLE
fix: RectangleHitbox should shrink to bounds

### DIFF
--- a/packages/flame/lib/src/collisions/hitboxes/rectangle_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/rectangle_hitbox.dart
@@ -38,6 +38,7 @@ class RectangleHitbox extends RectangleComponent with ShapeHitbox {
           parentSize: parentSize,
           angle: angle,
           anchor: anchor,
+          shrinkToBounds: true,
         );
 
   @override

--- a/packages/flame/lib/src/geometry/rectangle_component.dart
+++ b/packages/flame/lib/src/geometry/rectangle_component.dart
@@ -47,10 +47,14 @@ class RectangleComponent extends PolygonComponent {
   /// [parentSize].
   RectangleComponent.relative(
     Vector2 relation, {
-    Vector2? position,
     required Vector2 parentSize,
-    double angle = 0,
+    Vector2? position,
+    Vector2? scale,
+    double? angle = 0,
     Anchor? anchor,
+    int? priority,
+    Paint? paint,
+    bool? shrinkToBounds,
   }) : super.relative(
           [
             relation.clone(),
@@ -59,9 +63,13 @@ class RectangleComponent extends PolygonComponent {
             Vector2(-relation.x, relation.y),
           ],
           position: position,
+          scale: scale,
           parentSize: parentSize,
           angle: angle,
           anchor: anchor,
+          priority: priority,
+          paint: paint,
+          shrinkToBounds: shrinkToBounds,
         );
 
   /// This factory will create a [RectangleComponent] from a positioned [Rect].


### PR DESCRIPTION
# Description

The `RectangleHitbox` should shrink to bounds when the relative constructor is used, just like for the `PolygonComponent`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
