### PR TITLE
fix: Change AnimationWidget to use epoch time 

### DIFF
--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:flame/src/anchor.dart';
 import 'package:flame/src/cache/images.dart';
@@ -130,7 +129,7 @@ class _InternalSpriteAnimationWidgetState
   void _initAnimation() {
     setState(() {
       widget.animation.reset();
-      _lastUpdated = DateTime.now().millisecond.toDouble();
+      _lastUpdated = DateTime.now().microsecondsSinceEpoch.toDouble();
       _controller?.repeat(
         // Approximately 60 fps
         period: const Duration(milliseconds: 16),
@@ -145,9 +144,12 @@ class _InternalSpriteAnimationWidgetState
   }
 
   void _onAnimationValueChanged() {
-    final now = DateTime.now().millisecond.toDouble();
+    const microSecond = 1 / 1000000;
 
-    final dt = max(0, (now - (_lastUpdated ?? 0)) / 1000).toDouble();
+    final now = DateTime.now().microsecondsSinceEpoch.toDouble();
+    final lastUpdated = _lastUpdated ??= now;
+    final dt = (now - lastUpdated) * microSecond;
+
     widget.animation.update(dt);
 
     setState(() => _lastUpdated = now);

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -67,30 +67,48 @@ Future<void> main() async {
       },
     );
 
-    testWidgets('can safely change animation parameter', (tester) async {
-      final frames = List.generate(5, (_) => Sprite(image));
-      final animation1 = SpriteAnimation.spriteList(frames, stepTime: 0.1);
-      final animation2 = SpriteAnimation.spriteList(frames, stepTime: 0.1);
+    testWidgets(
+      'can safely change animation parameter',
+      (tester) async {
+        const executionCount = 1000;
+        var failedCount = 0;
 
-      await tester.pumpWidget(SpriteAnimationWidget(animation: animation1));
-      expect(animation1.onComplete, isNotNull);
-      expect(animation2.onComplete, isNull);
+        for (var idx = 0; idx < executionCount; idx++) {
+          try {
+            final frames = List.generate(5, (_) => Sprite(image));
+            final animation1 =
+                SpriteAnimation.spriteList(frames, stepTime: 0.1);
+            final animation2 =
+                SpriteAnimation.spriteList(frames, stepTime: 0.1);
 
-      await tester.pump();
-      expect(animation1.elapsed, isNonZero);
-      expect(animation2.elapsed, isZero);
+            await tester
+                .pumpWidget(SpriteAnimationWidget(animation: animation1));
+            expect(animation1.onComplete, isNotNull);
+            expect(animation2.onComplete, isNull);
 
-      // This will call didUpdateWidget life cycle
-      await tester.pumpWidget(SpriteAnimationWidget(animation: animation2));
-      expect(animation1.onComplete, isNull);
-      expect(animation2.onComplete, isNotNull);
+            await tester.pump();
+            expect(animation1.elapsed, isNonZero);
+            expect(animation2.elapsed, isZero);
 
-      // Reset the replaced animation for clarifying the expectation
-      animation1.reset();
+            // This will call didUpdateWidget lifecycle
+            await tester
+                .pumpWidget(SpriteAnimationWidget(animation: animation2));
+            expect(animation1.onComplete, isNull);
+            expect(animation2.onComplete, isNotNull);
 
-      await tester.pump();
-      expect(animation1.elapsed, isZero);
-      expect(animation2.elapsed, isNonZero);
-    });
+            // Reset the replaced animation for clarifying the expectation
+            animation1.reset();
+
+            await tester.pump();
+            expect(animation1.elapsed, isZero);
+            expect(animation2.elapsed, isNonZero);
+          } on TestFailure {
+            failedCount++;
+          }
+        }
+
+        expect(failedCount, isZero);
+      },
+    );
   });
 }


### PR DESCRIPTION
# Description
Currently, `AnimationWidget` is using a millisecond of the current second as elapsed time since the last frame.
It is dangerous because when the last frame occurs at end of the second and the current frame at the start of the second.
```
e.g. 
 Last frame: 08:00:00.990
 Current frame: 08:00:01.006
 ```
When the above situation occurs, `dt` became 0 and the SpriteAnimation does not update.

Changed to using elapsed time as subtraction of `microsecondsSinceEpoch` between frames.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
Fixes https://github.com/flame-engine/flame/issues/1765

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
