### PR TITLE
docs: Fix dangerous typo on flame_lint docs

### DIFF
--- a/packages/flame_lint/README.md
+++ b/packages/flame_lint/README.md
@@ -10,5 +10,5 @@ Package with the lint rules used in all Flame Engine projects.
 - Then include it on your `analysis_options.yaml` file:
 
 ```yaml
-include: package:flame_lint/analysis_options_package.yaml
+include: package:flame_lint/analysis_options.yaml
 ```


### PR DESCRIPTION
# Description

Fix dangerous typo on flame_lint docs

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
