### PR TITLE
feat: Allow children of `ComposedParticle` to have varied lifespan

### DIFF
--- a/packages/flame/lib/src/particles/composed_particle.dart
+++ b/packages/flame/lib/src/particles/composed_particle.dart
@@ -6,18 +6,22 @@ import 'package:flame/src/particles/particle.dart';
 /// by proxying all lifecycle hooks.
 class ComposedParticle extends Particle {
   final List<Particle> children;
+  final bool applyLifespanToChildren;
 
   ComposedParticle({
     required this.children,
     super.lifespan,
+    this.applyLifespanToChildren = true,
   });
 
   @override
   void setLifespan(double lifespan) {
     super.setLifespan(lifespan);
 
-    for (final child in children) {
-      child.setLifespan(lifespan);
+    if (applyLifespanToChildren) {
+      for (final child in children) {
+        child.setLifespan(lifespan);
+      }
     }
   }
 
@@ -31,6 +35,8 @@ class ComposedParticle extends Particle {
   @override
   void update(double dt) {
     super.update(dt);
+
+    children.removeWhere((particle) => particle.shouldRemove);
 
     for (final child in children) {
       child.update(dt);

--- a/packages/flame/lib/src/particles/composed_particle.dart
+++ b/packages/flame/lib/src/particles/composed_particle.dart
@@ -4,6 +4,9 @@ import 'package:flame/src/particles/particle.dart';
 
 /// A single [Particle] which manages multiple children
 /// by proxying all lifecycle hooks.
+///
+/// [applyLifespanToChildren] if true, then [children] will have the same
+/// lifespan as parent [ComposedParticle]
 class ComposedParticle extends Particle {
   final List<Particle> children;
   final bool applyLifespanToChildren;

--- a/packages/flame/lib/src/particles/composed_particle.dart
+++ b/packages/flame/lib/src/particles/composed_particle.dart
@@ -28,9 +28,7 @@ class ComposedParticle extends Particle {
   @override
   void render(Canvas c) {
     for (final child in children) {
-      if (!child.shouldRemove) {
-        child.render(c);
-      }
+      child.render(c);
     }
   }
 
@@ -38,10 +36,10 @@ class ComposedParticle extends Particle {
   void update(double dt) {
     super.update(dt);
 
+    children.removeWhere((particle) => particle.shouldRemove);
+
     for (final child in children) {
-      if (!child.shouldRemove) {
-        child.update(dt);
-      }
+      child.update(dt);
     }
   }
 }

--- a/packages/flame/lib/src/particles/composed_particle.dart
+++ b/packages/flame/lib/src/particles/composed_particle.dart
@@ -28,7 +28,9 @@ class ComposedParticle extends Particle {
   @override
   void render(Canvas c) {
     for (final child in children) {
-      child.render(c);
+      if (!child.shouldRemove) {
+        child.render(c);
+      }
     }
   }
 
@@ -36,10 +38,10 @@ class ComposedParticle extends Particle {
   void update(double dt) {
     super.update(dt);
 
-    children.removeWhere((particle) => particle.shouldRemove);
-
     for (final child in children) {
-      child.update(dt);
+      if (!child.shouldRemove) {
+        child.update(dt);
+      }
     }
   }
 }

--- a/packages/flame/test/particles/composed_particle_test.dart
+++ b/packages/flame/test/particles/composed_particle_test.dart
@@ -1,0 +1,89 @@
+import 'package:flame/particles.dart';
+import 'package:flame/src/components/particle_system_component.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ComposedParticle', () {
+    testWithFlameGame('particles with parent lifespan applied to children',
+        (game) async {
+      final childParticle1 = CircleParticle(
+        paint: Paint()..color = Colors.red,
+        lifespan: 1,
+      );
+      final childParticle2 = CircleParticle(
+        paint: Paint()..color = Colors.red,
+        lifespan: 3,
+      );
+
+      final particle = ComposedParticle(
+        children: [
+          childParticle1,
+          childParticle2,
+        ],
+        lifespan: 2,
+      );
+
+      final component = ParticleSystemComponent(
+        particle: particle,
+      );
+
+      game.add(component);
+      await game.ready();
+      game.update(1);
+
+      expect(particle.progress, 0.5);
+      expect(childParticle1.progress, 0.5);
+      expect(childParticle2.progress, 0.5);
+      expect(particle.children.length, 2);
+
+      game.update(1);
+
+      expect(particle.progress, 1);
+      expect(childParticle1.progress, 1);
+      expect(childParticle2.progress, 1);
+      expect(particle.children.length, 2);
+    });
+
+    testWithFlameGame('particles without parent lifespan applied to children',
+        (game) async {
+      final childParticle1 = CircleParticle(
+        paint: Paint()..color = Colors.red,
+        lifespan: 1,
+      );
+      final childParticle2 = CircleParticle(
+        paint: Paint()..color = Colors.red,
+        lifespan: 4,
+      );
+
+      final particle = ComposedParticle(
+        children: [
+          childParticle1,
+          childParticle2,
+        ],
+        lifespan: 2,
+        applyLifespanToChildren: false,
+      );
+
+      final component = ParticleSystemComponent(
+        particle: particle,
+      );
+
+      game.add(component);
+      await game.ready();
+      game.update(1);
+
+      expect(particle.progress, 0.5);
+      expect(childParticle1.progress, 1);
+      expect(childParticle2.progress, 0.25);
+      expect(particle.children.length, 2);
+      game.update(1);
+
+      expect(particle.progress, 1);
+      expect(childParticle1.progress, 1);
+      expect(childParticle2.progress, 0.5);
+      expect(particle.children.length, 1);
+    });
+  });
+}

--- a/packages/flame/test/particles/composed_particle_test.dart
+++ b/packages/flame/test/particles/composed_particle_test.dart
@@ -78,6 +78,7 @@ void main() {
       expect(childParticle1.progress, 1);
       expect(childParticle2.progress, 0.25);
       expect(particle.children.length, 2);
+
       game.update(1);
 
       expect(particle.progress, 1);


### PR DESCRIPTION
# Description

Existing behavior: `ComposedParticle` takes `lifespan` and `children` as a constructor argument. At the construction time `lifespan` is propagated to all child particles. 

New behavior: `ComposedParticle` has an extra optional parameter `applyLifespanToChildren`. If set to `true` then existing behavior is preserved and all child particles will be assigned the lifespan of `ComposedParticle`, if set to `false` child particles will keep their original lifespan. If a particle lifecycle ends before `ComposedParticle` ends then it is removed from children.
`applyLifespanToChildren` is set to `true` by default for backward compatibility. 

<strike>Please note, that this is a proposal. I will update the docs and examples if the approach is approved.</strike>

## Breaking Change

[x] No, this is not a breaking change.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Related Issues
https://github.com/flame-engine/flame/issues/1872

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues/1872
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
