### PR TITLE
feat: adding bloc getter to FlameBlocListenable mixin

### DIFF
--- a/packages/flame_bloc/lib/src/flame_bloc_listenable.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listenable.dart
@@ -9,24 +9,35 @@ import 'package:meta/meta.dart';
 mixin FlameBlocListenable<B extends BlocBase<S>, S> on Component {
   late S _state;
   late final StreamSubscription<S> _subscription;
-  B? _bloc;
+  late B _bloc;
+  B? _blocOverride;
+
+  /// Returns the bloc that this component is reading from once the component
+  /// has been mounted.
+  B get bloc {
+    assert(
+      isMounted,
+      'Cannot access the bloc instance before it has been mounted.',
+    );
+    return _bloc;
+  }
 
   /// Explicitly set the bloc instance which the component will be listening to.
   /// This is useful in cases where the bloc being listened to
   /// has not be provided via [FlameBlocProvider].
   set bloc(B bloc) {
     assert(
-      _bloc == null,
+      _blocOverride == null,
       'Cannot update the bloc instance once it has been set.',
     );
-    _bloc = bloc;
+    _blocOverride = bloc;
   }
 
   @override
   @mustCallSuper
   void onMount() {
     super.onMount();
-    var bloc = _bloc;
+    var bloc = _blocOverride;
     if (bloc == null) {
       final providers = ancestors().whereType<FlameBlocProvider<B, S>>();
       assert(
@@ -35,8 +46,9 @@ mixin FlameBlocListenable<B extends BlocBase<S>, S> on Component {
       );
 
       final provider = providers.first;
-      _bloc = bloc = provider.bloc;
+      _blocOverride = bloc = provider.bloc;
     }
+    _bloc = bloc;
     _state = bloc.state;
     _subscription = bloc.stream.listen((newState) {
       if (_state != newState) {

--- a/packages/flame_bloc/test/src/flame_bloc_listenable_test.dart
+++ b/packages/flame_bloc/test/src/flame_bloc_listenable_test.dart
@@ -98,5 +98,21 @@ void main() {
         expect(component.last, isNull);
       },
     );
+
+    testWithFlameGame(
+      'successfully retreive the bloc via getter',
+      (game) async {
+        final bloc = PlayerCubit();
+        final provider = FlameBlocProvider<PlayerCubit, PlayerState>.value(
+          value: bloc,
+        );
+        await game.ensureAdd(provider);
+
+        final component = PlayerListener();
+        await provider.ensureAdd(component);
+
+        expect(component.bloc, bloc);
+      },
+    );
   });
 }


### PR DESCRIPTION
# Description

This PR adds a getter to the `FlameBlocListenable` mixin. This getter will allow to use `FlameBlocListenable` as a standalone mixin to react to new states via `onNewState()`, access the current `state`, and also add events to the listenable Bloc via the `bloc` property.
Currently a workaround to give components this functionality is to use `FlameBlocListenable` and `FlameBlocReader` in parallel.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
Fixes https://github.com/flame-engine/flame/issues/1694

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
