### PR TITLE
feat!: Add ability to render without loading on image related widgets

### DIFF
--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flame/src/anchor.dart';
@@ -17,7 +18,7 @@ class SpriteAnimationWidget extends StatelessWidget {
   /// Should the animation be playing or not
   final bool playing;
 
-  final Future<SpriteAnimation> Function() _animationFuture;
+  final FutureOr<SpriteAnimation> Function() _animationFuture;
 
   /// A builder function that is called if the loading fails
   final WidgetBuilder? errorBuilder;
@@ -32,7 +33,7 @@ class SpriteAnimationWidget extends StatelessWidget {
     this.errorBuilder,
     this.loadingBuilder,
     Key? key,
-  })  : _animationFuture = (() => Future.value(animation)),
+  })  : _animationFuture = (() => animation),
         super(key: key);
 
   SpriteAnimationWidget.asset({

--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -42,14 +42,14 @@ class SpriteAnimationWidget extends StatelessWidget {
     Images? images,
     this.playing = true,
     this.anchor = Anchor.topLeft,
-    this.errorBuilder,
-    this.loadingBuilder,
     Key? key,
   })  : _animationFuture = (() => SpriteAnimation.load(
               path,
               data,
               images: images,
             )),
+        errorBuilder = null,
+        loadingBuilder = null,
         super(key: key);
 
   @override

--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -39,7 +39,7 @@ class SpriteAnimationWidget extends StatelessWidget {
   /// Loads image from the asset [path] and renders it as a widget.
   ///
   /// It will use the [loadingBuilder] while the image from [path] is loading.
-  /// To render without loading, or when you want to have a gapless playback 
+  /// To render without loading, or when you want to have a gapless playback
   /// when the [path] value changes, consider loading the [SpriteAnimation]
   /// beforehand and direct pass it to the default constructor.
   SpriteAnimationWidget.asset({

--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -18,7 +18,7 @@ class SpriteAnimationWidget extends StatelessWidget {
   /// Should the animation be playing or not
   final bool playing;
 
-  final FutureOr<SpriteAnimation> Function() _animationFuture;
+  final FutureOr<SpriteAnimation> _animationFuture;
 
   /// A builder function that is called if the loading fails
   final WidgetBuilder? errorBuilder;
@@ -26,12 +26,12 @@ class SpriteAnimationWidget extends StatelessWidget {
   /// A builder function that is called while the loading is on the way
   final WidgetBuilder? loadingBuilder;
 
-  SpriteAnimationWidget({
+  const SpriteAnimationWidget({
     required SpriteAnimation animation,
     this.playing = true,
     this.anchor = Anchor.topLeft,
     Key? key,
-  })  : _animationFuture = (() => animation),
+  })  : _animationFuture = animation,
         errorBuilder = null,
         loadingBuilder = null,
         super(key: key);
@@ -50,17 +50,17 @@ class SpriteAnimationWidget extends StatelessWidget {
     this.errorBuilder,
     this.loadingBuilder,
     Key? key,
-  })  : _animationFuture = (() => SpriteAnimation.load(
-              path,
-              data,
-              images: images,
-            )),
+  })  : _animationFuture = SpriteAnimation.load(
+          path,
+          data,
+          images: images,
+        ),
         super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return BaseFutureBuilder<SpriteAnimation>(
-      futureBuilder: _animationFuture,
+      future: _animationFuture,
       builder: (_, spriteAnimation) {
         return InternalSpriteAnimationWidget(
           animation: spriteAnimation,

--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -62,7 +62,7 @@ class SpriteAnimationWidget extends StatelessWidget {
     return BaseFutureBuilder<SpriteAnimation>(
       futureBuilder: _animationFuture,
       builder: (_, spriteAnimation) {
-        return _SpriteAnimationWidget(
+        return InternalSpriteAnimationWidget(
           animation: spriteAnimation,
           anchor: anchor,
           playing: playing,
@@ -75,7 +75,8 @@ class SpriteAnimationWidget extends StatelessWidget {
 }
 
 /// A [StatefulWidget] that render a [SpriteAnimation].
-class _SpriteAnimationWidget extends StatefulWidget {
+@visibleForTesting
+class InternalSpriteAnimationWidget extends StatefulWidget {
   /// The [SpriteAnimation] to be rendered
   final SpriteAnimation animation;
 
@@ -85,17 +86,19 @@ class _SpriteAnimationWidget extends StatefulWidget {
   /// Should the [animation] be playing or not
   final bool playing;
 
-  const _SpriteAnimationWidget({
+  const InternalSpriteAnimationWidget({
     required this.animation,
     this.playing = true,
     this.anchor = Anchor.topLeft,
-  });
+    Key? key,
+  }) : super(key: key);
 
   @override
-  State createState() => _SpriteAnimationWidgetState();
+  State createState() => _InternalSpriteAnimationWidgetState();
 }
 
-class _SpriteAnimationWidgetState extends State<_SpriteAnimationWidget>
+class _InternalSpriteAnimationWidgetState
+    extends State<InternalSpriteAnimationWidget>
     with SingleTickerProviderStateMixin {
   AnimationController? _controller;
   double? _lastUpdated;
@@ -111,7 +114,7 @@ class _SpriteAnimationWidgetState extends State<_SpriteAnimationWidget>
   }
 
   @override
-  void didUpdateWidget(_SpriteAnimationWidget oldWidget) {
+  void didUpdateWidget(InternalSpriteAnimationWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.animation != widget.animation) {

--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -30,26 +30,31 @@ class SpriteAnimationWidget extends StatelessWidget {
     required SpriteAnimation animation,
     this.playing = true,
     this.anchor = Anchor.topLeft,
-    this.errorBuilder,
-    this.loadingBuilder,
     Key? key,
   })  : _animationFuture = (() => animation),
+        errorBuilder = null,
+        loadingBuilder = null,
         super(key: key);
 
+  /// loads image from asset [path] and renders it as Widget.
+  /// it has [loadingBuilder] while the image from [path] loads image
+  /// To render without loading or gapless playback when the [path] change,
+  /// consider load [SpriteAnimation] from somewhere and directly pass it to
+  /// default constructor
   SpriteAnimationWidget.asset({
     required String path,
     required SpriteAnimationData data,
     Images? images,
     this.playing = true,
     this.anchor = Anchor.topLeft,
+    this.errorBuilder,
+    this.loadingBuilder,
     Key? key,
   })  : _animationFuture = (() => SpriteAnimation.load(
               path,
               data,
               images: images,
             )),
-        errorBuilder = null,
-        loadingBuilder = null,
         super(key: key);
 
   @override

--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -36,11 +36,12 @@ class SpriteAnimationWidget extends StatelessWidget {
         loadingBuilder = null,
         super(key: key);
 
-  /// loads image from asset [path] and renders it as Widget.
-  /// it has [loadingBuilder] while the image from [path] loads image
-  /// To render without loading or gapless playback when the [path] change,
-  /// consider load [SpriteAnimation] from somewhere and directly pass it to
-  /// default constructor
+  /// Loads image from the asset [path] and renders it as a widget.
+  ///
+  /// It will use the [loadingBuilder] while the image from [path] is loading.
+  /// To render without loading, or when you want to have a gapless playback 
+  /// when the [path] value changes, consider loading the [SpriteAnimation]
+  /// beforehand and direct pass it to the default constructor.
   SpriteAnimationWidget.asset({
     required String path,
     required SpriteAnimationData data,

--- a/packages/flame/lib/src/widgets/base_future_builder.dart
+++ b/packages/flame/lib/src/widgets/base_future_builder.dart
@@ -2,14 +2,14 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-class BaseFutureBuilder<T> extends StatefulWidget {
-  final FutureOr<T> Function() futureBuilder;
+class BaseFutureBuilder<T> extends StatelessWidget {
+  final FutureOr<T> future;
   final Widget Function(BuildContext, T) builder;
   final WidgetBuilder? errorBuilder;
   final WidgetBuilder? loadingBuilder;
 
   const BaseFutureBuilder({
-    required this.futureBuilder,
+    required this.future,
     required this.builder,
     this.loadingBuilder,
     this.errorBuilder,
@@ -17,39 +17,26 @@ class BaseFutureBuilder<T> extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<BaseFutureBuilder<T>> createState() => _BaseFutureBuilderState<T>();
-}
-
-class _BaseFutureBuilderState<T> extends State<BaseFutureBuilder<T>> {
-  late final FutureOr<T> maybeFuture;
-
-  @override
-  void initState() {
-    maybeFuture = widget.futureBuilder();
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    if (maybeFuture is Future<T>) {
+    if (future is Future<T>) {
       return FutureBuilder<T>(
-        future: maybeFuture as Future<T>,
+        future: future as Future<T>,
         builder: (_, snapshot) {
           switch (snapshot.connectionState) {
             case ConnectionState.waiting:
             case ConnectionState.none:
             case ConnectionState.active:
-              return widget.loadingBuilder?.call(context) ?? Container();
+              return loadingBuilder?.call(context) ?? Container();
             case ConnectionState.done:
               if (snapshot.hasData) {
-                return widget.builder(context, snapshot.data!);
+                return builder(context, snapshot.data!);
               }
-              return widget.loadingBuilder?.call(context) ?? Container();
+              return loadingBuilder?.call(context) ?? Container();
           }
         },
       );
     }
 
-    return widget.builder(context, maybeFuture as T);
+    return builder(context, future as T);
   }
 }

--- a/packages/flame/lib/src/widgets/base_future_builder.dart
+++ b/packages/flame/lib/src/widgets/base_future_builder.dart
@@ -26,12 +26,15 @@ class BaseFutureBuilder<T> extends StatelessWidget {
             case ConnectionState.waiting:
             case ConnectionState.none:
             case ConnectionState.active:
-              return loadingBuilder?.call(context) ?? Container();
+              return loadingBuilder?.call(context) ?? const SizedBox();
             case ConnectionState.done:
               if (snapshot.hasData) {
                 return builder(context, snapshot.data!);
               }
-              return loadingBuilder?.call(context) ?? Container();
+              if (snapshot.hasError) {
+                return errorBuilder?.call(context) ?? const SizedBox();
+              }
+              return loadingBuilder?.call(context) ?? const SizedBox();
           }
         },
       );

--- a/packages/flame/lib/src/widgets/base_future_builder.dart
+++ b/packages/flame/lib/src/widgets/base_future_builder.dart
@@ -39,6 +39,6 @@ class BaseFutureBuilder<T> extends StatelessWidget {
       );
     }
 
-    return builder(context, futureBuilder as T);
+    return builder(context, future);
   }
 }

--- a/packages/flame/lib/src/widgets/nine_tile_box.dart
+++ b/packages/flame/lib/src/widgets/nine_tile_box.dart
@@ -100,7 +100,7 @@ class NineTileBoxWidget extends StatelessWidget {
     return BaseFutureBuilder<Image>(
       futureBuilder: _imageFuture,
       builder: (_, image) {
-        return _NineTileBox(
+        return InternalNineTileBox(
           image: image,
           tileSize: tileSize,
           destTileSize: destTileSize,
@@ -116,7 +116,8 @@ class NineTileBoxWidget extends StatelessWidget {
   }
 }
 
-class _NineTileBox extends StatelessWidget {
+@visibleForTesting
+class InternalNineTileBox extends StatelessWidget {
   final Image image;
   final double tileSize;
   final double destTileSize;
@@ -127,15 +128,15 @@ class _NineTileBox extends StatelessWidget {
 
   final EdgeInsetsGeometry? padding;
 
-  const _NineTileBox({
+  const InternalNineTileBox({
     required this.image,
     required this.tileSize,
     required this.destTileSize,
-    Key? key,
     this.child,
     this.width,
     this.height,
     this.padding,
+    Key? key,
   }) : super(key: key);
 
   @override

--- a/packages/flame/lib/src/widgets/nine_tile_box.dart
+++ b/packages/flame/lib/src/widgets/nine_tile_box.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flame/cache.dart';
@@ -40,7 +41,7 @@ typedef NineTileBox = NineTileBoxWidget;
 
 /// A [StatelessWidget] that renders NineTileBox
 class NineTileBoxWidget extends StatelessWidget {
-  final Future<Image> Function() _imageFuture;
+  final FutureOr<Image> Function() _imageFuture;
 
   /// The size of the tile on the image
   final double tileSize;
@@ -71,7 +72,7 @@ class NineTileBoxWidget extends StatelessWidget {
     this.errorBuilder,
     this.loadingBuilder,
     Key? key,
-  })  : _imageFuture = (() => Future.value(image)),
+  })  : _imageFuture = (() => image),
         super(key: key);
 
   NineTileBoxWidget.asset({

--- a/packages/flame/lib/src/widgets/nine_tile_box.dart
+++ b/packages/flame/lib/src/widgets/nine_tile_box.dart
@@ -69,10 +69,10 @@ class NineTileBoxWidget extends StatelessWidget {
     this.height,
     this.child,
     this.padding,
-    this.errorBuilder,
-    this.loadingBuilder,
     Key? key,
   })  : _imageFuture = (() => image),
+        errorBuilder = null,
+        loadingBuilder = null,
         super(key: key);
 
   NineTileBoxWidget.asset({

--- a/packages/flame/lib/src/widgets/nine_tile_box.dart
+++ b/packages/flame/lib/src/widgets/nine_tile_box.dart
@@ -78,8 +78,8 @@ class NineTileBoxWidget extends StatelessWidget {
   /// Loads image from the asset [path] and renders it as a widget.
   ///
   /// It will use the [loadingBuilder] while the image from [path] is loading.
-  /// To render without loading, or when you want to have a gapless playback 
-  /// when the [path] value changes, consider loading the image beforehand 
+  /// To render without loading, or when you want to have a gapless playback
+  /// when the [path] value changes, consider loading the image beforehand
   /// and direct pass it to the default constructor.
   NineTileBoxWidget.asset({
     required String path,

--- a/packages/flame/lib/src/widgets/nine_tile_box.dart
+++ b/packages/flame/lib/src/widgets/nine_tile_box.dart
@@ -75,6 +75,11 @@ class NineTileBoxWidget extends StatelessWidget {
         loadingBuilder = null,
         super(key: key);
 
+  /// loads image from asset [path] and renders it as Widget.
+  /// it has [loadingBuilder] while the image from [path] loads image
+  /// To render without loading or gapless playback when the [path] change,
+  /// consider load an image from somewhere and directly pass it to
+  /// default constructor
   NineTileBoxWidget.asset({
     required String path,
     required this.tileSize,

--- a/packages/flame/lib/src/widgets/nine_tile_box.dart
+++ b/packages/flame/lib/src/widgets/nine_tile_box.dart
@@ -75,11 +75,12 @@ class NineTileBoxWidget extends StatelessWidget {
         loadingBuilder = null,
         super(key: key);
 
-  /// loads image from asset [path] and renders it as Widget.
-  /// it has [loadingBuilder] while the image from [path] loads image
-  /// To render without loading or gapless playback when the [path] change,
-  /// consider load an image from somewhere and directly pass it to
-  /// default constructor
+  /// Loads image from the asset [path] and renders it as a widget.
+  ///
+  /// It will use the [loadingBuilder] while the image from [path] is loading.
+  /// To render without loading, or when you want to have a gapless playback 
+  /// when the [path] value changes, consider loading the image beforehand 
+  /// and direct pass it to the default constructor.
   NineTileBoxWidget.asset({
     required String path,
     required this.tileSize,

--- a/packages/flame/lib/src/widgets/nine_tile_box.dart
+++ b/packages/flame/lib/src/widgets/nine_tile_box.dart
@@ -41,7 +41,7 @@ typedef NineTileBox = NineTileBoxWidget;
 
 /// A [StatelessWidget] that renders NineTileBox
 class NineTileBoxWidget extends StatelessWidget {
-  final FutureOr<Image> Function() _imageFuture;
+  final FutureOr<Image> _imageFuture;
 
   /// The size of the tile on the image
   final double tileSize;
@@ -61,7 +61,7 @@ class NineTileBoxWidget extends StatelessWidget {
   /// A builder function that is called while the loading is on the way
   final WidgetBuilder? loadingBuilder;
 
-  NineTileBoxWidget({
+  const NineTileBoxWidget({
     required Image image,
     required this.tileSize,
     required this.destTileSize,
@@ -70,7 +70,7 @@ class NineTileBoxWidget extends StatelessWidget {
     this.child,
     this.padding,
     Key? key,
-  })  : _imageFuture = (() => image),
+  })  : _imageFuture = image,
         errorBuilder = null,
         loadingBuilder = null,
         super(key: key);
@@ -92,13 +92,13 @@ class NineTileBoxWidget extends StatelessWidget {
     this.errorBuilder,
     this.loadingBuilder,
     Key? key,
-  })  : _imageFuture = (() => (images ?? Flame.images).load(path)),
+  })  : _imageFuture = (images ?? Flame.images).load(path),
         super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return BaseFutureBuilder<Image>(
-      futureBuilder: _imageFuture,
+      future: _imageFuture,
       builder: (_, image) {
         return InternalNineTileBox(
           image: image,

--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -51,13 +51,13 @@ class SpriteButton extends StatelessWidget {
     this.srcSize,
     this.pressedSrcPosition,
     this.pressedSrcSize,
-    this.errorBuilder,
-    this.loadingBuilder,
     Key? key,
   })  : _buttonsFuture = (() => [
               sprite,
               pressedSprite,
             ]),
+        errorBuilder = null,
+        loadingBuilder = null,
         super(key: key);
 
   SpriteButton.future({

--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -80,11 +80,13 @@ class SpriteButton extends StatelessWidget {
         ]),
         super(key: key);
 
-  /// loads image from asset [path], [pressedPath] and renders it as Widget.
-  /// it has [loadingBuilder] while the image is loading.
-  /// To render without loading or gapless playback when the [path] change,
-  /// consider load an image from somewhere and directly pass it to
-  /// default constructor
+  /// Loads the images from the asset [path] and [pressedPath] and renders 
+  /// it as a widget.
+  ///
+  /// It will use the [loadingBuilder] while the image from [path] is loading.
+  /// To render without loading, or when you want to have a gapless playback 
+  /// when the [path] value changes, consider loading the image beforehand 
+  /// and direct pass it to the default constructor.
   SpriteButton.asset({
     required String path,
     required String pressedPath,

--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -80,6 +80,11 @@ class SpriteButton extends StatelessWidget {
             ])),
         super(key: key);
 
+  /// loads image from asset [path], [pressedPath] and renders it as Widget.
+  /// it has [loadingBuilder] while the image is loading.
+  /// To render without loading or gapless playback when the [path] change,
+  /// consider load an image from somewhere and directly pass it to
+  /// default constructor
   SpriteButton.asset({
     required String path,
     required String pressedPath,

--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -38,11 +38,31 @@ class SpriteButton extends StatelessWidget {
   /// A builder function that is called while the loading is on the way
   final WidgetBuilder? loadingBuilder;
 
-  final Future<List<Sprite>> Function() _buttonsFuture;
+  final FutureOr<List<Sprite>> Function() _buttonsFuture;
 
   SpriteButton({
-    required FutureOr<Sprite> sprite,
-    required FutureOr<Sprite> pressedSprite,
+    required Sprite sprite,
+    required Sprite pressedSprite,
+    required this.onPressed,
+    required this.width,
+    required this.height,
+    required this.label,
+    this.srcPosition,
+    this.srcSize,
+    this.pressedSrcPosition,
+    this.pressedSrcSize,
+    this.errorBuilder,
+    this.loadingBuilder,
+    Key? key,
+  })  : _buttonsFuture = (() => [
+              sprite,
+              pressedSprite,
+            ]),
+        super(key: key);
+
+  SpriteButton.future({
+    required Future<Sprite> sprite,
+    required Future<Sprite> pressedSprite,
     required this.onPressed,
     required this.width,
     required this.height,
@@ -55,8 +75,8 @@ class SpriteButton extends StatelessWidget {
     this.loadingBuilder,
     Key? key,
   })  : _buttonsFuture = (() => Future.wait([
-              Future.value(sprite),
-              Future.value(pressedSprite),
+              sprite,
+              pressedSprite,
             ])),
         super(key: key);
 

--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -38,7 +38,7 @@ class SpriteButton extends StatelessWidget {
   /// A builder function that is called while the loading is on the way
   final WidgetBuilder? loadingBuilder;
 
-  final FutureOr<List<Sprite>> Function() _buttonsFuture;
+  final FutureOr<List<Sprite>> _buttonsFuture;
 
   SpriteButton({
     required Sprite sprite,
@@ -52,10 +52,10 @@ class SpriteButton extends StatelessWidget {
     this.pressedSrcPosition,
     this.pressedSrcSize,
     Key? key,
-  })  : _buttonsFuture = (() => [
-              sprite,
-              pressedSprite,
-            ]),
+  })  : _buttonsFuture = [
+          sprite,
+          pressedSprite,
+        ],
         errorBuilder = null,
         loadingBuilder = null,
         super(key: key);
@@ -74,10 +74,10 @@ class SpriteButton extends StatelessWidget {
     this.errorBuilder,
     this.loadingBuilder,
     Key? key,
-  })  : _buttonsFuture = (() => Future.wait([
-              sprite,
-              pressedSprite,
-            ])),
+  })  : _buttonsFuture = Future.wait([
+          sprite,
+          pressedSprite,
+        ]),
         super(key: key);
 
   /// loads image from asset [path], [pressedPath] and renders it as Widget.
@@ -100,26 +100,26 @@ class SpriteButton extends StatelessWidget {
     this.errorBuilder,
     this.loadingBuilder,
     Key? key,
-  })  : _buttonsFuture = (() => Future.wait([
-              Sprite.load(
-                path,
-                srcSize: srcSize,
-                srcPosition: srcPosition,
-                images: images,
-              ),
-              Sprite.load(
-                pressedPath,
-                srcSize: pressedSrcSize,
-                srcPosition: pressedSrcPosition,
-                images: images,
-              ),
-            ])),
+  })  : _buttonsFuture = Future.wait([
+          Sprite.load(
+            path,
+            srcSize: srcSize,
+            srcPosition: srcPosition,
+            images: images,
+          ),
+          Sprite.load(
+            pressedPath,
+            srcSize: pressedSrcSize,
+            srcPosition: pressedSrcPosition,
+            images: images,
+          ),
+        ]),
         super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return BaseFutureBuilder<List<Sprite>>(
-      futureBuilder: _buttonsFuture,
+      future: _buttonsFuture,
       builder: (_, list) {
         final sprite = list[0];
         final pressedSprite = list[1];

--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -80,12 +80,12 @@ class SpriteButton extends StatelessWidget {
         ]),
         super(key: key);
 
-  /// Loads the images from the asset [path] and [pressedPath] and renders 
+  /// Loads the images from the asset [path] and [pressedPath] and renders
   /// it as a widget.
   ///
   /// It will use the [loadingBuilder] while the image from [path] is loading.
-  /// To render without loading, or when you want to have a gapless playback 
-  /// when the [path] value changes, consider loading the image beforehand 
+  /// To render without loading, or when you want to have a gapless playback
+  /// when the [path] value changes, consider loading the image beforehand
   /// and direct pass it to the default constructor.
   SpriteButton.asset({
     required String path,

--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -124,7 +124,7 @@ class SpriteButton extends StatelessWidget {
         final sprite = list[0];
         final pressedSprite = list[1];
 
-        return _SpriteButton(
+        return InternalSpriteButton(
           onPressed: onPressed,
           label: label,
           width: width,
@@ -139,7 +139,8 @@ class SpriteButton extends StatelessWidget {
   }
 }
 
-class _SpriteButton extends StatefulWidget {
+@visibleForTesting
+class InternalSpriteButton extends StatefulWidget {
   final VoidCallback onPressed;
   final Widget label;
   final Sprite sprite;
@@ -147,20 +148,21 @@ class _SpriteButton extends StatefulWidget {
   final double width;
   final double height;
 
-  const _SpriteButton({
+  const InternalSpriteButton({
     required this.onPressed,
     required this.label,
     required this.sprite,
     required this.pressedSprite,
     this.width = 200,
     this.height = 50,
-  });
+    Key? key,
+  }) : super(key: key);
 
   @override
   State createState() => _ButtonState();
 }
 
-class _ButtonState extends State<_SpriteButton> {
+class _ButtonState extends State<InternalSpriteButton> {
   bool _pressed = false;
 
   @override

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -73,7 +73,7 @@ class SpriteWidget extends StatelessWidget {
     return BaseFutureBuilder<Sprite>(
       futureBuilder: _spriteFuture,
       builder: (_, sprite) {
-        return _SpriteWidget(
+        return InternalSpriteWidget(
           sprite: sprite,
           anchor: anchor,
           angle: angle,
@@ -86,7 +86,8 @@ class SpriteWidget extends StatelessWidget {
 }
 
 /// A [StatefulWidget] that renders a still [Sprite].
-class _SpriteWidget extends StatelessWidget {
+@visibleForTesting
+class InternalSpriteWidget extends StatelessWidget {
   /// The [Sprite] to be rendered
   final Sprite sprite;
 
@@ -96,11 +97,12 @@ class _SpriteWidget extends StatelessWidget {
   /// The angle to rotate this [sprite], in rad. (default = 0)
   final double angle;
 
-  const _SpriteWidget({
+  const InternalSpriteWidget({
     required this.sprite,
     this.anchor = Anchor.topLeft,
     this.angle = 0,
-  });
+    Key? key,
+  }) : super(key: key);
 
   @override
   Widget build(_) {

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -31,16 +31,16 @@ class SpriteWidget extends StatelessWidget {
   /// A builder function that is called while the loading is on the way
   final WidgetBuilder? loadingBuilder;
 
-  final FutureOr<Sprite> Function() _spriteFuture;
+  final FutureOr<Sprite> _spriteFuture;
 
-  SpriteWidget({
+  const SpriteWidget({
     required Sprite sprite,
     this.anchor = Anchor.topLeft,
     this.angle = 0,
     this.srcPosition,
     this.srcSize,
     Key? key,
-  })  : _spriteFuture = (() => sprite),
+  })  : _spriteFuture = sprite,
         errorBuilder = null,
         loadingBuilder = null,
         super(key: key);
@@ -60,18 +60,18 @@ class SpriteWidget extends StatelessWidget {
     this.errorBuilder,
     this.loadingBuilder,
     Key? key,
-  })  : _spriteFuture = (() => Sprite.load(
-              path,
-              srcSize: srcSize,
-              srcPosition: srcPosition,
-              images: images,
-            )),
+  })  : _spriteFuture = Sprite.load(
+          path,
+          srcSize: srcSize,
+          srcPosition: srcPosition,
+          images: images,
+        ),
         super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return BaseFutureBuilder<Sprite>(
-      futureBuilder: _spriteFuture,
+      future: _spriteFuture,
       builder: (_, sprite) {
         return InternalSpriteWidget(
           sprite: sprite,

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flame/cache.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/src/anchor.dart';
@@ -29,7 +31,7 @@ class SpriteWidget extends StatelessWidget {
   /// A builder function that is called while the loading is on the way
   final WidgetBuilder? loadingBuilder;
 
-  final Future<Sprite> Function() _spriteFuture;
+  final FutureOr<Sprite> Function() _spriteFuture;
 
   SpriteWidget({
     required Sprite sprite,
@@ -40,7 +42,7 @@ class SpriteWidget extends StatelessWidget {
     this.errorBuilder,
     this.loadingBuilder,
     Key? key,
-  })  : _spriteFuture = (() => Future.value(sprite)),
+  })  : _spriteFuture = (() => sprite),
         super(key: key);
 
   SpriteWidget.asset({

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -48,8 +48,8 @@ class SpriteWidget extends StatelessWidget {
   /// Load the image from the asset [path] and renders it as a widget.
   ///
   /// It will use the [loadingBuilder] while the image from [path] is loading.
-  /// To render without loading, or when you want to have a gapless playback 
-  /// when the [path] value changes, consider loading the image beforehand 
+  /// To render without loading, or when you want to have a gapless playback
+  /// when the [path] value changes, consider loading the image beforehand
   /// and direct pass it to the default constructor.
   SpriteWidget.asset({
     required String path,

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -39,10 +39,10 @@ class SpriteWidget extends StatelessWidget {
     this.angle = 0,
     this.srcPosition,
     this.srcSize,
-    this.errorBuilder,
-    this.loadingBuilder,
     Key? key,
   })  : _spriteFuture = (() => sprite),
+        errorBuilder = null,
+        loadingBuilder = null,
         super(key: key);
 
   SpriteWidget.asset({

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -45,6 +45,11 @@ class SpriteWidget extends StatelessWidget {
         loadingBuilder = null,
         super(key: key);
 
+  /// loads image from asset [path] and renders it as Widget.
+  /// it has [loadingBuilder] while the image from [path] loads image
+  /// To render without loading or gapless playback when the [path] change,
+  /// consider load an image from somewhere and directly pass it to
+  /// default constructor
   SpriteWidget.asset({
     required String path,
     Images? images,

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -45,11 +45,12 @@ class SpriteWidget extends StatelessWidget {
         loadingBuilder = null,
         super(key: key);
 
-  /// loads image from asset [path] and renders it as Widget.
-  /// it has [loadingBuilder] while the image from [path] loads image
-  /// To render without loading or gapless playback when the [path] change,
-  /// consider load an image from somewhere and directly pass it to
-  /// default constructor
+  /// Load the image from the asset [path] and renders it as a widget.
+  ///
+  /// It will use the [loadingBuilder] while the image from [path] is loading.
+  /// To render without loading, or when you want to have a gapless playback 
+  /// when the [path] value changes, consider loading the image beforehand 
+  /// and direct pass it to the default constructor.
   SpriteWidget.asset({
     required String path,
     Images? images,

--- a/packages/flame/test/widgets/nine_tile_box_widget_test.dart
+++ b/packages/flame/test/widgets/nine_tile_box_widget_test.dart
@@ -7,7 +7,8 @@ void main() async {
   final image = await generateImage();
 
   group('NineTileBoxWidget', () {
-    testWidgets('has no FutureBuilder when pass animation', (tester) async {
+    testWidgets('has no FutureBuilder when passed an animation',
+        (tester) async {
       await tester.pumpWidget(
         NineTileBoxWidget(
           image: image,
@@ -24,7 +25,7 @@ void main() async {
     });
 
     testWidgets(
-      'has FutureBuilder when pass asset path',
+      'has FutureBuilder when passed an asset path',
       (tester) async {
         ///How can I test this...?
       },

--- a/packages/flame/test/widgets/nine_tile_box_widget_test.dart
+++ b/packages/flame/test/widgets/nine_tile_box_widget_test.dart
@@ -21,6 +21,7 @@ void main() async {
       expect(futureBuilder, findsNothing);
       expect(nineTileBoxWidgetFinder, findsOneWidget);
     });
+
     testWidgets(
       'has FutureBuilder when pass asset path',
       (tester) async {

--- a/packages/flame/test/widgets/nine_tile_box_widget_test.dart
+++ b/packages/flame/test/widgets/nine_tile_box_widget_test.dart
@@ -15,10 +15,10 @@ void main() async {
         ),
       );
 
-      final futureBuilder = find.byType(FutureBuilder);
+      final futureBuilderFinder = find.byType(FutureBuilder);
       final nineTileBoxWidgetFinder = find.byType(NineTileBoxWidget);
 
-      expect(futureBuilder, findsNothing);
+      expect(futureBuilderFinder, findsNothing);
       expect(nineTileBoxWidgetFinder, findsOneWidget);
     });
 

--- a/packages/flame/test/widgets/nine_tile_box_widget_test.dart
+++ b/packages/flame/test/widgets/nine_tile_box_widget_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   final image = await generateImage();
+
   group('NineTileBoxWidget', () {
     testWidgets('has no FutureBuilder when pass animation', (tester) async {
       await tester.pumpWidget(

--- a/packages/flame/test/widgets/nine_tile_box_widget_test.dart
+++ b/packages/flame/test/widgets/nine_tile_box_widget_test.dart
@@ -1,3 +1,6 @@
+import 'dart:ui' as ui;
+
+import 'package:flame/flame.dart';
 import 'package:flame/widgets.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
@@ -12,8 +15,8 @@ void main() async {
       await tester.pumpWidget(
         NineTileBoxWidget(
           image: image,
-          tileSize: 1,
-          destTileSize: 1,
+          tileSize: 10,
+          destTileSize: 10,
         ),
       );
 
@@ -25,11 +28,44 @@ void main() async {
     });
 
     testWidgets(
-      'has FutureBuilder when passed an asset path',
+      'has FutureBuilder and LoadingWidget when passed an asset path',
       (tester) async {
-        ///How can I test this...?
+        const imagePath = 'test_path';
+        Flame.images.add(imagePath, image);
+
+        await tester.pumpWidget(
+          NineTileBoxWidget.asset(
+            path: imagePath,
+            tileSize: 10,
+            destTileSize: 10,
+            loadingBuilder: (_) => const _LoadingWidget(),
+          ),
+        );
+
+        final futureBuilderFinder = find.byType(FutureBuilder<ui.Image>);
+        final nineTileBoxWidgetFinder = find.byType(InternalNineTileBox);
+        final loadingWidgetFinder = find.byType(_LoadingWidget);
+
+        expect(futureBuilderFinder, findsOneWidget);
+        expect(loadingWidgetFinder, findsOneWidget);
+        expect(nineTileBoxWidgetFinder, findsNothing);
+
+        /// loading to be removed
+        await tester.pump();
+
+        expect(futureBuilderFinder, findsOneWidget);
+        expect(loadingWidgetFinder, findsNothing);
+        expect(nineTileBoxWidgetFinder, findsOneWidget);
       },
-      skip: true,
     );
   });
+}
+
+class _LoadingWidget extends StatelessWidget {
+  const _LoadingWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
+  }
 }

--- a/packages/flame/test/widgets/nine_tile_box_widget_test.dart
+++ b/packages/flame/test/widgets/nine_tile_box_widget_test.dart
@@ -1,0 +1,32 @@
+import 'package:flame/widgets.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() async {
+  final image = await generateImage();
+  group('NineTileBoxWidget', () {
+    testWidgets('has no FutureBuilder when pass animation', (tester) async {
+      await tester.pumpWidget(
+        NineTileBoxWidget(
+          image: image,
+          tileSize: 1,
+          destTileSize: 1,
+        ),
+      );
+
+      final futureBuilder = find.byType(FutureBuilder);
+      final nineTileBoxWidgetFinder = find.byType(NineTileBoxWidget);
+
+      expect(futureBuilder, findsNothing);
+      expect(nineTileBoxWidgetFinder, findsOneWidget);
+    });
+    testWidgets(
+      'has FutureBuilder when pass asset path',
+      (tester) async {
+        ///How can I test this...?
+      },
+      skip: true,
+    );
+  });
+}

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -17,10 +17,10 @@ void main() async {
       await tester
           .pumpWidget(SpriteAnimationWidget(animation: spriteAnimation));
 
-      final futureBuilder = find.byType(FutureBuilder);
+      final futureBuilderFinder = find.byType(FutureBuilder);
       final spriteAnimationWidgetFinder = find.byType(SpriteAnimationWidget);
 
-      expect(futureBuilder, findsNothing);
+      expect(futureBuilderFinder, findsNothing);
       expect(spriteAnimationWidgetFinder, findsOneWidget);
     });
 

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -7,7 +7,8 @@ void main() async {
   final image = await generateImage();
 
   group('SpriteAnimationWidget', () {
-    testWidgets('has no FutureBuilder when pass animation', (tester) async {
+    testWidgets('has no FutureBuilder when passed an animation',
+        (tester) async {
       final sprite1 = Sprite(image);
       final sprite2 = Sprite(image);
       final spriteAnimation = SpriteAnimation.spriteList(
@@ -26,7 +27,7 @@ void main() async {
     });
 
     testWidgets(
-      'has FutureBuilder when pass asset path',
+      'has FutureBuilder when passed an asset path',
       (tester) async {
         ///How can I test this...?
       },

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   final image = await generateImage();
+
   group('SpriteAnimationWidget', () {
     testWidgets('has no FutureBuilder when pass animation', (tester) async {
       final sprite1 = Sprite(image);

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -1,0 +1,34 @@
+import 'package:flame/widgets.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() async {
+  final image = await generateImage();
+  group('SpriteAnimationWidget', () {
+    testWidgets('has no FutureBuilder when pass animation', (tester) async {
+      final sprite1 = Sprite(image);
+      final sprite2 = Sprite(image);
+      final spriteAnimation = SpriteAnimation.spriteList(
+        [sprite1, sprite2],
+        stepTime: 0.1,
+      );
+
+      await tester
+          .pumpWidget(SpriteAnimationWidget(animation: spriteAnimation));
+
+      final futureBuilder = find.byType(FutureBuilder);
+      final spriteAnimationWidgetFinder = find.byType(SpriteAnimationWidget);
+
+      expect(futureBuilder, findsNothing);
+      expect(spriteAnimationWidgetFinder, findsOneWidget);
+    });
+    testWidgets(
+      'has FutureBuilder when pass asset path',
+      (tester) async {
+        ///How can I test this...?
+      },
+      skip: true,
+    );
+  });
+}

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -1,3 +1,5 @@
+import 'package:flame/extensions.dart';
+import 'package:flame/flame.dart';
 import 'package:flame/widgets.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
@@ -27,11 +29,49 @@ void main() async {
     });
 
     testWidgets(
-      'has FutureBuilder when passed an asset path',
+      'has FutureBuilder and LoadingWidget when passed an asset path',
       (tester) async {
-        ///How can I test this...?
+        const imagePath = 'test_path';
+        Flame.images.add(imagePath, image);
+        final spriteAnimationData = SpriteAnimationData.sequenced(
+          amount: 2,
+          stepTime: 1,
+          textureSize: Vector2(10, 10),
+        );
+
+        await tester.pumpWidget(
+          SpriteAnimationWidget.asset(
+            path: imagePath,
+            data: spriteAnimationData,
+            loadingBuilder: (_) => const _LoadingWidget(),
+          ),
+        );
+
+        final futureBuilderFinder = find.byType(FutureBuilder<SpriteAnimation>);
+        final spriteAnimationWidgetFinder =
+            find.byType(InternalSpriteAnimationWidget);
+        final loadingWidgetFinder = find.byType(_LoadingWidget);
+
+        expect(futureBuilderFinder, findsOneWidget);
+        expect(loadingWidgetFinder, findsOneWidget);
+        expect(spriteAnimationWidgetFinder, findsNothing);
+
+        /// loading to be removed
+        await tester.pump();
+
+        expect(futureBuilderFinder, findsOneWidget);
+        expect(loadingWidgetFinder, findsNothing);
+        expect(spriteAnimationWidgetFinder, findsOneWidget);
       },
-      skip: true,
     );
   });
+}
+
+class _LoadingWidget extends StatelessWidget {
+  const _LoadingWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
+  }
 }

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -23,6 +23,7 @@ void main() async {
       expect(futureBuilder, findsNothing);
       expect(spriteAnimationWidgetFinder, findsOneWidget);
     });
+
     testWidgets(
       'has FutureBuilder when pass asset path',
       (tester) async {

--- a/packages/flame/test/widgets/sprite_button_test.dart
+++ b/packages/flame/test/widgets/sprite_button_test.dart
@@ -1,3 +1,4 @@
+import 'package:flame/flame.dart';
 import 'package:flame/widgets.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
@@ -5,13 +6,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   final image = await generateImage();
+  final sprite1 = Sprite(image);
+  final sprite2 = Sprite(image);
 
   group('SpriteButton', () {
     testWidgets('has no FutureBuilder when passed an animation',
         (tester) async {
-      final sprite1 = Sprite(image);
-      final sprite2 = Sprite(image);
-
       await tester.pumpWidget(
         SpriteButton(
           sprite: sprite1,
@@ -31,11 +31,49 @@ void main() async {
     });
 
     testWidgets(
-      'has FutureBuilder when passed an asset path',
+      'has FutureBuilder and LoadingWidget when passed an asset path',
       (tester) async {
-        ///How can I test this...?
+        const imagePath1 = 'test_path_1';
+        const imagePath2 = 'test_path_2';
+        Flame.images.add(imagePath1, image);
+        Flame.images.add(imagePath2, image);
+
+        await tester.pumpWidget(
+          SpriteButton.asset(
+            path: imagePath1,
+            pressedPath: imagePath2,
+            onPressed: () {},
+            width: 100,
+            height: 100,
+            label: const SizedBox(),
+            loadingBuilder: (_) => const _LoadingWidget(),
+          ),
+        );
+
+        final futureBuilderFinder = find.byType(FutureBuilder<List<Sprite>>);
+        final nineTileBoxWidgetFinder = find.byType(InternalSpriteButton);
+        final loadingWidgetFinder = find.byType(_LoadingWidget);
+
+        expect(futureBuilderFinder, findsOneWidget);
+        expect(loadingWidgetFinder, findsOneWidget);
+        expect(nineTileBoxWidgetFinder, findsNothing);
+
+        /// loading to be removed
+        await tester.pump();
+
+        expect(futureBuilderFinder, findsOneWidget);
+        expect(loadingWidgetFinder, findsNothing);
+        expect(nineTileBoxWidgetFinder, findsOneWidget);
       },
-      skip: true,
     );
   });
+}
+
+class _LoadingWidget extends StatelessWidget {
+  const _LoadingWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
+  }
 }

--- a/packages/flame/test/widgets/sprite_button_test.dart
+++ b/packages/flame/test/widgets/sprite_button_test.dart
@@ -7,7 +7,8 @@ void main() async {
   final image = await generateImage();
 
   group('SpriteButton', () {
-    testWidgets('has no FutureBuilder when pass animation', (tester) async {
+    testWidgets('has no FutureBuilder when passed an animation',
+        (tester) async {
       final sprite1 = Sprite(image);
       final sprite2 = Sprite(image);
 
@@ -30,7 +31,7 @@ void main() async {
     });
 
     testWidgets(
-      'has FutureBuilder when pass asset path',
+      'has FutureBuilder when passed an asset path',
       (tester) async {
         ///How can I test this...?
       },

--- a/packages/flame/test/widgets/sprite_button_test.dart
+++ b/packages/flame/test/widgets/sprite_button_test.dart
@@ -21,10 +21,10 @@ void main() async {
         ),
       );
 
-      final futureBuilder = find.byType(FutureBuilder);
+      final futureBuilderFinder = find.byType(FutureBuilder);
       final nineTileBoxWidgetFinder = find.byType(SpriteButton);
 
-      expect(futureBuilder, findsNothing);
+      expect(futureBuilderFinder, findsNothing);
       expect(nineTileBoxWidgetFinder, findsOneWidget);
     });
 

--- a/packages/flame/test/widgets/sprite_button_test.dart
+++ b/packages/flame/test/widgets/sprite_button_test.dart
@@ -1,0 +1,38 @@
+import 'package:flame/widgets.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() async {
+  final image = await generateImage();
+  group('SpriteButton', () {
+    testWidgets('has no FutureBuilder when pass animation', (tester) async {
+      final sprite1 = Sprite(image);
+      final sprite2 = Sprite(image);
+
+      await tester.pumpWidget(
+        SpriteButton(
+          sprite: sprite1,
+          pressedSprite: sprite2,
+          onPressed: () {},
+          width: 100,
+          height: 100,
+          label: const SizedBox(),
+        ),
+      );
+
+      final futureBuilder = find.byType(FutureBuilder);
+      final nineTileBoxWidgetFinder = find.byType(SpriteButton);
+
+      expect(futureBuilder, findsNothing);
+      expect(nineTileBoxWidgetFinder, findsOneWidget);
+    });
+    testWidgets(
+      'has FutureBuilder when pass asset path',
+      (tester) async {
+        ///How can I test this...?
+      },
+      skip: true,
+    );
+  });
+}

--- a/packages/flame/test/widgets/sprite_button_test.dart
+++ b/packages/flame/test/widgets/sprite_button_test.dart
@@ -6,12 +6,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   final image = await generateImage();
-  final sprite1 = Sprite(image);
-  final sprite2 = Sprite(image);
 
   group('SpriteButton', () {
     testWidgets('has no FutureBuilder when passed an animation',
         (tester) async {
+      final sprite1 = Sprite(image);
+      final sprite2 = Sprite(image);
+
       await tester.pumpWidget(
         SpriteButton(
           sprite: sprite1,

--- a/packages/flame/test/widgets/sprite_button_test.dart
+++ b/packages/flame/test/widgets/sprite_button_test.dart
@@ -27,6 +27,7 @@ void main() async {
       expect(futureBuilder, findsNothing);
       expect(nineTileBoxWidgetFinder, findsOneWidget);
     });
+
     testWidgets(
       'has FutureBuilder when pass asset path',
       (tester) async {

--- a/packages/flame/test/widgets/sprite_button_test.dart
+++ b/packages/flame/test/widgets/sprite_button_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   final image = await generateImage();
+
   group('SpriteButton', () {
     testWidgets('has no FutureBuilder when pass animation', (tester) async {
       final sprite1 = Sprite(image);

--- a/packages/flame/test/widgets/sprite_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_widget_test.dart
@@ -11,10 +11,10 @@ void main() async {
 
       await tester.pumpWidget(SpriteWidget(sprite: sprite));
 
-      final futureBuilder = find.byType(FutureBuilder);
+      final futureBuilderFinder = find.byType(FutureBuilder);
       final spriteWidgetFinder = find.byType(SpriteWidget);
 
-      expect(futureBuilder, findsNothing);
+      expect(futureBuilderFinder, findsNothing);
       expect(spriteWidgetFinder, findsOneWidget);
     });
 

--- a/packages/flame/test/widgets/sprite_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_widget_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   final image = await generateImage();
+  
   group('SpriteWidget', () {
     testWidgets('has no FutureBuilder when pass sprite', (tester) async {
       final sprite = Sprite(image);

--- a/packages/flame/test/widgets/sprite_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_widget_test.dart
@@ -1,0 +1,28 @@
+import 'package:flame/widgets.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() async {
+  final image = await generateImage();
+  group('SpriteWidget', () {
+    testWidgets('has no FutureBuilder when pass sprite', (tester) async {
+      final sprite = Sprite(image);
+
+      await tester.pumpWidget(SpriteWidget(sprite: sprite));
+
+      final futureBuilder = find.byType(FutureBuilder);
+      final spriteWidgetFinder = find.byType(SpriteWidget);
+
+      expect(futureBuilder, findsNothing);
+      expect(spriteWidgetFinder, findsOneWidget);
+    });
+    testWidgets(
+      'has FutureBuilder when pass asset path',
+      (tester) async {
+        ///How can I test this...?
+      },
+      skip: true,
+    );
+  });
+}

--- a/packages/flame/test/widgets/sprite_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_widget_test.dart
@@ -5,9 +5,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   final image = await generateImage();
-  
+
   group('SpriteWidget', () {
-    testWidgets('has no FutureBuilder when pass sprite', (tester) async {
+    testWidgets('has no FutureBuilder when passed an sprite', (tester) async {
       final sprite = Sprite(image);
 
       await tester.pumpWidget(SpriteWidget(sprite: sprite));
@@ -20,7 +20,7 @@ void main() async {
     });
 
     testWidgets(
-      'has FutureBuilder when pass asset path',
+      'has FutureBuilder when passed an asset path',
       (tester) async {
         ///How can I test this...?
       },

--- a/packages/flame/test/widgets/sprite_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_widget_test.dart
@@ -1,3 +1,4 @@
+import 'package:flame/flame.dart';
 import 'package:flame/widgets.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
@@ -20,11 +21,42 @@ void main() async {
     });
 
     testWidgets(
-      'has FutureBuilder when passed an asset path',
+      'has FutureBuilder and LoadingWidget when passed an asset path',
       (tester) async {
-        ///How can I test this...?
+        const imagePath = 'test_path';
+        Flame.images.add(imagePath, image);
+
+        await tester.pumpWidget(
+          SpriteWidget.asset(
+            path: imagePath,
+            loadingBuilder: (_) => const _LoadingWidget(),
+          ),
+        );
+
+        final futureBuilderFinder = find.byType(FutureBuilder<Sprite>);
+        final spriteWidgetFinder = find.byType(InternalSpriteWidget);
+        final loadingWidgetFinder = find.byType(_LoadingWidget);
+
+        expect(futureBuilderFinder, findsOneWidget);
+        expect(loadingWidgetFinder, findsOneWidget);
+        expect(spriteWidgetFinder, findsNothing);
+
+        /// loading to be removed
+        await tester.pump();
+
+        expect(futureBuilderFinder, findsOneWidget);
+        expect(loadingWidgetFinder, findsNothing);
+        expect(spriteWidgetFinder, findsOneWidget);
       },
-      skip: true,
     );
   });
+}
+
+class _LoadingWidget extends StatelessWidget {
+  const _LoadingWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
+  }
 }

--- a/packages/flame/test/widgets/sprite_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_widget_test.dart
@@ -17,6 +17,7 @@ void main() async {
       expect(futureBuilder, findsNothing);
       expect(spriteWidgetFinder, findsOneWidget);
     });
+
     testWidgets(
       'has FutureBuilder when pass asset path',
       (tester) async {


### PR DESCRIPTION
# Description

At first, In #1667, I was planning to change only `SpriteWidget` to be able to remove showing LoadingBuilder when non-future sprite was passed.
But after some digging, I found that BaseFutureBuilder causes the loading because it only accepts Future as a parameter.
And `BaseFutureBuilder` are the very base of all image-related widgets such as NineTileBoxWidget, SpriteAnimationWidget, ... etc.

So the key point of this change should allow BaseFutureBuilder to FutureOr as a parameter and split the build function according to the parameter type.

<!-- Provide a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->

After #1645, the Default constructor of SpriteButton can pass Future<Sprite> but its constructor is not consistent with other image-related widgets.
Plus, type of `FutureOr<List<Sprite>> _buttonsFuture` only compatible with `Future<List<Sprite>>` but not `List<Sprite>`.
So I added secondary constructor `SpriteButton.future` that accepts only Future<Sprite> and **Replaced** the `FutureOr<Sprite>` to `Sprite` in the default constructor.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.


### Migration guide
It only breaks SpriteButton when you are using future as a `sprite` or `pressedSprite` parameter.
**You should use SpriteButton.future if previously you are using future as a parameter.**


## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->
Closes #1667 
<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
