### PR TITLE
feat!: Adding gameBuilder property to GameWidget

### DIFF
--- a/doc/flame/game.md
+++ b/doc/flame/game.md
@@ -1,3 +1,46 @@
+# GameWidget
+
+A `GameWidget` is the Flutter `Widget` that is used to insert a `Game` inside the flutter widget tree.
+
+It can directly receive a `Game` instance or it can receive a `GameBuilder` function that will be
+used to create the game once the `GameWidget` is inserted on the widget tree.
+
+Example:
+
+```dart
+class MyGamePage extends StatefulWidget {
+  @override
+  State createState() => _MyGamePageState();
+}
+
+class _MyGamePageState extends State<MyGamePage> {
+  late final MyGame _game;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _game = MyGame();
+  }
+
+  @override
+  void build(BuildContext context) {
+    return GameWidget(game: _game);
+  }
+}
+```
+
+or
+
+```dart
+class MyGamePage extends StatelessWidget {
+  @override
+  void build(BuildContext context) {
+    return GameWidget(gameBuilder: (context) => MyGame());
+  }
+}
+```
+
 # FlameGame
 
 `FlameGame` is the most basic and most commonly used `Game` class in Flame.
@@ -29,8 +72,8 @@ class MyCrate extends SpriteComponent {
   @override
   void onGameResize(Vector2 gameSize) {
     super.onGameResize(gameSize);
-    // We don't need to set the position in the constructor, we can set it 
-    // directly here since it will be called once before the first time it 
+    // We don't need to set the position in the constructor, we can set it
+    // directly here since it will be called once before the first time it
     // is rendered.
     position = gameSize / 2;
   }
@@ -108,7 +151,7 @@ just draw a background that covers the whole canvas if you would want it to chan
 ## SingleGameInstance mixin
 
 An optional mixin `SingleGameInstance` can be applied to your game if you are making a single-game
-application. This is a common scenario when building games: there is a single full-screen 
+application. This is a common scenario when building games: there is a single full-screen
 `GameWidget` which hosts a single `Game` instance.
 
 Adding this mixin provides performance advantages in certain scenarios. In particular, a component's
@@ -227,8 +270,8 @@ Widget build(BuildContext context) {
 }
 ```
 
-The order of rendering for an overlay is determined by the order of the keys in the 
-`overlayBuilderMap`. 
+The order of rendering for an overlay is determined by the order of the keys in the
+`overlayBuilderMap`.
 
-An example of feature can be found 
+An example of feature can be found
 [here](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/system/overlays_example.dart).

--- a/examples/lib/stories/games/games.dart
+++ b/examples/lib/stories/games/games.dart
@@ -12,7 +12,7 @@ void addGameStories(Dashbook dashbook) {
           margin: const EdgeInsets.all(45),
           child: ClipRect(
             child: GameWidget(
-              game: TRexGame(),
+              gameBuilder: (_) => TRexGame(),
               loadingBuilder: (_) => const Center(
                 child: Text('Loading'),
               ),

--- a/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
@@ -199,7 +199,7 @@ void main() {
       expect(events, ['onGameResize']); // no onRemove
       final game =
           tester.allWidgets.whereType<GameWidget<_MyGame>>().first.game;
-      expect(game.children, everyElement((Component c) => c.parent == game));
+      expect(game?.children, everyElement((Component c) => c.parent == game));
     });
 
     testWidgets('all events are executed in the correct order', (tester) async {

--- a/packages/flame/test/game/game_widget/game_widget_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_test.dart
@@ -109,4 +109,35 @@ void main() {
       expect(game.hasLayout, isTrue);
     },
   );
+
+  testWidgets(
+    'fails if neither game or game builder is informed',
+    (tester) async {
+      expect(
+        () async {
+          await tester.pumpWidget(GameWidget());
+        },
+        failsAssert('Neither game or gameBuilder were informed.'),
+      );
+    },
+  );
+
+  testWidgets(
+    'fails if both game or game builder is informed',
+    (tester) async {
+      expect(
+        () async {
+          await tester.pumpWidget(
+            GameWidget(
+              game: _MyGame(),
+              gameBuilder: (_) => _MyGame(),
+            ),
+          );
+        },
+        failsAssert(
+          'Both "game" and "gameBuilder" informed, only one can be used.',
+        ),
+      );
+    },
+  );
 }


### PR DESCRIPTION
# Description

Adds a `gameBuilder` property to `GameWidget` to allow users to create their game instances in a lazy way.

Quite useful too to inject context dependent dependencies into the game instance.

This is a breaking change because now the `game` field on `GameWidget` is optional since it can receive the instance or the builder. But I consider it minor as people shouldn't be accessing the game instance through the widget.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
