### PR TITLE
fix: camera incorrect follow with zoom and world boundaries

### DIFF
--- a/packages/flame/lib/src/game/camera/camera.dart
+++ b/packages/flame/lib/src/game/camera/camera.dart
@@ -337,7 +337,7 @@ class Camera extends Projector {
 
     final bounds = worldBounds;
     if (bounds != null) {
-      if (bounds.width > gameSize.x * zoom) {
+      if (bounds.width > gameSize.x) {
         final cameraLeftEdge = attemptedTarget.x;
         final cameraRightEdge = attemptedTarget.x + gameSize.x;
         if (cameraLeftEdge < bounds.left) {
@@ -349,7 +349,7 @@ class Camera extends Projector {
         attemptedTarget.x = (gameSize.x - bounds.width) / 2;
       }
 
-      if (bounds.height > gameSize.y * zoom) {
+      if (bounds.height > gameSize.y) {
         final cameraTopEdge = attemptedTarget.y;
         final cameraBottomEdge = attemptedTarget.y + gameSize.y;
         if (cameraTopEdge < bounds.top) {

--- a/packages/flame/test/game/camera/camera_test.dart
+++ b/packages/flame/test/game/camera/camera_test.dart
@@ -196,6 +196,36 @@ void main() {
     );
 
     testWithFlameGame(
+      'camera follow with zoom',
+      (game) async {
+        game.onGameResize(Vector2.all(100.0));
+        game.camera.zoom = 2;
+
+        final p = _TestComponent(Vector2.all(10.0))..anchor = Anchor.center;
+        await game.ensureAdd(p);
+        game.camera.followComponent(
+          p,
+          worldBounds: const Rect.fromLTWH(0, 0, 100, 100),
+        );
+
+        game.update(0);
+        expect(game.camera.position, Vector2(0, 0));
+
+        p.position.setValues(50.0, 60.0);
+        game.update(0);
+        expect(game.camera.position, Vector2(25, 35));
+
+        p.position.setValues(80.0, 90.0);
+        game.update(0);
+        expect(game.camera.position, Vector2(50, 50));
+
+        p.position.setValues(-10.0, -20.0);
+        game.update(0);
+        expect(game.camera.position, Vector2(0, 0));
+      },
+    );
+
+    testWithFlameGame(
       'camera relative offset without follow',
       (game) async {
         game.onGameResize(Vector2.all(200.0));


### PR DESCRIPTION
# Description

When the camera follows a component with world boundaries and zoom, the camera is incorrectly positioned.
I think it is because world boundaries already consider the zoom and it will never be greater than gameSize * zoom.

<!-- Provide a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
