### PR TITLE
chore: Fix some of the remaining lint problems

### DIFF
--- a/examples/lib/main.dart
+++ b/examples/lib/main.dart
@@ -17,7 +17,7 @@ import 'package:examples/stories/utils/utils.dart';
 import 'package:examples/stories/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 
-void main() async {
+void main() {
   final dashbook = Dashbook(
     title: 'Flame Examples',
     theme: ThemeData.dark(),

--- a/packages/flame/test/components/button_component_test.dart
+++ b/packages/flame/test/components/button_component_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../game/flame_game_test.dart';
 
-void main() async {
+void main() {
   group('ButtonComponent', () {
     testWithGame<GameWithTappables>(
         'correctly registers taps', GameWithTappables.new, (game) async {

--- a/packages/flame/test/components/hud_button_component_test.dart
+++ b/packages/flame/test/components/hud_button_component_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../game/flame_game_test.dart';
 
-void main() async {
+void main() {
   group('HudButtonComponent', () {
     testWithGame<GameWithTappables>(
         'correctly registers taps', GameWithTappables.new, (game) async {

--- a/packages/flame/test/components/hud_margin_component_test.dart
+++ b/packages/flame/test/components/hud_margin_component_test.dart
@@ -3,7 +3,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 
-void main() async {
+void main() {
   group('HudMarginComponent test', () {
     flameGame.test(
       'position set from margin should change onGameResize',

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -2,7 +2,7 @@ import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-void main() async {
+Future<void> main() async {
   // Generate an image
   final image = await generateImage();
 

--- a/packages/flame/test/components/sprite_animation_group_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_group_component_test.dart
@@ -7,7 +7,7 @@ enum _AnimationState {
   running,
 }
 
-void main() async {
+Future<void> main() async {
   // Generate a image
   final image = await generateImage();
 

--- a/packages/flame/test/components/sprite_component_test.dart
+++ b/packages/flame/test/components/sprite_component_test.dart
@@ -2,7 +2,7 @@ import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
-void main() async {
+Future<void> main() async {
   final image = await generateImage();
 
   group('SpriteComponent', () {

--- a/packages/flame/test/components/sprite_group_component_test.dart
+++ b/packages/flame/test/components/sprite_group_component_test.dart
@@ -7,7 +7,7 @@ enum _SpriteState {
   running,
 }
 
-void main() async {
+Future<void> main() async {
   // Generate a image
   final image = await generateImage();
 

--- a/packages/flame/test/game/game_widget/game_widget_keyboard_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_keyboard_test.dart
@@ -75,7 +75,7 @@ class _GamePage extends StatelessWidget {
   }
 }
 
-void main() async {
+void main() {
   final size = Vector2(1.0, 1.0);
 
   testWidgets('adds focus', (tester) async {

--- a/packages/flame/test/widgets/nine_tile_box_widget_test.dart
+++ b/packages/flame/test/widgets/nine_tile_box_widget_test.dart
@@ -6,7 +6,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-void main() async {
+Future<void> main() async {
   final image = await generateImage();
 
   group('NineTileBoxWidget', () {

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -5,7 +5,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-void main() async {
+Future<void> main() async {
   final image = await generateImage();
 
   group('SpriteAnimationWidget', () {

--- a/packages/flame/test/widgets/sprite_button_test.dart
+++ b/packages/flame/test/widgets/sprite_button_test.dart
@@ -4,7 +4,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-void main() async {
+Future<void> main() async {
   final image = await generateImage();
 
   group('SpriteButton', () {

--- a/packages/flame/test/widgets/sprite_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_widget_test.dart
@@ -4,7 +4,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-void main() async {
+Future<void> main() async {
   final image = await generateImage();
 
   group('SpriteWidget', () {

--- a/packages/flame_audio/example/lib/main.dart
+++ b/packages/flame_audio/example/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:flame_audio/audio_pool.dart';
 import 'package:flame_audio/flame_audio.dart';
 import 'package:flutter/widgets.dart' hide Animation;
 
-void main() async {
+void main() {
   runApp(GameWidget(game: AudioGame()));
 }
 

--- a/packages/flame_fire_atlas/example/lib/main.dart
+++ b/packages/flame_fire_atlas/example/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flame/input.dart';
 import 'package:flame_fire_atlas/flame_fire_atlas.dart';
 import 'package:flutter/material.dart';
 
-void main() async {
+void main() {
   WidgetsFlutterBinding.ensureInitialized();
 
   final game = ExampleGame();

--- a/packages/flame_forge2d/example/lib/main.dart
+++ b/packages/flame_forge2d/example/lib/main.dart
@@ -1,4 +1,4 @@
-void main() async {
+void main() {
   // There will be a new example in here after Google I/O, stay tuned!
   // If you want to see the previous examples, go to the flame_forge2d section
   // of https://examples.flame-engine.org

--- a/packages/flame_lint/lib/analysis_options.yaml
+++ b/packages/flame_lint/lib/analysis_options.yaml
@@ -142,7 +142,6 @@ linter:
     - unnecessary_this
     - unrelated_type_equality_checks
     - unsafe_html
-    - use_enums
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools


### PR DESCRIPTION
# Description

- Fix warnings raised by the `avoid_void_async` lint rule;
- Remove rule `use_enums`, which is not available in Dart 2.16


## Checklist


- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.


## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
