### PR TITLE
fix: `ParentIsA` missing `mustCallSuper`

### DIFF
--- a/packages/flame/lib/src/components/mixins/parent_is_a.dart
+++ b/packages/flame/lib/src/components/mixins/parent_is_a.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 import '../../../components.dart';
 
 /// A mixin that ensures a parent is of the given type [T].
@@ -6,6 +8,7 @@ mixin ParentIsA<T extends Component> on Component {
   T get parent => super.parent! as T;
 
   @override
+  @mustCallSuper
   void onMount() {
     assert(super.parent is T, 'Parent must be of type $T');
     super.onMount();


### PR DESCRIPTION
# Description

In https://github.com/flame-engine/flame/pull/1566 the `mustCallSuper` was forgotten after the refactor back to the original solution.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
