### PR TITLE
docs: auto expand flame section on documentation home page

### DIFF
--- a/doc/_sphinx/conf.py
+++ b/doc/_sphinx/conf.py
@@ -64,7 +64,7 @@ pygments_style = 'monokai'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['images', 'scripts', 'theme']
-html_js_files = ['versions.js']
+html_js_files = ['versions.js', 'menu-expand.js']
 
 # -- Custom setup ------------------------------------------------------------
 class TitleCollector(docutils.nodes.SparseNodeVisitor):

--- a/doc/_sphinx/scripts/menu-expand.js
+++ b/doc/_sphinx/scripts/menu-expand.js
@@ -1,6 +1,5 @@
 // Auto expand the first expandable node ("flame") when loaded.
 window.addEventListener('load', (_event) => {
-    // expand first node when on home page
     expandFirstOnHome();
 });
 
@@ -9,61 +8,14 @@ window.addEventListener('load', (_event) => {
  * 
  * If the current page is not the home page, this method does nothing.
  */
-// Two scenarios are possible here:
-// 1. docs.flame-engine.org/ host
-//  - the pathname for homepage can be /{version}/index.html or /{version}/
-// 2. local host
-// - the pathname for homepage will end with /html/index.html
+// When the path name ends with index.html or an empty string, it is home page.
 function expandFirstOnHome() {
     const parts = location.pathname.split('/');
-    const partsLength = parts.length;
-    let canExpandFirst = false;
-    if (location.host === 'docs.flame-engine.org') {
-        if (partsLength == 3 && parts[0] === '' && (parts[2] === '' || parts[2] === 'index.html')) {
-            canExpandFirst = true;
-        }
-    } else {
-        // local
-        if (parts[partsLength-2] == 'html' && parts[partsLength-1] == 'index.html') {
-            canExpandFirst = true;
-        }
-    }
+    const lastPart = parts[parts.length - 1];
+    const isHomePage = (lastPart == '') || (lastPart == 'index.html');
 
-    if (canExpandFirst) {
+    if (isHomePage) {
         // expand the first expandable node in the toctree
-        var menu = document.querySelector(".toctree-l1")
-        expand(menu);
+        $('li.toctree-l1').has('ul').first().addClass('current');
     }
-}
-
-/**
- * Given a Node, if is expandable, it expands unless it is already expanded.
- * 
- * @param {Node} node 
- */
-function expand(node) {
-    if (is_expandable(node) && !is_expanded(node)) {
-        node.classList.add("current");
-    }
-}
-
-/**
- * Returns whether or not the given node is an expandable list.
- * 
- * @param {Node} node 
- * @returns {boolean} true if the node is a toctree that can be expanded, false otherwise.
- */
-function is_expandable(node) {
-    return node.querySelectorAll("li").length > 0
-}
-
-/**
- * Returns whether or not the given expandable node is already expanded.
- * Nodes are considered expandaded if they are 'current'ly selected, so we take advantage of this.
- * 
- * @param {Node} node 
- * @returns {boolean} true if the node is already expanded, false otherwise.
- */
-function is_expanded(node) {
-    return node.classList.contains("current")
 }

--- a/doc/_sphinx/scripts/menu-expand.js
+++ b/doc/_sphinx/scripts/menu-expand.js
@@ -1,0 +1,69 @@
+// Auto expand the first expandable node ("flame") when loaded.
+window.addEventListener('load', (_event) => {
+    // expand first node when on home page
+    expandFirstOnHome();
+});
+
+/**
+ * This method expands the first expandable node on the home page.
+ * 
+ * If the current page is not the home page, this method does nothing.
+ */
+// Two scenarios are possible here:
+// 1. docs.flame-engine.org/ host
+//  - the pathname for homepage can be /{version}/index.html or /{version}/
+// 2. local host
+// - the pathname for homepage will end with /html/index.html
+function expandFirstOnHome() {
+    const parts = location.pathname.split('/');
+    const partsLength = parts.length;
+    let canExpandFirst = false;
+    if (location.host === 'docs.flame-engine.org') {
+        if (partsLength == 3 && parts[0] === '' && (parts[2] === '' || parts[2] === 'index.html')) {
+            canExpandFirst = true;
+        }
+    } else {
+        // local
+        if (parts[partsLength-2] == 'html' && parts[partsLength-1] == 'index.html') {
+            canExpandFirst = true;
+        }
+    }
+
+    if (canExpandFirst) {
+        // expand the first expandable node in the toctree
+        var menu = document.querySelector(".toctree-l1")
+        expand(menu);
+    }
+}
+
+/**
+ * Given a Node, if is expandable, it expands unless it is already expanded.
+ * 
+ * @param {Node} node 
+ */
+function expand(node) {
+    if (is_expandable(node) && !is_expanded(node)) {
+        node.classList.add("current");
+    }
+}
+
+/**
+ * Returns whether or not the given node is an expandable list.
+ * 
+ * @param {Node} node 
+ * @returns {boolean} true if the node is a toctree that can be expanded, false otherwise.
+ */
+function is_expandable(node) {
+    return node.querySelectorAll("li").length > 0
+}
+
+/**
+ * Returns whether or not the given expandable node is already expanded.
+ * Nodes are considered expandaded if they are 'current'ly selected, so we take advantage of this.
+ * 
+ * @param {Node} node 
+ * @returns {boolean} true if the node is already expanded, false otherwise.
+ */
+function is_expanded(node) {
+    return node.classList.contains("current")
+}


### PR DESCRIPTION
add an event listener to the docs site to listen everytime on load, then
expand the first expandable section ("flame") if the current page is
home page.

# Description

This PR includes a new js file that handles every load of the documentation site to auto expand flame section when in home page (the main index page) and leaves as it is in the other pages.
The other small change makes this file include in the build.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

The other 3 checks are not required.

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1773 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
