### PR TITLE
fix: `ParallaxComponent.update` mustCallSuper

### DIFF
--- a/packages/flame/lib/src/components/parallax_component.dart
+++ b/packages/flame/lib/src/components/parallax_component.dart
@@ -91,6 +91,7 @@ class ParallaxComponent<T extends FlameGame> extends PositionComponent
     parallax?.resize(newSize);
   }
 
+  @mustCallSuper
   @override
   void onMount() {
     assert(
@@ -99,6 +100,7 @@ class ParallaxComponent<T extends FlameGame> extends PositionComponent
     );
   }
 
+  @mustCallSuper
   @override
   void update(double dt) {
     parallax?.update(dt);


### PR DESCRIPTION
# Description

Since the parallax won't update otherwise (or even be rendered to its initial position).

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
