### PR TITLE
refactor: Improve tests

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -875,7 +875,7 @@ class _LifecycleManager {
   void _processChildrenQueue() {
     while (_children.isNotEmpty) {
       final child = _children.first;
-      assert(child.parent!.isMounted);
+      assert(child._parent!.isMounted);
       if (child.isLoaded) {
         child._mount();
         _children.removeFirst();

--- a/packages/flame/test/assets/images_test.dart
+++ b/packages/flame/test/assets/images_test.dart
@@ -5,15 +5,6 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockImage extends Mock implements Image {
-  int disposedCount = 0;
-
-  @override
-  void dispose() {
-    disposedCount++;
-  }
-}
-
 void main() {
   // A simple 1x1 pixel encoded as base64 - just so that we have something to
   // load into the Images cache.
@@ -54,7 +45,7 @@ void main() {
 
     test('clear', () {
       final cache = Images();
-      final image = MockImage();
+      final image = _MockImage();
       cache.add('test', image);
       expect(image.disposedCount, 0);
       cache.clear('test');
@@ -63,7 +54,7 @@ void main() {
 
     test('clearCache', () {
       final cache = Images();
-      final images = List.generate(10, (_) => MockImage());
+      final images = List.generate(10, (_) => _MockImage());
       for (var i = 0; i < images.length; i++) {
         cache.add(i.toString(), images[i]);
       }
@@ -105,4 +96,13 @@ void main() {
       expect(images.fromCache('image2'), isNotNull);
     });
   });
+}
+
+class _MockImage extends Mock implements Image {
+  int disposedCount = 0;
+
+  @override
+  void dispose() {
+    disposedCount++;
+  }
 }

--- a/packages/flame/test/cache/memory_cache_test.dart
+++ b/packages/flame/test/cache/memory_cache_test.dart
@@ -3,17 +3,19 @@ import 'package:test/test.dart';
 
 void main() {
   group('MemoryCache', () {
-    test('basic cache addition', () {
+    test('basic cache access', () {
       final cache = MemoryCache<int, String>();
       cache.setValue(0, 'bla');
       expect(cache.getValue(0), 'bla');
     });
 
-    test('contains key', () {
+    test('containsKey', () {
       final cache = MemoryCache<int, String>();
+      expect(cache.keys.length, 0);
       cache.setValue(0, 'bla');
       expect(cache.containsKey(0), true);
       expect(cache.containsKey(1), false);
+      expect(cache.keys.length, 1);
     });
 
     test('cache size', () {

--- a/packages/flame/test/collisions/collision_callback_benchmark.dart
+++ b/packages/flame/test/collisions/collision_callback_benchmark.dart
@@ -40,7 +40,7 @@ class _TestBlock extends PositionComponent with CollisionCallbacks {
 
 void main() {
   group('Benchmark collision detection', () {
-    withCollidables.test('collidable callbacks are called', (game) async {
+    testCollidableGame('collidable callbacks are called', (game) async {
       final rng = Random(0);
       final blocks = List.generate(
         100,

--- a/packages/flame/test/collisions/collision_callback_test.dart
+++ b/packages/flame/test/collisions/collision_callback_test.dart
@@ -7,7 +7,7 @@ import 'collision_test_helpers.dart';
 
 void main() {
   group('Collision callbacks', () {
-    withCollidables.test('collidable callbacks are called', (game) async {
+    testCollidableGame('collidable callbacks are called', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -48,7 +48,7 @@ void main() {
       expect(blockB.endCounter, 1);
     });
 
-    withCollidables.test(
+    testCollidableGame(
       'collidable callbacks are called when removing a Collidable',
       (game) async {
         final blockA = TestBlock(
@@ -76,7 +76,7 @@ void main() {
       },
     );
 
-    withCollidables.test('hitbox callbacks are called', (game) async {
+    testCollidableGame('hitbox callbacks are called', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -115,7 +115,7 @@ void main() {
     });
   });
 
-  withCollidables.test(
+  testCollidableGame(
     'hitbox callbacks are called when Collidable is removed',
     (game) async {
       final blockA = TestBlock(
@@ -145,7 +145,7 @@ void main() {
     },
   );
 
-  withCollidables.test(
+  testCollidableGame(
     'hitbox end callbacks are called when hitbox is moved away fast',
     (game) async {
       final blockA = TestBlock(
@@ -175,7 +175,7 @@ void main() {
     },
   );
 
-  withCollidables.test(
+  testCollidableGame(
     'onCollisionEnd is only called when there previously was a collision',
     (game) async {
       final blockA = TestBlock(
@@ -199,7 +199,7 @@ void main() {
     },
   );
 
-  withCollidables.test(
+  testCollidableGame(
     'callbacks are only called once for hitboxes on each other',
     (game) async {
       final blockA = TestBlock(
@@ -257,7 +257,7 @@ void main() {
     },
   );
 
-  withCollidables.test(
+  testCollidableGame(
     'end and start callbacks are only called once for hitboxes sharing a side',
     (game) async {
       final blockA = TestBlock(
@@ -316,7 +316,7 @@ void main() {
   );
 
   // Reproduced #1478
-  withCollidables.test(
+  testCollidableGame(
     'collision callbacks with many hitboxes added',
     (game) async {
       const side = 10.0;
@@ -379,7 +379,7 @@ void main() {
   );
 
   // Reproduced #1478
-  withCollidables.test(
+  testCollidableGame(
     'collision callbacks with changed game size',
     (game) async {
       final block = TestBlock(Vector2.all(20), Vector2.all(10))

--- a/packages/flame/test/collisions/collision_passthrough_test.dart
+++ b/packages/flame/test/collisions/collision_passthrough_test.dart
@@ -10,7 +10,7 @@ class Passthrough extends TestBlock with CollisionPassthrough {
 
 void main() {
   group('CollisionPassthrough', () {
-    withCollidables.test('Passing collisions to parent', (game) async {
+    testCollidableGame('Passing collisions to parent', (game) async {
       final passthrough = Passthrough();
       final hitboxParent =
           TestBlock(Vector2.zero(), Vector2.all(10), addTestHitbox: false)

--- a/packages/flame/test/collisions/collision_test_helpers.dart
+++ b/packages/flame/test/collisions/collision_test_helpers.dart
@@ -2,10 +2,17 @@ import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
+import 'package:meta/meta.dart';
 
 class HasCollidablesGame extends FlameGame with HasCollisionDetection {}
 
-final withCollidables = FlameTester(() => HasCollidablesGame());
+@isTest
+Future<void> testCollidableGame(
+  String testName,
+  Future Function(HasCollidablesGame) testBody,
+) {
+  return testWithGame(testName, () => HasCollidablesGame(), testBody);
+}
 
 class TestHitbox extends RectangleHitbox {
   int startCounter = 0;

--- a/packages/flame/test/collisions/collision_type_test.dart
+++ b/packages/flame/test/collisions/collision_type_test.dart
@@ -9,8 +9,8 @@ import 'package:test/test.dart';
 import 'collision_test_helpers.dart';
 
 void main() {
-  group('Varying CollisionType', () {
-    withCollidables.test('actives do collide', (game) async {
+  group('CollisionType', () {
+    testCollidableGame('actives do collide', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -27,7 +27,7 @@ void main() {
       expect(blockB.activeCollisions.length, 1);
     });
 
-    withCollidables.test('passives do not collide', (game) async {
+    testCollidableGame('passives do not collide', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -44,7 +44,7 @@ void main() {
       expect(blockB.activeCollisions.isEmpty, true);
     });
 
-    withCollidables.test('inactives do not collide', (game) async {
+    testCollidableGame('inactives do not collide', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -61,7 +61,7 @@ void main() {
       expect(blockB.activeCollisions.isEmpty, true);
     });
 
-    withCollidables.test('active collides with static', (game) async {
+    testCollidableGame('active collides with static', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -79,7 +79,7 @@ void main() {
       expect(blockB.activeCollisions.length, 1);
     });
 
-    withCollidables.test('passive collides with active', (game) async {
+    testCollidableGame('passive collides with active', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -97,7 +97,7 @@ void main() {
       expect(blockB.activeCollisions.length, 1);
     });
 
-    withCollidables.test('passive does not collide with inactive',
+    testCollidableGame('passive does not collide with inactive',
         (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
@@ -115,7 +115,7 @@ void main() {
       expect(blockB.activeCollisions.length, 0);
     });
 
-    withCollidables.test('inactive does not collide with static', (game) async {
+    testCollidableGame('inactive does not collide with static', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -132,7 +132,7 @@ void main() {
       expect(blockB.activeCollisions.length, 0);
     });
 
-    withCollidables.test('active does not collide with inactive', (game) async {
+    testCollidableGame('active does not collide with inactive', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -148,7 +148,7 @@ void main() {
       expect(blockB.activeCollisions.length, 0);
     });
 
-    withCollidables.test('inactive does not collide with active', (game) async {
+    testCollidableGame('inactive does not collide with active', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -164,7 +164,7 @@ void main() {
       expect(blockB.activeCollisions.length, 0);
     });
 
-    withCollidables.test(
+    testCollidableGame(
       'correct collisions with many involved collidables',
       (game) async {
         final rng = Random(0);
@@ -193,7 +193,7 @@ void main() {
       },
     );
 
-    withCollidables.test('detects collision after scale', (game) async {
+    testCollidableGame('detects collision after scale', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -218,7 +218,7 @@ void main() {
       expect(blockB.activeCollisions.length, 1);
     });
 
-    withCollidables.test('detects collision after flip', (game) async {
+    testCollidableGame('detects collision after flip', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -243,7 +243,7 @@ void main() {
       expect(blockB.activeCollisions.length, 1);
     });
 
-    withCollidables.test('detects collision after scale', (game) async {
+    testCollidableGame('detects collision after scale', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -268,7 +268,7 @@ void main() {
       expect(blockB.activeCollisions.length, 1);
     });
 
-    withCollidables.test('testPoint detects point after flip', (game) async {
+    testCollidableGame('testPoint detects point after flip', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -281,7 +281,7 @@ void main() {
       expect(blockA.containsPoint(Vector2(-1, 1)), true);
     });
 
-    withCollidables.test('testPoint detects point after scale', (game) async {
+    testCollidableGame('testPoint detects point after scale', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),
@@ -294,7 +294,7 @@ void main() {
       expect(blockA.containsPoint(Vector2.all(11)), true);
     });
 
-    withCollidables.test('detects collision on child components', (game) async {
+    testCollidableGame('detects collision on child components', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),

--- a/packages/flame/test/collisions/collision_type_test.dart
+++ b/packages/flame/test/collisions/collision_type_test.dart
@@ -97,8 +97,7 @@ void main() {
       expect(blockB.activeCollisions.length, 1);
     });
 
-    testCollidableGame('passive does not collide with inactive',
-        (game) async {
+    testCollidableGame('passive does not collide with inactive', (game) async {
       final blockA = TestBlock(
         Vector2.zero(),
         Vector2.all(10),

--- a/packages/flame/test/components/mixins/has_paint_test.dart
+++ b/packages/flame/test/components/mixins/has_paint_test.dart
@@ -1,17 +1,8 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-class _MyComponent extends PositionComponent with HasPaint {}
-
-enum _MyComponentKeys {
-  background,
-  foreground,
-}
-
-class _MyComponentWithType extends PositionComponent
-    with HasPaint<_MyComponentKeys> {}
 
 void main() {
   group('HasPaint', () {
@@ -52,7 +43,7 @@ void main() {
 
         expect(
           () => comp.getPaint(_MyComponentKeys.background),
-          throwsAssertionError,
+          failsAssert('A generics type is missing on the HasPaint mixin'),
         );
       },
     );
@@ -80,7 +71,7 @@ void main() {
             _MyComponentKeys.background,
             Paint()..color = color,
           ),
-          throwsAssertionError,
+          failsAssert('A generics type is missing on the HasPaint mixin'),
         );
       },
     );
@@ -107,7 +98,7 @@ void main() {
 
         expect(
           () => comp.deletePaint(_MyComponentKeys.background),
-          throwsAssertionError,
+          failsAssert('A generics type is missing on the HasPaint mixin'),
         );
       },
     );
@@ -256,3 +247,13 @@ void main() {
     );
   });
 }
+
+class _MyComponent extends PositionComponent with HasPaint {}
+
+enum _MyComponentKeys {
+  background,
+  foreground,
+}
+
+class _MyComponentWithType extends PositionComponent
+    with HasPaint<_MyComponentKeys> {}

--- a/packages/flame/test/components/mixins/parent_is_a_test.dart
+++ b/packages/flame/test/components/mixins/parent_is_a_test.dart
@@ -14,7 +14,7 @@ void main() {
     });
 
     testWithFlameGame(
-      'throws assertion error when the wrong parent is used',
+      'throws assertion error if the wrong parent is used',
       (game) async {
         final parent = _DifferentComponent()..addToParent(game);
         await game.ready();

--- a/packages/flame/test/components/mixins/parent_is_a_test.dart
+++ b/packages/flame/test/components/mixins/parent_is_a_test.dart
@@ -5,8 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ParentIsA', () {
     testWithFlameGame('successfully sets the parent link', (game) async {
-      final parent = _ParentComponent() ..addToParent(game);
-      final component = _TestComponent() ..addToParent(parent);
+      final parent = _ParentComponent()..addToParent(game);
+      final component = _TestComponent()..addToParent(parent);
       await game.ready();
 
       expect(component.isMounted, true);
@@ -16,7 +16,7 @@ void main() {
     testWithFlameGame(
       'throws assertion error when the wrong parent is used',
       (game) async {
-        final parent = _DifferentComponent() ..addToParent(game);
+        final parent = _DifferentComponent()..addToParent(game);
         await game.ready();
 
         parent.add(_TestComponent());

--- a/packages/flame/test/components/mixins/parent_is_a_test.dart
+++ b/packages/flame/test/components/mixins/parent_is_a_test.dart
@@ -19,9 +19,11 @@ void main() {
         final parent = _DifferentComponent()..addToParent(game);
         await game.ready();
 
-        parent.add(_TestComponent());
         expect(
-          () => game.update(0),
+          () {
+            parent.add(_TestComponent());
+            game.update(0);
+          },
           failsAssert('Parent must be of type _ParentComponent'),
         );
       },

--- a/packages/flame/test/components/mixins/parent_is_a_test.dart
+++ b/packages/flame/test/components/mixins/parent_is_a_test.dart
@@ -2,34 +2,35 @@ import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class ParentComponent extends Component {}
-
-class DifferentComponent extends Component {}
-
-class TestComponent extends Component with ParentIsA<ParentComponent> {}
-
 void main() {
   group('ParentIsA', () {
     testWithFlameGame('successfully sets the parent link', (game) async {
-      final parent = ParentComponent();
-      final component = TestComponent();
+      final parent = _ParentComponent() ..addToParent(game);
+      final component = _TestComponent() ..addToParent(parent);
+      await game.ready();
 
-      await parent.add(component);
-      await game.add(parent);
-
-      expect(component.parent, isA<ParentComponent>());
+      expect(component.isMounted, true);
+      expect(component.parent, isA<_ParentComponent>());
     });
 
-    test('throws assertion error when the wrong parent is used', () {
-      final parent = DifferentComponent();
-      final component = TestComponent();
+    testWithFlameGame(
+      'throws assertion error when the wrong parent is used',
+      (game) async {
+        final parent = _DifferentComponent() ..addToParent(game);
+        await game.ready();
 
-      parent.add(component);
-
-      expect(
-        component.onMount,
-        failsAssert('Parent must be of type ParentComponent'),
-      );
-    });
+        parent.add(_TestComponent());
+        expect(
+          () => game.update(0),
+          failsAssert('Parent must be of type _ParentComponent'),
+        );
+      },
+    );
   });
 }
+
+class _ParentComponent extends Component {}
+
+class _DifferentComponent extends Component {}
+
+class _TestComponent extends Component with ParentIsA<_ParentComponent> {}


### PR DESCRIPTION
# Description

- Modernize various tests (helper classes made private, proper name of test groups, use testWithFlameGame where appropriate, test for assert failure messages);
- For some tests improved coverage;
- Fixed bug with `ParentIsA` mixin, where wrong parent triggered a TypeCast error instead of an assertion error. The corresponding test couldn't catch this because it tried to call `onMount` manually instead of actually mounting the component, and the error was thrown before the mounting stage.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

WIP for #1351


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
