### PR TITLE
feat: Allow changing parent from null parent

### DIFF
--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -603,7 +603,11 @@ class Component {
   /// Changes the current parent for another parent and prepares the tree under
   /// the new root.
   void changeParent(Component newParent) {
-    newParent.lifecycle._adoption.add(this);
+    if (_parent == null) {
+      addToParent(newParent);
+    } else {
+      newParent.lifecycle._adoption.add(this);
+    }
   }
 
   //#endregion

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -233,8 +233,10 @@ class Component {
   set parent(Component? newParent) {
     if (newParent == null) {
       removeFromParent();
+    } else if (_parent == null) {
+      addToParent(newParent);
     } else {
-      changeParent(newParent);
+      newParent.lifecycle._adoption.add(this);
     }
   }
 
@@ -603,11 +605,7 @@ class Component {
   /// Changes the current parent for another parent and prepares the tree under
   /// the new root.
   void changeParent(Component newParent) {
-    if (_parent == null) {
-      addToParent(newParent);
-    } else {
-      newParent.lifecycle._adoption.add(this);
-    }
+    parent = newParent;
   }
 
   //#endregion

--- a/packages/flame/test/components/component_lifecycle_test.dart
+++ b/packages/flame/test/components/component_lifecycle_test.dart
@@ -106,7 +106,7 @@ void main() {
       },
     );
 
-    flameGame.test(
+    testWithFlameGame(
       'component mounted completes when changing parent from a null parent',
       (game) async {
         final parent = LifecycleComponent('parent');

--- a/packages/flame/test/components/component_lifecycle_test.dart
+++ b/packages/flame/test/components/component_lifecycle_test.dart
@@ -113,11 +113,10 @@ void main() {
         final child = LifecycleComponent('child');
         game.add(parent);
 
-        var mounted = child.mounted;
+        final mounted = child.mounted;
         await game.ready();
 
         child.changeParent(parent);
-        mounted = child.mounted;
         game.update(0);
         await game.ready();
 

--- a/packages/flame/test/components/component_lifecycle_test.dart
+++ b/packages/flame/test/components/component_lifecycle_test.dart
@@ -106,6 +106,25 @@ void main() {
       },
     );
 
+    flameGame.test(
+      'component mounted completes when changing parent from a null parent',
+      (game) async {
+        final parent = LifecycleComponent('parent');
+        final child = LifecycleComponent('child');
+        game.add(parent);
+
+        var mounted = child.mounted;
+        await game.ready();
+
+        child.changeParent(parent);
+        mounted = child.mounted;
+        game.update(0);
+        await game.ready();
+
+        await expectLater(mounted, completes);
+      },
+    );
+
     testWithFlameGame(
       'Component.mounted completes after the component is mounted',
       (game) async {

--- a/packages/flame/test/components/component_lifecycle_test.dart
+++ b/packages/flame/test/components/component_lifecycle_test.dart
@@ -121,6 +121,8 @@ void main() {
         game.update(0);
         await game.ready();
 
+        expect(child.parent, parent);
+        expect(child.isMounted, true);
         await expectLater(mounted, completes);
       },
     );


### PR DESCRIPTION
# Description

`changeParent` should be allowed even when the current parent is null.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
