### PR TITLE
refactor: Added MultiDragListener - common API between HasDraggables and MultiTouchDragDetector

### DIFF
--- a/packages/flame/lib/events.dart
+++ b/packages/flame/lib/events.dart
@@ -1,0 +1,41 @@
+export 'src/events/game_mixins/multi_touch_drag_detector.dart'
+    show MultiTouchDragDetector;
+export 'src/events/interfaces/multi_drag_listener.dart' show MultiDragListener;
+export 'src/events/interfaces/multi_tap_listener.dart' show MultiTapListener;
+export 'src/game/mixins/has_draggables.dart' show HasDraggables;
+export 'src/game/mixins/has_hoverables.dart' show HasHoverables;
+export 'src/game/mixins/has_tappables.dart' show HasTappables;
+export 'src/game/mixins/keyboard.dart'
+    show HasKeyboardHandlerComponents, KeyboardEvents;
+export 'src/game/mixins/multi_touch_tap_detector.dart'
+    show MultiTouchTapDetector;
+export 'src/gestures/detectors.dart'
+    show
+        DoubleTapDetector,
+        ForcePressDetector,
+        HorizontalDragDetector,
+        LongPressDetector,
+        MouseMovementDetector,
+        PanDetector,
+        ScaleDetector,
+        ScrollDetector,
+        SecondaryTapDetector,
+        TapDetector,
+        VerticalDragDetector;
+export 'src/gestures/events.dart'
+    show
+        DragDownInfo,
+        DragEndInfo,
+        DragStartInfo,
+        DragUpdateInfo,
+        ForcePressInfo,
+        LongPressEndInfo,
+        LongPressMoveUpdateInfo,
+        LongPressStartInfo,
+        PointerHoverInfo,
+        PointerScrollInfo,
+        ScaleEndInfo,
+        ScaleStartInfo,
+        ScaleUpdateInfo,
+        TapDownInfo,
+        TapUpInfo;

--- a/packages/flame/lib/input.dart
+++ b/packages/flame/lib/input.dart
@@ -5,6 +5,7 @@ export 'src/components/input/hud_button_component.dart';
 export 'src/components/input/hud_margin_component.dart';
 export 'src/components/input/joystick_component.dart';
 export 'src/components/input/sprite_button_component.dart';
+export 'src/events/game_mixins/multi_touch_drag_detector.dart';
 export 'src/extensions/vector2.dart';
 export 'src/game/mixins/keyboard.dart';
 export 'src/game/mixins/multi_touch_tap_detector.dart';

--- a/packages/flame/lib/src/events/flame_drag_adapter.dart
+++ b/packages/flame/lib/src/events/flame_drag_adapter.dart
@@ -3,40 +3,34 @@ import 'package:flame/src/game/mixins/game.dart';
 import 'package:flutter/gestures.dart';
 import 'package:meta/meta.dart';
 
+/// Helper class to convert drag API as expected by the
+/// [ImmediateMultiDragGestureRecognizer] into the API expected by Flame's
+/// [MultiDragListener].
 @internal
 class FlameDragAdapter implements Drag {
-  FlameDragAdapter(this._game, Offset startPoint)
-      : _pointerId = _globallyUniqueIdCounter++,
-        assert(_game is Game) {
+  FlameDragAdapter(this._game, Offset startPoint) {
+    _id = _globalIdCounter++;
     start(startPoint);
   }
 
   final MultiDragListener _game;
-  final int _pointerId;
-  static int _globallyUniqueIdCounter = 0;
+  late final int _id;
+  static int _globalIdCounter = 0;
 
   void start(Offset point) {
-    _game.handleDragStart(
-      _pointerId,
-      DragStartDetails(
-        globalPosition: point,
-        localPosition: (_game as Game).renderBox.globalToLocal(point),
-      ),
+    final event = DragStartDetails(
+      globalPosition: point,
+      localPosition: (_game as Game).renderBox.globalToLocal(point),
     );
+    _game.handleDragStart(_id, event);
   }
 
   @override
-  void cancel() {
-    _game.handleDragCancel(_pointerId);
-  }
+  void update(DragUpdateDetails event) => _game.handleDragUpdate(_id, event);
 
   @override
-  void end(DragEndDetails details) {
-    _game.handleDragEnd(_pointerId, details);
-  }
+  void end(DragEndDetails event) => _game.handleDragEnd(_id, event);
 
   @override
-  void update(DragUpdateDetails details) {
-    _game.handleDragUpdate(_pointerId, details);
-  }
+  void cancel() => _game.handleDragCancel(_id);
 }

--- a/packages/flame/lib/src/events/flame_drag_adapter.dart
+++ b/packages/flame/lib/src/events/flame_drag_adapter.dart
@@ -9,7 +9,6 @@ import 'package:meta/meta.dart';
 @internal
 class FlameDragAdapter implements Drag {
   FlameDragAdapter(this._game, Offset startPoint) {
-    _id = _globalIdCounter++;
     start(startPoint);
   }
 
@@ -22,6 +21,7 @@ class FlameDragAdapter implements Drag {
       globalPosition: point,
       localPosition: (_game as Game).renderBox.globalToLocal(point),
     );
+    _id = _globalIdCounter++;
     _game.handleDragStart(_id, event);
   }
 

--- a/packages/flame/lib/src/events/flame_drag_adapter.dart
+++ b/packages/flame/lib/src/events/flame_drag_adapter.dart
@@ -1,0 +1,42 @@
+import 'package:flame/src/events/interfaces/multi_drag_listener.dart';
+import 'package:flame/src/game/mixins/game.dart';
+import 'package:flutter/gestures.dart';
+import 'package:meta/meta.dart';
+
+@internal
+class FlameDragAdapter implements Drag {
+  FlameDragAdapter(this._game, Offset startPoint)
+      : _pointerId = _globallyUniqueIdCounter++,
+        assert(_game is Game) {
+    start(startPoint);
+  }
+
+  final MultiDragListener _game;
+  final int _pointerId;
+  static int _globallyUniqueIdCounter = 0;
+
+  void start(Offset point) {
+    _game.handleDragStart(
+      _pointerId,
+      DragStartDetails(
+        globalPosition: point,
+        localPosition: (_game as Game).renderBox.globalToLocal(point),
+      ),
+    );
+  }
+
+  @override
+  void cancel() {
+    _game.handleDragCancel(_pointerId);
+  }
+
+  @override
+  void end(DragEndDetails details) {
+    _game.handleDragEnd(_pointerId, details);
+  }
+
+  @override
+  void update(DragUpdateDetails details) {
+    _game.handleDragUpdate(_pointerId, details);
+  }
+}

--- a/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
+++ b/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
@@ -10,7 +10,7 @@ mixin MultiTouchDragDetector on Game implements MultiDragListener {
   void onDragEnd(int pointerId, DragEndInfo info) {}
   void onDragCancel(int pointerId) {}
 
-  //#region MultiTapListener API
+  //#region MultiDragListener API
   @override
   void handleDragStart(int pointerId, DragStartDetails details) {
     onDragStart(pointerId, DragStartInfo.fromDetails(this, details));

--- a/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
+++ b/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
@@ -1,4 +1,3 @@
-
 import 'package:flame/src/events/interfaces/multi_drag_listener.dart';
 import 'package:flame/src/game/mixins/game.dart';
 import 'package:flame/src/gestures/events.dart';

--- a/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
+++ b/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
@@ -1,0 +1,34 @@
+
+import 'package:flame/src/events/interfaces/multi_drag_listener.dart';
+import 'package:flame/src/game/mixins/game.dart';
+import 'package:flame/src/gestures/events.dart';
+import 'package:flutter/gestures.dart';
+
+mixin MultiTouchDragDetector on Game implements MultiDragListener {
+  void onDragStart(int pointerId, DragStartInfo info) {}
+  void onDragUpdate(int pointerId, DragUpdateInfo info) {}
+  void onDragEnd(int pointerId, DragEndInfo info) {}
+  void onDragCancel(int pointerId) {}
+
+  //#region MultiTapListener API
+  @override
+  void handleDragStart(int pointerId, DragStartDetails details) {
+    onDragStart(pointerId, DragStartInfo.fromDetails(this, details));
+  }
+
+  @override
+  void handleDragUpdate(int pointerId, DragUpdateDetails details) {
+    onDragUpdate(pointerId, DragUpdateInfo.fromDetails(this, details));
+  }
+
+  @override
+  void handleDragEnd(int pointerId, DragEndDetails details) {
+    onDragEnd(pointerId, DragEndInfo.fromDetails(this, details));
+  }
+
+  @override
+  void handleDragCancel(int pointerId) {
+    onDragCancel(pointerId);
+  }
+  //#endregion
+}

--- a/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
+++ b/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
@@ -1,8 +1,22 @@
 import 'package:flame/src/events/interfaces/multi_drag_listener.dart';
 import 'package:flame/src/game/mixins/game.dart';
+import 'package:flame/src/game/mixins/has_draggables.dart';
 import 'package:flame/src/gestures/events.dart';
 import 'package:flutter/gestures.dart';
 
+/// Mixin that can be added to a [Game] allowing it to receive drag events.
+///
+/// The user can override one of the callback methods
+///  - [onDragStart]
+///  - [onDragUpdate]
+///  - [onDragEnd]
+///  - [onDragCancel]
+/// in order to respond to each corresponding event. Those events whose methods
+/// are not overridden are ignored.
+///
+/// See [MultiDragGestureRecognizer] for the description of each individual
+/// event. If your game is derived from the FlameGame class, consider using the
+/// [HasDraggables] mixin instead.
 mixin MultiTouchDragDetector on Game implements MultiDragListener {
   void onDragStart(int pointerId, DragStartInfo info) {}
   void onDragUpdate(int pointerId, DragUpdateInfo info) {}

--- a/packages/flame/lib/src/events/interfaces/multi_drag_listener.dart
+++ b/packages/flame/lib/src/events/interfaces/multi_drag_listener.dart
@@ -1,0 +1,17 @@
+import 'package:flame/src/events/game_mixins/multi_touch_drag_detector.dart';
+import 'package:flame/src/game/mixins/has_draggables.dart';
+import 'package:flutter/gestures.dart';
+
+/// Interface that must be implemented by a game in order for it to be eligible
+/// to receive events from an [ImmediateMultiDragGestureRecognizer].
+///
+/// Instead of implementing this class directly consider using one of the
+/// prebuilt mixins:
+///  - [HasDraggables] for a `FlameGame`
+///  - [MultiTouchDragDetector] for a custom `Game`
+abstract class MultiDragListener {
+  void handleDragStart(int pointerId, DragStartDetails details);
+  void handleDragUpdate(int pointerId, DragUpdateDetails details);
+  void handleDragEnd(int pointerId, DragEndDetails details);
+  void handleDragCancel(int pointerId);
+}

--- a/packages/flame/lib/src/game/game_widget/gestures.dart
+++ b/packages/flame/lib/src/game/game_widget/gestures.dart
@@ -216,7 +216,6 @@ Widget applyAdvancedGesturesDetectors(Game game, Widget child) {
       },
     );
   }
-
   return RawGestureDetector(
     gestures: gestures,
     behavior: HitTestBehavior.opaque,

--- a/packages/flame/lib/src/game/game_widget/gestures.dart
+++ b/packages/flame/lib/src/game/game_widget/gestures.dart
@@ -1,4 +1,5 @@
-import 'package:flame/extensions.dart';
+import 'package:flame/src/events/flame_drag_adapter.dart';
+import 'package:flame/src/events/interfaces/multi_drag_listener.dart';
 import 'package:flame/src/events/interfaces/multi_tap_listener.dart';
 import 'package:flame/src/game/mixins/game.dart';
 import 'package:flame/src/game/mixins/has_draggables.dart';
@@ -206,51 +207,14 @@ Widget applyAdvancedGesturesDetectors(Game game, Widget child) {
       },
     );
   }
-
-  void addDragRecognizer(Drag Function(int, DragStartInfo) config) {
+  if (game is MultiDragListener) {
     addRecognizer(
       ImmediateMultiDragGestureRecognizer.new,
       (ImmediateMultiDragGestureRecognizer instance) {
-        var lastGeneratedDragId = 0;
-        instance.onStart = (Offset o) {
-          final pointerId = lastGeneratedDragId++;
-
-          final global = o;
-          final local = game
-              .convertGlobalToLocalCoordinate(
-                global.toVector2(),
-              )
-              .toOffset();
-
-          final details = DragStartDetails(
-            localPosition: local,
-            globalPosition: global,
-          );
-          return config(
-            pointerId,
-            DragStartInfo.fromDetails(game, details),
-          );
-        };
+        final g = game as MultiDragListener;
+        instance.onStart = (Offset point) => FlameDragAdapter(g, point);
       },
     );
-  }
-
-  if (game is MultiTouchDragDetector) {
-    addDragRecognizer((int pointerId, DragStartInfo info) {
-      game.onDragStart(pointerId, info);
-      return _DragEvent(game)
-        ..onUpdate = ((details) => game.onDragUpdate(pointerId, details))
-        ..onEnd = ((details) => game.onDragEnd(pointerId, details))
-        ..onCancel = (() => game.onDragCancel(pointerId));
-    });
-  } else if (game is HasDraggables) {
-    addDragRecognizer((int pointerId, DragStartInfo position) {
-      game.onDragStart(pointerId, position);
-      return _DragEvent(game)
-        ..onUpdate = ((details) => game.onDragUpdate(pointerId, details))
-        ..onEnd = ((details) => game.onDragEnd(pointerId, details))
-        ..onCancel = (() => game.onDragCancel(pointerId));
-    });
   }
 
   return RawGestureDetector(
@@ -274,30 +238,4 @@ Widget applyMouseDetectors(Game game, Widget child) {
             ? game.onScroll(PointerScrollInfo.fromDetails(game, event))
             : null,
   );
-}
-
-class _DragEvent extends Drag {
-  final Game gameRef;
-  void Function(DragUpdateInfo)? onUpdate;
-  VoidCallback? onCancel;
-  void Function(DragEndInfo)? onEnd;
-
-  _DragEvent(this.gameRef);
-
-  @override
-  void update(DragUpdateDetails details) {
-    final event = DragUpdateInfo.fromDetails(gameRef, details);
-    onUpdate?.call(event);
-  }
-
-  @override
-  void cancel() {
-    onCancel?.call();
-  }
-
-  @override
-  void end(DragEndDetails details) {
-    final event = DragEndInfo.fromDetails(gameRef, details);
-    onEnd?.call(event);
-  }
 }

--- a/packages/flame/lib/src/game/game_widget/gestures.dart
+++ b/packages/flame/lib/src/game/game_widget/gestures.dart
@@ -1,11 +1,6 @@
+import 'package:flame/events.dart';
 import 'package:flame/src/events/flame_drag_adapter.dart';
-import 'package:flame/src/events/interfaces/multi_drag_listener.dart';
-import 'package:flame/src/events/interfaces/multi_tap_listener.dart';
 import 'package:flame/src/game/mixins/game.dart';
-import 'package:flame/src/game/mixins/has_draggables.dart';
-import 'package:flame/src/game/mixins/has_hoverables.dart';
-import 'package:flame/src/gestures/detectors.dart';
-import 'package:flame/src/gestures/events.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flame/lib/src/game/mixins/game.dart
+++ b/packages/flame/lib/src/game/mixins/game.dart
@@ -26,6 +26,7 @@ mixin Game {
 
   /// Just a reference back to the render box that is kept up to date by the
   /// engine.
+  GameRenderBox get renderBox => _gameRenderBox!;
   GameRenderBox? _gameRenderBox;
 
   /// Currently attached build context. Can be null if not attached.

--- a/packages/flame/lib/src/game/mixins/has_draggables.dart
+++ b/packages/flame/lib/src/game/mixins/has_draggables.dart
@@ -1,9 +1,11 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
+import 'package:flame/src/events/interfaces/multi_drag_listener.dart';
 import 'package:flame/src/gestures/events.dart';
+import 'package:flutter/gestures.dart';
 import 'package:meta/meta.dart';
 
-mixin HasDraggables on FlameGame {
+mixin HasDraggables on FlameGame implements MultiDragListener {
   @mustCallSuper
   void onDragStart(int pointerId, DragStartInfo info) {
     propagateToChildren<Draggable>(
@@ -31,4 +33,26 @@ mixin HasDraggables on FlameGame {
       (c) => c.handleDragCanceled(pointerId),
     );
   }
+
+  //#region MultiDragListener API
+  @override
+  void handleDragStart(int pointerId, DragStartDetails details) {
+    onDragStart(pointerId, DragStartInfo.fromDetails(this, details));
+  }
+
+  @override
+  void handleDragUpdate(int pointerId, DragUpdateDetails details) {
+    onDragUpdate(pointerId, DragUpdateInfo.fromDetails(this, details));
+  }
+
+  @override
+  void handleDragEnd(int pointerId, DragEndDetails details) {
+    onDragEnd(pointerId, DragEndInfo.fromDetails(this, details));
+  }
+
+  @override
+  void handleDragCancel(int pointerId) {
+    onDragCancel(pointerId);
+  }
+  //#endregion
 }

--- a/packages/flame/lib/src/gestures/detectors.dart
+++ b/packages/flame/lib/src/gestures/detectors.dart
@@ -1,13 +1,6 @@
 import 'package:flame/src/game/mixins/game.dart';
 import 'package:flame/src/gestures/events.dart';
 
-mixin MultiTouchDragDetector on Game {
-  void onDragStart(int pointerId, DragStartInfo info) {}
-  void onDragUpdate(int pointerId, DragUpdateInfo info) {}
-  void onDragEnd(int pointerId, DragEndInfo info) {}
-  void onDragCancel(int pointerId) {}
-}
-
 // Basic touch detectors
 mixin TapDetector on Game {
   void onTap() {}


### PR DESCRIPTION
# Description

Created `MultiDragListener` abstract class, which allows us to simplify code in `gestures.dart`.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.


## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
