### PR TITLE
refactor: Add onComplete as optional parameter

### DIFF
--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -87,7 +87,7 @@ functionality inherited by all other effects. This includes:
     removed from the game tree and garbage-collected once the effect completes. Set this to false
     if you plan to reuse the effect after it is finished.
 
-  - Optional user-provided `onFinishCallback`, which will be invoked when the effect has just
+  - Optional user-provided `onComplete`, which will be invoked when the effect has just
     completed its execution but before it is removed from the game.
 
   - The `reset()` method reverts the effect to its original state, allowing it to run once again.

--- a/examples/games/padracing/lib/padracing_game.dart
+++ b/examples/games/padracing/lib/padracing_game.dart
@@ -97,7 +97,7 @@ class PadRacingGame extends Forge2DGame with KeyboardEvents {
         ScaleEffect.to(
           Vector2.all(playZoom),
           EffectController(duration: 1.0),
-        )..onFinishCallback = () => start(numberOfPlayers: numberOfPlayers),
+        )..onComplete = () => start(numberOfPlayers: numberOfPlayers),
       )
       ..add(
         MoveEffect.to(

--- a/examples/games/padracing/lib/padracing_game.dart
+++ b/examples/games/padracing/lib/padracing_game.dart
@@ -97,7 +97,8 @@ class PadRacingGame extends Forge2DGame with KeyboardEvents {
         ScaleEffect.to(
           Vector2.all(playZoom),
           EffectController(duration: 1.0),
-        )..onComplete = () => start(numberOfPlayers: numberOfPlayers),
+          onComplete: () => start(numberOfPlayers: numberOfPlayers),
+        ),
       )
       ..add(
         MoveEffect.to(

--- a/packages/flame/lib/src/effects/anchor_by_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_by_effect.dart
@@ -23,7 +23,7 @@ class AnchorByEffect extends AnchorEffect {
     Vector2 offset,
     EffectController controller, {
     AnchorProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _offset = offset.clone(),
         super(controller, target, onComplete: onComplete);
 

--- a/packages/flame/lib/src/effects/anchor_by_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_by_effect.dart
@@ -23,9 +23,9 @@ class AnchorByEffect extends AnchorEffect {
     Vector2 offset,
     EffectController controller, {
     AnchorProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _offset = offset.clone(),
-        super(controller, target, onFinishCallback: onFinishCallback);
+        super(controller, target, onComplete: onComplete);
 
   final Vector2 _offset;
 

--- a/packages/flame/lib/src/effects/anchor_by_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_by_effect.dart
@@ -23,8 +23,9 @@ class AnchorByEffect extends AnchorEffect {
     Vector2 offset,
     EffectController controller, {
     AnchorProvider? target,
+    Function()? onFinishCallback,
   })  : _offset = offset.clone(),
-        super(controller, target);
+        super(controller, target, onFinishCallback: onFinishCallback);
 
   final Vector2 _offset;
 

--- a/packages/flame/lib/src/effects/anchor_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_effect.dart
@@ -21,8 +21,8 @@ abstract class AnchorEffect extends Effect
   AnchorEffect(
     EffectController controller,
     AnchorProvider? target, {
-    Function()? onFinishCallback,
-  }) : super(controller, onFinishCallback: onFinishCallback) {
+    Function()? onComplete,
+  }) : super(controller, onComplete: onComplete) {
     this.target = target;
   }
 
@@ -30,25 +30,25 @@ abstract class AnchorEffect extends Effect
     Vector2 offset,
     EffectController controller, {
     AnchorProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) =>
       AnchorByEffect(
         offset,
         controller,
         target: target,
-        onFinishCallback: onFinishCallback,
+        onComplete: onComplete,
       );
 
   factory AnchorEffect.to(
     Anchor destination,
     EffectController controller, {
     AnchorProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) =>
       AnchorToEffect(
         destination,
         controller,
         target: target,
-        onFinishCallback: onFinishCallback,
+        onComplete: onComplete,
       );
 }

--- a/packages/flame/lib/src/effects/anchor_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_effect.dart
@@ -21,7 +21,7 @@ abstract class AnchorEffect extends Effect
   AnchorEffect(
     EffectController controller,
     AnchorProvider? target, {
-    Function()? onComplete,
+    void Function()? onComplete,
   }) : super(controller, onComplete: onComplete) {
     this.target = target;
   }
@@ -30,7 +30,7 @@ abstract class AnchorEffect extends Effect
     Vector2 offset,
     EffectController controller, {
     AnchorProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) =>
       AnchorByEffect(
         offset,
@@ -43,7 +43,7 @@ abstract class AnchorEffect extends Effect
     Anchor destination,
     EffectController controller, {
     AnchorProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) =>
       AnchorToEffect(
         destination,

--- a/packages/flame/lib/src/effects/anchor_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_effect.dart
@@ -18,8 +18,11 @@ import 'package:vector_math/vector_math_64.dart';
 abstract class AnchorEffect extends Effect
     with EffectTarget<AnchorProvider>
     implements MeasurableEffect {
-  AnchorEffect(EffectController controller, AnchorProvider? target)
-      : super(controller) {
+  AnchorEffect(
+    EffectController controller,
+    AnchorProvider? target, {
+    Function()? onFinishCallback,
+  }) : super(controller, onFinishCallback: onFinishCallback) {
     this.target = target;
   }
 
@@ -27,13 +30,25 @@ abstract class AnchorEffect extends Effect
     Vector2 offset,
     EffectController controller, {
     AnchorProvider? target,
+    Function()? onFinishCallback,
   }) =>
-      AnchorByEffect(offset, controller, target: target);
+      AnchorByEffect(
+        offset,
+        controller,
+        target: target,
+        onFinishCallback: onFinishCallback,
+      );
 
   factory AnchorEffect.to(
     Anchor destination,
     EffectController controller, {
     AnchorProvider? target,
+    Function()? onFinishCallback,
   }) =>
-      AnchorToEffect(destination, controller, target: target);
+      AnchorToEffect(
+        destination,
+        controller,
+        target: target,
+        onFinishCallback: onFinishCallback,
+      );
 }

--- a/packages/flame/lib/src/effects/anchor_to_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_to_effect.dart
@@ -14,9 +14,9 @@ class AnchorToEffect extends AnchorEffect {
     Anchor destination,
     EffectController controller, {
     AnchorProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _destination = destination,
-        super(controller, target, onFinishCallback: onFinishCallback);
+        super(controller, target, onComplete: onComplete);
 
   final Anchor _destination;
   late Vector2 _offset;

--- a/packages/flame/lib/src/effects/anchor_to_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_to_effect.dart
@@ -14,7 +14,7 @@ class AnchorToEffect extends AnchorEffect {
     Anchor destination,
     EffectController controller, {
     AnchorProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _destination = destination,
         super(controller, target, onComplete: onComplete);
 

--- a/packages/flame/lib/src/effects/anchor_to_effect.dart
+++ b/packages/flame/lib/src/effects/anchor_to_effect.dart
@@ -14,8 +14,9 @@ class AnchorToEffect extends AnchorEffect {
     Anchor destination,
     EffectController controller, {
     AnchorProvider? target,
+    Function()? onFinishCallback,
   })  : _destination = destination,
-        super(controller, target);
+        super(controller, target, onFinishCallback: onFinishCallback);
 
   final Anchor _destination;
   late Vector2 _offset;

--- a/packages/flame/lib/src/effects/color_effect.dart
+++ b/packages/flame/lib/src/effects/color_effect.dart
@@ -21,7 +21,7 @@ class ColorEffect extends ComponentEffect<HasPaint> {
     Offset offset,
     EffectController controller, {
     this.paintId,
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _tween = Tween(begin: offset.dx, end: offset.dy),
         super(controller, onComplete: onComplete);
 

--- a/packages/flame/lib/src/effects/color_effect.dart
+++ b/packages/flame/lib/src/effects/color_effect.dart
@@ -21,8 +21,9 @@ class ColorEffect extends ComponentEffect<HasPaint> {
     Offset offset,
     EffectController controller, {
     this.paintId,
+    Function()? onFinishCallback,
   })  : _tween = Tween(begin: offset.dx, end: offset.dy),
-        super(controller);
+        super(controller, onFinishCallback: onFinishCallback);
 
   @override
   Future<void> onMount() async {

--- a/packages/flame/lib/src/effects/color_effect.dart
+++ b/packages/flame/lib/src/effects/color_effect.dart
@@ -21,9 +21,9 @@ class ColorEffect extends ComponentEffect<HasPaint> {
     Offset offset,
     EffectController controller, {
     this.paintId,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _tween = Tween(begin: offset.dx, end: offset.dy),
-        super(controller, onFinishCallback: onFinishCallback);
+        super(controller, onComplete: onComplete);
 
   @override
   Future<void> onMount() async {

--- a/packages/flame/lib/src/effects/component_effect.dart
+++ b/packages/flame/lib/src/effects/component_effect.dart
@@ -7,7 +7,10 @@ import 'package:flame/src/effects/effect.dart';
 /// A general abstraction for creating effects targeting [Component]s, currently
 /// used by `SizeEffect`, `OpacityEffect` and `Transform2DEffect`.
 abstract class ComponentEffect<T extends Component> extends Effect {
-  ComponentEffect(EffectController controller) : super(controller);
+  ComponentEffect(
+    EffectController controller, {
+    Function()? onFinishCallback,
+  }) : super(controller, onFinishCallback: onFinishCallback);
 
   late T target;
 

--- a/packages/flame/lib/src/effects/component_effect.dart
+++ b/packages/flame/lib/src/effects/component_effect.dart
@@ -9,8 +9,8 @@ import 'package:flame/src/effects/effect.dart';
 abstract class ComponentEffect<T extends Component> extends Effect {
   ComponentEffect(
     EffectController controller, {
-    Function()? onFinishCallback,
-  }) : super(controller, onFinishCallback: onFinishCallback);
+    Function()? onComplete,
+  }) : super(controller, onComplete: onComplete);
 
   late T target;
 

--- a/packages/flame/lib/src/effects/component_effect.dart
+++ b/packages/flame/lib/src/effects/component_effect.dart
@@ -9,7 +9,7 @@ import 'package:flame/src/effects/effect.dart';
 abstract class ComponentEffect<T extends Component> extends Effect {
   ComponentEffect(
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   }) : super(controller, onComplete: onComplete);
 
   late T target;

--- a/packages/flame/lib/src/effects/effect.dart
+++ b/packages/flame/lib/src/effects/effect.dart
@@ -47,10 +47,10 @@ abstract class Effect extends Component {
   /// Optional callback function to be invoked once the effect completes.
   void Function()? onComplete;
 
-  @Deprecated('Use Effect.onComplete instead')
+  @Deprecated('It will be removed in v1.3.0. Use Effect.onComplete instead')
   void Function()? get onFinishCallback => onComplete;
 
-  @Deprecated('Use Effect.onComplete instead')
+  @Deprecated('It will be removed in v1.3.0. Use Effect.onComplete instead')
   set onFinishCallback(void Function()? callback) {
     onComplete = callback;
   }

--- a/packages/flame/lib/src/effects/effect.dart
+++ b/packages/flame/lib/src/effects/effect.dart
@@ -25,7 +25,7 @@ import 'package:meta/meta.dart';
 /// changes in the effect's target; and also the `reset()` method if they have
 /// non-trivial internal state.
 abstract class Effect extends Component {
-  Effect(this.controller)
+  Effect(this.controller, {this.onFinishCallback})
       : removeOnFinish = true,
         _paused = false,
         _started = false,

--- a/packages/flame/lib/src/effects/effect.dart
+++ b/packages/flame/lib/src/effects/effect.dart
@@ -25,7 +25,7 @@ import 'package:meta/meta.dart';
 /// changes in the effect's target; and also the `reset()` method if they have
 /// non-trivial internal state.
 abstract class Effect extends Component {
-  Effect(this.controller, {this.onFinishCallback})
+  Effect(this.controller, {this.onComplete})
       : removeOnFinish = true,
         _paused = false,
         _started = false,
@@ -45,7 +45,7 @@ abstract class Effect extends Component {
   bool removeOnFinish;
 
   /// Optional callback function to be invoked once the effect completes.
-  void Function()? onFinishCallback;
+  void Function()? onComplete;
 
   /// Boolean indicators of the effect's state, their purpose is to ensure that
   /// the `onStart()` and `onFinish()` callbacks are called exactly once.
@@ -185,7 +185,7 @@ abstract class Effect extends Component {
   /// the effect has finished again.
   @mustCallSuper
   void onFinish() {
-    onFinishCallback?.call();
+    onComplete?.call();
   }
 
   /// Apply the given [progress] level to the effect's target.

--- a/packages/flame/lib/src/effects/effect.dart
+++ b/packages/flame/lib/src/effects/effect.dart
@@ -47,6 +47,14 @@ abstract class Effect extends Component {
   /// Optional callback function to be invoked once the effect completes.
   void Function()? onComplete;
 
+  @Deprecated('Use Effect.onComplete instead')
+  void Function()? get onFinishCallback => onComplete;
+
+  @Deprecated('Use Effect.onComplete instead')
+  set onFinishCallback(void Function()? callback) {
+    onComplete = callback;
+  }
+
   /// Boolean indicators of the effect's state, their purpose is to ensure that
   /// the `onStart()` and `onFinish()` callbacks are called exactly once.
   bool _started;

--- a/packages/flame/lib/src/effects/move_along_path_effect.dart
+++ b/packages/flame/lib/src/effects/move_along_path_effect.dart
@@ -30,9 +30,14 @@ class MoveAlongPathEffect extends MoveEffect {
     bool absolute = false,
     bool oriented = false,
     PositionProvider? target,
+    Function()? onFinishCallback,
   })  : _isAbsolute = absolute,
         _followDirection = oriented,
-        super(controller, target) {
+        super(
+          controller,
+          target,
+          onFinishCallback: onFinishCallback,
+        ) {
     final metrics = path.computeMetrics().toList();
     if (metrics.length != 1) {
       throw ArgumentError(

--- a/packages/flame/lib/src/effects/move_along_path_effect.dart
+++ b/packages/flame/lib/src/effects/move_along_path_effect.dart
@@ -30,13 +30,13 @@ class MoveAlongPathEffect extends MoveEffect {
     bool absolute = false,
     bool oriented = false,
     PositionProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _isAbsolute = absolute,
         _followDirection = oriented,
         super(
           controller,
           target,
-          onFinishCallback: onFinishCallback,
+          onComplete: onComplete,
         ) {
     final metrics = path.computeMetrics().toList();
     if (metrics.length != 1) {

--- a/packages/flame/lib/src/effects/move_along_path_effect.dart
+++ b/packages/flame/lib/src/effects/move_along_path_effect.dart
@@ -30,7 +30,7 @@ class MoveAlongPathEffect extends MoveEffect {
     bool absolute = false,
     bool oriented = false,
     PositionProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _isAbsolute = absolute,
         _followDirection = oriented,
         super(

--- a/packages/flame/lib/src/effects/move_by_effect.dart
+++ b/packages/flame/lib/src/effects/move_by_effect.dart
@@ -22,8 +22,9 @@ class MoveByEffect extends MoveEffect {
     Vector2 offset,
     EffectController controller, {
     PositionProvider? target,
+    Function()? onFinishCallback,
   })  : _offset = offset.clone(),
-        super(controller, target);
+        super(controller, target, onFinishCallback: onFinishCallback);
 
   final Vector2 _offset;
 

--- a/packages/flame/lib/src/effects/move_by_effect.dart
+++ b/packages/flame/lib/src/effects/move_by_effect.dart
@@ -22,7 +22,7 @@ class MoveByEffect extends MoveEffect {
     Vector2 offset,
     EffectController controller, {
     PositionProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _offset = offset.clone(),
         super(controller, target, onComplete: onComplete);
 

--- a/packages/flame/lib/src/effects/move_by_effect.dart
+++ b/packages/flame/lib/src/effects/move_by_effect.dart
@@ -22,9 +22,9 @@ class MoveByEffect extends MoveEffect {
     Vector2 offset,
     EffectController controller, {
     PositionProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _offset = offset.clone(),
-        super(controller, target, onFinishCallback: onFinishCallback);
+        super(controller, target, onComplete: onComplete);
 
   final Vector2 _offset;
 

--- a/packages/flame/lib/src/effects/move_effect.dart
+++ b/packages/flame/lib/src/effects/move_effect.dart
@@ -17,8 +17,11 @@ import 'package:vector_math/vector_math_64.dart';
 abstract class MoveEffect extends Effect
     with EffectTarget<PositionProvider>
     implements MeasurableEffect {
-  MoveEffect(EffectController controller, PositionProvider? target)
-      : super(controller) {
+  MoveEffect(
+    EffectController controller,
+    PositionProvider? target, {
+    Function()? onFinishCallback,
+  }) : super(controller, onFinishCallback: onFinishCallback) {
     this.target = target;
   }
 
@@ -26,13 +29,25 @@ abstract class MoveEffect extends Effect
     Vector2 offset,
     EffectController controller, {
     PositionProvider? target,
+    Function()? onFinishCallback,
   }) =>
-      MoveByEffect(offset, controller, target: target);
+      MoveByEffect(
+        offset,
+        controller,
+        target: target,
+        onFinishCallback: onFinishCallback,
+      );
 
   factory MoveEffect.to(
     Vector2 destination,
     EffectController controller, {
     PositionProvider? target,
+    Function()? onFinishCallback,
   }) =>
-      MoveToEffect(destination, controller, target: target);
+      MoveToEffect(
+        destination,
+        controller,
+        target: target,
+        onFinishCallback: onFinishCallback,
+      );
 }

--- a/packages/flame/lib/src/effects/move_effect.dart
+++ b/packages/flame/lib/src/effects/move_effect.dart
@@ -20,8 +20,8 @@ abstract class MoveEffect extends Effect
   MoveEffect(
     EffectController controller,
     PositionProvider? target, {
-    Function()? onFinishCallback,
-  }) : super(controller, onFinishCallback: onFinishCallback) {
+    Function()? onComplete,
+  }) : super(controller, onComplete: onComplete) {
     this.target = target;
   }
 
@@ -29,25 +29,25 @@ abstract class MoveEffect extends Effect
     Vector2 offset,
     EffectController controller, {
     PositionProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) =>
       MoveByEffect(
         offset,
         controller,
         target: target,
-        onFinishCallback: onFinishCallback,
+        onComplete: onComplete,
       );
 
   factory MoveEffect.to(
     Vector2 destination,
     EffectController controller, {
     PositionProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) =>
       MoveToEffect(
         destination,
         controller,
         target: target,
-        onFinishCallback: onFinishCallback,
+        onComplete: onComplete,
       );
 }

--- a/packages/flame/lib/src/effects/move_effect.dart
+++ b/packages/flame/lib/src/effects/move_effect.dart
@@ -20,7 +20,7 @@ abstract class MoveEffect extends Effect
   MoveEffect(
     EffectController controller,
     PositionProvider? target, {
-    Function()? onComplete,
+    void Function()? onComplete,
   }) : super(controller, onComplete: onComplete) {
     this.target = target;
   }
@@ -29,7 +29,7 @@ abstract class MoveEffect extends Effect
     Vector2 offset,
     EffectController controller, {
     PositionProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) =>
       MoveByEffect(
         offset,
@@ -42,7 +42,7 @@ abstract class MoveEffect extends Effect
     Vector2 destination,
     EffectController controller, {
     PositionProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) =>
       MoveToEffect(
         destination,

--- a/packages/flame/lib/src/effects/move_to_effect.dart
+++ b/packages/flame/lib/src/effects/move_to_effect.dart
@@ -23,7 +23,7 @@ class MoveToEffect extends MoveEffect {
     Vector2 destination,
     EffectController controller, {
     PositionProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _destination = destination.clone(),
         _offset = Vector2.zero(),
         super(controller, target, onComplete: onComplete);

--- a/packages/flame/lib/src/effects/move_to_effect.dart
+++ b/packages/flame/lib/src/effects/move_to_effect.dart
@@ -23,10 +23,10 @@ class MoveToEffect extends MoveEffect {
     Vector2 destination,
     EffectController controller, {
     PositionProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _destination = destination.clone(),
         _offset = Vector2.zero(),
-        super(controller, target, onFinishCallback: onFinishCallback);
+        super(controller, target, onComplete: onComplete);
 
   final Vector2 _destination;
   final Vector2 _offset;

--- a/packages/flame/lib/src/effects/move_to_effect.dart
+++ b/packages/flame/lib/src/effects/move_to_effect.dart
@@ -23,9 +23,10 @@ class MoveToEffect extends MoveEffect {
     Vector2 destination,
     EffectController controller, {
     PositionProvider? target,
+    Function()? onFinishCallback,
   })  : _destination = destination.clone(),
         _offset = Vector2.zero(),
-        super(controller, target);
+        super(controller, target, onFinishCallback: onFinishCallback);
 
   final Vector2 _destination;
   final Vector2 _offset;

--- a/packages/flame/lib/src/effects/opacity_effect.dart
+++ b/packages/flame/lib/src/effects/opacity_effect.dart
@@ -18,30 +18,49 @@ class OpacityEffect extends ComponentEffect<HasPaint> {
     double offset,
     EffectController controller, {
     this.paintId,
+    Function()? onFinishCallback,
   })  : _alphaOffset = (255 * offset).round(),
-        super(controller);
+        super(controller, onFinishCallback: onFinishCallback);
 
   /// This constructor will set the opacity to the specified opacity over time.
   factory OpacityEffect.to(
     double targetOpacity,
     EffectController controller, {
     String? paintId,
+    Function()? onFinishCallback,
   }) {
-    return _OpacityToEffect(targetOpacity, controller, paintId: paintId);
+    return _OpacityToEffect(
+      targetOpacity,
+      controller,
+      paintId: paintId,
+      onFinishCallback: onFinishCallback,
+    );
   }
 
   factory OpacityEffect.fadeIn(
     EffectController controller, {
     String? paintId,
+    Function()? onFinishCallback,
   }) {
-    return _OpacityToEffect(1.0, controller, paintId: paintId);
+    return _OpacityToEffect(
+      1.0,
+      controller,
+      paintId: paintId,
+      onFinishCallback: onFinishCallback,
+    );
   }
 
   factory OpacityEffect.fadeOut(
     EffectController controller, {
     String? paintId,
+    Function()? onFinishCallback,
   }) {
-    return _OpacityToEffect(0.0, controller, paintId: paintId);
+    return _OpacityToEffect(
+      0.0,
+      controller,
+      paintId: paintId,
+      onFinishCallback: onFinishCallback,
+    );
   }
 
   @override
@@ -79,7 +98,13 @@ class _OpacityToEffect extends OpacityEffect {
     this._targetOpacity,
     EffectController controller, {
     String? paintId,
-  }) : super.by(0.0, controller, paintId: paintId);
+    Function()? onFinishCallback,
+  }) : super.by(
+          0.0,
+          controller,
+          paintId: paintId,
+          onFinishCallback: onFinishCallback,
+        );
 
   @override
   void onStart() {

--- a/packages/flame/lib/src/effects/opacity_effect.dart
+++ b/packages/flame/lib/src/effects/opacity_effect.dart
@@ -18,7 +18,7 @@ class OpacityEffect extends ComponentEffect<HasPaint> {
     double offset,
     EffectController controller, {
     this.paintId,
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _alphaOffset = (255 * offset).round(),
         super(controller, onComplete: onComplete);
 
@@ -27,7 +27,7 @@ class OpacityEffect extends ComponentEffect<HasPaint> {
     double targetOpacity,
     EffectController controller, {
     String? paintId,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) {
     return _OpacityToEffect(
       targetOpacity,
@@ -40,7 +40,7 @@ class OpacityEffect extends ComponentEffect<HasPaint> {
   factory OpacityEffect.fadeIn(
     EffectController controller, {
     String? paintId,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) {
     return _OpacityToEffect(
       1.0,
@@ -53,7 +53,7 @@ class OpacityEffect extends ComponentEffect<HasPaint> {
   factory OpacityEffect.fadeOut(
     EffectController controller, {
     String? paintId,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) {
     return _OpacityToEffect(
       0.0,
@@ -98,7 +98,7 @@ class _OpacityToEffect extends OpacityEffect {
     this._targetOpacity,
     EffectController controller, {
     String? paintId,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) : super.by(
           0.0,
           controller,

--- a/packages/flame/lib/src/effects/opacity_effect.dart
+++ b/packages/flame/lib/src/effects/opacity_effect.dart
@@ -18,48 +18,48 @@ class OpacityEffect extends ComponentEffect<HasPaint> {
     double offset,
     EffectController controller, {
     this.paintId,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _alphaOffset = (255 * offset).round(),
-        super(controller, onFinishCallback: onFinishCallback);
+        super(controller, onComplete: onComplete);
 
   /// This constructor will set the opacity to the specified opacity over time.
   factory OpacityEffect.to(
     double targetOpacity,
     EffectController controller, {
     String? paintId,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) {
     return _OpacityToEffect(
       targetOpacity,
       controller,
       paintId: paintId,
-      onFinishCallback: onFinishCallback,
+      onComplete: onComplete,
     );
   }
 
   factory OpacityEffect.fadeIn(
     EffectController controller, {
     String? paintId,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) {
     return _OpacityToEffect(
       1.0,
       controller,
       paintId: paintId,
-      onFinishCallback: onFinishCallback,
+      onComplete: onComplete,
     );
   }
 
   factory OpacityEffect.fadeOut(
     EffectController controller, {
     String? paintId,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) {
     return _OpacityToEffect(
       0.0,
       controller,
       paintId: paintId,
-      onFinishCallback: onFinishCallback,
+      onComplete: onComplete,
     );
   }
 
@@ -98,12 +98,12 @@ class _OpacityToEffect extends OpacityEffect {
     this._targetOpacity,
     EffectController controller, {
     String? paintId,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) : super.by(
           0.0,
           controller,
           paintId: paintId,
-          onFinishCallback: onFinishCallback,
+          onComplete: onComplete,
         );
 
   @override

--- a/packages/flame/lib/src/effects/remove_effect.dart
+++ b/packages/flame/lib/src/effects/remove_effect.dart
@@ -6,10 +6,10 @@ import 'package:flame/src/effects/effect.dart';
 class RemoveEffect extends Effect {
   RemoveEffect({
     double delay = 0.0,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) : super(
           LinearEffectController(delay),
-          onFinishCallback: onFinishCallback,
+          onComplete: onComplete,
         );
 
   @override

--- a/packages/flame/lib/src/effects/remove_effect.dart
+++ b/packages/flame/lib/src/effects/remove_effect.dart
@@ -4,7 +4,13 @@ import 'package:flame/src/effects/effect.dart';
 /// This simple effect, when attached to a component, will cause that component
 /// to be removed from the game tree after `delay` seconds.
 class RemoveEffect extends Effect {
-  RemoveEffect({double delay = 0.0}) : super(LinearEffectController(delay));
+  RemoveEffect({
+    double delay = 0.0,
+    Function()? onFinishCallback,
+  }) : super(
+          LinearEffectController(delay),
+          onFinishCallback: onFinishCallback,
+        );
 
   @override
   void apply(double progress) {

--- a/packages/flame/lib/src/effects/remove_effect.dart
+++ b/packages/flame/lib/src/effects/remove_effect.dart
@@ -6,7 +6,7 @@ import 'package:flame/src/effects/effect.dart';
 class RemoveEffect extends Effect {
   RemoveEffect({
     double delay = 0.0,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) : super(
           LinearEffectController(delay),
           onComplete: onComplete,

--- a/packages/flame/lib/src/effects/rotate_effect.dart
+++ b/packages/flame/lib/src/effects/rotate_effect.dart
@@ -24,7 +24,7 @@ class RotateEffect extends Effect
   RotateEffect.by(
     double angle,
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _angle = angle,
         super(
           controller,
@@ -34,7 +34,7 @@ class RotateEffect extends Effect
   factory RotateEffect.to(
     double angle,
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   }) {
     return _RotateToEffect(
       angle,
@@ -61,7 +61,7 @@ class _RotateToEffect extends RotateEffect {
   _RotateToEffect(
     double angle,
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _destinationAngle = angle,
         super.by(0, controller, onComplete: onComplete);
 

--- a/packages/flame/lib/src/effects/rotate_effect.dart
+++ b/packages/flame/lib/src/effects/rotate_effect.dart
@@ -24,22 +24,22 @@ class RotateEffect extends Effect
   RotateEffect.by(
     double angle,
     EffectController controller, {
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _angle = angle,
         super(
           controller,
-          onFinishCallback: onFinishCallback,
+          onComplete: onComplete,
         );
 
   factory RotateEffect.to(
     double angle,
     EffectController controller, {
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) {
     return _RotateToEffect(
       angle,
       controller,
-      onFinishCallback: onFinishCallback,
+      onComplete: onComplete,
     );
   }
 
@@ -61,9 +61,9 @@ class _RotateToEffect extends RotateEffect {
   _RotateToEffect(
     double angle,
     EffectController controller, {
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _destinationAngle = angle,
-        super.by(0, controller, onFinishCallback: onFinishCallback);
+        super.by(0, controller, onComplete: onComplete);
 
   final double _destinationAngle;
 

--- a/packages/flame/lib/src/effects/rotate_effect.dart
+++ b/packages/flame/lib/src/effects/rotate_effect.dart
@@ -21,12 +21,26 @@ import 'package:flame/src/effects/provider_interfaces.dart';
 class RotateEffect extends Effect
     with EffectTarget<AngleProvider>
     implements MeasurableEffect {
-  RotateEffect.by(double angle, EffectController controller)
-      : _angle = angle,
-        super(controller);
+  RotateEffect.by(
+    double angle,
+    EffectController controller, {
+    Function()? onFinishCallback,
+  })  : _angle = angle,
+        super(
+          controller,
+          onFinishCallback: onFinishCallback,
+        );
 
-  factory RotateEffect.to(double angle, EffectController controller) {
-    return _RotateToEffect(angle, controller);
+  factory RotateEffect.to(
+    double angle,
+    EffectController controller, {
+    Function()? onFinishCallback,
+  }) {
+    return _RotateToEffect(
+      angle,
+      controller,
+      onFinishCallback: onFinishCallback,
+    );
   }
 
   /// The magnitude of the effect: how much the target should turn as the
@@ -44,9 +58,12 @@ class RotateEffect extends Effect
 }
 
 class _RotateToEffect extends RotateEffect {
-  _RotateToEffect(double angle, EffectController controller)
-      : _destinationAngle = angle,
-        super.by(0, controller);
+  _RotateToEffect(
+    double angle,
+    EffectController controller, {
+    Function()? onFinishCallback,
+  })  : _destinationAngle = angle,
+        super.by(0, controller, onFinishCallback: onFinishCallback);
 
   final double _destinationAngle;
 

--- a/packages/flame/lib/src/effects/scale_effect.dart
+++ b/packages/flame/lib/src/effects/scale_effect.dart
@@ -19,14 +19,14 @@ class ScaleEffect extends Effect with EffectTarget<ScaleProvider> {
   ScaleEffect.by(
     Vector2 scaleFactor,
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _scaleFactor = scaleFactor.clone(),
         super(controller, onComplete: onComplete);
 
   factory ScaleEffect.to(
     Vector2 targetScale,
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   }) =>
       _ScaleToEffect(
         targetScale,
@@ -59,7 +59,7 @@ class _ScaleToEffect extends ScaleEffect {
   _ScaleToEffect(
     Vector2 targetScale,
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _targetScale = targetScale.clone(),
         super.by(
           Vector2.zero(),

--- a/packages/flame/lib/src/effects/scale_effect.dart
+++ b/packages/flame/lib/src/effects/scale_effect.dart
@@ -16,12 +16,23 @@ import 'package:vector_math/vector_math_64.dart';
 /// requires that any other effect or update logic applied to the same component
 /// also used incremental updates.
 class ScaleEffect extends Effect with EffectTarget<ScaleProvider> {
-  ScaleEffect.by(Vector2 scaleFactor, EffectController controller)
-      : _scaleFactor = scaleFactor.clone(),
-        super(controller);
+  ScaleEffect.by(
+    Vector2 scaleFactor,
+    EffectController controller, {
+    Function()? onFinishCallback,
+  })  : _scaleFactor = scaleFactor.clone(),
+        super(controller, onFinishCallback: onFinishCallback);
 
-  factory ScaleEffect.to(Vector2 targetScale, EffectController controller) =>
-      _ScaleToEffect(targetScale, controller);
+  factory ScaleEffect.to(
+    Vector2 targetScale,
+    EffectController controller, {
+    Function()? onFinishCallback,
+  }) =>
+      _ScaleToEffect(
+        targetScale,
+        controller,
+        onFinishCallback: onFinishCallback,
+      );
 
   final Vector2 _scaleFactor;
   late Vector2 _scaleDelta;
@@ -45,9 +56,16 @@ class ScaleEffect extends Effect with EffectTarget<ScaleProvider> {
 class _ScaleToEffect extends ScaleEffect {
   final Vector2 _targetScale;
 
-  _ScaleToEffect(Vector2 targetScale, EffectController controller)
-      : _targetScale = targetScale.clone(),
-        super.by(Vector2.zero(), controller);
+  _ScaleToEffect(
+    Vector2 targetScale,
+    EffectController controller, {
+    Function()? onFinishCallback,
+  })  : _targetScale = targetScale.clone(),
+        super.by(
+          Vector2.zero(),
+          controller,
+          onFinishCallback: onFinishCallback,
+        );
 
   @override
   void onStart() {

--- a/packages/flame/lib/src/effects/scale_effect.dart
+++ b/packages/flame/lib/src/effects/scale_effect.dart
@@ -19,19 +19,19 @@ class ScaleEffect extends Effect with EffectTarget<ScaleProvider> {
   ScaleEffect.by(
     Vector2 scaleFactor,
     EffectController controller, {
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _scaleFactor = scaleFactor.clone(),
-        super(controller, onFinishCallback: onFinishCallback);
+        super(controller, onComplete: onComplete);
 
   factory ScaleEffect.to(
     Vector2 targetScale,
     EffectController controller, {
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) =>
       _ScaleToEffect(
         targetScale,
         controller,
-        onFinishCallback: onFinishCallback,
+        onComplete: onComplete,
       );
 
   final Vector2 _scaleFactor;
@@ -59,12 +59,12 @@ class _ScaleToEffect extends ScaleEffect {
   _ScaleToEffect(
     Vector2 targetScale,
     EffectController controller, {
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _targetScale = targetScale.clone(),
         super.by(
           Vector2.zero(),
           controller,
-          onFinishCallback: onFinishCallback,
+          onComplete: onComplete,
         );
 
   @override

--- a/packages/flame/lib/src/effects/sequence_effect.dart
+++ b/packages/flame/lib/src/effects/sequence_effect.dart
@@ -32,7 +32,7 @@ class SequenceEffect extends Effect {
     bool alternate = false,
     bool infinite = false,
     int repeatCount = 1,
-    Function()? onComplete,
+    void Function()? onComplete,
   }) {
     assert(effects.isNotEmpty, 'The list of effects cannot be empty');
     assert(
@@ -51,7 +51,7 @@ class SequenceEffect extends Effect {
 
   SequenceEffect._(
     EffectController ec, {
-    Function()? onComplete,
+    void Function()? onComplete,
   }) : super(ec, onComplete: onComplete);
 
   @override

--- a/packages/flame/lib/src/effects/sequence_effect.dart
+++ b/packages/flame/lib/src/effects/sequence_effect.dart
@@ -32,7 +32,7 @@ class SequenceEffect extends Effect {
     bool alternate = false,
     bool infinite = false,
     int repeatCount = 1,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) {
     assert(effects.isNotEmpty, 'The list of effects cannot be empty');
     assert(
@@ -46,14 +46,13 @@ class SequenceEffect extends Effect {
       ec = RepeatedEffectController(ec, repeatCount);
     }
     effects.forEach((e) => e.removeOnFinish = false);
-    return SequenceEffect._(ec, onFinishCallback: onFinishCallback)
-      ..addAll(effects);
+    return SequenceEffect._(ec, onComplete: onComplete)..addAll(effects);
   }
 
   SequenceEffect._(
     EffectController ec, {
-    Function()? onFinishCallback,
-  }) : super(ec, onFinishCallback: onFinishCallback);
+    Function()? onComplete,
+  }) : super(ec, onComplete: onComplete);
 
   @override
   void apply(double progress) {}

--- a/packages/flame/lib/src/effects/sequence_effect.dart
+++ b/packages/flame/lib/src/effects/sequence_effect.dart
@@ -32,6 +32,7 @@ class SequenceEffect extends Effect {
     bool alternate = false,
     bool infinite = false,
     int repeatCount = 1,
+    Function()? onFinishCallback,
   }) {
     assert(effects.isNotEmpty, 'The list of effects cannot be empty');
     assert(
@@ -45,10 +46,14 @@ class SequenceEffect extends Effect {
       ec = RepeatedEffectController(ec, repeatCount);
     }
     effects.forEach((e) => e.removeOnFinish = false);
-    return SequenceEffect._(ec)..addAll(effects);
+    return SequenceEffect._(ec, onFinishCallback: onFinishCallback)
+      ..addAll(effects);
   }
 
-  SequenceEffect._(EffectController ec) : super(ec);
+  SequenceEffect._(
+    EffectController ec, {
+    Function()? onFinishCallback,
+  }) : super(ec, onFinishCallback: onFinishCallback);
 
   @override
   void apply(double progress) {}

--- a/packages/flame/lib/src/effects/size_effect.dart
+++ b/packages/flame/lib/src/effects/size_effect.dart
@@ -20,8 +20,9 @@ class SizeEffect extends Effect with EffectTarget<SizeProvider> {
     Vector2 offset,
     EffectController controller, {
     SizeProvider? target,
+    Function()? onFinishCallback,
   })  : _offset = offset.clone(),
-        super(controller) {
+        super(controller, onFinishCallback: onFinishCallback) {
     this.target = target;
   }
 
@@ -31,8 +32,12 @@ class SizeEffect extends Effect with EffectTarget<SizeProvider> {
   /// of the affected component is `Vector2(100, 100)` at the start of the
   /// affected the effect will peak when the size is `Vector2(200, 100)`, if
   /// there is nothing else affecting the size at the same time.
-  factory SizeEffect.to(Vector2 targetSize, EffectController controller) =>
-      _SizeToEffect(targetSize, controller);
+  factory SizeEffect.to(
+    Vector2 targetSize,
+    EffectController controller, {
+    Function()? onFinishCallback,
+  }) =>
+      _SizeToEffect(targetSize, controller, onFinishCallback: onFinishCallback);
 
   Vector2 _offset;
 
@@ -48,9 +53,16 @@ class SizeEffect extends Effect with EffectTarget<SizeProvider> {
 class _SizeToEffect extends SizeEffect {
   final Vector2 _targetSize;
 
-  _SizeToEffect(Vector2 targetSize, EffectController controller)
-      : _targetSize = targetSize.clone(),
-        super.by(Vector2.zero(), controller);
+  _SizeToEffect(
+    Vector2 targetSize,
+    EffectController controller, {
+    Function()? onFinishCallback,
+  })  : _targetSize = targetSize.clone(),
+        super.by(
+          Vector2.zero(),
+          controller,
+          onFinishCallback: onFinishCallback,
+        );
 
   @override
   void onStart() {

--- a/packages/flame/lib/src/effects/size_effect.dart
+++ b/packages/flame/lib/src/effects/size_effect.dart
@@ -20,7 +20,7 @@ class SizeEffect extends Effect with EffectTarget<SizeProvider> {
     Vector2 offset,
     EffectController controller, {
     SizeProvider? target,
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _offset = offset.clone(),
         super(controller, onComplete: onComplete) {
     this.target = target;
@@ -35,7 +35,7 @@ class SizeEffect extends Effect with EffectTarget<SizeProvider> {
   factory SizeEffect.to(
     Vector2 targetSize,
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   }) =>
       _SizeToEffect(targetSize, controller, onComplete: onComplete);
 
@@ -56,7 +56,7 @@ class _SizeToEffect extends SizeEffect {
   _SizeToEffect(
     Vector2 targetSize,
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   })  : _targetSize = targetSize.clone(),
         super.by(
           Vector2.zero(),

--- a/packages/flame/lib/src/effects/size_effect.dart
+++ b/packages/flame/lib/src/effects/size_effect.dart
@@ -20,9 +20,9 @@ class SizeEffect extends Effect with EffectTarget<SizeProvider> {
     Vector2 offset,
     EffectController controller, {
     SizeProvider? target,
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _offset = offset.clone(),
-        super(controller, onFinishCallback: onFinishCallback) {
+        super(controller, onComplete: onComplete) {
     this.target = target;
   }
 
@@ -35,9 +35,9 @@ class SizeEffect extends Effect with EffectTarget<SizeProvider> {
   factory SizeEffect.to(
     Vector2 targetSize,
     EffectController controller, {
-    Function()? onFinishCallback,
+    Function()? onComplete,
   }) =>
-      _SizeToEffect(targetSize, controller, onFinishCallback: onFinishCallback);
+      _SizeToEffect(targetSize, controller, onComplete: onComplete);
 
   Vector2 _offset;
 
@@ -56,12 +56,12 @@ class _SizeToEffect extends SizeEffect {
   _SizeToEffect(
     Vector2 targetSize,
     EffectController controller, {
-    Function()? onFinishCallback,
+    Function()? onComplete,
   })  : _targetSize = targetSize.clone(),
         super.by(
           Vector2.zero(),
           controller,
-          onFinishCallback: onFinishCallback,
+          onComplete: onComplete,
         );
 
   @override

--- a/packages/flame/lib/src/effects/transform2d_effect.dart
+++ b/packages/flame/lib/src/effects/transform2d_effect.dart
@@ -15,7 +15,7 @@ import 'package:flame/src/game/transform2d.dart';
 abstract class Transform2DEffect extends ComponentEffect<PositionComponent> {
   Transform2DEffect(
     EffectController controller, {
-    Function()? onComplete,
+    void Function()? onComplete,
   }) : super(controller, onComplete: onComplete);
 
   late Transform2D transform;

--- a/packages/flame/lib/src/effects/transform2d_effect.dart
+++ b/packages/flame/lib/src/effects/transform2d_effect.dart
@@ -13,7 +13,10 @@ import 'package:flame/src/game/transform2d.dart';
 /// but in the future it will be extended to work with any [Transform2D]-based
 /// classes.
 abstract class Transform2DEffect extends ComponentEffect<PositionComponent> {
-  Transform2DEffect(EffectController controller) : super(controller);
+  Transform2DEffect(
+    EffectController controller, {
+    Function()? onFinishCallback,
+  }) : super(controller, onFinishCallback: onFinishCallback);
 
   late Transform2D transform;
 

--- a/packages/flame/lib/src/effects/transform2d_effect.dart
+++ b/packages/flame/lib/src/effects/transform2d_effect.dart
@@ -15,8 +15,8 @@ import 'package:flame/src/game/transform2d.dart';
 abstract class Transform2DEffect extends ComponentEffect<PositionComponent> {
   Transform2DEffect(
     EffectController controller, {
-    Function()? onFinishCallback,
-  }) : super(controller, onFinishCallback: onFinishCallback);
+    Function()? onComplete,
+  }) : super(controller, onComplete: onComplete);
 
   late Transform2D transform;
 

--- a/packages/flame/test/effects/effect_test.dart
+++ b/packages/flame/test/effects/effect_test.dart
@@ -143,7 +143,7 @@ void main() {
         ..onStartCallback = () {
           nStarted++;
         }
-        ..onFinishCallback = () {
+        ..onComplete = () {
           nFinished++;
         };
 


### PR DESCRIPTION
# Description

Adding `onComplete` as optional parameter to all the effects and deprecating `onFinishCallback`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [NA] I have updated/added tests for ALL new/updated/fixed functionality.
- [NA] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [NA] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Fixes #1683

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
