### PR TITLE
fix: SpriteButton tap cancellation

### DIFF
--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -178,6 +178,9 @@ class _ButtonState extends State<InternalSpriteButton> {
 
         widget.onPressed.call();
       },
+      onTapCancel: () {
+        setState(() => _pressed = false);
+      },
       child: Container(
         width: width,
         height: height,


### PR DESCRIPTION
# Description

This PR fixes an issue in which the `SpriteButton` appears as pressed when the user cancelled its press by dragging its finger away from the `SpriteButton`, releasing it outside.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1843
