### PR TITLE
refactor!: Matcher closeToVector() now accepts Vector2 as an argument

### DIFF
--- a/packages/flame/test/components/hud_margin_component_test.dart
+++ b/packages/flame/test/components/hud_margin_component_test.dart
@@ -17,16 +17,16 @@ void main() {
         // and the component has its anchor in the top left corner (which then
         // is were the margin will be calculated from).
         // (500, 500) - size(20, 20) - position(10, 20) = (470, 460)
-        expect(marginComponent.position, closeToVector(470, 460));
+        expect(marginComponent.position, closeToVector(Vector2(470, 460)));
         game.onGameResize(Vector2.all(1000));
         game.update(0);
         // After resizing the game, the component should still be 30 pixels from
         // the right edge and 40 pixels from the bottom.
-        expect(marginComponent.position, closeToVector(970, 960));
+        expect(marginComponent.position, closeToVector(Vector2(970, 960)));
         // After the size of the component is changed the position is also
         // changed.
         marginComponent.size.add(Vector2.all(10));
-        expect(marginComponent.position, closeToVector(960, 950));
+        expect(marginComponent.position, closeToVector(Vector2(960, 950)));
       },
     );
 
@@ -42,12 +42,12 @@ void main() {
         // and the component has its anchor in the top left corner (which then
         // is were the margin will be calculated from).
         // (500, 500) - size(20, 20) - position(10, 20) = (470, 460)
-        expect(marginComponent.position, closeToVector(470, 460));
+        expect(marginComponent.position, closeToVector(Vector2(470, 460)));
         game.update(0);
         game.camera.zoom = 2.0;
         game.onGameResize(Vector2.all(500));
         game.update(0);
-        expect(marginComponent.position, closeToVector(470, 460));
+        expect(marginComponent.position, closeToVector(Vector2(470, 460)));
       },
     );
   });

--- a/packages/flame/test/components/isometric_tile_map_component_test.dart
+++ b/packages/flame/test/components/isometric_tile_map_component_test.dart
@@ -63,7 +63,10 @@ void main() {
         tileHeight: 8.0,
       );
 
-      expect(c.getBlockCenterPosition(const Block(0, 0)), closeToVector(0, 0));
+      expect(
+        c.getBlockCenterPosition(const Block(0, 0)),
+        closeToVector(Vector2.zero()),
+      );
     });
 
     test('height scaling', () {
@@ -76,7 +79,7 @@ void main() {
       //expect the block to be directly below
       expect(
         c.getBlockRenderPositionInts(1, 1),
-        closeToVector(-156 / 2, 12.5, epsilon: 1e-13),
+        closeToVector(Vector2(-156 / 2, 12.5), 1e-13),
       );
     });
   });

--- a/packages/flame/test/components/joystick_component_test.dart
+++ b/packages/flame/test/components/joystick_component_test.dart
@@ -51,7 +51,7 @@ void main() {
         );
         await game.add(joystick);
         await game.ready();
-        expect(joystick.knob!.position, closeToVector(10, 10));
+        expect(joystick.knob!.position, closeToVector(Vector2(10, 10)));
         // Start dragging the joystick
         game.onDragStart(
           1,
@@ -77,7 +77,7 @@ void main() {
           ),
         );
         game.update(0);
-        expect(joystick.knob!.position, closeToVector(20, 10));
+        expect(joystick.knob!.position, closeToVector(Vector2(20, 10)));
         // Drag the knob back towards it's base position
         game.onDragUpdate(
           1,
@@ -91,7 +91,7 @@ void main() {
           ),
         );
         game.update(0);
-        expect(joystick.knob!.position, closeToVector(20, 10));
+        expect(joystick.knob!.position, closeToVector(Vector2(20, 10)));
       },
     );
   });

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -424,45 +424,43 @@ void main() {
         ..scale = Vector2(2.0, 3.0)
         ..position = startPosition;
       final centerPosition = component.center;
-      final x = centerPosition.x;
-      final y = centerPosition.y;
 
       component.flipVerticallyAroundCenter();
       // Same position after one vertical flip.
-      expect(component.center, closeToVector(x, y, epsilon: 1e-14));
+      expect(component.center, closeToVector(centerPosition, 1e-14));
 
       component.flipVerticallyAroundCenter();
       // Same position after flipping back the vertical flip.
-      expect(component.center, closeToVector(x, y, epsilon: 1e-14));
+      expect(component.center, closeToVector(centerPosition, 1e-14));
 
       component.flipHorizontallyAroundCenter();
       // Same position after one horizontal flip.
-      expect(component.center, closeToVector(x, y, epsilon: 1e-14));
+      expect(component.center, closeToVector(centerPosition, 1e-14));
 
       component.flipHorizontallyAroundCenter();
       // Same position after flipping back the horizontal flip.
-      expect(component.center, closeToVector(x, y, epsilon: 1e-14));
+      expect(component.center, closeToVector(centerPosition, 1e-14));
 
       component.flipVerticallyAroundCenter();
       component.flipHorizontallyAroundCenter();
       // Same position after flipping both vertically and horizontally.
-      expect(component.center, closeToVector(x, y, epsilon: 1e-14));
+      expect(component.center, closeToVector(centerPosition, 1e-14));
 
       component.flipVerticallyAroundCenter();
       component.flipHorizontallyAroundCenter();
       // Same position after flipping back both vertically and horizontally.
-      expect(component.center, closeToVector(x, y, epsilon: 1e-14));
+      expect(component.center, closeToVector(centerPosition, 1e-14));
 
       component.flipHorizontallyAroundCenter();
       component.flipVerticallyAroundCenter();
       // Same position after flipping both horizontally and vertically.
-      expect(component.center, closeToVector(x, y, epsilon: 1e-14));
+      expect(component.center, closeToVector(centerPosition, 1e-14));
 
       component.flipVerticallyAroundCenter();
       component.flipHorizontallyAroundCenter();
       // Same position after flipping back both horizontally and vertically in
       // the reverse order.
-      expect(component.center, closeToVector(x, y, epsilon: 1e-14));
+      expect(component.center, closeToVector(centerPosition, 1e-14));
     });
 
     test('isHorizontallyFlipped', () {

--- a/packages/flame/test/effects/controllers/speed_effect_controller_test.dart
+++ b/packages/flame/test/effects/controllers/speed_effect_controller_test.dart
@@ -69,7 +69,7 @@ void main() {
 
         expect(effect.controller.duration, 5);
         game.update(5);
-        expect(component.position, closeToVector(8, 12));
+        expect(component.position, closeToVector(Vector2(8, 12)));
       });
 
       test('speed on MoveAlongPathEffect', () async {
@@ -90,7 +90,7 @@ void main() {
 
         expect(effect.controller.duration, 25);
         game.update(25);
-        expect(component.position, closeToVector(10, 30));
+        expect(component.position, closeToVector(Vector2(10, 30)));
       });
 
       test('speed on RotateEffect', () async {
@@ -123,7 +123,7 @@ void main() {
         game.update(10);
         expect(effect.controller.completed, true);
 
-        expect(component.position, closeToVector(10, 0));
+        expect(component.position, closeToVector(Vector2(10, 0)));
         component.position = Vector2.all(40);
         effect.reset();
         game.update(0);

--- a/packages/flame/test/effects/scale_effect_test.dart
+++ b/packages/flame/test/effects/scale_effect_test.dart
@@ -17,17 +17,17 @@ void main() {
         ScaleEffect.by(Vector2.all(2.0), EffectController(duration: 1)),
       );
       game.update(0);
-      expect(component.scale, closeToVector(1, 1));
+      expect(component.scale, closeToVector(Vector2(1, 1)));
       expect(component.children.length, 1);
 
       game.update(0.5);
-      expect(component.scale, closeToVector(1.5, 1.5));
+      expect(component.scale, closeToVector(Vector2(1.5, 1.5)));
 
       game.update(0.5);
-      expect(component.scale, closeToVector(2, 2));
+      expect(component.scale, closeToVector(Vector2(2, 2)));
       game.update(0);
       expect(component.children.length, 0);
-      expect(component.scale, closeToVector(2, 2));
+      expect(component.scale, closeToVector(Vector2(2, 2)));
     });
 
     flameGame.test('absolute', (game) async {
@@ -39,17 +39,17 @@ void main() {
         ScaleEffect.to(Vector2.all(3.0), EffectController(duration: 1)),
       );
       game.update(0);
-      expect(component.scale, closeToVector(1, 1));
+      expect(component.scale, closeToVector(Vector2(1, 1)));
       expect(component.children.length, 1);
 
       game.update(0.5);
-      expect(component.scale, closeToVector(2, 2));
+      expect(component.scale, closeToVector(Vector2(2, 2)));
 
       game.update(0.5);
-      expect(component.scale, closeToVector(3, 3));
+      expect(component.scale, closeToVector(Vector2(3, 3)));
       game.update(0);
       expect(component.children.length, 0);
-      expect(component.scale, closeToVector(3, 3));
+      expect(component.scale, closeToVector(Vector2(3, 3)));
     });
 
     flameGame.test('reset relative', (game) async {
@@ -68,7 +68,7 @@ void main() {
         effect.reset();
         game.update(1);
         expectedScale *= 2;
-        expect(component.scale, closeToVector(expectedScale, expectedScale));
+        expect(component.scale, closeToVector(Vector2.all(expectedScale)));
       }
     });
 
@@ -87,7 +87,7 @@ void main() {
         // `Vector2(1, 1)`, regardless of its initial orientation.
         effect.reset();
         game.update(1);
-        expect(component.scale, closeToVector(1, 1));
+        expect(component.scale, closeToVector(Vector2.all(1)));
       }
     });
 
@@ -148,7 +148,7 @@ void main() {
       game.update(1000 - totalTime);
       // Typically, `component.scale` could accumulate numeric discrepancy on
       // the order of 1e-11 .. 1e-12 by now.
-      expect(component.scale, closeToVector(1, 1, epsilon: 1e-10));
+      expect(component.scale, closeToVector(Vector2.all(1), 1e-10));
     });
   });
 }

--- a/packages/flame/test/effects/sequence_effect_test.dart
+++ b/packages/flame/test/effects/sequence_effect_test.dart
@@ -110,7 +110,7 @@ void main() {
           Vector2(30, 40),
         ];
         for (final p in expectedPositions) {
-          expect(component.position, closeToVector(p.x, p.y, epsilon: 1e-12));
+          expect(component.position, closeToVector(p, 1e-12));
           game.update(0.1);
         }
       });
@@ -128,7 +128,7 @@ void main() {
         await game.ready();
 
         game.update(10);
-        expect(component.position, closeToVector(30, 40));
+        expect(component.position, closeToVector(Vector2(30, 40)));
       });
 
       test('k-step sequence', () async {
@@ -145,16 +145,16 @@ void main() {
         await game.ready();
 
         for (var i = 0; i < 10; i++) {
-          final x = ((i + 1) ~/ 2) * 10;
-          final y = (i ~/ 2) * 10;
-          expect(component.position, closeToVector(x, y));
+          final x = ((i + 1) ~/ 2) * 10.0;
+          final y = (i ~/ 2) * 10.0;
+          expect(component.position, closeToVector(Vector2(x, y)));
           expect(effect.isMounted, true);
           game.update(1);
         }
         game.update(5); // Will schedule the `effect` component for deletion
         game.update(0); // Second update ensures the game deletes the component
         expect(effect.isMounted, false);
-        expect(component.position, closeToVector(50, 50));
+        expect(component.position, closeToVector(Vector2(50, 50)));
       });
 
       test('alternating sequence', () async {
@@ -179,7 +179,7 @@ void main() {
           for (var i = 10.0; i > 0; i--) Vector2(i, 0),
         ];
         for (final p in expectedPath) {
-          expect(component.position, closeToVector(p.x, p.y, epsilon: 1e-14));
+          expect(component.position, closeToVector(p, 1e-14));
           game.update(0.1);
         }
         game.update(0.001);
@@ -214,11 +214,11 @@ void main() {
           ...forwardPath.reversed,
         ];
         for (final p in expectedPath) {
-          expect(component.position, closeToVector(p.x, p.y, epsilon: 1e-14));
+          expect(component.position, closeToVector(p, 1e-14));
           game.update(0.1);
         }
         game.update(0.001);
-        expect(component.position, closeToVector(0, 0));
+        expect(component.position, closeToVector(Vector2.zero()));
         expect(effect.controller.completed, true);
       });
 
@@ -301,7 +301,7 @@ void main() {
           ...forwardPath.reversed,
         ];
         for (final p in expectedPath) {
-          expect(component.position, closeToVector(p.x, p.y, epsilon: 1e-12));
+          expect(component.position, closeToVector(p, 1e-12));
           game.update(dt);
         }
         game.update(1e-5);

--- a/packages/flame/test/effects/size_effect_test.dart
+++ b/packages/flame/test/effects/size_effect_test.dart
@@ -112,7 +112,8 @@ void main() {
       game.update(1);
       expect(component.size, closeToVector(Vector2(1, 1))); // 5*1/10 + 0.5*1
       game.update(1);
-      expect(component.size, closeToVector(Vector2(1, 1))); // 5*2/10 + 0.5*1 - 0.5*1
+      // 5*2/10 + 0.5*1 - 0.5*1
+      expect(component.size, closeToVector(Vector2(1, 1)));
       for (var i = 0; i < 10; i++) {
         game.update(1);
       }
@@ -144,7 +145,7 @@ void main() {
       game.update(1000 - totalTime);
       // Typically, `component.size` could accumulate numeric discrepancy on the
       // order of 1e-11 .. 1e-12 by now.
-      expect(component.size, closeToVector(Vector2(0, 0),  1e-10));
+      expect(component.size, closeToVector(Vector2(0, 0), 1e-10));
     });
   });
 }

--- a/packages/flame/test/effects/size_effect_test.dart
+++ b/packages/flame/test/effects/size_effect_test.dart
@@ -17,17 +17,17 @@ void main() {
         SizeEffect.by(Vector2.all(1.0), EffectController(duration: 1)),
       );
       game.update(0);
-      expect(component.size, closeToVector(1, 1));
+      expect(component.size, closeToVector(Vector2(1, 1)));
       expect(component.children.length, 1);
 
       game.update(0.5);
-      expect(component.size, closeToVector(1.5, 1.5));
+      expect(component.size, closeToVector(Vector2(1.5, 1.5)));
 
       game.update(0.5);
-      expect(component.size, closeToVector(2, 2));
+      expect(component.size, closeToVector(Vector2(2, 2)));
       game.update(0);
       expect(component.children.length, 0);
-      expect(component.size, closeToVector(2, 2));
+      expect(component.size, closeToVector(Vector2(2, 2)));
     });
 
     flameGame.test('absolute', (game) async {
@@ -39,17 +39,17 @@ void main() {
         SizeEffect.to(Vector2.all(3.0), EffectController(duration: 1)),
       );
       game.update(0);
-      expect(component.size, closeToVector(1, 1));
+      expect(component.size, closeToVector(Vector2(1, 1)));
       expect(component.children.length, 1);
 
       game.update(0.5);
-      expect(component.size, closeToVector(2, 2));
+      expect(component.size, closeToVector(Vector2(2, 2)));
 
       game.update(0.5);
-      expect(component.size, closeToVector(3, 3));
+      expect(component.size, closeToVector(Vector2(3, 3)));
       game.update(0);
       expect(component.children.length, 0);
-      expect(component.size, closeToVector(3, 3));
+      expect(component.size, closeToVector(Vector2(3, 3)));
     });
 
     flameGame.test('reset relative', (game) async {
@@ -68,7 +68,7 @@ void main() {
         effect.reset();
         game.update(1);
         expectedSize.add(Vector2.all(1.0));
-        expect(component.size, closeToVector(expectedSize.x, expectedSize.y));
+        expect(component.size, closeToVector(expectedSize));
       }
     });
 
@@ -87,7 +87,7 @@ void main() {
         // `Vector2(1, 1)`, regardless of its initial orientation.
         effect.reset();
         game.update(1);
-        expect(component.size, closeToVector(1, 1));
+        expect(component.size, closeToVector(Vector2(1, 1)));
       }
     });
 
@@ -110,13 +110,13 @@ void main() {
       );
 
       game.update(1);
-      expect(component.size, closeToVector(1, 1)); // 5*1/10 + 0.5*1
+      expect(component.size, closeToVector(Vector2(1, 1))); // 5*1/10 + 0.5*1
       game.update(1);
-      expect(component.size, closeToVector(1, 1)); // 5*2/10 + 0.5*1 - 0.5*1
+      expect(component.size, closeToVector(Vector2(1, 1))); // 5*2/10 + 0.5*1 - 0.5*1
       for (var i = 0; i < 10; i++) {
         game.update(1);
       }
-      expect(component.size, closeToVector(5, 5));
+      expect(component.size, closeToVector(Vector2(5, 5)));
       expect(component.children.length, 0);
     });
 
@@ -144,7 +144,7 @@ void main() {
       game.update(1000 - totalTime);
       // Typically, `component.size` could accumulate numeric discrepancy on the
       // order of 1e-11 .. 1e-12 by now.
-      expect(component.size, closeToVector(0, 0, epsilon: 1e-10));
+      expect(component.size, closeToVector(Vector2(0, 0),  1e-10));
     });
   });
 }

--- a/packages/flame/test/experimental/bounded_position_behavior_test.dart
+++ b/packages/flame/test/experimental/bounded_position_behavior_test.dart
@@ -54,7 +54,7 @@ void main() {
       game.add(target);
       target.add(BoundedPositionBehavior(bounds: shape));
       await game.ready();
-      expect(target.position, closeToVector(10, 0, epsilon: 0.5));
+      expect(target.position, closeToVector(Vector2(10, 0), 0.5));
     });
 
     testWithFlameGame('adjust target position on shape change', (game) async {
@@ -68,7 +68,7 @@ void main() {
 
       behavior.bounds = Circle(Vector2.zero(), 5);
       expect((behavior.bounds as Circle).radius, 5);
-      expect(target.position, closeToVector(5, 0, epsilon: 0.1));
+      expect(target.position, closeToVector(Vector2(5, 0), 0.1));
     });
   });
 }

--- a/packages/flame/test/experimental/camera_component_test.dart
+++ b/packages/flame/test/experimental/camera_component_test.dart
@@ -17,7 +17,7 @@ void main() {
       for (var i = 0; i < 20; i++) {
         player.position.add(Vector2(i * 5.0, 20.0 - i));
         game.update(0.01);
-        expect(camera.viewfinder.position, closeToVector(player.x, player.y));
+        expect(camera.viewfinder.position, closeToVector(player.position));
       }
     });
 
@@ -56,12 +56,12 @@ void main() {
 
       camera.moveTo(Vector2(100, 0), speed: 5);
       for (var i = 0; i < 10; i++) {
-        expect(camera.viewfinder.position, closeToVector(0.5 * i, 0));
+        expect(camera.viewfinder.position, closeToVector(Vector2(0.5 * i, 0)));
         game.update(0.1);
       }
       camera.moveTo(Vector2(5, 200), speed: 10);
       for (var i = 0; i < 10; i++) {
-        expect(camera.viewfinder.position, closeToVector(5, 1.0 * i));
+        expect(camera.viewfinder.position, closeToVector(Vector2(5, 1.0 * i)));
         game.update(0.1);
       }
       expect(camera.viewfinder.children.length, 1);
@@ -78,11 +78,11 @@ void main() {
       expect(camera.viewfinder.position, Vector2(10, 10));
       camera.viewfinder.position = Vector2(-10, 10);
       game.update(0);
-      expect(camera.viewfinder.position, closeToVector(0, 10, epsilon: 0.5));
+      expect(camera.viewfinder.position, closeToVector(Vector2(0, 10), 0.5));
 
       camera.moveTo(Vector2(-20, 0), speed: 10);
       for (var i = 0; i < 20; i++) {
-        expect(camera.viewfinder.position, closeToVector(0, 10, epsilon: 0.5));
+        expect(camera.viewfinder.position, closeToVector(Vector2(0, 10), 0.5));
         game.update(0.5);
       }
 

--- a/packages/flame/test/experimental/follow_behavior_test.dart
+++ b/packages/flame/test/experimental/follow_behavior_test.dart
@@ -74,7 +74,7 @@ void main() {
 
       const dt = 0.11;
       for (var i = 0; i < 20; i++) {
-        expect(followTarget, closeToVector(3, 1 + i * dt, epsilon: 1e-14));
+        expect(followTarget, closeToVector(Vector2(3, 1 + i * dt), 1e-14));
         game.update(dt);
       }
     });
@@ -91,7 +91,7 @@ void main() {
         game.update(0.01);
         expect(
           pursuer.position,
-          closeToVector(target.position.x, target.position.y, epsilon: 1e-12),
+          closeToVector(target.position, 1e-12),
         );
       }
     });
@@ -111,7 +111,7 @@ void main() {
         final distance = speed * i * dt;
         expect(
           pursuer.position,
-          closeToVector(distance * 0.6, distance * 0.8, epsilon: 1e-12),
+          closeToVector(Vector2(distance * 0.6, distance * 0.8), 1e-12),
         );
         game.update(dt);
       }

--- a/packages/flame/test/experimental/geometry/shapes/circle_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/circle_test.dart
@@ -17,7 +17,7 @@ void main() {
       expect('$circle', 'Circle([5.0, 10.0], 2.5)');
       // Modifying original `center` vector does not affect the shape
       center.x += 111;
-      expect(circle.center, closeToVector(5, 10));
+      expect(circle.center, closeToVector(Vector2(5, 10)));
     });
 
     test('negative radius', () {
@@ -65,7 +65,7 @@ void main() {
 
     test('move', () {
       final circle = Circle(Vector2.zero(), 1);
-      expect(circle.center, closeToVector(0, 0));
+      expect(circle.center, closeToVector(Vector2.zero()));
       expect(circle.radius, 1);
       expect(
         circle.aabb,
@@ -73,7 +73,7 @@ void main() {
       );
 
       circle.move(Vector2(4, 7));
-      expect(circle.center, closeToVector(4, 7));
+      expect(circle.center, closeToVector(Vector2(4, 7)));
       expect(circle.radius, 1);
       expect(
         circle.aabb,
@@ -102,7 +102,7 @@ void main() {
       final transform = Transform2D()..position = Vector2(10, 40);
       final result = circle.project(transform);
       expect(result, isA<Circle>());
-      expect(result.center, closeToVector(10, 40));
+      expect(result.center, closeToVector(Vector2(10, 40)));
       expect((result as Circle).radius, 100);
 
       transform.scale.setValues(1, 2);
@@ -125,23 +125,26 @@ void main() {
       expect(result, isA<Circle>());
       expect(result, target);
       expect(target.radius, 200);
-      expect(target.center, closeToVector(10, 20));
+      expect(target.center, closeToVector(Vector2(10, 20)));
     });
 
     test('support', () {
       final circle = Circle(Vector2(2, 1), 10);
-      expect(circle.support(Vector2(1, 0)), closeToVector(12, 1));
-      expect(circle.support(Vector2(-1, 0)), closeToVector(-8, 1));
-      expect(circle.support(Vector2(0, 3.14)), closeToVector(2, 11));
-      expect(circle.support(Vector2(0, -3)), closeToVector(2, -9));
+      expect(circle.support(Vector2(1, 0)), closeToVector(Vector2(12, 1)));
+      expect(circle.support(Vector2(-1, 0)), closeToVector(Vector2(-8, 1)));
+      expect(circle.support(Vector2(0, 3.14)), closeToVector(Vector2(2, 11)));
+      expect(circle.support(Vector2(0, -3)), closeToVector(Vector2(2, -9)));
       expect(
         circle.support(Vector2(1, 1)),
-        closeToVector(2 + 10 / sqrt(2), 1 + 10 / sqrt(2)),
+        closeToVector(Vector2(2 + 10 / sqrt(2), 1 + 10 / sqrt(2))),
       );
-      expect(circle.support(Vector2(3, 4)), closeToVector(2 + 6, 1 + 8));
+      expect(
+        circle.support(Vector2(3, 4)),
+        closeToVector(Vector2(2 + 6, 1 + 8)),
+      );
       expect(
         circle.support(Vector2(-2, -1)),
-        closeToVector(2 - 20 / sqrt(5), 1 - 10 / sqrt(5)),
+        closeToVector(Vector2(2 - 20 / sqrt(5), 1 - 10 / sqrt(5))),
       );
     });
   });

--- a/packages/flame/test/experimental/geometry/shapes/polygon_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/polygon_test.dart
@@ -37,7 +37,7 @@ void main() {
         polygon.aabb,
         closeToAabb(Aabb2.minMax(Vector2.zero(), Vector2(80, 60))),
       );
-      expect(polygon.center, closeToVector(80 / 3, 60 * 2 / 3, epsilon: 1e-14));
+      expect(polygon.center, closeToVector(Vector2(80 / 3, 60 * 2 / 3), 1e-14));
       expect('$polygon', 'Polygon([[0.0,0.0], [0.0,60.0], [80.0,60.0]])');
     });
 
@@ -107,7 +107,7 @@ void main() {
       );
       // Force computing (and caching) the aabb and the center
       expect(polygon.aabb.min, Vector2.zero());
-      expect(polygon.center, closeToVector(80 / 3, 40, epsilon: 1e-14));
+      expect(polygon.center, closeToVector(Vector2(80 / 3, 40), 1e-14));
 
       polygon.move(Vector2(5, -10));
       expect(
@@ -122,7 +122,7 @@ void main() {
         polygon.aabb,
         closeToAabb(Aabb2.minMax(Vector2(5, -10), Vector2(85, 50))),
       );
-      expect(polygon.center, closeToVector(95 / 3, 30, epsilon: 1e-14));
+      expect(polygon.center, closeToVector(Vector2(95 / 3, 30), 1e-14));
     });
 
     test('support', () {
@@ -208,10 +208,10 @@ void main() {
       final a = 10 * sqrt(2);
       expect(result, isA<Polygon>());
       expect((result as Polygon).edges.length, 4);
-      expect(result.vertices[0], closeToVector(-a, -a, epsilon: 1e-14));
-      expect(result.vertices[1], closeToVector(-a, a, epsilon: 1e-14));
-      expect(result.vertices[2], closeToVector(a, a, epsilon: 1e-14));
-      expect(result.vertices[3], closeToVector(a, -a, epsilon: 1e-14));
+      expect(result.vertices[0], closeToVector(Vector2(-a, -a), 1e-14));
+      expect(result.vertices[1], closeToVector(Vector2(-a, a), 1e-14));
+      expect(result.vertices[2], closeToVector(Vector2(a, a), 1e-14));
+      expect(result.vertices[3], closeToVector(Vector2(a, -a), 1e-14));
     });
 
     test('project with target', () {

--- a/packages/flame/test/experimental/geometry/shapes/rectangle_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/rectangle_test.dart
@@ -18,7 +18,7 @@ void main() {
       expect(rectangle.isConvex, true);
       expect(rectangle.isClosed, true);
       expect(rectangle.perimeter, 34);
-      expect(rectangle.center, closeToVector(6.5, 6));
+      expect(rectangle.center, closeToVector(Vector2(6.5, 6)));
       expect('$rectangle', 'Rectangle([4.0, 0.0], [9.0, 12.0])');
     });
 
@@ -135,14 +135,14 @@ void main() {
 
     test('move', () {
       final rectangle = Rectangle.fromLTRB(4, 2, 9, 12);
-      expect(rectangle.aabb.min, closeToVector(4, 2));
+      expect(rectangle.aabb.min, closeToVector(Vector2(4, 2)));
 
       rectangle.move(Vector2(-3, 1));
       expect(rectangle.left, 4 - 3);
       expect(rectangle.right, 9 - 3);
       expect(rectangle.top, 2 + 1);
       expect(rectangle.bottom, 12 + 1);
-      expect(rectangle.center, closeToVector(6.5 - 3, 7 + 1));
+      expect(rectangle.center, closeToVector(Vector2(6.5 - 3, 7 + 1)));
       expect(
         rectangle.aabb,
         closeToAabb(Aabb2.minMax(Vector2(1, 3), Vector2(6, 13))),
@@ -200,10 +200,13 @@ void main() {
       expect(rectangle.support(Vector2(0, 11)).y, 3);
       expect(rectangle.support(Vector2(0, -1)).y, 2);
 
-      expect(rectangle.support(Vector2(1, 1)), closeToVector(9, 3));
-      expect(rectangle.support(Vector2(-3, 2)), closeToVector(4, 3));
-      expect(rectangle.support(Vector2(-0.13, -2.01)), closeToVector(4, 2));
-      expect(rectangle.support(Vector2(9, -200)), closeToVector(9, 2));
+      expect(rectangle.support(Vector2(1, 1)), closeToVector(Vector2(9, 3)));
+      expect(rectangle.support(Vector2(-3, 2)), closeToVector(Vector2(4, 3)));
+      expect(
+        rectangle.support(Vector2(-0.13, -2.01)),
+        closeToVector(Vector2(4, 2)),
+      );
+      expect(rectangle.support(Vector2(9, -200)), closeToVector(Vector2(9, 2)));
     });
   });
 }

--- a/packages/flame/test/experimental/geometry/shapes/rounded_rectangle_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/rounded_rectangle_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(rrect.isConvex, true);
       expect(rrect.isClosed, true);
       expect(rrect.perimeter, closeTo(30.566, 0.001));
-      expect(rrect.center, closeToVector(6.5, 6));
+      expect(rrect.center, closeToVector(Vector2(6.5, 6)));
       expect(
         rrect.aabb,
         closeToAabb(Aabb2.minMax(Vector2(4, 0), Vector2(9, 12))),
@@ -116,8 +116,8 @@ void main() {
 
     test('move', () {
       final rrect = RoundedRectangle.fromLTRBR(4, 2, 9, 12, 1);
-      expect(rrect.aabb.min, closeToVector(4, 2));
-      expect(rrect.aabb.max, closeToVector(9, 12));
+      expect(rrect.aabb.min, closeToVector(Vector2(4, 2)));
+      expect(rrect.aabb.max, closeToVector(Vector2(9, 12)));
 
       rrect.move(Vector2(-3, 1));
       expect(rrect.left, 4 - 3);
@@ -125,7 +125,7 @@ void main() {
       expect(rrect.top, 2 + 1);
       expect(rrect.bottom, 12 + 1);
       expect(rrect.radius, 1);
-      expect(rrect.center, closeToVector(6.5 - 3, 7 + 1));
+      expect(rrect.center, closeToVector(Vector2(6.5 - 3, 7 + 1)));
       expect(
         rrect.aabb,
         closeToAabb(Aabb2.minMax(Vector2(1, 3), Vector2(6, 13))),
@@ -178,7 +178,7 @@ void main() {
         final expected = rect.support(direction) + circle.support(direction);
         expect(
           rrect.support(direction),
-          closeToVector(expected.x, expected.y, epsilon: 1e-14),
+          closeToVector(expected, 1e-14),
         );
       }
     });

--- a/packages/flame/test/experimental/viewfinder_test.dart
+++ b/packages/flame/test/experimental/viewfinder_test.dart
@@ -16,8 +16,8 @@ void main() {
         final camera = CameraComponent(world: world)..addToParent(game);
         world.add(_Rect());
         await game.ready();
-        expect(game.canvasSize, closeToVector(800, 600));
-        expect(camera.viewfinder.position, closeToVector(0, 0));
+        expect(game.canvasSize, closeToVector(Vector2(800, 600)));
+        expect(camera.viewfinder.position, closeToVector(Vector2(0, 0)));
         expect(camera.viewfinder.zoom, 1);
 
         // By default, the camera uses anchor=center, and places the world's
@@ -44,7 +44,7 @@ void main() {
           ..addToParent(game);
         world.add(_Rect());
         await game.ready();
-        expect(camera.viewfinder.position, closeToVector(100, -50));
+        expect(camera.viewfinder.position, closeToVector(Vector2(100, -50)));
 
         final canvas = MockCanvas();
         game.render(canvas);
@@ -126,11 +126,11 @@ void main() {
         for (var t = 0.0; t < 1.0; t += 0.1) {
           expect(
             camera.viewfinder.position,
-            closeToVector(5 * t, 13 * t, epsilon: 1e-14),
+            closeToVector(Vector2(5 * t, 13 * t), 1e-14),
           );
           expect(
             camera.viewport.position,
-            closeToVector(40 * t, -77 * t, epsilon: 1e-12),
+            closeToVector(Vector2(40 * t, -77 * t), 1e-12),
           );
           game.update(0.1);
         }

--- a/packages/flame/test/extensions/matrix4_test.dart
+++ b/packages/flame/test/extensions/matrix4_test.dart
@@ -32,7 +32,7 @@ void main() {
       final matrix4 = Matrix4.translation(Vector3(0, 10, 0));
       final input = Vector2.all(10);
 
-      expect(matrix4.transform2(input), closeToVector(10, 20));
+      expect(matrix4.transform2(input), closeToVector(Vector2(10, 20)));
     });
 
     test('test transformed2', () {
@@ -41,8 +41,8 @@ void main() {
       final out = Vector2.zero();
       final result = matrix4.transformed2(input, out);
 
-      expect(out, closeToVector(input.x, input.y));
-      expect(result, closeToVector(10, 20));
+      expect(out, closeToVector(input));
+      expect(result, closeToVector(Vector2(10, 20)));
     });
   });
 }

--- a/packages/flame/test/extensions/rect_test.dart
+++ b/packages/flame/test/extensions/rect_test.dart
@@ -43,8 +43,8 @@ void main() {
       const input = Rect.fromLTWH(0, 0, 10, 10);
       final result = input.transform(matrix4);
 
-      expect(result.topLeft.toVector2(), closeToVector(10, 10));
-      expect(result.bottomRight.toVector2(), closeToVector(20, 20));
+      expect(result.topLeft.toVector2(), closeToVector(Vector2(10, 10)));
+      expect(result.bottomRight.toVector2(), closeToVector(Vector2(20, 20)));
     });
   });
 }

--- a/packages/flame/test/extensions/vector2_test.dart
+++ b/packages/flame/test/extensions/vector2_test.dart
@@ -149,48 +149,48 @@ void main() {
     test('rotate - no center defined', () {
       final position = Vector2(0.0, 1.0);
       position.rotate(-math.pi / 2);
-      expect(position, closeToVector(1.0, 0.0));
+      expect(position, closeToVector(Vector2(1.0, 0.0)));
     });
 
     test('rotate - no center defined, negative position', () {
       final position = Vector2(0.0, -1.0);
       position.rotate(-math.pi / 2);
-      expect(position, closeToVector(-1.0, 0.0));
+      expect(position, closeToVector(Vector2(-1.0, 0.0)));
     });
 
     test('rotate - with center defined', () {
       final position = Vector2(0.0, 1.0);
       final center = Vector2(1.0, 1.0);
       position.rotate(-math.pi / 2, center: center);
-      expect(position, closeToVector(1.0, 2.0));
+      expect(position, closeToVector(Vector2(1.0, 2.0)));
     });
 
     test('rotate - with positive direction', () {
       final position = Vector2(0.0, 1.0);
       final center = Vector2(1.0, 1.0);
       position.rotate(math.pi / 2, center: center);
-      expect(position, closeToVector(1.0, 0.0));
+      expect(position, closeToVector(Vector2(1.0, 0.0)));
     });
 
     test('rotate - with a negative y position', () {
       final position = Vector2(2.0, -3.0);
       final center = Vector2(1.0, 1.0);
       position.rotate(math.pi / 2, center: center);
-      expect(position, closeToVector(5.0, 2.0));
+      expect(position, closeToVector(Vector2(5.0, 2.0)));
     });
 
     test('rotate - with a negative x position', () {
       final position = Vector2(-2.0, 3.0);
       final center = Vector2(1.0, 1.0);
       position.rotate(math.pi / 2, center: center);
-      expect(position, closeToVector(-1.0, -2.0));
+      expect(position, closeToVector(Vector2(-1.0, -2.0)));
     });
 
     test('rotate - with a negative position', () {
       final position = Vector2(-2.0, -3.0);
       final center = Vector2(1.0, 0.0);
       position.rotate(math.pi / 2, center: center);
-      expect(position, closeToVector(4.0, -3.0));
+      expect(position, closeToVector(Vector2(4.0, -3.0)));
     });
 
     test('screenAngle', () {

--- a/packages/flame/test/game/flame_game_test.dart
+++ b/packages/flame/test/game/flame_game_test.dart
@@ -25,7 +25,7 @@ void main() {
       game.add(innerGame);
       await game.ready();
 
-      expect(innerGame.canvasSize, closeToVector(800, 600));
+      expect(innerGame.canvasSize, closeToVector(Vector2(800, 600)));
       expect(innerGame.isLoaded, true);
       expect(innerGame.isMounted, true);
     });

--- a/packages/flame/test/game/game_widget/game_widget_tap_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_tap_test.dart
@@ -52,7 +52,7 @@ void main() {
       verify: (game, tester) async {
         expect(game.doubleTapRegistered, isTrue);
         final tapVector = tapPosition.toVector2();
-        expect(game.doubleTapPosition, closeToVector(tapVector.x, tapVector.y));
+        expect(game.doubleTapPosition, closeToVector(tapVector));
       },
     );
   });

--- a/packages/flame/test/game/projector_test.dart
+++ b/packages/flame/test/game/projector_test.dart
@@ -10,8 +10,8 @@ void main() {
       final projector = IdentityProjector();
       checkProjectorReversibility(projector);
       final v = Vector2(3.14, -3.15);
-      expect(projector.projectVector(v), closeToVector(v.x, v.y));
-      expect(projector.scaleVector(v), closeToVector(v.x, v.y));
+      expect(projector.projectVector(v), closeToVector(v));
+      expect(projector.scaleVector(v), closeToVector(v));
     });
   });
 
@@ -22,8 +22,14 @@ void main() {
         _ScaleProjector(-1),
       ]);
       checkProjectorReversibility(projector);
-      expect(projector.projectVector(Vector2(4, 5)), closeToVector(-12, -15));
-      expect(projector.projectVector(Vector2(1, -2)), closeToVector(-3, 6));
+      expect(
+        projector.projectVector(Vector2(4, 5)),
+        closeToVector(Vector2(-12, -15)),
+      );
+      expect(
+        projector.projectVector(Vector2(1, -2)),
+        closeToVector(Vector2(-3, 6)),
+      );
     });
   });
 }
@@ -39,19 +45,19 @@ void checkProjectorReversibility(Projector projector) {
     );
     expect(
       projector.projectVector(projector.unprojectVector(point)),
-      closeToVector(point.x, point.y, epsilon: 1e-13),
+      closeToVector(point, 1e-13),
     );
     expect(
       projector.unprojectVector(projector.projectVector(point)),
-      closeToVector(point.x, point.y, epsilon: 1e-13),
+      closeToVector(point, 1e-13),
     );
     expect(
       projector.scaleVector(projector.unscaleVector(point)),
-      closeToVector(point.x, point.y, epsilon: 1e-13),
+      closeToVector(point, 1e-13),
     );
     expect(
       projector.unscaleVector(projector.scaleVector(point)),
-      closeToVector(point.x, point.y, epsilon: 1e-13),
+      closeToVector(point, 1e-13),
     );
   }
 }

--- a/packages/flame_test/example/test/main_test.dart
+++ b/packages/flame_test/example/test/main_test.dart
@@ -9,14 +9,8 @@ void main() {
       final changer = MyVectorChanger();
       final vector = Vector2.all(1.0);
       final changedVector = changer.addOne(vector);
-      expect(
-        vector + Vector2.all(1.0),
-        closeToVector(changedVector.x, changedVector.y),
-      );
-      expect(
-        vector + Vector2.all(1.1),
-        closeToVector(changedVector.x, changedVector.y, epsilon: 0.2),
-      );
+      expect(vector + Vector2.all(1.0), closeToVector(changedVector));
+      expect(vector + Vector2.all(1.1), closeToVector(changedVector, 0.2));
     });
 
     test('can test double', () {

--- a/packages/flame_test/lib/src/close_to_vector.dart
+++ b/packages/flame_test/lib/src/close_to_vector.dart
@@ -12,10 +12,6 @@ Matcher closeToVector(Vector2 vector, [double epsilon = 1e-15]) {
   return _IsCloseTo(vector, epsilon);
 }
 
-Matcher closeToVectorOld(num x, num y, {double epsilon = 1e-15}) {
-  return _IsCloseTo(Vector2(x.toDouble(), y.toDouble()), epsilon);
-}
-
 class _IsCloseTo extends Matcher {
   const _IsCloseTo(this._value, this._epsilon);
 

--- a/packages/flame_test/lib/src/close_to_vector.dart
+++ b/packages/flame_test/lib/src/close_to_vector.dart
@@ -11,6 +11,7 @@ import 'package:vector_math/vector_math_64.dart';
 Matcher closeToVector(Vector2 vector, [double epsilon = 1e-15]) {
   return _IsCloseTo(vector, epsilon);
 }
+
 Matcher closeToVectorOld(num x, num y, {double epsilon = 1e-15}) {
   return _IsCloseTo(Vector2(x.toDouble(), y.toDouble()), epsilon);
 }

--- a/packages/flame_test/lib/src/close_to_vector.dart
+++ b/packages/flame_test/lib/src/close_to_vector.dart
@@ -2,13 +2,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 /// Returns a matcher which checks if the argument is a vector within distance
-/// [epsilon] of point ([x], [y]). For example:
+/// [epsilon] of [vector]. For example:
 ///
 /// ```dart
-/// expect(scale, closeToVector(2, -2));
-/// expect(position, closeToVector(120, 150, epsilon: 1e-10));
+/// expect(scale, closeToVector(Vector2(2, -2)));
+/// expect(position, closeToVector(expectedPosition, 1e-10));
 /// ```
-Matcher closeToVector(num x, num y, {double epsilon = 1e-15}) {
+Matcher closeToVector(Vector2 vector, [double epsilon = 1e-15]) {
+  return _IsCloseTo(vector, epsilon);
+}
+Matcher closeToVectorOld(num x, num y, {double epsilon = 1e-15}) {
   return _IsCloseTo(Vector2(x.toDouble(), y.toDouble()), epsilon);
 }
 

--- a/packages/flame_test/test/close_to_vector_test.dart
+++ b/packages/flame_test/test/close_to_vector_test.dart
@@ -5,17 +5,17 @@ import 'package:vector_math/vector_math_64.dart';
 void main() {
   group('closeToVector', () {
     test('matches normally', () {
-      expect(Vector2.zero(), closeToVector(0, 0));
-      expect(Vector2(-14, 99), closeToVector(-14, 99));
-      expect(Vector2(1e-20, -1e-16), closeToVector(0, 0));
+      expect(Vector2.zero(), closeToVector(Vector2(0, 0)));
+      expect(Vector2(-14, 99), closeToVector(Vector2(-14, 99)));
+      expect(Vector2(1e-20, -1e-16), closeToVector(Vector2(0, 0)));
 
-      expect(Vector2(1.0001, 2.0), closeToVector(1, 2, epsilon: 0.01));
-      expect(Vector2(13, 14), closeToVector(10, 10, epsilon: 5));
+      expect(Vector2(1.0001, 2.0), closeToVector(Vector2(1, 2), 0.01));
+      expect(Vector2(13, 14), closeToVector(Vector2(10, 10), 5));
     });
 
     test('fails on type mismatch', () {
       try {
-        expect(3.14, closeToVector(0, 0));
+        expect(3.14, closeToVector(Vector2.zero()));
       } on TestFailure catch (e) {
         expect(
           e.message,
@@ -28,7 +28,7 @@ void main() {
 
     test('fails on value mismatch', () {
       try {
-        expect(Vector2(101, 217), closeToVector(100, 220));
+        expect(Vector2(101, 217), closeToVector(Vector2(100, 220)));
       } on TestFailure catch (e) {
         expect(
           e.message,


### PR DESCRIPTION
# Description

This PR changes the signature of the `closeToVector()` helper function:
- Old: `closeToVector(num x, num y, {double epsilon = 1e-15})`
- New: `closeToVector(Vector2 vector, [double epsilon = 1e-15])`


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] Yes, this is a breaking change.
- [-] No, this is *not* a breaking change.

### Migration instructions

This will be breaking for anyone who uses `closeToVector()` in their tests. Migration is purely mechanical: 
- replace `closeToVector(a, b)` with `closeToVector(Vector2(a, b))`;
- replace `closeToVector(vec.x, vec.y)` with `closeToVector(vec)`;
- parameter `epsilon:` is now unnamed.


## Related Issues

Closes #1526


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
