### PR TITLE
docs: replace images in README with absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Flame officially provides bridge libraries to the following packages:
 
 The Flame Engine's top sponsors:
 
-[![Very Good Ventures](/media/unicorn_two_toned.png)](https://verygood.ventures/)
+[![Very Good Ventures](https://raw.githubusercontent.com/flame-engine/flame/main/media/unicorn_two_toned.png)](https://verygood.ventures/)
 
-[![Cypher Stack](/media/logo_cypherstack.png)](https://cypherstack.com/)
+[![Cypher Stack](https://raw.githubusercontent.com/flame-engine/flame/main/media/logo_cypherstack.png)](https://cypherstack.com/)
 
 Want to sponsor Flame? Check our Patreon on the section below, or contact us on Discord.
 

--- a/i18n/README-ES.md
+++ b/i18n/README-ES.md
@@ -85,7 +85,7 @@ Por medio de estas librerías, serás capaz de acceder a componentes de Flame, h
 
 Top de patrocinadores del Flame Engine:
 
-[![Cypher Stack](/media/logo_cypherstack.png)](https://cypherstack.com/)
+[![Cypher Stack](https://raw.githubusercontent.com/flame-engine/flame/main/media/logo_cypherstack.png)](https://cypherstack.com/)
 
 ¿Quieres patrocinar Flame? Mira nuestro Patreon en la siguiente sección, o contactanos en Discord. 
 

--- a/i18n/README-JA.md
+++ b/i18n/README-JA.md
@@ -83,7 +83,7 @@ Flame は公式に以下のパッケージのブリッジライブラリを提�
 
 Flame エンジンのトップスポンサーは以下の通りです:
 
-[![Cypher Stack](/media/logo_cypherstack.png)](https://cypherstack.com/)
+[![Cypher Stack](https://raw.githubusercontent.com/flame-engine/flame/main/media/logo_cypherstack.png)](https://cypherstack.com/)
 
 Flame のスポンサーになることを希望する方は、以下のセクションにある私たちの Patreon か、または Discord で連絡してください。
 

--- a/i18n/README-PL.md
+++ b/i18n/README-PL.md
@@ -88,9 +88,9 @@ Flame oficjalnie udostępnia biblioteki bridge do następujących pakietów:
 
 Top sponsorzy Flame Engine:
 
-[![Very Good Ventures](/media/unicorn_two_toned.png)](https://verygood.ventures/)
+[![Very Good Ventures](https://raw.githubusercontent.com/flame-engine/flame/main/media/unicorn_two_toned.png)](https://verygood.ventures/)
 
-[![Cypher Stack](/media/logo_cypherstack.png)](https://cypherstack.com/)
+[![Cypher Stack](https://raw.githubusercontent.com/flame-engine/flame/main/media/logo_cypherstack.png)](https://cypherstack.com/)
 
 Chcesz sponsorować Flame? Sprawdź nasz Patreon w sekcji poniżej lub skontaktuj się z nami na Discordzie.
 

--- a/i18n/README-RU.md
+++ b/i18n/README-RU.md
@@ -89,9 +89,9 @@ Flame официально предоставляет связанные биб�
 
 Лучшие спонсоры движка Flame:
 
-[![Very Good Ventures](/media/unicorn_two_toned.png)](https://verygood.ventures/)
+[![Very Good Ventures](https://raw.githubusercontent.com/flame-engine/flame/main/media/unicorn_two_toned.png)](https://verygood.ventures/)
 
-[![Cypher Stack](/media/logo_cypherstack.png)](https://cypherstack.com/)
+[![Cypher Stack](https://raw.githubusercontent.com/flame-engine/flame/main/media/logo_cypherstack.png)](https://cypherstack.com/)
 
 Хотите спонсировать Flame? Обратите внимание на наш Patreon в следующем разделе, или свяжитесь с нами через Discord.
 

--- a/i18n/README-ZH.md
+++ b/i18n/README-ZH.md
@@ -91,7 +91,7 @@ Flame 引擎的目的是为使用 Flutter 开发的游戏会遇到的常见问�
 
 Flame 引擎最大的赞助者：
 
-[![Cypher Stack](/media/logo_cypherstack.png)](https://cypherstack.com/)
+[![Cypher Stack](https://raw.githubusercontent.com/flame-engine/flame/main/media/logo_cypherstack.png)](https://cypherstack.com/)
 
 如果你想要赞助 Flame，请查看下方的 Pateron 信息，或在 Discord 频道中联系我们。
 


### PR DESCRIPTION
The images path under sponsors has a relative path from the repository, which are being changed to absolute path (starting with https)

# Description

There are no breaking changes for this PR. The only changes are the image path changes in README (and translations) which now point to the images actual path in web

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

The other 3 checks are not required.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Fixes #1795 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
