### PR TITLE
feat: Make _ButtonState public for SpriteButtonComponent

### DIFF
--- a/packages/flame/lib/src/components/input/sprite_button_component.dart
+++ b/packages/flame/lib/src/components/input/sprite_button_component.dart
@@ -1,16 +1,20 @@
 import 'package:flame/components.dart';
 
-enum _ButtonState {
+enum ButtonState {
   up,
   down,
 }
 
 /// The [SpriteButtonComponent] bundles two [Sprite]s, one that shows while
-/// the button is being pressed, and one that shows otherwise.
+/// the button is being pressed, and one that shows otherwise. 
+/// 
+/// Each of the two [Sprite]s correspond to one of the two [ButtonState]s.
+/// If needed, state of the button can be manually changed by modifying 
+/// [current].
 ///
 /// Note: You have to set the [button] in [onLoad] if you are not passing it in
 /// through the constructor.
-class SpriteButtonComponent extends SpriteGroupComponent<_ButtonState>
+class SpriteButtonComponent extends SpriteGroupComponent<ButtonState>
     with Tappable {
   /// Callback for what should happen when the button is pressed.
   void Function()? onPressed;
@@ -30,7 +34,7 @@ class SpriteButtonComponent extends SpriteGroupComponent<_ButtonState>
     super.children,
     super.priority,
   }) : super(
-          current: _ButtonState.up,
+          current: ButtonState.up,
           size: size ?? button?.originalSize,
         );
 
@@ -40,14 +44,14 @@ class SpriteButtonComponent extends SpriteGroupComponent<_ButtonState>
       button != null,
       'The button sprite has to be set either in onLoad or in the constructor',
     );
-    sprites = {_ButtonState.up: button!};
-    sprites![_ButtonState.down] = buttonDown ?? button!;
+    sprites = {ButtonState.up: button!};
+    sprites![ButtonState.down] = buttonDown ?? button!;
     super.onMount();
   }
 
   @override
   bool onTapDown(_) {
-    current = _ButtonState.down;
+    current = ButtonState.down;
     return false;
   }
 
@@ -59,7 +63,7 @@ class SpriteButtonComponent extends SpriteGroupComponent<_ButtonState>
 
   @override
   bool onTapCancel() {
-    current = _ButtonState.up;
+    current = ButtonState.up;
     onPressed?.call();
     return false;
   }

--- a/packages/flame/lib/src/components/input/sprite_button_component.dart
+++ b/packages/flame/lib/src/components/input/sprite_button_component.dart
@@ -6,10 +6,10 @@ enum ButtonState {
 }
 
 /// The [SpriteButtonComponent] bundles two [Sprite]s, one that shows while
-/// the button is being pressed, and one that shows otherwise. 
-/// 
+/// the button is being pressed, and one that shows otherwise.
+///
 /// Each of the two [Sprite]s correspond to one of the two [ButtonState]s.
-/// If needed, state of the button can be manually changed by modifying 
+/// If needed, state of the button can be manually changed by modifying
 /// [current].
 ///
 /// Note: You have to set the [button] in [onLoad] if you are not passing it in


### PR DESCRIPTION
# Description

This PR makes the internal button state of `SpriteButtonComponent` public. This will make it easier for users to manually change the button state, if needed, by change the value of `current`. One use case discussed on discord was to make the button appear visually pressed on press on a key.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #1940 
