### PR TITLE
perf!: Game.images/assets are now same as Flame.images/assets by default

### DIFF
--- a/packages/flame/lib/src/game/game.dart
+++ b/packages/flame/lib/src/game/game.dart
@@ -1,6 +1,7 @@
 import 'package:flame/cache.dart';
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
+import 'package:flame/src/flame.dart';
 import 'package:flame/src/game/game_render_box.dart';
 import 'package:flame/src/game/projector.dart';
 import 'package:flutter/rendering.dart';
@@ -15,8 +16,15 @@ import 'package:meta/meta.dart';
 /// Methods [update] and [render] need to be implemented in order to connect
 /// your class with the internal game loop.
 abstract class Game {
-  final images = Images();
-  final assets = AssetsCache();
+  /// The cache of all images loaded into the game. This defaults to the global
+  /// [Flame.images] cache, but you can replace it with a new cache instance if
+  /// needed.
+  Images images = Flame.images;
+
+  /// The cache of all (non-image) assets loaded into the game. This defaults to
+  /// the global [Flame.assets] cache, but you can replace this with another
+  /// instance if needed.
+  AssetsCache assets = Flame.assets;
 
   /// This should update the state of the game.
   void update(double dt);

--- a/packages/flame/test/cache/images_test.dart
+++ b/packages/flame/test/cache/images_test.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flame/cache.dart';
+import 'package:flame/flame.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -81,11 +82,27 @@ void main() {
     testWithFlameGame(
       'prefix on game.images can be changed',
       (game) async {
+        game.images = Images();
         expect(game.images.prefix, 'assets/images/');
         game.images.prefix = 'assets/pictures/';
         expect(game.images.prefix, 'assets/pictures/');
         game.images.prefix = '';
         expect(game.images.prefix, '');
+      },
+    );
+
+    testWithFlameGame(
+      'Game.images is same as Flame.images',
+      (game) async {
+        expect(game.images, equals(Flame.images));
+
+        final img = _MockImage();
+        game.images.add('my image', img);
+        expect(Flame.images.containsKey('my image'), isTrue);
+
+        game.images = Images();
+        game.images.add('new image', img);
+        expect(Flame.images.containsKey('new image'), isFalse);
       },
     );
 


### PR DESCRIPTION
# Description

The caches `Game.images` and `Game.assets` now coincide with the static caches `Flame.images` and `Flame.assets` by default.

This aims to avoid the situation where the same image (asset) may be loaded twice into two separate caches without the user noticing.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] Yes, this is a breaking change.
- [-] No, this is *not* a breaking change.

### Migration instructions

For the majority of users this change would not be breaking. However, it can affect those users who have multiple game instances simultaneously, where they use image files with same names but different content.

For such users the solution is to assign a private game instance when creating the game:
```dart
final game = MyGame() 
  ..images = Images()
  ..assets = AssetsCache();
```


## Related Issues

Closes #1750


<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
