### PR TITLE
feat: add options to flame test

### DIFF
--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -104,6 +104,11 @@ class GameTester<T extends Game> {
     String description,
     VerifyFunction<T> verify, {
     String? skip,
+    String? testOn,
+    Timeout? timeout,
+    dynamic tags,
+    Map<String, dynamic>? onPlatform,
+    int? retry,
   }) {
     flutter_test.test(
       description,
@@ -112,6 +117,11 @@ class GameTester<T extends Game> {
         await verify(game);
       },
       skip: skip,
+      testOn: testOn,
+      timeout: timeout,
+      tags: tags,
+      onPlatform: onPlatform,
+      retry: retry,
     );
   }
 
@@ -123,9 +133,20 @@ class GameTester<T extends Game> {
   @Deprecated('Use testGameWidget instead')
   void widgetTest(
     String description,
-    WidgetVerifyFunction<T>? verify,
-  ) {
-    testGameWidget(description, verify: verify);
+    WidgetVerifyFunction<T>? verify, {
+    bool? skip,
+    Timeout? timeout,
+    bool? semanticsEnabled,
+    dynamic tags,
+  }) {
+    testGameWidget(
+      description,
+      verify: verify,
+      skip: skip,
+      timeout: timeout,
+      semanticsEnabled: semanticsEnabled,
+      tags: tags,
+    );
   }
 
   /// Creates a [Game] specific test case with given [description]
@@ -139,31 +160,42 @@ class GameTester<T extends Game> {
     String description, {
     WidgetSetupFunction<T>? setUp,
     WidgetVerifyFunction<T>? verify,
+    bool? skip,
+    Timeout? timeout,
+    bool? semanticsEnabled,
+    dynamic tags,
   }) {
-    testWidgets(description, (tester) async {
-      final game = createGame();
+    testWidgets(
+      description,
+      (tester) async {
+        final game = createGame();
 
-      await tester.runAsync(() async {
-        final gameWidget =
-            createGameWidget?.call(game) ?? GameWidget(game: game);
+        await tester.runAsync(() async {
+          final gameWidget =
+              createGameWidget?.call(game) ?? GameWidget(game: game);
 
-        final _pump = pumpWidget ??
-            (GameWidget<T> _gameWidget, WidgetTester _tester) =>
-                _tester.pumpWidget(_gameWidget);
+          final _pump = pumpWidget ??
+              (GameWidget<T> _gameWidget, WidgetTester _tester) =>
+                  _tester.pumpWidget(_gameWidget);
 
-        await _pump(gameWidget, tester);
-        await tester.pump();
-
-        if (setUp != null) {
-          await setUp.call(game, tester);
+          await _pump(gameWidget, tester);
           await tester.pump();
-        }
-      });
 
-      if (verify != null) {
-        await verify(game, tester);
-      }
-    });
+          if (setUp != null) {
+            await setUp.call(game, tester);
+            await tester.pump();
+          }
+        });
+
+        if (verify != null) {
+          await verify(game, tester);
+        }
+      },
+      skip: skip,
+      timeout: timeout,
+      semanticsEnabled: semanticsEnabled ?? true,
+      tags: tags,
+    );
   }
 
   GameTester<T> configure({


### PR DESCRIPTION
# Description

Add test options to enclosing test function on `flame_test`.

This allows users to skip or tag individual tests. 


## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

