### PR TITLE
feat: Allow followBodyComponent to follow centre of mass (#1947)

### DIFF
--- a/packages/flame_forge2d/lib/forge2d_camera.dart
+++ b/packages/flame_forge2d/lib/forge2d_camera.dart
@@ -12,16 +12,18 @@ extension Forge2DCameraExtension on Camera {
   /// [relativeOffset] (default to the center).
   /// [worldBounds] can be optionally set to add boundaries to how far the
   /// camera is allowed to move.
-  /// The component is "grabbed" by its anchor (default top left).
-  /// So for example if you want the center of the object to be at the fixed
-  /// position, set the components anchor to center.
+  /// [useCenterOfMass] set true to follow the body's center of mass rather than
+  /// position (default to false).
   void followBodyComponent(
     BodyComponent bodyComponent, {
     Anchor relativeOffset = Anchor.center,
     Rect? worldBounds,
+    bool useCenterOfMass = false,
   }) {
     followVector2(
-      bodyComponent.body.position,
+      useCenterOfMass
+          ? bodyComponent.body.worldCenter
+          : bodyComponent.body.position,
       relativeOffset: relativeOffset,
       worldBounds: worldBounds,
     );


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
This PR adds the optional named parameter useCenterOfMass to followBodyComponent. It defaults to false so no breaking changes. Setting true allows camera following that does not "wobble" when an otherwise stationary BodyComponent (with an offset centre of mass) rotates.

Also removed reference to component anchor in documentation/comments since BodyComponent does not use an anchor.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #1947 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
