### PR TITLE
refactor: Remove unecessary copy operation on Camera

### DIFF
--- a/packages/flame/lib/src/game/camera/camera.dart
+++ b/packages/flame/lib/src/game/camera/camera.dart
@@ -161,7 +161,7 @@ class Camera extends Projector {
   /// When using this method you are responsible for saving/restoring canvas
   /// state to avoid leakage.
   void apply(Canvas canvas) {
-    canvas.transform(_transformMatrix(position, zoom).storage);
+    canvas.transform(_transformMatrix().storage);
   }
 
   Vector2? _canvasSize;
@@ -178,7 +178,7 @@ class Camera extends Projector {
     _viewport.resize(canvasSize);
   }
 
-  Matrix4 _transformMatrix(Vector2 position, double zoom) {
+  Matrix4 _transformMatrix() {
     final translateX = -_position.x * zoom;
     final translateY = -_position.y * zoom;
     if (_transform.m11 == zoom &&


### PR DESCRIPTION
# Description

Turns out we have two ways of accessing camera position: `position` is for the outside, it creates a copy. This method was already non-static and accessing `_position` via this, so I just removed both parameters to make it less confusing.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
