### PR TITLE
feat: Add `removeWhere` to `Component`

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -580,8 +580,7 @@ class Component {
     components.forEach(remove);
   }
 
-  /// Removes all the children the [test] function returns true for and calls
-  /// [onRemove] for all of them and their children.
+  /// Removes all the children for which the [test] function returns true.
   void removeWhere(bool Function(Component component) test) {
     children.forEach((component) {
       if (test(component)) {

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -580,6 +580,16 @@ class Component {
     components.forEach(remove);
   }
 
+  /// Removes all the children the [test] function returns true for and calls
+  /// [onRemove] for all of them and their children.
+  void removeWhere(bool Function(Component component) test) {
+    children.forEach((component) {
+      if (test(component)) {
+        remove(component);
+      }
+    });
+  }
+
   /// Remove the component from its parent in the next tick.
   void removeFromParent() {
     _parent?.remove(this);

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -33,6 +33,12 @@ class _ParentOnPrepareComponent extends _OnPrepareComponent {
   }
 }
 
+class _IdentifiableComponent extends Component {
+  final int id;
+
+  _IdentifiableComponent(this.id);
+}
+
 void main() {
   final prepareGame = FlameTester(_PrepareGame.new);
 
@@ -342,6 +348,26 @@ void main() {
 
           game.resumeEngine();
           game.update(0);
+        },
+      );
+
+      testWithFlameGame(
+        'removeWhere removes the correct components',
+        (game) async {
+          final components = List.generate(
+            10,
+            _IdentifiableComponent.new,
+          );
+          game.addAll(components);
+          await game.ready();
+          expect(game.children.length, 10);
+          game.removeWhere((c) => (c as _IdentifiableComponent).id.isEven);
+          game.update(0);
+          expect(game.children.length, 5);
+          expect(
+            game.children.every((c) => (c as _IdentifiableComponent).id.isOdd),
+            true,
+          );
         },
       );
     });

--- a/packages/flame_bloc/example/lib/src/game/game.dart
+++ b/packages/flame_bloc/example/lib/src/game/game.dart
@@ -2,7 +2,6 @@ import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame/input.dart';
 import 'package:flame_bloc/flame_bloc.dart';
-
 import 'package:flame_bloc_example/src/game/components/enemy.dart';
 import 'package:flame_bloc_example/src/game/components/enemy_creator.dart';
 import 'package:flame_bloc_example/src/game/components/player.dart';
@@ -19,7 +18,7 @@ class GameStatsController extends Component with HasGameRef<SpaceShooterGame> {
               newState.status == GameStatus.initial;
         },
         onNewState: (state) {
-          gameRef.children.removeWhere((element) => element is EnemyComponent);
+          gameRef.removeWhere((element) => element is EnemyComponent);
         },
       ),
     );


### PR DESCRIPTION
# Description

Since `removeWhere` will be removed from the `ComponentSet` in #1877 we should expose it on the component.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
