### PR TITLE
fix: Use a fixed update rate for `Forge2DGame`

### DIFF
--- a/packages/flame_forge2d/lib/forge2d_game.dart
+++ b/packages/flame_forge2d/lib/forge2d_game.dart
@@ -21,10 +21,12 @@ class Forge2DGame extends FlameGame {
 
   final World world;
 
+  static const _worldStepTime = 1 / 60;
+
   @override
   void update(double dt) {
     super.update(dt);
-    world.stepDt(dt);
+    world.stepDt(_worldStepTime);
   }
 
   Vector2 worldToScreen(Vector2 position) {


### PR DESCRIPTION
# Description

I think this is how it is supposed to be, to avoid overflowing values in the calculations if there is a lag.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
