### PR TITLE
chore: Fix flutter analyze warnings in main

### DIFF
--- a/packages/flame/lib/src/flame.dart
+++ b/packages/flame/lib/src/flame.dart
@@ -2,8 +2,8 @@ library flame;
 
 import 'package:flutter/services.dart';
 
-import 'cache/assets_cache.dart';
-import 'cache/images.dart';
+import 'cache/assets_cache.dart' show AssetsCache;
+import 'cache/images.dart' show Images;
 import 'device.dart';
 
 /// This class holds static references to some useful objects to use in your


### PR DESCRIPTION
# Description

The following warnings are currently produced for the main branch with Flutter 2.10.0:
```
Analyzing flame...                                                      

   info • Avoid method calls or property accesses on a "dynamic" target • packages/flame/lib/src/widgets/nine_tile_box.dart:90:31 • avoid_dynamic_calls
  error • The return type 'dynamic' isn't a 'Future<Image>', as required by the closure's context • packages/flame/lib/src/widgets/nine_tile_box.dart:90:31 •
         return_of_invalid_type_from_closure
  error • The argument type 'dynamic' can't be assigned to the parameter type 'Images?' • packages/flame/lib/src/widgets/sprite_button.dart:82:25 • argument_type_not_assignable
  error • The argument type 'dynamic' can't be assigned to the parameter type 'Images?' • packages/flame/lib/src/widgets/sprite_button.dart:88:25 • argument_type_not_assignable
  error • The argument type 'dynamic' can't be assigned to the parameter type 'Images?' • packages/flame/lib/src/widgets/sprite_widget.dart:61:23 • argument_type_not_assignable
  error • Missing variable type for 'svgString' • packages/flame_svg/lib/svg.dart:27:11 • implicit_dynamic_variable
   info • Avoid method calls or property accesses on a "dynamic" target • packages/flame_svg/lib/svg.dart:27:29 • avoid_dynamic_calls
  error • The argument type 'dynamic' can't be assigned to the parameter type 'String' • packages/flame_svg/lib/svg.dart:28:40 • argument_type_not_assignable
  error • The argument type 'dynamic' can't be assigned to the parameter type 'String' • packages/flame_svg/lib/svg.dart:28:51 • argument_type_not_assignable

9 issues found. (ran in 7.3s)
```
This PR fixes these warnings.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
