### PR TITLE
feat: Added IterableExtension

### DIFF
--- a/packages/flame/lib/extensions.dart
+++ b/packages/flame/lib/extensions.dart
@@ -1,6 +1,7 @@
 export 'src/extensions/canvas.dart';
 export 'src/extensions/color.dart';
 export 'src/extensions/image.dart';
+export 'src/extensions/iterable.dart';
 export 'src/extensions/matrix4.dart';
 export 'src/extensions/offset.dart';
 export 'src/extensions/paint.dart';

--- a/packages/flame/lib/src/components/component.dart
+++ b/packages/flame/lib/src/components/component.dart
@@ -5,6 +5,7 @@ import 'package:flame/src/cache/value_cache.dart';
 import 'package:flame/src/components/component_set.dart';
 import 'package:flame/src/components/mixins/coordinate_transform.dart';
 import 'package:flame/src/components/position_type.dart';
+import 'package:flame/src/extensions/iterable.dart';
 import 'package:flame/src/game/flame_game.dart';
 import 'package:flame/src/game/mixins/game.dart';
 import 'package:flame/src/gestures/events.dart';
@@ -269,10 +270,7 @@ class Component {
   ///
   /// As opposed to `children.whereType<T>().first`, this method returns null
   /// instead of a [StateError] when no matching children are found.
-  T? firstChild<T extends Component>() {
-    final it = children.whereType<T>().iterator;
-    return it.moveNext() ? it.current : null;
-  }
+  T? firstChild<T extends Component>() => children.whereType<T>().maybeFirst;
 
   /// Returns the last child that matches the given type [T].
   T? lastChild<T extends Component>() {

--- a/packages/flame/lib/src/extensions/iterable.dart
+++ b/packages/flame/lib/src/extensions/iterable.dart
@@ -1,0 +1,57 @@
+extension IterableExtension<E> on Iterable<E> {
+  /// Similar to [map], but also supplies index of each element.
+  Iterable<T> indexedMap<T>(T Function(int index, E e) mapFunction) =>
+      _MappedIterable<E, T>(this, mapFunction);
+}
+
+typedef _IndexedMapFn<E, T> = T Function(int index, E element);
+
+class _MappedIterable<E, T> extends Iterable<T> {
+  _MappedIterable(this._iterable, this._transform);
+
+  final Iterable<E> _iterable;
+  final _IndexedMapFn<E, T> _transform;
+
+  @override
+  Iterator<T> get iterator =>
+      _IndexedMappedIterator<E, T>(_iterable.iterator, _transform);
+
+  // Length related functions are independent of the mapping.
+  @override
+  int get length => _iterable.length;
+  @override
+  bool get isEmpty => _iterable.isEmpty;
+
+  // Index based lookup can be done before transforming.
+  @override
+  T get first => _transform(0, _iterable.first);
+  @override
+  T get last => _transform(length - 1, _iterable.last);
+  @override
+  T get single => _transform(0, _iterable.single);
+  @override
+  T elementAt(int index) => _transform(index, _iterable.elementAt(index));
+}
+
+class _IndexedMappedIterator<E, T> extends Iterator<T> {
+  _IndexedMappedIterator(this._iterator, this._transform);
+
+  int _index = 0;
+  T? _current;
+  final Iterator<E> _iterator;
+  final _IndexedMapFn<E, T> _transform;
+
+  @override
+  bool moveNext() {
+    if (_iterator.moveNext()) {
+      _current = _transform(_index, _iterator.current);
+      _index++;
+      return true;
+    }
+    _current = null;
+    return false;
+  }
+
+  @override
+  T get current => _current as T;
+}

--- a/packages/flame/lib/src/extensions/iterable.dart
+++ b/packages/flame/lib/src/extensions/iterable.dart
@@ -8,6 +8,16 @@ extension IterableExtension<E> on Iterable<E> {
   /// Similar to [map], but also supplies index of each element.
   Iterable<T> indexedMap<T>(T Function(int index, E e) mapFunction) =>
       _MappedIterable<E, T>(this, mapFunction);
+
+  /// Similar to [forEach], but also supplies index of each element.
+  void indexedForEach(void Function(int index, E element) action) {
+    final it = iterator;
+    var i = 0;
+    while (it.moveNext()) {
+      action(i, it.current);
+      i++;
+    }
+  }
 }
 
 typedef _IndexedMapFn<E, T> = T Function(int index, E element);

--- a/packages/flame/lib/src/extensions/iterable.dart
+++ b/packages/flame/lib/src/extensions/iterable.dart
@@ -1,4 +1,10 @@
 extension IterableExtension<E> on Iterable<E> {
+  /// Returns the first element, or null if the iterable is empty.
+  E? get maybeFirst {
+    final it = iterator;
+    return it.moveNext() ? it.current : null;
+  }
+
   /// Similar to [map], but also supplies index of each element.
   Iterable<T> indexedMap<T>(T Function(int index, E e) mapFunction) =>
       _MappedIterable<E, T>(this, mapFunction);

--- a/packages/flame/test/extensions/iterable_extension_test.dart
+++ b/packages/flame/test/extensions/iterable_extension_test.dart
@@ -36,5 +36,10 @@ void main() {
       final out = src.indexedMap((index, e) => '$e:$index');
       expect(out.single, 'Flame:0');
     });
+
+    test('maybeFirst', () {
+      expect([3, 5, 11, -2].maybeFirst, 3);
+      expect(<int>[].maybeFirst, null);
+    });
   });
 }

--- a/packages/flame/test/extensions/iterable_extension_test.dart
+++ b/packages/flame/test/extensions/iterable_extension_test.dart
@@ -20,5 +20,15 @@ void main() {
       final out = src.indexedMap((i, e) => e.toDouble() / (i + 1));
       expect(out, [0, 1 / 2, 2 / 3, 3 / 4, 4 / 5, 5 / 6]);
     });
+
+    test('indexedMap properties', () {
+      final src = [3, 7, 12, -11];
+      final out = src.indexedMap((i, e) => i + e);
+      expect(out.isEmpty, false);
+      expect(out.length, 4);
+      expect(out.first, src.first + 0);
+      expect(out.last, src.last + 3);
+      expect(out.elementAt(1), src[1] + 1);
+    });
   });
 }

--- a/packages/flame/test/extensions/iterable_extension_test.dart
+++ b/packages/flame/test/extensions/iterable_extension_test.dart
@@ -1,0 +1,25 @@
+
+import 'package:flame/extensions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('IterableExtension', () {
+    test('indexedMap<int, int>', () {
+      final src = [3, 7, 12, -1];
+      final out = src.indexedMap((i, e) => i + e).toList();
+      expect(out, [3 + 0, 7 + 1, 12 + 2, -1 + 3]);
+    });
+
+    test('indexedMap<str, str>', () {
+      final src = ['a', 'b', 'c', 'd', 'e', 'f'];
+      final out = src.indexedMap((i, e) => e * i).toList();
+      expect(out, ['', 'b', 'cc', 'ddd', 'eeee', 'fffff']);
+    });
+
+    test('indexedMap<int, double>', () {
+      final src = <int>[0, 1, 2, 3, 4, 5];
+      final out = src.indexedMap((i, e) => e.toDouble()/(i + 1));
+      expect(out, [0, 1/2, 2/3, 3/4, 4/5, 5/6]);
+    });
+  });
+}

--- a/packages/flame/test/extensions/iterable_extension_test.dart
+++ b/packages/flame/test/extensions/iterable_extension_test.dart
@@ -30,5 +30,11 @@ void main() {
       expect(out.last, src.last + 3);
       expect(out.elementAt(1), src[1] + 1);
     });
+
+    test('indexedMap.single', () {
+      final src = ['Flame'];
+      final out = src.indexedMap((index, e) => '$e:$index');
+      expect(out.single, 'Flame:0');
+    });
   });
 }

--- a/packages/flame/test/extensions/iterable_extension_test.dart
+++ b/packages/flame/test/extensions/iterable_extension_test.dart
@@ -41,5 +41,14 @@ void main() {
       expect([3, 5, 11, -2].maybeFirst, 3);
       expect(<int>[].maybeFirst, null);
     });
+
+    test('indexedForEach', () {
+      final src = [3, 7, 12, -11];
+      final out = [0, 0, 0, 0];
+      src.indexedForEach((i, element) {
+        out[i] = element;
+      });
+      expect(out, src);
+    });
   });
 }

--- a/packages/flame/test/extensions/iterable_extension_test.dart
+++ b/packages/flame/test/extensions/iterable_extension_test.dart
@@ -1,4 +1,3 @@
-
 import 'package:flame/extensions.dart';
 import 'package:test/test.dart';
 
@@ -18,8 +17,8 @@ void main() {
 
     test('indexedMap<int, double>', () {
       final src = <int>[0, 1, 2, 3, 4, 5];
-      final out = src.indexedMap((i, e) => e.toDouble()/(i + 1));
-      expect(out, [0, 1/2, 2/3, 3/4, 4/5, 5/6]);
+      final out = src.indexedMap((i, e) => e.toDouble() / (i + 1));
+      expect(out, [0, 1 / 2, 2 / 3, 3 / 4, 4 / 5, 5 / 6]);
     });
   });
 }


### PR DESCRIPTION
# Description

New methods
- `Iterable<T>.indexedMap((i, e) => ...)` allows computing a map over an iterable but also having access to the indexes of the elements;
- `Iterable<T>.indexedForEach((i, e) => ...)` allows iterating over an iterable while also having access to the indexes of elements;
- `Iterable<T>.maybeFirst` which returns either the first element or null if the iterable is empty.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.


## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
