### PR TITLE
docs: Add warning about very large numbers on the camera class

### DIFF
--- a/packages/flame/lib/src/game/camera/camera.dart
+++ b/packages/flame/lib/src/game/camera/camera.dart
@@ -38,6 +38,11 @@ import 'package:flame/game.dart';
 /// the position where components are rendered with relation to the Viewport.
 /// Components marked as `positionType = PositionType.viewport;` are
 /// always rendered in screen coordinates, bypassing the camera altogether.
+///
+/// Note: beware of using very large numbers with the camera (like coordinates
+/// spanning the dozens of millions). Due to the required matrix operations
+/// performed by the Camera, using such large numbers can cause performance
+/// issues. Consider breaking down huge maps into manageable chunks.
 class Camera extends Projector {
   Camera() : _viewport = DefaultViewport() {
     _combinedProjector = Projector.compose([this, _viewport]);


### PR DESCRIPTION
# Description

Add warning about very large numbers on the camera class

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes https://github.com/flame-engine/flame/issues/1126

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
