### PR TITLE
feat!: remove `onTimingsCallback` for Flutter 3.0

### DIFF
--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -10,10 +10,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   Game game;
   GameLoop? gameLoop;
 
-  GameRenderBox(this.buildContext, this.game) {
-    //ignore: deprecated_member_use_from_same_package
-    WidgetsBinding.instance!.addTimingsCallback(game.onTimingsCallback);
-  }
+  GameRenderBox(this.buildContext, this.game);
 
   @override
   bool get isRepaintBoundary => true;

--- a/packages/flame/lib/src/game/mixins/fps_counter.dart
+++ b/packages/flame/lib/src/game/mixins/fps_counter.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/scheduler.dart';
+import 'dart:collection';
 
 import '../../../game.dart';
 
@@ -11,19 +11,28 @@ const frameInterval =
   'FPSCounter will be removed in v1.3.0',
 )
 mixin FPSCounter on Game {
-  List<FrameTiming> _previousTimings = [];
+  /// The sliding window size, i.e. the number of game ticks over which the fps
+  /// measure will be averaged.
+  final int windowSize = 60;
+
+  /// The queue of the recent game tick durations.
+  /// The length of this queue will not exceed [windowSize].
+  final Queue<double> window = Queue();
+
+  /// The sum of all values in the [window] queue.
+  double _sum = 0;
 
   @override
-  void onTimingsCallback(List<FrameTiming> timings) =>
-      _previousTimings = timings;
+  void update(double dt) {
+    window.addLast(dt);
+    _sum += dt;
+    if (window.length > windowSize) {
+      _sum -= window.removeFirst();
+    }
+  }
 
-  /// Returns the FPS based on the frame times from [onTimingsCallback].
+  /// Get the current average FPS over the last [windowSize] frames.
   double fps([int average = 1]) {
-    return _previousTimings.length *
-        _maxFrames /
-        _previousTimings.map((t) {
-          return (t.totalSpan.inMicroseconds ~/ frameInterval.inMicroseconds) +
-              1;
-        }).fold(0, (a, b) => a + b);
+    return window.isEmpty ? 0 : window.length / _sum;
   }
 }

--- a/packages/flame/lib/src/game/mixins/game.dart
+++ b/packages/flame/lib/src/game/mixins/game.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
@@ -95,10 +93,6 @@ mixin Game {
   /// The default implementation does nothing; override to use the hook.
   /// Check [AppLifecycleState] for details about the events received.
   void lifecycleStateChange(AppLifecycleState state) {}
-
-  /// Use for calculating the FPS.
-  @Deprecated('Use FPSComponent instead, will be removed in v1.3.0')
-  void onTimingsCallback(List<FrameTiming> timings) {}
 
   /// Method to perform late initialization of the [Game] class.
   ///


### PR DESCRIPTION
# Description

This technically speaking is a breaking change, but since we are already planning on deprecating the `FPSCounter` the team has internally decided to turn the `fps()` method into a copy of the functionality from #1595 so that we can remove the method `onTimingsCallback` already so Flutter 3.0 users wont have any warnings. This method is either not used or a really small portion of people are using it, compared to the `FPSCounter`. 

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] Yes, this is a breaking change, ~~but as we are doing this on purpose I have not added the suffix `!`~~.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
