### PR TITLE
feat: Possibility to ignore hitboxes for ray casting

### DIFF
--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -231,8 +231,8 @@ something.
 
 For all of the following methods, if there are any hitboxes that you wish to ignore, you can add the
 `ignoreHitboxes` argument which is a list of the hitboxes that you wish to disregard for the call.
-This can be quite useful for example if you are casting rays from within a hitbox, which could be on your player
-or NPC; or if you don't want a ray to bounce off a `ScreenHitbox`.
+This can be quite useful for example if you are casting rays from within a hitbox, which could be on
+your player or NPC; or if you don't want a ray to bounce off a `ScreenHitbox`.
 
 
 ### Ray casting

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -229,6 +229,11 @@ Ray casting and ray tracing are methods for sending out rays from a point in you
 being able to see what these rays collide with and how they reflect after hitting
 something.
 
+For all of the following methods, if there are any hitboxes that you which to ignore you can add the
+`ignoreHitboxes` argument which is a list of the hitboxes that you which to disregard for the call.
+This can be quite useful if you are casting rays from within a hitbox, which could be on your player
+or npc for example.
+
 
 ### Ray casting
 

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -229,10 +229,10 @@ Ray casting and ray tracing are methods for sending out rays from a point in you
 being able to see what these rays collide with and how they reflect after hitting
 something.
 
-For all of the following methods, if there are any hitboxes that you which to ignore you can add the
-`ignoreHitboxes` argument which is a list of the hitboxes that you which to disregard for the call.
-This can be quite useful if you are casting rays from within a hitbox, which could be on your player
-or npc for example.
+For all of the following methods, if there are any hitboxes that you wish to ignore, you can add the
+`ignoreHitboxes` argument which is a list of the hitboxes that you wish to disregard for the call.
+This can be quite useful for example if you are casting rays from within a hitbox, which could be on your player
+or NPC; or if you don't want a ray to bounce off a `ScreenHitbox`.
 
 
 ### Ray casting

--- a/packages/flame/lib/src/collisions/collision_detection.dart
+++ b/packages/flame/lib/src/collisions/collision_detection.dart
@@ -70,9 +70,17 @@ abstract class CollisionDetection<T extends Hitbox<T>> {
   /// Returns the first hitbox that the given [ray] hits and the associated
   /// intersection information; or null if the ray doesn't hit any hitbox.
   ///
+  /// [ignoreHitboxes] can be used if you want to ignore certain hitboxes, i.e.
+  /// the rays will go straight through them. For example the hitbox of the
+  /// component that you might be casting the rays from.
+  ///
   /// If [out] is provided that object will be modified and returned with the
   /// result.
-  RaycastResult<T>? raycast(Ray2 ray, {RaycastResult<T>? out});
+  RaycastResult<T>? raycast(
+    Ray2 ray, {
+    List<ShapeHitbox>? ignoreHitboxes,
+    RaycastResult<T>? out,
+  });
 
   /// Casts rays uniformly between [startAngle] to [startAngle]+[sweepAngle]
   /// from the given [origin] and returns all hitboxes and intersection points
@@ -84,6 +92,10 @@ abstract class CollisionDetection<T extends Hitbox<T>> {
   /// If there are less objects in [rays] than the operation requires, the
   /// missing [Ray2] objects will be created and added to [rays].
   ///
+  /// [ignoreHitboxes] can be used if you want to ignore certain hitboxes, i.e.
+  /// the rays will go straight through them. For example the hitbox of the
+  /// component that you might be casting the rays from.
+  ///
   /// If [out] is provided the [RaycastResult]s in that list be modified and
   /// returned with the result. If there are less objects in [out] than the
   /// result requires, the missing [RaycastResult] objects will be created.
@@ -93,6 +105,7 @@ abstract class CollisionDetection<T extends Hitbox<T>> {
     double startAngle = 0,
     double sweepAngle = tau,
     List<Ray2>? rays,
+    List<ShapeHitbox>? ignoreHitboxes,
     List<RaycastResult<T>>? out,
   });
 
@@ -103,12 +116,17 @@ abstract class CollisionDetection<T extends Hitbox<T>> {
   /// [maxDepth] is how many times the ray should collide before returning a
   /// result, defaults to 10.
   ///
+  /// [ignoreHitboxes] can be used if you want to ignore certain hitboxes, i.e.
+  /// the rays will go straight through them. For example the hitbox of the
+  /// component that you might be casting the rays from.
+  ///
   /// If [out] is provided the [RaycastResult]s in that list be modified and
   /// returned with the result. If there are less objects in [out] than the
   /// result requires, the missing [RaycastResult] objects will be created.
   Iterable<RaycastResult<T>> raytrace(
     Ray2 ray, {
     int maxDepth = 10,
+    List<ShapeHitbox>? ignoreHitboxes,
     List<RaycastResult<T>>? out,
   });
 }

--- a/packages/flame/lib/src/collisions/collision_detection.dart
+++ b/packages/flame/lib/src/collisions/collision_detection.dart
@@ -78,7 +78,7 @@ abstract class CollisionDetection<T extends Hitbox<T>> {
   /// result.
   RaycastResult<T>? raycast(
     Ray2 ray, {
-    List<ShapeHitbox>? ignoreHitboxes,
+    List<T>? ignoreHitboxes,
     RaycastResult<T>? out,
   });
 
@@ -105,7 +105,7 @@ abstract class CollisionDetection<T extends Hitbox<T>> {
     double startAngle = 0,
     double sweepAngle = tau,
     List<Ray2>? rays,
-    List<ShapeHitbox>? ignoreHitboxes,
+    List<T>? ignoreHitboxes,
     List<RaycastResult<T>>? out,
   });
 
@@ -126,7 +126,7 @@ abstract class CollisionDetection<T extends Hitbox<T>> {
   Iterable<RaycastResult<T>> raytrace(
     Ray2 ray, {
     int maxDepth = 10,
-    List<ShapeHitbox>? ignoreHitboxes,
+    List<T>? ignoreHitboxes,
     List<RaycastResult<T>>? out,
   });
 }


### PR DESCRIPTION
# Description

A lot of the time it is useful to be able to ignore certain hitboxes, if you are for example casting rays from within the hitbox of one of your components. This PR adds this functionality to `raycast`, `raycastAll` and `raytrace`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
