### PR TITLE
perf: SpriteAnimationWidget will re-render only when needed

### DIFF
--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -150,13 +150,18 @@ class _InternalSpriteAnimationWidgetState
     final lastUpdated = _lastUpdated ??= now;
     final dt = (now - lastUpdated) * microSecond;
 
+    final frameIndexBeforeTick = widget.animation.currentIndex;
     widget.animation.update(dt);
+    final frameIndexAfterTick = widget.animation.currentIndex;
 
-    setState(() => _lastUpdated = now);
+    if (frameIndexBeforeTick != frameIndexAfterTick) {
+      setState(() {});
+    }
+    _lastUpdated = now;
   }
 
   void _pauseAnimation() {
-    setState(() => _controller?.stop());
+    _controller?.stop();
   }
 
   @override
@@ -167,12 +172,10 @@ class _InternalSpriteAnimationWidgetState
 
   @override
   Widget build(BuildContext ctx) {
-    return Container(
-      child: CustomPaint(
-        painter: SpritePainter(
-          widget.animation.getSprite(),
-          widget.anchor,
-        ),
+    return CustomPaint(
+      painter: SpritePainter(
+        widget.animation.getSprite(),
+        widget.anchor,
       ),
     );
   }

--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -127,14 +127,12 @@ class _InternalSpriteAnimationWidgetState
   }
 
   void _initAnimation() {
-    setState(() {
-      widget.animation.reset();
-      _lastUpdated = DateTime.now().microsecondsSinceEpoch.toDouble();
-      _controller?.repeat(
-        // Approximately 60 fps
-        period: const Duration(milliseconds: 16),
-      );
-    });
+    widget.animation.reset();
+    _lastUpdated = DateTime.now().microsecondsSinceEpoch.toDouble();
+    _controller?.repeat(
+      // Approximately 60 fps
+      period: const Duration(milliseconds: 16),
+    );
   }
 
   void _setupController() {

--- a/packages/flame/lib/src/widgets/sprite_painter.dart
+++ b/packages/flame/lib/src/widgets/sprite_painter.dart
@@ -31,7 +31,10 @@ class SpritePainter extends CustomPainter {
     final spriteAnchorPosition = anchorPosition..multiply(paintSize);
 
     canvas.translateVector(boxAnchorPosition..sub(spriteAnchorPosition));
-    if (_angle != 0) {
+
+    if (_angle == 0) {
+      _sprite.render(canvas, size: paintSize);
+    } else {
       canvas.renderRotated(
         _angle,
         spriteAnchorPosition,

--- a/packages/flame/lib/src/widgets/sprite_painter.dart
+++ b/packages/flame/lib/src/widgets/sprite_painter.dart
@@ -31,10 +31,12 @@ class SpritePainter extends CustomPainter {
     final spriteAnchorPosition = anchorPosition..multiply(paintSize);
 
     canvas.translateVector(boxAnchorPosition..sub(spriteAnchorPosition));
-    canvas.renderRotated(
-      _angle,
-      spriteAnchorPosition,
-      (canvas) => _sprite.render(canvas, size: paintSize),
-    );
+    if (_angle != 0) {
+      canvas.renderRotated(
+        _angle,
+        spriteAnchorPosition,
+        (canvas) => _sprite.render(canvas, size: paintSize),
+      );
+    }
   }
 }


### PR DESCRIPTION
# Description

As-Is
`SpriteAnimationWidget` is re-rendering even if the frame index is not changed. This wastes the resource.

To-Be
`SpriteAnimationWidget` now only re-renders(call setState) only when the frame index is changed.

Additionally, the `canvas.renderRotated` is called in `SpritePainter` even though the rotation angle is 0. I think it is not needed.
 
## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->



<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
