### PR TITLE
fix: Overlays can now be properly added during onLoad

### DIFF
--- a/packages/flame/lib/src/game/game.dart
+++ b/packages/flame/lib/src/game/game.dart
@@ -167,8 +167,6 @@ abstract class Game {
       );
     }
     _gameRenderBox = gameRenderBox;
-    overlays._game = this;
-
     onAttach();
   }
 
@@ -300,7 +298,7 @@ abstract class Game {
   /// overlays.add(pauseOverlayIdentifier); // marks 'PauseMenu' to be rendered.
   /// overlays.remove(pauseOverlayIdentifier); // hides 'PauseMenu'.
   /// ```
-  final overlays = _ActiveOverlays();
+  late final overlays = _ActiveOverlays(this);
 
   /// Used to change the mouse cursor of the GameWidget running this game.
   /// Setting the value to null will make the GameWidget defer the choice
@@ -335,20 +333,22 @@ abstract class Game {
 /// A helper class used to control the visibility of overlays on a [Game]
 /// instance. See [Game.overlays].
 class _ActiveOverlays {
-  Game? _game;
+  _ActiveOverlays(this._game);
+
+  final Game _game;
   final Set<String> _activeOverlays = {};
 
   /// Clear all active overlays.
   void clear() {
     _activeOverlays.clear();
-    _game?._refreshWidget();
+    _game._refreshWidget();
   }
 
   /// Marks the [overlayName] to be rendered.
   bool add(String overlayName) {
     final setChanged = _activeOverlays.add(overlayName);
     if (setChanged) {
-      _game?._refreshWidget();
+      _game._refreshWidget();
     }
     return setChanged;
   }
@@ -360,7 +360,7 @@ class _ActiveOverlays {
 
     final overlayCountAfterAdded = _activeOverlays.length;
     if (overlayCountBeforeAdded != overlayCountAfterAdded) {
-      _game?._refreshWidget();
+      _game._refreshWidget();
     }
   }
 
@@ -368,7 +368,7 @@ class _ActiveOverlays {
   bool remove(String overlayName) {
     final hasRemoved = _activeOverlays.remove(overlayName);
     if (hasRemoved) {
-      _game?._refreshWidget();
+      _game._refreshWidget();
     }
     return hasRemoved;
   }
@@ -380,7 +380,7 @@ class _ActiveOverlays {
 
     final overlayCountAfterRemoved = _activeOverlays.length;
     if (overlayCountBeforeRemoved != overlayCountAfterRemoved) {
-      _game?._refreshWidget();
+      _game._refreshWidget();
     }
   }
 

--- a/packages/flame/test/_resources/custom_flame_game.dart
+++ b/packages/flame/test/_resources/custom_flame_game.dart
@@ -1,0 +1,19 @@
+import 'package:flame/game.dart';
+
+class CustomFlameGame extends FlameGame {
+  CustomFlameGame({
+    super.children,
+    Future<void>? Function(FlameGame)? onLoad,
+    void Function(FlameGame)? onMount,
+  })  : _onLoad = onLoad,
+        _onMount = onMount;
+
+  final Future<void>? Function(FlameGame)? _onLoad;
+  final void Function(FlameGame)? _onMount;
+
+  @override
+  Future<void>? onLoad() => _onLoad?.call(this);
+
+  @override
+  void onMount() => _onMount?.call(this);
+}

--- a/packages/flame/test/game/active_overlays_test.dart
+++ b/packages/flame/test/game/active_overlays_test.dart
@@ -1,8 +1,90 @@
 import 'package:flame/game.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../_resources/custom_flame_game.dart';
 
 void main() {
   group('_ActiveOverlays', () {
+    testWidgets(
+      'Overlay can be added via initialActiveOverlays',
+      (tester) async {
+        const key1 = ValueKey('one');
+        const key2 = ValueKey('two');
+        await tester.pumpWidget(
+          GameWidget(
+            game: FlameGame(),
+            overlayBuilderMap: {
+              'first!': (_, __) => Container(key: key1),
+              'second': (_, __) => Container(key: key2),
+            },
+            initialActiveOverlays: const ['first!'],
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byKey(key1), findsOneWidget);
+        expect(find.byKey(key2), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Overlay can be added in onLoad',
+      (tester) async {
+        const key1 = ValueKey('one');
+        const key2 = ValueKey('two');
+        await tester.pumpWidget(
+          GameWidget(
+            game: CustomFlameGame(
+              onLoad: (game) async {
+                game.overlays.add('first!');
+              },
+            ),
+            overlayBuilderMap: {
+              'first!': (_, __) => Container(key: key1),
+              'second': (_, __) => Container(key: key2),
+            },
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byKey(key1), findsOneWidget);
+        expect(find.byKey(key2), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Overlay can be added and removed at runtime',
+      (tester) async {
+        const key1 = ValueKey('one');
+        const key2 = ValueKey('two');
+        final game = FlameGame();
+        await tester.pumpWidget(
+          GameWidget(
+            game: game,
+            overlayBuilderMap: {
+              'first!': (_, __) => Container(key: key1),
+              'second': (_, __) => Container(key: key2),
+            },
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byKey(key1), findsNothing);
+        expect(find.byKey(key2), findsNothing);
+
+        game.overlays.add('second');
+        await tester.pump();
+        expect(find.byKey(key1), findsNothing);
+        expect(find.byKey(key2), findsOneWidget);
+
+        game.overlays.remove('second');
+        await tester.pump();
+        expect(find.byKey(key1), findsNothing);
+        expect(find.byKey(key2), findsNothing);
+      },
+    );
+
     group('add', () {
       test('can add an overlay', () {
         final overlays = FlameGame().overlays;


### PR DESCRIPTION
# Description

The problem was that the variable `_ActiveOverlays._game` was assigned too late, and as a result the request to refresh the widget was silently dropped.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [-] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Closes #1757 


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
