### PR TITLE
fix: Ignore unhandled key events

### DIFF
--- a/examples/lib/main.dart
+++ b/examples/lib/main.dart
@@ -15,9 +15,25 @@ import 'package:examples/stories/svg/svg.dart';
 import 'package:examples/stories/system/system.dart';
 import 'package:examples/stories/utils/utils.dart';
 import 'package:examples/stories/widgets/widgets.dart';
+import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 
 void main() {
+  runApp(MaterialApp(
+    home: Scaffold(
+      body: GameWidget(
+        game: FlameGame(),
+        initialActiveOverlays: const ['text-field'],
+        overlayBuilderMap: {
+          'text-field': (_, g) => TextField(
+            onChanged: (s) => print(s),
+          ),
+        },
+      ),
+    ),
+  ),
+  );return;
+
   final dashbook = Dashbook(
     title: 'Flame Examples',
     theme: ThemeData.dark(),

--- a/examples/lib/main.dart
+++ b/examples/lib/main.dart
@@ -15,25 +15,9 @@ import 'package:examples/stories/svg/svg.dart';
 import 'package:examples/stories/system/system.dart';
 import 'package:examples/stories/utils/utils.dart';
 import 'package:examples/stories/widgets/widgets.dart';
-import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MaterialApp(
-    home: Scaffold(
-      body: GameWidget(
-        game: FlameGame(),
-        initialActiveOverlays: const ['text-field'],
-        overlayBuilderMap: {
-          'text-field': (_, g) => TextField(
-            onChanged: (s) => print(s),
-          ),
-        },
-      ),
-    ),
-  ),
-  );return;
-
   final dashbook = Dashbook(
     title: 'Flame Examples',
     theme: ThemeData.dark(),

--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -288,7 +288,7 @@ class _GameWidgetState<T extends Game> extends State<GameWidget<T>> {
     if (game is KeyboardEvents) {
       return game.onKeyEvent(event, RawKeyboard.instance.keysPressed);
     }
-    return KeyEventResult.handled;
+    return KeyEventResult.ignored;
   }
 
   @override

--- a/packages/flame/test/game/game_widget/game_widget_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_test.dart
@@ -220,5 +220,33 @@ void main() {
 
       expect(game2, isNull);
     });
+
+    testWidgets(
+      'able to enter text into an overlay widget',
+          (tester) async {
+        var enteredText = '';
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: GameWidget(
+                game: FlameGame(),
+                initialActiveOverlays: const ['text-field'],
+                overlayBuilderMap: {
+                  'text-field': (_, g) => TextField(
+                    onChanged: (s) => enteredText = s,
+                  ),
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+        // await tester.enterText(find.byType(TextField), 'flame');
+        await tester.tap(find.byType(TextField));
+        tester.testTextInput.enterText('flame');
+        expect(enteredText, 'flame');
+      },
+    );
   });
 }

--- a/packages/flame/test/game/game_widget/game_widget_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_test.dart
@@ -223,7 +223,7 @@ void main() {
 
     testWidgets(
       'able to enter text into an overlay widget',
-          (tester) async {
+      (tester) async {
         var enteredText = '';
         await tester.pumpWidget(
           MaterialApp(
@@ -233,8 +233,8 @@ void main() {
                 initialActiveOverlays: const ['text-field'],
                 overlayBuilderMap: {
                   'text-field': (_, g) => TextField(
-                    onChanged: (s) => enteredText = s,
-                  ),
+                        onChanged: (s) => enteredText = s,
+                      ),
                 },
               ),
             ),


### PR DESCRIPTION
# Description

Key events that are not handled by the GameWidget ought to be ignored, so that they can propagate to the overlay widgets.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Closes #1710

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
