### PR TITLE
refactor: Organize Component class

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -158,9 +158,30 @@ class Component {
   void _setRemovingBit() => _state |= _removing;
   void _clearRemovingBit() => _state &= ~_removing;
 
+  Completer<void>? _mountCompleter;
+  Completer<void>? _loadCompleter;
+
+  /// A future that will complete once this component has finished loading.
+  Future<void> get loaded {
+    if (isLoaded) {
+      return Future.value();
+    }
+    _loadCompleter ??= Completer<void>();
+    return _loadCompleter!.future;
+  }
+
+  /// A future that will complete once the component is mounted on its parent
+  Future<void> get mounted {
+    if (isMounted) {
+      return Future.value();
+    }
+    _mountCompleter ??= Completer<void>();
+    return _mountCompleter!.future;
+  }
+
   //#endregion
 
-  //#region The parent and the children
+  //#region Component tree
 
   /// Who owns this component in the component tree.
   ///
@@ -204,9 +225,6 @@ class Component {
   }
 
   //#endregion
-
-  Completer<void>? _mountCompleter;
-  Completer<void>? _loadCompleter;
 
   @protected
   _LifecycleManager get lifecycle {
@@ -364,15 +382,6 @@ class Component {
   /// the lifetime of the [Component] object. Do not call this method manually.
   Future<void>? onLoad() => null;
 
-  /// A future that will complete once this component has finished loading.
-  Future<void> get loaded {
-    if (isLoaded) {
-      return Future.value();
-    }
-    _loadCompleter ??= Completer<void>();
-    return _loadCompleter!.future;
-  }
-
   /// Called when the component is added to its parent.
   ///
   /// This method only runs when the component is fully loaded, i.e. after
@@ -408,15 +417,6 @@ class Component {
   /// trigger. Thus, [onRemove] runs if and only if there was a corresponding
   /// [onMount] call before.
   void onRemove() {}
-
-  /// A future that will complete once the component is mounted on its parent
-  Future<void> get mounted {
-    if (isMounted) {
-      return Future.value();
-    }
-    _mountCompleter ??= Completer<void>();
-    return _mountCompleter!.future;
-  }
 
   /// This method is called periodically by the game engine to request that your
   /// component updates itself.

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -233,29 +233,6 @@ class Component {
 
   _LifecycleManager? _lifecycleManager;
 
-  /// Render priority of this component. This allows you to control the order in
-  /// which your components are rendered.
-  ///
-  /// Components are always updated and rendered in the order defined by what
-  /// this number is when the component is added to the game.
-  /// The smaller the priority, the sooner your component will be
-  /// updated/rendered.
-  /// It can be any integer (negative, zero, or positive).
-  /// If two components share the same priority, they will probably be drawn in
-  /// the order they were added.
-  ///
-  /// Note that setting the priority is relatively expensive if the component is
-  /// already added to a component tree since all siblings have to be re-added
-  /// to the parent.
-  int get priority => _priority;
-  set priority(int newPriority) {
-    if (parent == null) {
-      _priority = newPriority;
-    } else {
-      parent!.children.changePriority(this, newPriority);
-    }
-  }
-
   int _priority;
 
   /// Whether this component should be removed or not.
@@ -821,6 +798,29 @@ class Component {
     }
     if (containsLocalPoint(point)) {
       yield ComponentPointPair(this, point);
+    }
+  }
+
+  /// Render priority of this component. This allows you to control the order in
+  /// which your components are rendered.
+  ///
+  /// Components are always updated and rendered in the order defined by what
+  /// this number is when the component is added to the game.
+  /// The smaller the priority, the sooner your component will be
+  /// updated/rendered.
+  /// It can be any integer (negative, zero, or positive).
+  /// If two components share the same priority, they will probably be drawn in
+  /// the order they were added.
+  ///
+  /// Note that setting the priority is relatively expensive if the component is
+  /// already added to a component tree since all siblings have to be re-added
+  /// to the parent.
+  int get priority => _priority;
+  set priority(int newPriority) {
+    if (parent == null) {
+      _priority = newPriority;
+    } else {
+      parent!.children.changePriority(this, newPriority);
     }
   }
 

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -209,6 +209,12 @@ class Component {
   bool get hasChildren => _children?.isNotEmpty ?? false;
   ComponentSet? _children;
 
+  /// Returns the closest parent further up the hierarchy that satisfies type=T,
+  /// or null if no such parent can be found.
+  T? findParent<T extends Component>() {
+    return (_parent is T ? _parent : _parent?.findParent<T>()) as T?;
+  }
+
   /// Returns the first child that matches the given type [T].
   ///
   /// As opposed to `children.whereType<T>().first`, this method returns null
@@ -266,6 +272,13 @@ class Component {
     if (includeSelf && reversed) {
       yield this;
     }
+  }
+
+  @internal
+  static Game? staticGameInstance;
+  Game? findGame() {
+    return staticGameInstance ??
+        ((this is Game) ? (this as Game) : _parent?.findGame());
   }
 
   //#endregion
@@ -708,13 +721,6 @@ class Component {
 
   //#endregion
 
-  @internal
-  static Game? staticGameInstance;
-  Game? findGame() {
-    return staticGameInstance ??
-        ((this is Game) ? (this as Game) : _parent?.findGame());
-  }
-
   /// Whether the children list contains the given component.
   ///
   /// This method uses reference equality.
@@ -744,12 +750,6 @@ class Component {
     return descendants(reversed: true, includeSelf: includeSelf)
         .whereType<T>()
         .every(handler);
-  }
-
-  /// Returns the closest parent further up the hierarchy that satisfies type=T,
-  /// or null if no such parent can be found.
-  T? findParent<T extends Component>() {
-    return (parent is T ? parent : parent?.findParent<T>()) as T?;
   }
 
   //#region Hit Testing

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -284,6 +284,26 @@ class Component {
     }
   }
 
+  /// This method first calls the passed handler on the leaves in the tree,
+  /// the children without any children of their own.
+  /// Then it continues through all other children. The propagation continues
+  /// until the handler returns false, which means "do not continue", or when
+  /// the handler has been called with all children.
+  ///
+  /// This method is important to be used by the engine to propagate actions
+  /// like rendering, taps, etc, but you can call it yourself if you need to
+  /// apply an action to the whole component chain.
+  /// It will only consider components of type T in the hierarchy,
+  /// so use T = Component to target everything.
+  bool propagateToChildren<T extends Component>(
+    bool Function(T) handler, {
+    bool includeSelf = false,
+  }) {
+    return descendants(reversed: true, includeSelf: includeSelf)
+        .whereType<T>()
+        .every(handler);
+  }
+
   @internal
   static Game? staticGameInstance;
   Game? findGame() {
@@ -631,6 +651,7 @@ class Component {
   _LifecycleManager get lifecycle {
     return _lifecycleManager ??= _LifecycleManager(this);
   }
+
   _LifecycleManager? _lifecycleManager;
 
   bool get hasPendingLifecycleEvents {
@@ -710,7 +731,7 @@ class Component {
     }
     if (_children != null) {
       _children!.forEach(
-            (child) => child._mount(parent: this, existingChild: true),
+        (child) => child._mount(parent: this, existingChild: true),
       );
     }
     _lifecycleManager?.processQueues();
@@ -726,7 +747,7 @@ class Component {
   void _remove() {
     _parent!.children.remove(this);
     propagateToChildren(
-          (Component component) {
+      (Component component) {
         component.onRemove();
         component._clearMountedBit();
         component._clearRemovingBit();
@@ -738,26 +759,6 @@ class Component {
   }
 
   //#endregion
-
-  /// This method first calls the passed handler on the leaves in the tree,
-  /// the children without any children of their own.
-  /// Then it continues through all other children. The propagation continues
-  /// until the handler returns false, which means "do not continue", or when
-  /// the handler has been called with all children.
-  ///
-  /// This method is important to be used by the engine to propagate actions
-  /// like rendering, taps, etc, but you can call it yourself if you need to
-  /// apply an action to the whole component chain.
-  /// It will only consider components of type T in the hierarchy,
-  /// so use T = Component to target everything.
-  bool propagateToChildren<T extends Component>(
-    bool Function(T) handler, {
-    bool includeSelf = false,
-  }) {
-    return descendants(reversed: true, includeSelf: includeSelf)
-        .whereType<T>()
-        .every(handler);
-  }
 
   //#region Hit Testing
 

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -877,7 +877,7 @@ class Component {
 
   void renderDebugMode(Canvas canvas) {}
 
-//#endregion
+  //#endregion
 
   //#region Legacy component placement overrides
 
@@ -900,7 +900,7 @@ class Component {
     }
   }
 
-//#endregion
+  //#endregion
 }
 
 typedef ComponentSetFactory = ComponentSet Function();

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -209,6 +209,16 @@ class Component {
   bool get hasChildren => _children?.isNotEmpty ?? false;
   ComponentSet? _children;
 
+  /// `Component.childrenFactory` is the default method for creating children
+  /// containers within all components. Replace this method if you want to have
+  /// customized (non-default) [ComponentSet] instances in your project.
+  static ComponentSetFactory childrenFactory = ComponentSet.createDefault;
+
+  /// This method creates the children container for the current component.
+  /// Override this method if you need to have a custom [ComponentSet] within
+  /// a particular class.
+  ComponentSet createComponentSet() => childrenFactory();
+
   /// Returns the closest parent further up the hierarchy that satisfies type=T,
   /// or null if no such parent can be found.
   T? findParent<T extends Component>() {
@@ -842,16 +852,6 @@ class Component {
   void reorderChildren() => _children?.rebalanceAll();
 
   //#endregion
-
-  /// `Component.childrenFactory` is the default method for creating children
-  /// containers within all components. Replace this method if you want to have
-  /// customized (non-default) [ComponentSet] instances in your project.
-  static ComponentSetFactory childrenFactory = ComponentSet.createDefault;
-
-  /// This method creates the children container for the current component.
-  /// Override this method if you need to have a custom [ComponentSet] within
-  /// a particular class.
-  ComponentSet createComponentSet() => childrenFactory();
 }
 
 typedef ComponentSetFactory = ComponentSet Function();

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -281,6 +281,11 @@ class Component {
         ((this is Game) ? (this as Game) : _parent?.findGame());
   }
 
+  /// Whether the children list contains the given component.
+  ///
+  /// This method uses reference equality.
+  bool contains(Component c) => _children?.contains(c) ?? false;
+
   //#endregion
 
   /// Whether this component should be removed or not.
@@ -480,6 +485,8 @@ class Component {
 
   //#endregion
 
+  //#region Legacy component placement overrides
+
   /// What coordinate system this component should respect (i.e. should it
   /// observe camera, viewport, or use the raw canvas).
   ///
@@ -498,6 +505,8 @@ class Component {
         return info.eventPosition.widget;
     }
   }
+
+  //#endregion
 
   /// Remove the component from its parent in the next tick.
   void removeFromParent() {
@@ -721,17 +730,6 @@ class Component {
 
   //#endregion
 
-  /// Whether the children list contains the given component.
-  ///
-  /// This method uses reference equality.
-  bool contains(Component c) => _children?.contains(c) ?? false;
-
-  /// Call this if any of this component's children priorities have changed
-  /// at runtime.
-  ///
-  /// This will call [ComponentSet.rebalanceAll] on the [children] ordered set.
-  void reorderChildren() => _children?.rebalanceAll();
-
   /// This method first calls the passed handler on the leaves in the tree,
   /// the children without any children of their own.
   /// Then it continues through all other children. The propagation continues
@@ -837,6 +835,12 @@ class Component {
   /// component list isn't re-ordered when it is called.
   /// See FlameGame.changePriority instead.
   void changePriorityWithoutResorting(int priority) => _priority = priority;
+
+  /// Call this if any of this component's children priorities have changed
+  /// at runtime.
+  ///
+  /// This will call [ComponentSet.rebalanceAll] on the [children] ordered set.
+  void reorderChildren() => _children?.rebalanceAll();
 
   //#endregion
 

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -29,12 +29,7 @@ class Component {
     }
   }
 
-  /// What coordinate system this component should respect (i.e. should it
-  /// observe camera, viewport, or use the raw canvas).
-  ///
-  /// Do note that this currently only works if the component is added directly
-  /// to the root `FlameGame`.
-  PositionType positionType = PositionType.game;
+  //#region Lifecycle state
 
   /// Bitfield which keeps track of the current state of the component: which
   /// lifecycle events it has already executed, and which are currently being
@@ -163,9 +158,35 @@ class Component {
   void _setRemovingBit() => _state |= _removing;
   void _clearRemovingBit() => _state &= ~_removing;
 
-  /// The current parent of the component, or null if there is none.
+  //#endregion
+
+  //#region The parent and the children
+
+  /// Who owns this component in the component tree.
+  ///
+  /// This can be null if the component hasn't been added to the component tree
+  /// yet, or if it is the root of component tree.
+  ///
+  /// Setting this property is equivalent to the [changeParent] method, or to
+  /// [removeFromParent] if setting to null.
   Component? get parent => _parent;
   Component? _parent;
+  set parent(Component? newParent) {
+    if (newParent == null) {
+      removeFromParent();
+    } else {
+      changeParent(newParent);
+    }
+  }
+
+  /// The children components of this component.
+  ///
+  /// This getter will automatically create the [ComponentSet] container within
+  /// the current object if it didn't exist before. Check the [hasChildren]
+  /// property in order to avoid instantiating the children container.
+  ComponentSet get children => _children ??= createComponentSet();
+  bool get hasChildren => _children?.isNotEmpty ?? false;
+  ComponentSet? _children;
 
   /// Returns the first child that matches the given type [T].
   ///
@@ -182,14 +203,7 @@ class Component {
     return it.moveNext() ? it.current : null;
   }
 
-  /// The children of the current component.
-  ///
-  /// This getter will automatically create the [ComponentSet] container within
-  /// the current object if it didn't exist before. Check the [hasChildren]
-  /// property in order to avoid instantiating the children container.
-  ComponentSet get children => _children ??= createComponentSet();
-  bool get hasChildren => _children?.isNotEmpty ?? false;
-  ComponentSet? _children;
+  //#endregion
 
   Completer<void>? _mountCompleter;
   Completer<void>? _loadCompleter;
@@ -440,6 +454,13 @@ class Component {
   //#endregion
 
   void renderDebugMode(Canvas canvas) {}
+
+  /// What coordinate system this component should respect (i.e. should it
+  /// observe camera, viewport, or use the raw canvas).
+  ///
+  /// Do note that this currently only works if the component is added directly
+  /// to the root `FlameGame`.
+  PositionType positionType = PositionType.game;
 
   @protected
   Vector2 eventPosition(PositionInfo info) {

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -270,13 +270,6 @@ class Component {
 
   //#endregion
 
-  @protected
-  _LifecycleManager get lifecycle {
-    return _lifecycleManager ??= _LifecycleManager(this);
-  }
-
-  _LifecycleManager? _lifecycleManager;
-
   /// Whether this component should be removed or not.
   ///
   /// It will be checked once per component per tick, and if it is true,
@@ -294,7 +287,7 @@ class Component {
     removeFromParent();
   }
 
-  //#region Debug rendering
+  //#region Debugging assistance
 
   /// Returns whether this [Component] is in debug mode or not.
   /// When a child is added to the [Component] it gets the same [debugMode] as
@@ -691,6 +684,14 @@ class Component {
 
   //#endregion
 
+  //#region Internal lifecycle management
+
+  @protected
+  _LifecycleManager get lifecycle {
+    return _lifecycleManager ??= _LifecycleManager(this);
+  }
+  _LifecycleManager? _lifecycleManager;
+
   bool get hasPendingLifecycleEvents {
     return _lifecycleManager?.hasPendingEvents ?? false;
   }
@@ -704,6 +705,8 @@ class Component {
       }
     }
   }
+
+  //#endregion
 
   @internal
   static Game? staticGameInstance;
@@ -748,6 +751,8 @@ class Component {
   T? findParent<T extends Component>() {
     return (parent is T ? parent : parent?.findParent<T>()) as T?;
   }
+
+  //#region Hit Testing
 
   /// Checks whether the [point] is within this component's bounds.
   ///
@@ -800,6 +805,10 @@ class Component {
     }
   }
 
+  //#endregion
+
+  //#region Priority
+
   /// Render priority of this component. This allows you to control the order in
   /// which your components are rendered.
   ///
@@ -828,6 +837,8 @@ class Component {
   /// component list isn't re-ordered when it is called.
   /// See FlameGame.changePriority instead.
   void changePriorityWithoutResorting(int priority) => _priority = priority;
+
+  //#endregion
 
   /// `Component.childrenFactory` is the default method for creating children
   /// containers within all components. Replace this method if you want to have

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -349,16 +349,6 @@ class Component {
   @mustCallSuper
   void onGameResize(Vector2 size) => handleResize(size);
 
-  @internal
-  void handleResize(Vector2 size) {
-    _children?.forEach((child) => child.onGameResize(size));
-    _lifecycleManager?._children.forEach((child) {
-      if (child.isLoading || child.isLoaded) {
-        child.onGameResize(size);
-      }
-    });
-  }
-
   /// Late initialization method for [Component].
   ///
   /// Usually, this method is the main place where you initialize your
@@ -645,6 +635,16 @@ class Component {
         _lifecycleManager = null;
       }
     }
+  }
+
+  @internal
+  void handleResize(Vector2 size) {
+    _children?.forEach((child) => child.onGameResize(size));
+    _lifecycleManager?._children.forEach((child) {
+      if (child.isLoading || child.isLoaded) {
+        child.onGameResize(size);
+      }
+    });
   }
 
   Future<void>? _startLoading() {

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -750,7 +750,7 @@ class Component {
     }
     if (_children != null) {
       _children!.forEach(
-            (child) => child._mount(parent: this, existingChild: true),
+        (child) => child._mount(parent: this, existingChild: true),
       );
     }
     _lifecycleManager?.processQueues();
@@ -766,7 +766,7 @@ class Component {
   void _remove() {
     _parent!.children.remove(this);
     propagateToChildren(
-          (Component component) {
+      (Component component) {
         component.onRemove();
         component._clearMountedBit();
         component._clearRemovingBit();


### PR DESCRIPTION
# Description

Over time, the Component class became quite disorganized.
In this PR I move around various methods/properties of the `Component` class so that methods that perform related functions would be next to each other; classifying them into several named regions.

Also, updated doc-comment for the class, because that was obviously long overdue.

No functions/methods/properties were removed or modified.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
