### PR TITLE
docs: Return Widget instead of void in the game_widget.md

### DIFF
--- a/doc/flame/game_widget.md
+++ b/doc/flame/game_widget.md
@@ -44,7 +44,7 @@ class _MyGamePageState extends State<MyGamePage> {
   }
 
   @override
-  void build(BuildContext context) {
+  Widget build(BuildContext context) {
     return GameWidget(game: _game);
   }
 }
@@ -55,7 +55,7 @@ In a `StatelessWidget` with the `gameFactory` argument:
 ```dart
 class MyGamePage extends StatelessWidget {
   @override
-  void build(BuildContext context) {
+  Widget build(BuildContext context) {
     return GameWidget.controlled(gameFactory: MyGame.new);
   }
 }


### PR DESCRIPTION
# Description
The return type of [GameWidget docs](https://docs.flame-engine.org/1.2.0/flame/game_widget.html) should be `Widget` instead of `void`

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

<!-- Links -->
Fixes #1735