### PR TITLE
fix: Subscription for events when game changes in GameWidget

### DIFF
--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -198,8 +198,10 @@ class _GameWidgetState<T extends Game> extends State<GameWidget<T>> {
     if (oldWidget.game != widget.game) {
       // Reset the loaderFuture so that onMount will run again
       // (onLoad is still cached).
+      oldWidget.game.removeGameStateListener(_onGameStateChange);
       oldWidget.game.onRemove();
       _loaderFuture = null;
+      widget.game.addGameStateListener(_onGameStateChange);
     }
   }
 

--- a/packages/flame/lib/src/game/mixins/game.dart
+++ b/packages/flame/lib/src/game/mixins/game.dart
@@ -287,20 +287,22 @@ mixin Game {
     _refreshWidget();
   }
 
-  final List<VoidCallback> _gameStateListeners = [];
+  @visibleForTesting
+  final List<VoidCallback> gameStateListeners = [];
+
   void addGameStateListener(VoidCallback callback) {
-    _gameStateListeners.add(callback);
+    gameStateListeners.add(callback);
   }
 
   void removeGameStateListener(VoidCallback callback) {
-    _gameStateListeners.remove(callback);
+    gameStateListeners.remove(callback);
   }
 
   /// When a Game is attached to a `GameWidget`, this method will force that
   /// widget to be rebuilt. This can be used when updating any property which is
   /// implemented within the Flutter tree.
   void _refreshWidget() {
-    _gameStateListeners.forEach((callback) => callback());
+    gameStateListeners.forEach((callback) => callback());
   }
 }
 

--- a/packages/flame/test/game/game_widget/game_widget_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_test.dart
@@ -109,4 +109,22 @@ void main() {
       expect(game.hasLayout, isTrue);
     },
   );
+
+  testWidgets('Subscription is valid after game change', (tester) async {
+    const key = Key('flame-game');
+    final game1 = FlameGame();
+    await tester.pumpWidget(GameWidget(key: key, game: game1));
+    expect(game1.isMounted, true);
+    expect(game1.gameStateListeners.length, 1);
+
+    final game2 = FlameGame();
+    await tester.pumpWidget(GameWidget(key: key, game: game2));
+    final widget = tester.firstWidget<GameWidget>(
+      find.byWidgetPredicate((widget) => widget is GameWidget),
+    );
+    expect(widget.game, game2);
+    expect(game2.isMounted, true);
+    expect(game2.gameStateListeners.length, 1);
+    expect(game1.gameStateListeners.length, 0);
+  });
 }


### PR DESCRIPTION
# Description

Make sure that subscription to `GameStateChange` events is properly updated when the `game:` property of a `GameWidget` changes.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Closes #1658


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
