### PR TITLE
fix: World component can now be queried with `componentsAtPoint`

### DIFF
--- a/packages/flame/lib/src/experimental/camera_component.dart
+++ b/packages/flame/lib/src/experimental/camera_component.dart
@@ -122,7 +122,7 @@ class CameraComponent extends Component {
       if (viewport.containsLocalPoint(viewportPoint)) {
         currentCameras.add(this);
         final worldPoint = viewfinder.transform.globalToLocal(viewportPoint);
-        yield* world.componentsAtPointFromCamera(worldPoint, nestedPoints);
+        yield* world.componentsAtPoint(worldPoint, nestedPoints);
         yield* viewfinder.componentsAtPoint(worldPoint, nestedPoints);
         currentCameras.removeLast();
       }

--- a/packages/flame/lib/src/experimental/world.dart
+++ b/packages/flame/lib/src/experimental/world.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flame/src/components/component.dart';
+import 'package:flame/src/components/mixins/coordinate_transform.dart';
 import 'package:flame/src/experimental/camera_component.dart';
 import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -10,7 +11,7 @@ import 'package:vector_math/vector_math_64.dart';
 /// The primary feature of this component is that it disables regular rendering,
 /// and allows itself to be rendered through a [CameraComponent] only. The
 /// updates proceed through the world tree normally.
-class World extends Component {
+class World extends Component implements CoordinateTransform {
   @override
   void renderTree(Canvas canvas) {}
 
@@ -25,18 +26,8 @@ class World extends Component {
   bool containsLocalPoint(Vector2 point) => true;
 
   @override
-  Iterable<Component> componentsAtPoint(
-    Vector2 point, [
-    List<Vector2>? nestedPoints,
-  ]) {
-    return const Iterable.empty();
-  }
+  Vector2? localToParent(Vector2 point) => null;
 
-  @internal
-  Iterable<Component> componentsAtPointFromCamera(
-    Vector2 point,
-    List<Vector2>? nestedPoints,
-  ) {
-    return super.componentsAtPoint(point, nestedPoints);
-  }
+  @override
+  Vector2? parentToLocal(Vector2 point) => null;
 }

--- a/packages/flame/test/experimental/camera_component_test.dart
+++ b/packages/flame/test/experimental/camera_component_test.dart
@@ -139,6 +139,17 @@ void main() {
       expect(it.current, game);
       expect(nested, [Vector2(400, 300)]);
       expect(it.moveNext(), false);
+
+      // Check that `componentsAtPoint` is usable with non-top-level components
+      // also.
+      expect(
+        world.componentsAtPoint(Vector2(100, 100)).toList(),
+        [component, world],
+      );
+      expect(
+        component.componentsAtPoint(Vector2(100, 50)).toList(),
+        [component],
+      );
     });
   });
 }


### PR DESCRIPTION
# Description

The `componentsAtPoint` function allows us to find a component located at a specific position. Usually it is applied to the top-level Game, but there are instances when it could also be useful to apply this function to the `World` component. This PR enables such functionality.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
