### PR TITLE
feat: add `children` argument to `SpriteComponent.fromImage`

### DIFF
--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -42,13 +42,13 @@ class SpriteComponent extends PositionComponent
     Vector2? srcPosition,
     Vector2? srcSize,
     Paint? paint,
-    super.position,
+    Vector2? position,
     Vector2? size,
-    super.scale,
-    super.angle,
-    super.anchor,
-    super.children,
-    super.priority,
+    Vector2? scale,
+    double? angle,
+    Anchor? anchor,
+    Iterable<Component>? children,
+    int? priority,
   }) : this(
           sprite: Sprite(
             image,
@@ -56,7 +56,13 @@ class SpriteComponent extends PositionComponent
             srcSize: srcSize,
           ),
           paint: paint,
+          position: position,
           size: size ?? srcSize ?? image.size,
+          scale: scale,
+          angle: angle,
+          anchor: anchor,
+          children: children,
+          priority: priority,
         );
 
   @override

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -42,12 +42,13 @@ class SpriteComponent extends PositionComponent
     Vector2? srcPosition,
     Vector2? srcSize,
     Paint? paint,
-    Vector2? position,
+    super.position,
     Vector2? size,
-    Vector2? scale,
-    double? angle,
-    Anchor? anchor,
-    int? priority,
+    super.scale,
+    super.angle,
+    super.anchor,
+    super.children,
+    super.priority,
   }) : this(
           sprite: Sprite(
             image,
@@ -55,12 +56,7 @@ class SpriteComponent extends PositionComponent
             srcSize: srcSize,
           ),
           paint: paint,
-          position: position,
           size: size ?? srcSize ?? image.size,
-          scale: scale,
-          angle: angle,
-          anchor: anchor,
-          priority: priority,
         );
 
   @override


### PR DESCRIPTION
# Description

Missing `children` argument on the named constructor.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
