### PR TITLE
feat: Tiled component is positionable

### DIFF
--- a/packages/flame_tiled/lib/src/tiled_component.dart
+++ b/packages/flame_tiled/lib/src/tiled_component.dart
@@ -21,21 +21,21 @@ class TiledComponent<T extends FlameGame> extends PositionComponent
   /// [PositionComponent] larger or smaller, change its [scale].
   @override
   set size(Vector2 size) {
-    // Intenitonally left empty
+    // Intentionally left empty.
   }
 
   /// This property **cannot** be reassigned at runtime. To make the
   /// [PositionComponent] larger or smaller, change its [scale].
   @override
   set width(double w) {
-    // Intenitonally left empty
+    // Intentionally left empty.
   }
 
   /// This property **cannot** be reassigned at runtime. To make the
   /// [PositionComponent] larger or smaller, change its [scale].
   @override
   set height(double h) {
-    // Intenitonally left empty
+    // Intentionally left empty.
   }
 
   /// {@macro _tiled_component}

--- a/packages/flame_tiled/lib/src/tiled_component.dart
+++ b/packages/flame_tiled/lib/src/tiled_component.dart
@@ -79,7 +79,7 @@ class TiledComponent<T extends FlameGame> extends PositionComponent
     );
   }
 
-  static NotifyingVector2 _computeSize(RenderableTiledMap tileMap) {
+  static Vector2 _computeSize(RenderableTiledMap tileMap) {
     final tMap = tileMap.map;
 
     final xScale = tileMap.destTileSize.x / tMap.tileWidth;
@@ -97,29 +97,29 @@ class TiledComponent<T extends FlameGame> extends PositionComponent
     switch (tMap.orientation!) {
       case MapOrientation.staggered:
         return tMap.staggerAxis == StaggerAxis.y
-            ? NotifyingVector2(
+            ? Vector2(
                 tileScaled.x * tileMap.map.width + tileScaled.x / 2,
                 tileScaled.y + ((tileMap.map.height - 1) * tileScaled.y / 2),
               )
-            : NotifyingVector2(
+            : Vector2(
                 tileScaled.x + ((tileMap.map.width - 1) * tileScaled.x / 2),
                 tileScaled.y * tileMap.map.height + tileScaled.y / 2,
               );
 
       case MapOrientation.hexagonal:
         return tMap.staggerAxis == StaggerAxis.y
-            ? NotifyingVector2(
+            ? Vector2(
                 tileMap.map.width * tileScaled.x + tileScaled.x / 2,
                 tileScaled.y + ((tileMap.map.height - 1) * tileScaled.y * 0.75),
               )
-            : NotifyingVector2(
+            : Vector2(
                 tileScaled.x + ((tileMap.map.width - 1) * tileScaled.x * 0.75),
                 (tileMap.map.height * tileScaled.y) + tileScaled.y / 2,
               );
 
       case MapOrientation.isometric:
       case MapOrientation.orthogonal:
-        return NotifyingVector2(
+        return Vector2(
           tileMap.map.width * tileScaled.x,
           tileMap.map.height * tileScaled.y,
         );

--- a/packages/flame_tiled/lib/src/tiled_component.dart
+++ b/packages/flame_tiled/lib/src/tiled_component.dart
@@ -12,20 +12,42 @@ import 'package:tiled/tiled.dart';
 /// It uses a preloaded [RenderableTiledMap] to batch rendering calls into
 /// Sprite Batches.
 /// {@endtemplate}
-class TiledComponent<T extends FlameGame> extends Component with HasGameRef<T> {
+class TiledComponent<T extends FlameGame> extends PositionComponent
+    with HasGameRef<T> {
   /// Map instance of this component.
   RenderableTiledMap tileMap;
 
-  /// The logical size of the component. The game assumes that this is the
-  /// approximate size of the object that will be drawn on the screen.
-  late final Vector2 size = _computeSize();
+  /// This property **cannot** be reassigned at runtime. To make the
+  /// [PositionComponent] larger or smaller, change its [scale].
+  @override
+  set size(Vector2 size) {
+    // Intenitonally left empty
+  }
+
+  /// This property **cannot** be reassigned at runtime. To make the
+  /// [PositionComponent] larger or smaller, change its [scale].
+  @override
+  set width(double w) {
+    // Intenitonally left empty
+  }
+
+  /// This property **cannot** be reassigned at runtime. To make the
+  /// [PositionComponent] larger or smaller, change its [scale].
+  @override
+  set height(double h) {
+    // Intenitonally left empty
+  }
 
   /// {@macro _tiled_component}
   TiledComponent(
     this.tileMap, {
+    super.position,
+    super.scale,
+    super.angle,
+    super.anchor,
     super.children,
     super.priority,
-  });
+  }) : super(size: _computeSize(tileMap));
 
   @override
   Future<void>? onLoad() async {
@@ -57,7 +79,7 @@ class TiledComponent<T extends FlameGame> extends Component with HasGameRef<T> {
     );
   }
 
-  Vector2 _computeSize() {
+  static NotifyingVector2 _computeSize(RenderableTiledMap tileMap) {
     final tMap = tileMap.map;
 
     final xScale = tileMap.destTileSize.x / tMap.tileWidth;
@@ -69,35 +91,35 @@ class TiledComponent<T extends FlameGame> extends Component with HasGameRef<T> {
     );
 
     if (tMap.orientation == null) {
-      return Vector2.zero();
+      return NotifyingVector2.zero();
     }
 
     switch (tMap.orientation!) {
       case MapOrientation.staggered:
         return tMap.staggerAxis == StaggerAxis.y
-            ? Vector2(
+            ? NotifyingVector2(
                 tileScaled.x * tileMap.map.width + tileScaled.x / 2,
                 tileScaled.y + ((tileMap.map.height - 1) * tileScaled.y / 2),
               )
-            : Vector2(
+            : NotifyingVector2(
                 tileScaled.x + ((tileMap.map.width - 1) * tileScaled.x / 2),
                 tileScaled.y * tileMap.map.height + tileScaled.y / 2,
               );
 
       case MapOrientation.hexagonal:
         return tMap.staggerAxis == StaggerAxis.y
-            ? Vector2(
+            ? NotifyingVector2(
                 tileMap.map.width * tileScaled.x + tileScaled.x / 2,
                 tileScaled.y + ((tileMap.map.height - 1) * tileScaled.y * 0.75),
               )
-            : Vector2(
+            : NotifyingVector2(
                 tileScaled.x + ((tileMap.map.width - 1) * tileScaled.x * 0.75),
                 (tileMap.map.height * tileScaled.y) + tileScaled.y / 2,
               );
 
       case MapOrientation.isometric:
       case MapOrientation.orthogonal:
-        return Vector2(
+        return NotifyingVector2(
           tileMap.map.width * tileScaled.x,
           tileMap.map.height * tileScaled.y,
         );

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
 
+import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
@@ -13,13 +14,53 @@ import 'package:tiled/tiled.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('correct loads the file', () async {
-    Flame.bundle = TestAssetBundle(
-      imageNames: ['map-level1.png', 'image1.png'],
-      mapPath: 'test/assets/map.tmx',
-    );
-    final tiled = await TiledComponent.load('x', Vector2.all(16));
-    expect(tiled.tileMap.renderableLayers.length, equals(3));
+  group('TiledComponent', () {
+    late TiledComponent tiled;
+    setUp(() async {
+      Flame.bundle = TestAssetBundle(
+        imageNames: ['map-level1.png', 'image1.png'],
+        mapPath: 'test/assets/map.tmx',
+      );
+      tiled = await TiledComponent.load('x', Vector2.all(16));
+    });
+
+    test('correct loads the file', () async {
+      expect(tiled.tileMap.renderableLayers.length, equals(3));
+    });
+
+    group('is positionable', () {
+      test('size, width, and height are readable - not writable', () async {
+        expect(tiled.size, Vector2(512.0, 2048.0));
+        expect(tiled.width, 512);
+        expect(tiled.height, 2048);
+
+        tiled.size = Vector2(256, 1024);
+        expect(tiled.size, Vector2(512.0, 2048.0));
+        tiled.width = 2;
+        expect(tiled.size, Vector2(512.0, 2048.0));
+        tiled.height = 2;
+        expect(tiled.size, Vector2(512.0, 2048.0));
+      });
+
+      test('from constructor', () async {
+        final map = TiledComponent(
+          tiled.tileMap,
+          position: Vector2(10, 20),
+          anchor: Anchor.bottomCenter,
+          children: [tiled],
+          angle: 1.4,
+          priority: 2,
+          scale: Vector2(1.5, 2.0),
+        );
+
+        expect(tiled.parent, map);
+        expect(map.anchor, Anchor.bottomCenter);
+        expect(map.angle, 1.4);
+        expect(map.priority, 2);
+        expect(map.position, Vector2(10, 20));
+        expect(map.scale, Vector2(1.5, 2.0));
+      });
+    });
   });
 
   test('correctly loads external tileset', () async {


### PR DESCRIPTION
# Description

Update `TiledComponent` to extend `PositionComponent` instead of `Component`. With some quirks:

1. Size is computed from the Map and not settable. I've made these operations fail silently for now.
2. Width and Height setters by proxy are ignored.
3. Scale does work

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

I do not believe this is breaking, since tests are still passing. It is only adding functionality to TiledComponent.

## Related Issues

Fixes #1890