### PR TITLE
fix!: Make all `ComponentSet` modifications internal

### DIFF
--- a/packages/flame/lib/src/components/core/component_set.dart
+++ b/packages/flame/lib/src/components/core/component_set.dart
@@ -36,11 +36,31 @@ class ComponentSet extends QueryableOrderedSet<Component> {
   @override
   bool add(Component component) => super.add(component);
 
+  /// Marked as internal, because the users shouldn't be able to add elements
+  /// into the [ComponentSet] directly, bypassing the normal lifecycle handling.
+  @internal
+  @override
+  int addAll(Iterable<Component> components) => super.addAll(components);
+
   /// Marked as internal, because the users shouldn't be able to remove elements
   /// from the [ComponentSet] directly, bypassing the normal lifecycle handling.
   @internal
   @override
   bool remove(Component component) => super.remove(component);
+
+  /// Marked as internal, because the users shouldn't be able to remove elements
+  /// from the [ComponentSet] directly, bypassing the normal lifecycle handling.
+  @internal
+  @override
+  Iterable<Component> removeAll(Iterable<Component> components) =>
+      super.removeAll(components);
+
+  /// Marked as internal, because the users shouldn't be able to remove elements
+  /// from the [ComponentSet] directly, bypassing the normal lifecycle handling.
+  @internal
+  @override
+  Iterable<Component> removeWhere(bool Function(Component element) test) =>
+      super.removeWhere(test);
 
   /// Marked as internal, because the users shouldn't be able to remove elements
   /// from the [ComponentSet] directly, bypassing the normal lifecycle handling.


### PR DESCRIPTION
# Description

These methods should never have been exposed, since you bypass the component lifecycle with them.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] Yes, this is a breaking change.

### Migration instructions

For most methods `Component` has the corresponding methods directly on it already.
For example, instead of using `component.children.addAll` you should do `component.addAll`.

## Related Issues

Depends on #1878 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
