### PR TITLE
fix: Avoid leaks when using PictureRecorders

### DIFF
--- a/packages/flame/lib/extensions.dart
+++ b/packages/flame/lib/extensions.dart
@@ -4,6 +4,7 @@ export 'src/extensions/image.dart';
 export 'src/extensions/matrix4.dart';
 export 'src/extensions/offset.dart';
 export 'src/extensions/paint.dart';
+export 'src/extensions/picture_extension.dart';
 export 'src/extensions/rect.dart';
 export 'src/extensions/rectangle.dart';
 export 'src/extensions/size.dart';

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:flame/src/extensions/picture_extension.dart';
 import 'package:flame/src/palette.dart';
 import 'package:flame/src/text/text_renderer.dart';
 import 'package:flutter/widgets.dart' hide Image;
@@ -214,7 +215,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
     final c = Canvas(recorder, size.toRect());
     c.scale(pixelRatio);
     _fullRender(c);
-    return recorder.endRecording().toImage(
+    return recorder.endRecording().asImage(
           (width * pixelRatio).ceil(),
           (height * pixelRatio).ceil(),
         );

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -215,7 +215,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
     final c = Canvas(recorder, size.toRect());
     c.scale(pixelRatio);
     _fullRender(c);
-    return recorder.endRecording().asImage(
+    return recorder.endRecording().toImageSafe(
           (width * pixelRatio).ceil(),
           (height * pixelRatio).ceil(),
         );

--- a/packages/flame/lib/src/extensions/picture_extension.dart
+++ b/packages/flame/lib/src/extensions/picture_extension.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 extension PictureExtension on Picture {
   /// Converts [Picture] into an [Image] and disposes of the picture.
-  Future<Image> asImage(int width, int height) {
+  Future<Image> toImageSafe(int width, int height) {
     return toImage(width, height).then((image) {
       dispose();
       return image;

--- a/packages/flame/lib/src/extensions/picture_extension.dart
+++ b/packages/flame/lib/src/extensions/picture_extension.dart
@@ -1,0 +1,11 @@
+import 'dart:ui';
+
+extension PictureExtension on Picture {
+  /// Converts [Picture] into an [Image] and disposes of the picture.
+  Future<Image> asImage(int width, int height) {
+    return toImage(width, height).then((image) {
+      dispose();
+      return image;
+    });
+  }
+}

--- a/packages/flame/lib/src/image_composition.dart
+++ b/packages/flame/lib/src/image_composition.dart
@@ -122,7 +122,7 @@ class ImageComposition {
 
     return recorder
         .endRecording()
-        .asImage(output.width.toInt(), output.height.toInt());
+        .toImageSafe(output.width.toInt(), output.height.toInt());
   }
 }
 

--- a/packages/flame/lib/src/image_composition.dart
+++ b/packages/flame/lib/src/image_composition.dart
@@ -122,7 +122,7 @@ class ImageComposition {
 
     return recorder
         .endRecording()
-        .toImage(output.width.toInt(), output.height.toInt());
+        .asImage(output.width.toInt(), output.height.toInt());
   }
 }
 

--- a/packages/flame/lib/src/sprite_batch.dart
+++ b/packages/flame/lib/src/sprite_batch.dart
@@ -192,7 +192,7 @@ class SpriteBatch {
     canvas.drawImage(image, Offset(-image.width * 2, 0), _emptyPaint);
 
     final picture = recorder.endRecording();
-    final atlas = picture.asImage(image.width * 2, image.height);
+    final atlas = picture.toImageSafe(image.width * 2, image.height);
     return atlas;
   }
 

--- a/packages/flame/lib/src/sprite_batch.dart
+++ b/packages/flame/lib/src/sprite_batch.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:flame/game.dart';
 import 'package:flame/src/cache/images.dart';
 import 'package:flame/src/extensions/image.dart';
+import 'package:flame/src/extensions/picture_extension.dart';
 import 'package:flame/src/flame.dart';
 
 extension SpriteBatchExtension on Game {
@@ -191,7 +192,7 @@ class SpriteBatch {
     canvas.drawImage(image, Offset(-image.width * 2, 0), _emptyPaint);
 
     final picture = recorder.endRecording();
-    final atlas = picture.toImage(image.width * 2, image.height);
+    final atlas = picture.asImage(image.width * 2, image.height);
     return atlas;
   }
 

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -59,7 +59,7 @@ void main() {
       overlapMap.render(canvas);
       final picture = canvasRecorder.endRecording();
 
-      final image = await picture.toImage(32, 16);
+      final image = await picture.asImage(32, 16);
       final bytes = await image.toByteData();
       canvasPixelData = bytes!.buffer.asUint8List();
     });
@@ -144,7 +144,7 @@ void main() {
       overlapMap.render(canvas);
       final picture = canvasRecorder.endRecording();
 
-      final image = await picture.toImage(64, 48);
+      final image = await picture.asImage(64, 48);
       final bytes = await image.toByteData();
       canvasPixelData = bytes!.buffer.asUint8List();
     });

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -59,7 +59,7 @@ void main() {
       overlapMap.render(canvas);
       final picture = canvasRecorder.endRecording();
 
-      final image = await picture.asImage(32, 16);
+      final image = await picture.toImageSafe(32, 16);
       final bytes = await image.toByteData();
       canvasPixelData = bytes!.buffer.asUint8List();
     });
@@ -144,7 +144,7 @@ void main() {
       overlapMap.render(canvas);
       final picture = canvasRecorder.endRecording();
 
-      final image = await picture.asImage(64, 48);
+      final image = await picture.toImageSafe(64, 48);
       final bytes = await image.toByteData();
       canvasPixelData = bytes!.buffer.asUint8List();
     });


### PR DESCRIPTION
# Description

When using `PictureRecorder`, the `Picture` object that it creates needs to be properly disposed after it is no longer used.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
