### PR TITLE
feat: Keep stacktrace when rethrowing an error from GameWidget

### DIFF
--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:developer';
 
 import 'package:flame/extensions.dart';
 import 'package:flame/input.dart';
@@ -301,17 +300,10 @@ class _GameWidgetState<T extends Game> extends State<GameWidget<T>> {
                         if (snapshot.hasError) {
                           final errorBuilder = widget.errorBuilder;
                           if (errorBuilder == null) {
-                            // @Since('2.16')
-                            // throw Error.throwWithStackTrace(
-                            //   snapshot.error!,
-                            //   snapshot.stackTrace,
-                            // )
-                            log(
-                              'Error while loading Game widget',
-                              error: snapshot.error,
-                              stackTrace: snapshot.stackTrace,
+                            throw Error.throwWithStackTrace(
+                              snapshot.error!,
+                              snapshot.stackTrace!,
                             );
-                            throw snapshot.error!;
                           } else {
                             return errorBuilder(context, snapshot.error!);
                           }


### PR DESCRIPTION
# Description

We were planning to make this change once we upgrade min Dart version to 2.16; which we finally did in #1617.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
