### PR TITLE
chore(release): publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,139 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2022-08-19
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`flame` - `v1.3.0`](#flame---v130)
+ - [`flame_test` - `v1.7.0`](#flame_test---v170)
+
+Packages with other changes:
+
+ - [`flame_bloc` - `v1.7.0`](#flame_bloc---v170)
+ - [`flame_fire_atlas` - `v1.3.0`](#flame_fire_atlas---v130)
+ - [`flame_flare` - `v1.4.0`](#flame_flare---v140)
+ - [`flame_forge2d` - `v0.12.2`](#flame_forge2d---v0122)
+ - [`flame_lint` - `v0.1.2`](#flame_lint---v012)
+ - [`flame_oxygen` - `v0.1.5`](#flame_oxygen---v015)
+ - [`flame_svg` - `v1.5.0`](#flame_svg---v150)
+ - [`flame_tiled` - `v1.7.2`](#flame_tiled---v172)
+ - [`flame_rive` - `v1.5.1`](#flame_rive---v151)
+ - [`flame_audio` - `v1.3.1`](#flame_audio---v131)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `flame_rive` - `v1.5.1`
+ - `flame_audio` - `v1.3.1`
+
+---
+
+#### `flame` - `v1.3.0`
+
+ - **REFACTOR**: Use new "super"-constructors in ShapeComponents ([#1752](https://github.com/flame-engine/flame/issues/1752)). ([b69e8d85](https://github.com/flame-engine/flame/commit/b69e8d85c77346081d1fc5a2ee5cbf9c204a9edf))
+ - **REFACTOR**: Game is now a class, not a mixin ([#1751](https://github.com/flame-engine/flame/issues/1751)). ([5225a4eb](https://github.com/flame-engine/flame/commit/5225a4ebd55a21f5709ccab9a1e24c728b2747ed))
+ - **PERF**: Use TextElements within the TextComponent ([#1802](https://github.com/flame-engine/flame/issues/1802)). ([7b044430](https://github.com/flame-engine/flame/commit/7b04443046978c9bcdcf3eacab4813f3bcb545af))
+ - **PERF**: Avoid unnecessary copy in AssetsCache.readBinaryFile ([#1749](https://github.com/flame-engine/flame/issues/1749)). ([7e79638d](https://github.com/flame-engine/flame/commit/7e79638dd577cb07d55402d4e862de08ce832b85))
+ - **FIX**: ButtonComponent behavior when the engine is paused ([#1726](https://github.com/flame-engine/flame/issues/1726)). ([197e63d6](https://github.com/flame-engine/flame/commit/197e63d69e2a4c6779e49b918d05a60447ce9462))
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FIX**: World component can now be queried with `componentsAtPoint` ([#1739](https://github.com/flame-engine/flame/issues/1739)). ([f750d705](https://github.com/flame-engine/flame/commit/f750d705d14dd0ba95d550b2b8a320201a96584b))
+ - **FIX**: Merge basic and advanced gesture detectors ([#1718](https://github.com/flame-engine/flame/issues/1718)). ([f08f8e12](https://github.com/flame-engine/flame/commit/f08f8e12f5322c7bea1491908f06b350e13c14b7))
+ - **FIX**: Correct key events in GameWidget.controller ([#1745](https://github.com/flame-engine/flame/issues/1745)). ([01ed2ec9](https://github.com/flame-engine/flame/commit/01ed2ec967ee29c946c967786eec6bf7cc6ec958))
+ - **FIX**: Camera incorrect follow with zoom and world boundaries. ([c1756177](https://github.com/flame-engine/flame/commit/c175617714e2f15f4379ed8ea412c7cb8bfa1842))
+ - **FIX**: Add missing paint arguments on shapes ([#1727](https://github.com/flame-engine/flame/issues/1727)). ([e59f3428](https://github.com/flame-engine/flame/commit/e59f3428469e4298d812bb665171679df8895daf))
+ - **FIX**: Delay camera update ([#1811](https://github.com/flame-engine/flame/issues/1811)). ([a5598a8f](https://github.com/flame-engine/flame/commit/a5598a8fa43552028654a3a4b760b7b375dd81e5))
+ - **FIX**: Overlays can now be properly added during onLoad ([#1759](https://github.com/flame-engine/flame/issues/1759)). ([9f35b154](https://github.com/flame-engine/flame/commit/9f35b15420bea9ac5eeeddc245484b854e8eed38))
+ - **FIX**: SpriteAnimationWidget can now be update animation safely ([#1738](https://github.com/flame-engine/flame/issues/1738)). ([eb070195](https://github.com/flame-engine/flame/commit/eb0701951c165576fac1f540c8860e560a8961e6))
+ - **FIX**: JoystickComponent drags using the delta Viewport ([#1831](https://github.com/flame-engine/flame/issues/1831)). ([54e40de6](https://github.com/flame-engine/flame/commit/54e40de674f628282ea19af4f5ce2173ee48fd6e))
+ - **FIX**: Specify size for the SpriteWidget ([#1760](https://github.com/flame-engine/flame/issues/1760)). ([82f75fcb](https://github.com/flame-engine/flame/commit/82f75fcb57c8185a7138ee6ceb9082a418099df8))
+ - **FEAT**: New colours to pallete.dart ([#1783](https://github.com/flame-engine/flame/issues/1783)). ([85cd60e1](https://github.com/flame-engine/flame/commit/85cd60e16c7b4dafdf1823bf85a7ae8a50fd05f2))
+ - **FEAT**: add `children` argument to `SpriteComponent.fromImage` ([#1793](https://github.com/flame-engine/flame/issues/1793)). ([80a63362](https://github.com/flame-engine/flame/commit/80a633622a5784f377ef08515115d66ff200b848))
+ - **FEAT**: Added Decorator class and HasDecorator mixin ([#1781](https://github.com/flame-engine/flame/issues/1781)). ([8d00847c](https://github.com/flame-engine/flame/commit/8d00847cfcecb60a96772ccba1bcf3aec56b78ff))
+ - **FEAT**: Added TextFormatter classes ([#1720](https://github.com/flame-engine/flame/issues/1720)). ([c44272be](https://github.com/flame-engine/flame/commit/c44272be45eadfabc8f03ef250eb663e59ef2aab))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **FEAT**: Added Rotate3DDecorator ([#1805](https://github.com/flame-engine/flame/issues/1805)). ([f05194c8](https://github.com/flame-engine/flame/commit/f05194c80c4d09d024be486882e5defbb10dd506))
+ - **FEAT**: Added Shadow3DDecorator ([#1812](https://github.com/flame-engine/flame/issues/1812)). ([0a41b2da](https://github.com/flame-engine/flame/commit/0a41b2dabe51dbdfcd0b4c9f441bc4cc2e9e1b5e))
+ - **FEAT**: Add tertiary tap detector mixin ([#1815](https://github.com/flame-engine/flame/issues/1815)). ([e9e7b0d5](https://github.com/flame-engine/flame/commit/e9e7b0d598dac588daf37010b53221da4aea24be))
+ - **FEAT**: Add `Ray2` class to be used in raytracing/casting ([#1788](https://github.com/flame-engine/flame/issues/1788)). ([26196c01](https://github.com/flame-engine/flame/commit/26196c0152911c6d20b3feffe96319df4a625a7f))
+ - **FEAT**: Added RouterComponent  ([#1755](https://github.com/flame-engine/flame/issues/1755)). ([24092bd7](https://github.com/flame-engine/flame/commit/24092bd72d2e615c06908d9784f19fecb4d0b8b9))
+ - **FEAT**: Structured text and text styles ([#1830](https://github.com/flame-engine/flame/issues/1830)). ([bfdc3a29](https://github.com/flame-engine/flame/commit/bfdc3a291ba08ee0df07a80f0709c8470ed8a739))
+ - **FEAT**: Drag events that dispatch using componentsAtPoint ([#1715](https://github.com/flame-engine/flame/issues/1715)). ([10669c12](https://github.com/flame-engine/flame/commit/10669c12702a3a82fcf5be9161107dce4349a79f))
+ - **FEAT**: Added routes that can return a value ([#1848](https://github.com/flame-engine/flame/issues/1848)). ([f1b276e0](https://github.com/flame-engine/flame/commit/f1b276e020c6f80a18764e63ffbea21abb52b1f2))
+ - **FEAT**: PositionComponent now has a built-in Decorator ([#1846](https://github.com/flame-engine/flame/issues/1846)). ([8dd52c33](https://github.com/flame-engine/flame/commit/8dd52c338bbd66938dd90c068f99107337bae4ea))
+ - **FEAT**: add `HasAncestor` mixin ([#1711](https://github.com/flame-engine/flame/issues/1711)). ([987a44f4](https://github.com/flame-engine/flame/commit/987a44f441429534c743388b44e6d84b28e8f5ca))
+ - **FEAT**: Added ability to control overlays via the RouterComponent ([#1840](https://github.com/flame-engine/flame/issues/1840)). ([e2de70c9](https://github.com/flame-engine/flame/commit/e2de70c98afabb6e570c3442213b2246a724bdd9))
+ - **FEAT**: Add vector projection and inversion ([#1787](https://github.com/flame-engine/flame/issues/1787)). ([d197870f](https://github.com/flame-engine/flame/commit/d197870f529829adc51bbafc28180bde33d6f2cb))
+ - **DOCS**: Klondike tutorial, part 4 ([#1740](https://github.com/flame-engine/flame/issues/1740)). ([02d0b71b](https://github.com/flame-engine/flame/commit/02d0b71b2379d12b36b53a76b6bcf5f4018ec9df))
+ - **BREAKING** **REFACTOR**: Matcher closeToVector() now accepts Vector2 as an argument ([#1761](https://github.com/flame-engine/flame/issues/1761)). ([c5083501](https://github.com/flame-engine/flame/commit/c5083501d54023f04d3f09e3358bce039ade9a20))
+ - **BREAKING** **PERF**: Game.images/assets are now same as Flame.images/assets by default ([#1775](https://github.com/flame-engine/flame/issues/1775)). ([0ccb0e2e](https://github.com/flame-engine/flame/commit/0ccb0e2ef525661830c7b4662662ba64fda830fe))
+ - **BREAKING** **FEAT**: Raycasting and raytracing ([#1785](https://github.com/flame-engine/flame/issues/1785)). ([ed452dd1](https://github.com/flame-engine/flame/commit/ed452dd172289d49b6a9fbf02ee5b61b33f84c4c))
+
+#### `flame_test` - `v1.7.0`
+
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Added size parameter for testGolden() ([#1780](https://github.com/flame-engine/flame/issues/1780)). ([8e41d83e](https://github.com/flame-engine/flame/commit/8e41d83ea4e057e1a428f0456450d697351683bf))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **BREAKING** **REFACTOR**: Matcher closeToVector() now accepts Vector2 as an argument ([#1761](https://github.com/flame-engine/flame/issues/1761)). ([c5083501](https://github.com/flame-engine/flame/commit/c5083501d54023f04d3f09e3358bce039ade9a20))
+
+#### `flame_bloc` - `v1.7.0`
+
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Adding bloc getter to FlameBlocListenable mixin ([#1732](https://github.com/flame-engine/flame/issues/1732)). ([3d19caa3](https://github.com/flame-engine/flame/commit/3d19caa36dcb470b306b841ef9c03647a2f307d7))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **DOCS**: Fixing typo in `FlameMultiBlocProvider` dartdoc. ([67be6ab8](https://github.com/flame-engine/flame/commit/67be6ab86264f6def4b1b3b0e4ba00763c7dab4e))
+ - **DOCS**: updating README to the new flame bloc version ([#1737](https://github.com/flame-engine/flame/issues/1737)). ([6a2356aa](https://github.com/flame-engine/flame/commit/6a2356aa5eba1696caa6f88ecfe8143c4ffdb507))
+
+#### `flame_fire_atlas` - `v1.3.0`
+
+ - **PERF**: Avoid unnecessary copy in AssetsCache.readBinaryFile ([#1749](https://github.com/flame-engine/flame/issues/1749)). ([7e79638d](https://github.com/flame-engine/flame/commit/7e79638dd577cb07d55402d4e862de08ce832b85))
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+
+#### `flame_flare` - `v1.4.0`
+
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **DOCS**: Documenting how to write documentation ([#1721](https://github.com/flame-engine/flame/issues/1721)). ([ea354e3a](https://github.com/flame-engine/flame/commit/ea354e3a81e3810a8d2b9e3783d9833ae92349e0))
+
+#### `flame_forge2d` - `v0.12.2`
+
+ - **FIX**: `renderChain` should allow open-ended chain drawing ([#1804](https://github.com/flame-engine/flame/issues/1804)). ([60daa196](https://github.com/flame-engine/flame/commit/60daa196a8b2f9d3b022bf4d25b0dc8af29f40b8))
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+
+#### `flame_lint` - `v0.1.2`
+
+ - **REFACTOR**: Move to package imports ([#1625](https://github.com/flame-engine/flame/issues/1625)). ([843ddc36](https://github.com/flame-engine/flame/commit/843ddc36249272fcb518b44672e1012307dfa1b5))
+ - **REFACTOR**: Add a few more rules to flame_lint, including use_key_in_widget_constructors ([#1248](https://github.com/flame-engine/flame/issues/1248)). ([bac6c8a4](https://github.com/flame-engine/flame/commit/bac6c8a4469f2c5c2926335f2f589eec9b1a5b5b))
+ - **FIX**: Upgrade dartdoc (upgrade analyzer transitive dependency) ([#1630](https://github.com/flame-engine/flame/issues/1630)). ([6da8adb2](https://github.com/flame-engine/flame/commit/6da8adb28cffd8fcb43e6bf8a33aae22578f1b40))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **FEAT**: Add more lint rules ([#1703](https://github.com/flame-engine/flame/issues/1703)). ([49252f8e](https://github.com/flame-engine/flame/commit/49252f8ef29aa6b77144dcb97c24346f2f39380b))
+ - **FEAT**: Add non_constant_identifier_names rule ([#1656](https://github.com/flame-engine/flame/issues/1656)). ([1b40de09](https://github.com/flame-engine/flame/commit/1b40de094f4e66be7622d077a6e18cecf1964dde))
+ - **FEAT**: Bump to Flutter 2.10.0 ([#1617](https://github.com/flame-engine/flame/issues/1617)). ([beac9013](https://github.com/flame-engine/flame/commit/beac901313456cf0b39b6f4e6459f0feed183614))
+ - **DOCS**: Fix various dartdoc warnings ([#1353](https://github.com/flame-engine/flame/issues/1353)). ([9f096053](https://github.com/flame-engine/flame/commit/9f096053fd3c8ebd52d301710625a187db09704f))
+
+#### `flame_oxygen` - `v0.1.5`
+
+ - **REFACTOR**: Game is now a class, not a mixin ([#1751](https://github.com/flame-engine/flame/issues/1751)). ([5225a4eb](https://github.com/flame-engine/flame/commit/5225a4ebd55a21f5709ccab9a1e24c728b2747ed))
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+
+#### `flame_svg` - `v1.5.0`
+
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+
+#### `flame_tiled` - `v1.7.2`
+
+ - **FIX**: Remove unnecessary x offset ([#1838](https://github.com/flame-engine/flame/issues/1838)). ([4ea12b72](https://github.com/flame-engine/flame/commit/4ea12b724e04843b3b7dcd02dc2fb5060c9cf283))
+
+
 ## 2022-08-10
 
 ### Changes

--- a/doc/flame/examples/pubspec.yaml
+++ b/doc/flame/examples/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2

--- a/doc/tutorials/klondike/app/pubspec.yaml
+++ b/doc/tutorials/klondike/app/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: ^2.17.0
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
 flutter:
   assets:
     - assets/images/

--- a/examples/games/padracing/pubspec.yaml
+++ b/examples/games/padracing/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flame_forge2d: ^0.11.0
   flutter:
     sdk: flutter
@@ -15,7 +15,7 @@ dependencies:
   url_launcher: ^6.1.2
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_test:
     sdk: flutter
 

--- a/examples/games/trex/pubspec.yaml
+++ b/examples/games/trex/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
 flutter:
   uses-material-design: true
 

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
 
 dependencies:
   dashbook: 0.1.8
-  flame: ^1.2.1
-  flame_audio: ^1.3.0
+  flame: ^1.3.0
+  flame_audio: ^1.3.1
   flame_forge2d: ^0.11.0
-  flame_svg: ^1.4.0
+  flame_svg: ^1.5.0
   flutter:
     sdk: flutter
   google_fonts: ^2.3.2
@@ -24,7 +24,7 @@ dependencies:
     path: games/trex
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
 flutter:
   uses-material-design: true
 

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,3 +1,45 @@
+## 1.3.0
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**: Use new "super"-constructors in ShapeComponents ([#1752](https://github.com/flame-engine/flame/issues/1752)). ([b69e8d85](https://github.com/flame-engine/flame/commit/b69e8d85c77346081d1fc5a2ee5cbf9c204a9edf))
+ - **REFACTOR**: Game is now a class, not a mixin ([#1751](https://github.com/flame-engine/flame/issues/1751)). ([5225a4eb](https://github.com/flame-engine/flame/commit/5225a4ebd55a21f5709ccab9a1e24c728b2747ed))
+ - **PERF**: Use TextElements within the TextComponent ([#1802](https://github.com/flame-engine/flame/issues/1802)). ([7b044430](https://github.com/flame-engine/flame/commit/7b04443046978c9bcdcf3eacab4813f3bcb545af))
+ - **PERF**: Avoid unnecessary copy in AssetsCache.readBinaryFile ([#1749](https://github.com/flame-engine/flame/issues/1749)). ([7e79638d](https://github.com/flame-engine/flame/commit/7e79638dd577cb07d55402d4e862de08ce832b85))
+ - **FIX**: ButtonComponent behavior when the engine is paused ([#1726](https://github.com/flame-engine/flame/issues/1726)). ([197e63d6](https://github.com/flame-engine/flame/commit/197e63d69e2a4c6779e49b918d05a60447ce9462))
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FIX**: World component can now be queried with `componentsAtPoint` ([#1739](https://github.com/flame-engine/flame/issues/1739)). ([f750d705](https://github.com/flame-engine/flame/commit/f750d705d14dd0ba95d550b2b8a320201a96584b))
+ - **FIX**: Merge basic and advanced gesture detectors ([#1718](https://github.com/flame-engine/flame/issues/1718)). ([f08f8e12](https://github.com/flame-engine/flame/commit/f08f8e12f5322c7bea1491908f06b350e13c14b7))
+ - **FIX**: Correct key events in GameWidget.controller ([#1745](https://github.com/flame-engine/flame/issues/1745)). ([01ed2ec9](https://github.com/flame-engine/flame/commit/01ed2ec967ee29c946c967786eec6bf7cc6ec958))
+ - **FIX**: Camera incorrect follow with zoom and world boundaries. ([c1756177](https://github.com/flame-engine/flame/commit/c175617714e2f15f4379ed8ea412c7cb8bfa1842))
+ - **FIX**: Add missing paint arguments on shapes ([#1727](https://github.com/flame-engine/flame/issues/1727)). ([e59f3428](https://github.com/flame-engine/flame/commit/e59f3428469e4298d812bb665171679df8895daf))
+ - **FIX**: Delay camera update ([#1811](https://github.com/flame-engine/flame/issues/1811)). ([a5598a8f](https://github.com/flame-engine/flame/commit/a5598a8fa43552028654a3a4b760b7b375dd81e5))
+ - **FIX**: Overlays can now be properly added during onLoad ([#1759](https://github.com/flame-engine/flame/issues/1759)). ([9f35b154](https://github.com/flame-engine/flame/commit/9f35b15420bea9ac5eeeddc245484b854e8eed38))
+ - **FIX**: SpriteAnimationWidget can now be update animation safely ([#1738](https://github.com/flame-engine/flame/issues/1738)). ([eb070195](https://github.com/flame-engine/flame/commit/eb0701951c165576fac1f540c8860e560a8961e6))
+ - **FIX**: JoystickComponent drags using the delta Viewport ([#1831](https://github.com/flame-engine/flame/issues/1831)). ([54e40de6](https://github.com/flame-engine/flame/commit/54e40de674f628282ea19af4f5ce2173ee48fd6e))
+ - **FIX**: Specify size for the SpriteWidget ([#1760](https://github.com/flame-engine/flame/issues/1760)). ([82f75fcb](https://github.com/flame-engine/flame/commit/82f75fcb57c8185a7138ee6ceb9082a418099df8))
+ - **FEAT**: New colours to pallete.dart ([#1783](https://github.com/flame-engine/flame/issues/1783)). ([85cd60e1](https://github.com/flame-engine/flame/commit/85cd60e16c7b4dafdf1823bf85a7ae8a50fd05f2))
+ - **FEAT**: add `children` argument to `SpriteComponent.fromImage` ([#1793](https://github.com/flame-engine/flame/issues/1793)). ([80a63362](https://github.com/flame-engine/flame/commit/80a633622a5784f377ef08515115d66ff200b848))
+ - **FEAT**: Added Decorator class and HasDecorator mixin ([#1781](https://github.com/flame-engine/flame/issues/1781)). ([8d00847c](https://github.com/flame-engine/flame/commit/8d00847cfcecb60a96772ccba1bcf3aec56b78ff))
+ - **FEAT**: Added TextFormatter classes ([#1720](https://github.com/flame-engine/flame/issues/1720)). ([c44272be](https://github.com/flame-engine/flame/commit/c44272be45eadfabc8f03ef250eb663e59ef2aab))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **FEAT**: Added Rotate3DDecorator ([#1805](https://github.com/flame-engine/flame/issues/1805)). ([f05194c8](https://github.com/flame-engine/flame/commit/f05194c80c4d09d024be486882e5defbb10dd506))
+ - **FEAT**: Added Shadow3DDecorator ([#1812](https://github.com/flame-engine/flame/issues/1812)). ([0a41b2da](https://github.com/flame-engine/flame/commit/0a41b2dabe51dbdfcd0b4c9f441bc4cc2e9e1b5e))
+ - **FEAT**: Add tertiary tap detector mixin ([#1815](https://github.com/flame-engine/flame/issues/1815)). ([e9e7b0d5](https://github.com/flame-engine/flame/commit/e9e7b0d598dac588daf37010b53221da4aea24be))
+ - **FEAT**: Add `Ray2` class to be used in raytracing/casting ([#1788](https://github.com/flame-engine/flame/issues/1788)). ([26196c01](https://github.com/flame-engine/flame/commit/26196c0152911c6d20b3feffe96319df4a625a7f))
+ - **FEAT**: Added RouterComponent  ([#1755](https://github.com/flame-engine/flame/issues/1755)). ([24092bd7](https://github.com/flame-engine/flame/commit/24092bd72d2e615c06908d9784f19fecb4d0b8b9))
+ - **FEAT**: Structured text and text styles ([#1830](https://github.com/flame-engine/flame/issues/1830)). ([bfdc3a29](https://github.com/flame-engine/flame/commit/bfdc3a291ba08ee0df07a80f0709c8470ed8a739))
+ - **FEAT**: Drag events that dispatch using componentsAtPoint ([#1715](https://github.com/flame-engine/flame/issues/1715)). ([10669c12](https://github.com/flame-engine/flame/commit/10669c12702a3a82fcf5be9161107dce4349a79f))
+ - **FEAT**: Added routes that can return a value ([#1848](https://github.com/flame-engine/flame/issues/1848)). ([f1b276e0](https://github.com/flame-engine/flame/commit/f1b276e020c6f80a18764e63ffbea21abb52b1f2))
+ - **FEAT**: PositionComponent now has a built-in Decorator ([#1846](https://github.com/flame-engine/flame/issues/1846)). ([8dd52c33](https://github.com/flame-engine/flame/commit/8dd52c338bbd66938dd90c068f99107337bae4ea))
+ - **FEAT**: add `HasAncestor` mixin ([#1711](https://github.com/flame-engine/flame/issues/1711)). ([987a44f4](https://github.com/flame-engine/flame/commit/987a44f441429534c743388b44e6d84b28e8f5ca))
+ - **FEAT**: Added ability to control overlays via the RouterComponent ([#1840](https://github.com/flame-engine/flame/issues/1840)). ([e2de70c9](https://github.com/flame-engine/flame/commit/e2de70c98afabb6e570c3442213b2246a724bdd9))
+ - **FEAT**: Add vector projection and inversion ([#1787](https://github.com/flame-engine/flame/issues/1787)). ([d197870f](https://github.com/flame-engine/flame/commit/d197870f529829adc51bbafc28180bde33d6f2cb))
+ - **DOCS**: Klondike tutorial, part 4 ([#1740](https://github.com/flame-engine/flame/issues/1740)). ([02d0b71b](https://github.com/flame-engine/flame/commit/02d0b71b2379d12b36b53a76b6bcf5f4018ec9df))
+ - **BREAKING** **REFACTOR**: Matcher closeToVector() now accepts Vector2 as an argument ([#1761](https://github.com/flame-engine/flame/issues/1761)). ([c5083501](https://github.com/flame-engine/flame/commit/c5083501d54023f04d3f09e3358bce039ade9a20))
+ - **BREAKING** **PERF**: Game.images/assets are now same as Flame.images/assets by default ([#1775](https://github.com/flame-engine/flame/issues/1775)). ([0ccb0e2e](https://github.com/flame-engine/flame/commit/0ccb0e2ef525661830c7b4662662ba64fda830fe))
+ - **BREAKING** **FEAT**: Raycasting and raytracing ([#1785](https://github.com/flame-engine/flame/issues/1785)). ([ed452dd1](https://github.com/flame-engine/flame/commit/ed452dd172289d49b6a9fbf02ee5b61b33f84c4c))
+
 ## 1.2.1
 
 > Note: This release has breaking changes.

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_test:
     sdk: flutter

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 1.2.1
+version: 1.3.0
 homepage: https://github.com/flame-engine/flame
 
 environment:
@@ -18,8 +18,8 @@ dependencies:
 dev_dependencies:
   canvas_test: ^0.2.0
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
-  flame_test: ^1.6.0
+  flame_lint: ^0.1.2
+  flame_test: ^1.7.0
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_audio/CHANGELOG.md
+++ b/packages/flame_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+ - Update a dependency to the latest release.
+
 ## 1.3.0
 
 > Note: This release has breaking changes.

--- a/packages/flame_audio/example/pubspec.yaml
+++ b/packages/flame_audio/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  flame: ^1.2.1
-  flame_audio: ^1.3.0
+  flame: ^1.3.0
+  flame_audio: ^1.3.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
 flutter:
   assets:
     - assets/audio/music/bg_music.ogg

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_audio
 description: Audio support for the Flame game engine. This containst all audio related code will live in the future, using the audioplayers package.
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_audio
 
 environment:
@@ -9,11 +9,11 @@ environment:
 
 dependencies:
   audioplayers: ^1.0.1
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
   synchronized: ^3.0.0
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2

--- a/packages/flame_bloc/CHANGELOG.md
+++ b/packages/flame_bloc/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.7.0
+
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Adding bloc getter to FlameBlocListenable mixin ([#1732](https://github.com/flame-engine/flame/issues/1732)). ([3d19caa3](https://github.com/flame-engine/flame/commit/3d19caa36dcb470b306b841ef9c03647a2f307d7))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **DOCS**: Fixing typo in `FlameMultiBlocProvider` dartdoc. ([67be6ab8](https://github.com/flame-engine/flame/commit/67be6ab86264f6def4b1b3b0e4ba00763c7dab4e))
+ - **DOCS**: updating README to the new flame bloc version ([#1737](https://github.com/flame-engine/flame/issues/1737)). ([6a2356aa](https://github.com/flame-engine/flame/commit/6a2356aa5eba1696caa6f88ecfe8143c4ffdb507))
+
 ## 1.6.0
 
  - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))

--- a/packages/flame_bloc/example/pubspec.yaml
+++ b/packages/flame_bloc/example/pubspec.yaml
@@ -10,13 +10,13 @@ environment:
 
 dependencies:
   equatable: ^2.0.3
-  flame_bloc: ^1.6.0
+  flame_bloc: ^1.7.0
   flutter:
     sdk: flutter
   flutter_bloc: ^8.0.1
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_bloc
 description: Bloc integration to Flame games
-version: 1.6.0
+version: 1.7.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_bloc
 
 environment:
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   bloc: ^8.0.2
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
   flutter_bloc: ^8.0.1
@@ -17,8 +17,8 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
-  flame_test: ^1.6.0
+  flame_lint: ^0.1.2
+  flame_test: ^1.7.0
   flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter

--- a/packages/flame_fire_atlas/CHANGELOG.md
+++ b/packages/flame_fire_atlas/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.0
+
+ - **PERF**: Avoid unnecessary copy in AssetsCache.readBinaryFile ([#1749](https://github.com/flame-engine/flame/issues/1749)). ([7e79638d](https://github.com/flame-engine/flame/commit/7e79638dd577cb07d55402d4e862de08ce832b85))
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+
 ## 1.2.0
 
  - **PERF**: Avoid unnecessary copy in AssetsCache.readBinaryFile ([#1749](https://github.com/flame-engine/flame/issues/1749)). ([7e79638d](https://github.com/flame-engine/flame/commit/7e79638dd577cb07d55402d4e862de08ce832b85))

--- a/packages/flame_fire_atlas/example/pubspec.yaml
+++ b/packages/flame_fire_atlas/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  flame: ^1.2.1
-  flame_fire_atlas: ^1.2.0
+  flame: ^1.3.0
+  flame_fire_atlas: ^1.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_fire_atlas
 description: Easy to use texture atlases for the flame engine created with the fire atlas editor
-version: 1.2.0
+version: 1.3.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_fire_atlas
 
 environment:
@@ -9,13 +9,13 @@ environment:
 
 dependencies:
   archive: ^3.1.5
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_flare/CHANGELOG.md
+++ b/packages/flame_flare/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0
+
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **DOCS**: Documenting how to write documentation ([#1721](https://github.com/flame-engine/flame/issues/1721)). ([ea354e3a](https://github.com/flame-engine/flame/commit/ea354e3a81e3810a8d2b9e3783d9833ae92349e0))
+
 ## 1.3.0
 
  - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))

--- a/packages/flame_flare/example/pubspec.yaml
+++ b/packages/flame_flare/example/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
-  flame_flare: ^1.3.0
+  flame: ^1.3.0
+  flame_flare: ^1.4.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
 flutter:
   assets:
     - assets/Bob_Minion.flr

--- a/packages/flame_flare/pubspec.yaml
+++ b/packages/flame_flare/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_flare
 description: This packages allows you to use flare animations into a Flame game.
-version: 1.3.0
+version: 1.4.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_flare
 
 environment:
@@ -8,11 +8,11 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flare_flutter: ^3.0.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.2
+
+ - **FIX**: `renderChain` should allow open-ended chain drawing ([#1804](https://github.com/flame-engine/flame/issues/1804)). ([60daa196](https://github.com/flame-engine/flame/commit/60daa196a8b2f9d3b022bf4d25b0dc8af29f40b8))
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+
 ## 0.12.1
 
  - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_forge2d
 description: Forge2D (Box2D) support for the Flame game engine. This uses the forge2d package and provides wrappers and components to be used inside Flame.
-version: 0.12.1
+version: 0.12.2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_forge2d
 
 environment:
@@ -8,15 +8,15 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
   forge2d: ">=0.11.0 <0.12.0"
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
-  flame_test: ^1.6.0
+  flame_lint: ^0.1.2
+  flame_test: ^1.7.0
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_lint/CHANGELOG.md
+++ b/packages/flame_lint/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.1.2
+
+ - **REFACTOR**: Move to package imports ([#1625](https://github.com/flame-engine/flame/issues/1625)). ([843ddc36](https://github.com/flame-engine/flame/commit/843ddc36249272fcb518b44672e1012307dfa1b5))
+ - **REFACTOR**: Add a few more rules to flame_lint, including use_key_in_widget_constructors ([#1248](https://github.com/flame-engine/flame/issues/1248)). ([bac6c8a4](https://github.com/flame-engine/flame/commit/bac6c8a4469f2c5c2926335f2f589eec9b1a5b5b))
+ - **FIX**: Upgrade dartdoc (upgrade analyzer transitive dependency) ([#1630](https://github.com/flame-engine/flame/issues/1630)). ([6da8adb2](https://github.com/flame-engine/flame/commit/6da8adb28cffd8fcb43e6bf8a33aae22578f1b40))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **FEAT**: Add more lint rules ([#1703](https://github.com/flame-engine/flame/issues/1703)). ([49252f8e](https://github.com/flame-engine/flame/commit/49252f8ef29aa6b77144dcb97c24346f2f39380b))
+ - **FEAT**: Add non_constant_identifier_names rule ([#1656](https://github.com/flame-engine/flame/issues/1656)). ([1b40de09](https://github.com/flame-engine/flame/commit/1b40de094f4e66be7622d077a6e18cecf1964dde))
+ - **FEAT**: Bump to Flutter 2.10.0 ([#1617](https://github.com/flame-engine/flame/issues/1617)). ([beac9013](https://github.com/flame-engine/flame/commit/beac901313456cf0b39b6f4e6459f0feed183614))
+ - **DOCS**: Fix various dartdoc warnings ([#1353](https://github.com/flame-engine/flame/issues/1353)). ([9f096053](https://github.com/flame-engine/flame/commit/9f096053fd3c8ebd52d301710625a187db09704f))
+
 ## 0.1.1
 
  - **REFACTOR**: Move to package imports ([#1625](https://github.com/flame-engine/flame/issues/1625)). ([843ddc36](https://github.com/flame-engine/flame/commit/843ddc36249272fcb518b44672e1012307dfa1b5))

--- a/packages/flame_lint/pubspec.yaml
+++ b/packages/flame_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_lint
 description: Flame lint package
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_lint
 
 environment:

--- a/packages/flame_oxygen/CHANGELOG.md
+++ b/packages/flame_oxygen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.5
+
+ - **REFACTOR**: Game is now a class, not a mixin ([#1751](https://github.com/flame-engine/flame/issues/1751)). ([5225a4eb](https://github.com/flame-engine/flame/commit/5225a4ebd55a21f5709ccab9a1e24c728b2747ed))
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+
 ## 0.1.4
 
  - **REFACTOR**: Game is now a class, not a mixin ([#1751](https://github.com/flame-engine/flame/issues/1751)). ([5225a4eb](https://github.com/flame-engine/flame/commit/5225a4ebd55a21f5709ccab9a1e24c728b2747ed))

--- a/packages/flame_oxygen/example/pubspec.yaml
+++ b/packages/flame_oxygen/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  flame: ^1.2.1
-  flame_oxygen: ^0.1.4
+  flame: ^1.3.0
+  flame_oxygen: ^0.1.5
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
 flutter:
   uses-material-design: true
   assets:

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_oxygen
 description: Integrate the Oxygen ECS with the Flame Engine.
-version: 0.1.4
+version: 0.1.5
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_oxygen
 
 environment:
@@ -8,11 +8,11 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
   oxygen: ^0.2.0
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2

--- a/packages/flame_rive/CHANGELOG.md
+++ b/packages/flame_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+ - Update a dependency to the latest release.
+
 ## 1.5.0
 
  - **FIX**: Flame_rive now can load Nested Artboards and update to 0.9.0 rive package  ([#1741](https://github.com/flame-engine/flame/issues/1741)). ([82e4be96](https://github.com/flame-engine/flame/commit/82e4be96f3090908e95659a96006bf50fbb5b08c))

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  flame: ^1.2.1
-  flame_rive: ^1.5.0
+  flame: ^1.3.0
+  flame_rive: ^1.5.1
   flutter:
     sdk: flutter
   rive: 0.9.0
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -1,20 +1,20 @@
 name: flame_rive
 description: Rive support for the Flame game engine. This uses the rive package and provides wrappers and components to be used inside Flame.
 homepage: https://github.com/flame-engine/flame
-version: 1.5.0
+version: 1.5.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
   rive: ^0.9.0
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_test:
     sdk: flutter

--- a/packages/flame_svg/CHANGELOG.md
+++ b/packages/flame_svg/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.0
+
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+
 ## 1.4.0
 
  - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  flame: ^1.2.1
-  flame_svg: ^1.4.0
+  flame: ^1.3.0
+  flame_svg: ^1.5.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_svg
 description: Package to add SVG rendering support for the Flame game engine
-version: 1.4.0
+version: 1.5.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_svg
 
 environment:
@@ -8,13 +8,13 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
   flutter_svg: ^1.0.3
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   mocktail: ^0.3.0
   test: ^1.17.12

--- a/packages/flame_test/CHANGELOG.md
+++ b/packages/flame_test/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.7.0
+
+> Note: This release has breaking changes.
+
+ - **FIX**: Correct flutter constraint ([#1731](https://github.com/flame-engine/flame/issues/1731)). ([c7383843](https://github.com/flame-engine/flame/commit/c738384314a1a5c3695d1c3adaebcb59604df83a))
+ - **FEAT**: Added size parameter for testGolden() ([#1780](https://github.com/flame-engine/flame/issues/1780)). ([8e41d83e](https://github.com/flame-engine/flame/commit/8e41d83ea4e057e1a428f0456450d697351683bf))
+ - **FEAT**: Move to Flutter 3.0.0 and Dart 2.17.0 ([#1713](https://github.com/flame-engine/flame/issues/1713)). ([2a41d0d6](https://github.com/flame-engine/flame/commit/2a41d0d683391194b7209c47bde91199ab7a663e))
+ - **BREAKING** **REFACTOR**: Matcher closeToVector() now accepts Vector2 as an argument ([#1761](https://github.com/flame-engine/flame/issues/1761)). ([c5083501](https://github.com/flame-engine/flame/commit/c5083501d54023f04d3f09e3358bce039ade9a20))
+
 ## 1.6.0
 
 > Note: This release has breaking changes.

--- a/packages/flame_test/example/pubspec.yaml
+++ b/packages/flame_test/example/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
-  flame_test: ^1.6.0
+  flame_lint: ^0.1.2
+  flame_test: ^1.7.0
 flutter:
   assets:
     - assets/images/

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_test
 description: A package with classes to help testing applications using Flame
-version: 1.6.0
+version: 1.7.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_test
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
   flutter_test:
@@ -19,4 +19,4 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2

--- a/packages/flame_tiled/CHANGELOG.md
+++ b/packages/flame_tiled/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.2
+
+ - **FIX**: Remove unnecessary x offset ([#1838](https://github.com/flame-engine/flame/issues/1838)). ([4ea12b72](https://github.com/flame-engine/flame/commit/4ea12b724e04843b3b7dcd02dc2fb5060c9cf283))
+
 ## 1.7.1
 
  - **FIX**: Remove unnecessary x offset ([#1838](https://github.com/flame-engine/flame/issues/1838)). ([4ea12b72](https://github.com/flame-engine/flame/commit/4ea12b724e04843b3b7dcd02dc2fb5060c9cf283))

--- a/packages/flame_tiled/example/pubspec.yaml
+++ b/packages/flame_tiled/example/pubspec.yaml
@@ -7,13 +7,13 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  flame: ^1.2.1
-  flame_tiled: ^1.7.1
+  flame: ^1.3.0
+  flame_tiled: ^1.7.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
 flutter:
   uses-material-design: true
   assets:

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_tiled
 description: Tiled support for the Flame game engine. This uses the tiled package and provides wrappers and components to be used inside Flame.
-version: 1.7.1
+version: 1.7.2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_tiled
 
 environment:
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
   meta: ^1.7.0
@@ -18,5 +18,5 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^4.1.0
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   test: any

--- a/tutorials/space_shooter/pubspec.yaml
+++ b/tutorials/space_shooter/pubspec.yaml
@@ -10,14 +10,14 @@ environment:
 
 dependencies:
   dashbook: ^0.1.5
-  flame: ^1.2.1
+  flame: ^1.3.0
   flutter:
     sdk: flutter
   flutter_highlight: ^0.7.0
   flutter_markdown: ^0.6.7
 
 dev_dependencies:
-  flame_lint: ^0.1.1
+  flame_lint: ^0.1.2
   flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
 - flame@1.3.0
 - flame_test@1.7.0
 - flame_bloc@1.7.0
 - flame_fire_atlas@1.3.0
 - flame_flare@1.4.0
 - flame_forge2d@0.12.2
 - flame_lint@0.1.2
 - flame_oxygen@0.1.5
 - flame_svg@1.5.0
 - flame_tiled@1.7.2
 - flame_rive@1.5.1
 - flame_audio@1.3.1
