### PR TITLE
feat(flame_bloc): add optional bloc parameter to FlameBlocListener

### DIFF
--- a/packages/flame_bloc/lib/src/flame_bloc_listenable.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listenable.dart
@@ -13,8 +13,8 @@ mixin FlameBlocListenable<B extends BlocBase<S>, S> on Component {
   B? _bloc;
 
   /// Explicitly set the bloc instance which the component will be listening to.
-  /// This is useful in cases where the bloc being listened to has not be provided
-  /// via [FlameBlocProvider].
+  /// This is useful in cases where the bloc being listened to
+  /// has not be provided via [FlameBlocProvider].
   set bloc(B bloc) {
     assert(
       _bloc == null,

--- a/packages/flame_bloc/lib/src/flame_bloc_listener.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listener.dart
@@ -10,10 +10,15 @@ class FlameBlocListener<B extends BlocBase<S>, S> extends Component
     with FlameBlocListenable<B, S> {
   /// {@macro flame_bloc_listener}
   FlameBlocListener({
+    B? bloc,
     required void Function(S state) onNewState,
     bool Function(S previousState, S newState)? listenWhen,
   })  : _onNewState = onNewState,
-        _listenWhen = listenWhen;
+        _listenWhen = listenWhen {
+    if (bloc != null) {
+      this.bloc = bloc;
+    }
+  }
 
   final void Function(S state) _onNewState;
   final bool Function(S previousState, S newState)? _listenWhen;

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   bloc: ^8.0.2
+  meta: ^1.7.0
   flame: ^1.1.1
   flutter_bloc: ^8.0.1
 

--- a/packages/flame_bloc/test/src/flame_bloc_listenable_test.dart
+++ b/packages/flame_bloc/test/src/flame_bloc_listenable_test.dart
@@ -52,6 +52,15 @@ void main() {
     );
 
     testWithFlameGame(
+      'throws assertion error when the bloc set multiple times',
+      (game) async {
+        final bloc = PlayerCubit();
+        final component = PlayerListener()..bloc = bloc;
+        expect(() => component.bloc = bloc, throwsAssertionError);
+      },
+    );
+
+    testWithFlameGame(
       'closes the subscription when it is removed',
       (game) async {
         final bloc = PlayerCubit();

--- a/packages/flame_bloc/test/src/flame_bloc_listener_test.dart
+++ b/packages/flame_bloc/test/src/flame_bloc_listener_test.dart
@@ -48,5 +48,22 @@ void main() {
         expect(states, isEmpty);
       },
     );
+
+    testWithFlameGame(
+      'a bloc can be explicitly passed',
+      (game) async {
+        final bloc = PlayerCubit();
+        final states = <PlayerState>[];
+        final component = FlameBlocListener<PlayerCubit, PlayerState>(
+          bloc: bloc,
+          onNewState: states.add,
+        );
+        await game.ensureAdd(component);
+
+        bloc.kill();
+        await Future.microtask(() {});
+        expect(states, equals([PlayerState.dead]));
+      },
+    );
   });
 }


### PR DESCRIPTION
# Description

<!-- Provide a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->
- feat(flame_bloc): add optional bloc parameter to FlameBlocListener
  - this enables developers to manage bloc instances without providing them to the component tree and improves the performance by avoiding having to perform ancestor lookups
  - in addition it aligns with the existing BlocListener API in flutter_bloc

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
