### PR TITLE
refactor: Replace some usages of fold<> with .sum

### DIFF
--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 import 'dart:ui' hide Offset;
 
+import 'package:collection/collection.dart';
 import 'package:flame/src/anchor.dart';
 import 'package:flame/src/components/component.dart';
 import 'package:flame/src/components/mixins/coordinate_transform.dart';
@@ -197,7 +198,8 @@ class PositionComponent extends Component
     // TODO(spydon): take scale into consideration
     return ancestors()
         .whereType<PositionComponent>()
-        .fold<double>(angle, (totalAngle, c) => totalAngle + c.angle);
+        .map((c) => c.angle)
+        .sum + angle;
   }
 
   /// The resulting scale after all the ancestors and the components own scale

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -196,8 +196,10 @@ class PositionComponent extends Component
   /// has been applied.
   double get absoluteAngle {
     // TODO(spydon): take scale into consideration
-    return ancestors().whereType<PositionComponent>().map((c) => c.angle).sum +
-        angle;
+    return ancestors(includeSelf: true)
+        .whereType<PositionComponent>()
+        .map((c) => c.angle)
+        .sum;
   }
 
   /// The resulting scale after all the ancestors and the components own scale

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -196,10 +196,8 @@ class PositionComponent extends Component
   /// has been applied.
   double get absoluteAngle {
     // TODO(spydon): take scale into consideration
-    return ancestors()
-        .whereType<PositionComponent>()
-        .map((c) => c.angle)
-        .sum + angle;
+    return ancestors().whereType<PositionComponent>().map((c) => c.angle).sum +
+        angle;
   }
 
   /// The resulting scale after all the ancestors and the components own scale

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui';
 
+import 'package:collection/collection.dart';
 import 'package:flame/components.dart';
 import 'package:flame/src/extensions/picture_extension.dart';
 import 'package:flame/src/palette.dart';
@@ -149,7 +150,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
   bool get finished => _lifeTime > totalCharTime + _boxConfig.dismissDelay;
 
   int get _actualTextLength {
-    return _lines.map((e) => e.length).fold(0, (p, c) => p + c);
+    return _lines.map((e) => e.length).sum;
   }
 
   int get currentChar => _boxConfig.timePerChar == 0.0

--- a/packages/flame/lib/src/experimental/geometry/shapes/polygon.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/polygon.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:collection/collection.dart';
 import 'package:flame/src/experimental/geometry/shapes/shape.dart';
 import 'package:flame/src/game/transform2d.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -105,9 +106,7 @@ class Polygon extends Shape {
   @override
   double get perimeter => _perimeter ??= _calculatePerimeter();
   double? _perimeter;
-  double _calculatePerimeter() {
-    return _edges.fold<double>(0, (sum, edge) => sum + edge.length);
-  }
+  double _calculatePerimeter() => edges.map((e) => e.length).sum;
 
   @override
   Aabb2 get aabb => _aabb ??= _calculateAabb();

--- a/packages/flame/lib/src/geometry/line_segment.dart
+++ b/packages/flame/lib/src/geometry/line_segment.dart
@@ -26,22 +26,16 @@ class LineSegment {
       }
     } else {
       // In here we know that the lines are parallel
-      final overlaps = ({
-        from: otherSegment.containsPoint(from),
-        to: otherSegment.containsPoint(to),
-        otherSegment.from: containsPoint(otherSegment.from),
-        otherSegment.to: containsPoint(otherSegment.to),
-      }..removeWhere((_key, onSegment) => !onSegment))
-          .keys
-          .toSet();
+      final overlaps = {
+        if (otherSegment.containsPoint(from)) from,
+        if (otherSegment.containsPoint(to)) to,
+        if (containsPoint(otherSegment.from)) otherSegment.from,
+        if (containsPoint(otherSegment.to)) otherSegment.to,
+      };
       if (overlaps.isNotEmpty) {
-        return [
-          overlaps.fold<Vector2>(
-                Vector2.zero(),
-                (sum, point) => sum + point,
-              ) /
-              overlaps.length.toDouble(),
-        ];
+        final sum = Vector2.zero();
+        overlaps.forEach(sum.add);
+        return [sum..scale(1/overlaps.length)];
       }
     }
     return [];

--- a/packages/flame/lib/src/geometry/line_segment.dart
+++ b/packages/flame/lib/src/geometry/line_segment.dart
@@ -35,7 +35,7 @@ class LineSegment {
       if (overlaps.isNotEmpty) {
         final sum = Vector2.zero();
         overlaps.forEach(sum.add);
-        return [sum..scale(1/overlaps.length)];
+        return [sum..scale(1 / overlaps.length)];
       }
     }
     return [];


### PR DESCRIPTION
# Description

In some places in code we used patterns like `fold(0, (a, b) => a + b)`, which can be replaced with a simple `.sum` from the Iterable extension.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
