### PR TITLE
refactor: Update and guarantee consistency on mocktail dev dependency version across repo

### DIFF
--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  mocktail: ^0.2.0
+  mocktail: ^0.3.0
   canvas_test: ^0.2.0
   flame_test: ^1.4.0
   flame_lint: ^0.0.1

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -21,5 +21,5 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^1.0.0
   flame_test: ^1.4.0
-  mocktail: ^0.2.0
+  mocktail: ^0.3.0
   flame_lint: ^0.0.1

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -17,5 +17,5 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flame_lint: ^0.0.1
-  mocktail: ^0.1.2
+  mocktail: ^0.3.0
   dartdoc: ^4.1.0

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -17,4 +17,4 @@ dev_dependencies:
   dartdoc: ^4.1.0
   flame_lint: ^0.0.1
   test: ^1.17.12
-  mocktail: ^0.2.0
+  mocktail: ^0.3.0


### PR DESCRIPTION
# Description

When running `melos bootstrap`, I realized flame was loading a very old mocktail version that actually has an issue with they dart version constraint:

```
[luan@aurora flame]$ melos bootstrap
melos bootstrap
   └> /home/luan/projects/gamedev/flame/flame

Running "flutter pub get" in workspace packages...
Note: this may take a while in large workspaces such as this one.
  ✓ examples
    └> examples
  - flame
    └> packages/flame
    └> Failed to install.

Running "flutter pub get" in flame...                           
Error on line 8, column 8 of /home/luan/.pub-cache/hosted/pub.dartlang.org/mocktail-0.1.2/pubspec.yaml: Invalid version constraint: Expected version number after ">=" in ">=2.12-0-0 <3.0.0", got "2.12-0-0 <3.0.0".
  ╷
8 │   sdk: ">=2.12-0-0 <3.0.0"
  │        ^^^^^^^^^^^^^^^^^^^
  ╵
pub get failed (65;   ╵)
BootstrapException: failed to install flame at /home/luan/projects/gamedev/flame/flame/packages/flame.
```

That led me to realize that each package uses its own version of mocktail. For the sake of consistency, and keeping dependencies updated, I am updating all to use the current latest (`0.3.0`).

Sadly I am not sure if we can have a base yaml to enforce versions across projects (like a base pom or gradle file).

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
