### PR TITLE
docs: Auto expand flame section on documentation home page (#1823)

### DIFF
--- a/doc/_sphinx/conf.py
+++ b/doc/_sphinx/conf.py
@@ -64,7 +64,7 @@ pygments_style = 'monokai'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['images', 'scripts', 'theme']
-html_js_files = ['versions.js']
+html_js_files = ['versions.js', 'menu-expand.js']
 
 # -- Custom setup ------------------------------------------------------------
 class TitleCollector(docutils.nodes.SparseNodeVisitor):

--- a/doc/_sphinx/scripts/menu-expand.js
+++ b/doc/_sphinx/scripts/menu-expand.js
@@ -1,0 +1,21 @@
+// Auto expand the first expandable node ("flame") when loaded.
+window.addEventListener('load', (_event) => {
+    expandFirstOnHome();
+});
+
+/**
+ * This method expands the first expandable node on the home page.
+ * 
+ * If the current page is not the home page, this method does nothing.
+ */
+// When the path name ends with index.html or an empty string, it is home page.
+function expandFirstOnHome() {
+    const parts = location.pathname.split('/');
+    const lastPart = parts[parts.length - 1];
+    const isHomePage = (lastPart == '') || (lastPart == 'index.html');
+
+    if (isHomePage) {
+        // expand the first expandable node in the toctree
+        $('li.toctree-l1').has('ul').first().addClass('current');
+    }
+}


### PR DESCRIPTION
# Description

add an event listener to the docs site to listen everytime on load, then
expand the first expandable section ("flame") if the current page is
home page.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
