### PR TITLE
fix: GameWidget will not listen to keyboard events without the KeyboardEvents mixin

### DIFF
--- a/packages/flame/test/game/game_widget/game_widget_keyboard_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_keyboard_test.dart
@@ -8,15 +8,12 @@ import 'package:flutter_test/flutter_test.dart';
 class _KeyboardEventsGame extends FlameGame with KeyboardEvents {
   final List<String> keysPressed = [];
 
-  _KeyboardEventsGame();
-
   @override
   KeyEventResult onKeyEvent(
     RawKeyEvent event,
     Set<LogicalKeyboardKey> keysPressed,
   ) {
     this.keysPressed.add(event.character ?? 'none');
-
     return KeyEventResult.handled;
   }
 }
@@ -33,78 +30,27 @@ class _KeyboardHandlerComponent extends Component with KeyboardHandler {
 
 class _HasKeyboardHandlerComponentsGame extends FlameGame
     with HasKeyboardHandlerComponents {
-  _HasKeyboardHandlerComponentsGame();
-
-  late _KeyboardHandlerComponent keyboardHandler;
-
-  @override
-  Future<void> onLoad() async {
-    keyboardHandler = _KeyboardHandlerComponent();
-    add(keyboardHandler);
-  }
-}
-
-class _GamePage extends StatelessWidget {
-  final Widget child;
-
-  const _GamePage({required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Stack(
-          children: [
-            Positioned.fill(
-              child: child,
-            ),
-            Positioned(
-              top: 0,
-              right: 0,
-              child: ElevatedButton(
-                child: const Text('Back'),
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+  _HasKeyboardHandlerComponentsGame({super.children});
 }
 
 void main() {
-  final size = Vector2(1.0, 1.0);
-
   testWidgets('adds focus', (tester) async {
     final focusNode = FocusNode();
-
-    final game = _KeyboardEventsGame();
-
     await tester.pumpWidget(
-      _GamePage(
-        child: GameWidget(
-          game: game,
-          focusNode: focusNode,
-        ),
+      GameWidget(
+        game: _KeyboardEventsGame(),
+        focusNode: focusNode,
       ),
     );
+    await tester.pump();
 
     expect(focusNode.hasFocus, true);
   });
 
   testWidgets('game with KeyboardEvents receives keys', (tester) async {
     final game = _KeyboardEventsGame();
-
-    await tester.pumpWidget(
-      _GamePage(
-        child: GameWidget(
-          game: game,
-        ),
-      ),
-    );
+    await tester.pumpWidget(GameWidget(game: game));
+    await tester.pump();
 
     await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
     await tester.sendKeyDownEvent(LogicalKeyboardKey.keyB);
@@ -116,26 +62,20 @@ void main() {
   testWidgets(
     'game with HasKeyboardHandlerComponents receives keys',
     (tester) async {
-      final game = _HasKeyboardHandlerComponentsGame();
-
-      await tester.pumpWidget(
-        _GamePage(
-          child: GameWidget(
-            game: game,
-          ),
-        ),
+      final keyboardHandler = _KeyboardHandlerComponent();
+      final game = _HasKeyboardHandlerComponentsGame(
+        children: [keyboardHandler],
       );
 
-      game.onGameResize(size);
-      game.update(0.1);
-
+      await tester.pumpWidget(GameWidget(game: game));
+      await tester.pump();
       await tester.pump();
 
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyF);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyI);
 
-      expect(game.keyboardHandler.keysPressed, ['z', 'f', 'i']);
+      expect(keyboardHandler.keysPressed, ['z', 'f', 'i']);
     },
   );
 }


### PR DESCRIPTION
# Description

Currently, the `GameWidget` uses a `Focus` widget always, even if the game is unable to receive keyboard events.
This PR makes it so that the `Focus` node is only used when the game has `KeyboardEvents` mixin that is used for listening to keyboard events. This is similar to how we use gesture detectors and mouse detectors.

Another advantage here is that now `Focus` is in parallel with the overlay widgets, which means that it won't interfere with the overlay's text input attempts.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change (shouldn't be?).


## Related Issues

Closes #1710


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
