### PR TITLE
feat: onComponentTypeCheck support for ShapeHitbox

### DIFF
--- a/packages/flame/lib/src/collisions/broadphase/quadtree/has_quadtree_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/broadphase/quadtree/has_quadtree_collision_detection.dart
@@ -68,16 +68,16 @@ mixin HasQuadTreeCollisionDetection on FlameGame
 
   bool onComponentTypeCheck(PositionComponent one, PositionComponent another) {
     var checkParent = false;
-    if (one is CollisionCallbacks) {
-      if (!(one as CollisionCallbacks).onComponentTypeCheck(another)) {
+    if (one is GenericCollisionCallbacks) {
+      if (!(one as GenericCollisionCallbacks).onComponentTypeCheck(another)) {
         return false;
       }
     } else {
       checkParent = true;
     }
 
-    if (another is CollisionCallbacks) {
-      if (!(another as CollisionCallbacks).onComponentTypeCheck(one)) {
+    if (another is GenericCollisionCallbacks) {
+      if (!(another as GenericCollisionCallbacks).onComponentTypeCheck(one)) {
         return false;
       }
     } else {

--- a/packages/flame/lib/src/collisions/collision_callbacks.dart
+++ b/packages/flame/lib/src/collisions/collision_callbacks.dart
@@ -74,6 +74,9 @@ mixin GenericCollisionCallbacks<T> {
     onCollisionEndCallback?.call(other);
   }
 
+  @mustCallSuper
+  bool onComponentTypeCheck(PositionComponent other);
+
   /// Assign your own [CollisionCallback] if you want a callback when this
   /// shape collides with another [T].
   CollisionCallback<T>? onCollisionCallback;
@@ -132,6 +135,7 @@ mixin CollisionCallbacks on Component
   /// reimplement [onComponentTypeCheck]. The result of calculation is cached
   /// so you should not check any dynamical parameters here, the function
   /// intended to be used as pure type checker.
+  @override
   @mustCallSuper
   bool onComponentTypeCheck(PositionComponent other) {
     final myParent = parent;

--- a/packages/flame/lib/src/collisions/collision_callbacks.dart
+++ b/packages/flame/lib/src/collisions/collision_callbacks.dart
@@ -74,6 +74,11 @@ mixin GenericCollisionCallbacks<T> {
     onCollisionEndCallback?.call(other);
   }
 
+  /// Works only for the QuadTree collision detection.
+  /// If you need to prevent collision of items of different types -
+  /// reimplement [onComponentTypeCheck]. The result of calculation is cached
+  /// so you should not check any dynamical parameters here, the function
+  /// intended to be used as pure type checker.
   @mustCallSuper
   bool onComponentTypeCheck(PositionComponent other);
 
@@ -130,11 +135,6 @@ mixin CollisionCallbacks on Component
     onCollisionEndCallback?.call(other);
   }
 
-  /// Works only for the QuadTree collision detection.
-  /// If you need to prevent collision of items of different types -
-  /// reimplement [onComponentTypeCheck]. The result of calculation is cached
-  /// so you should not check any dynamical parameters here, the function
-  /// intended to be used as pure type checker.
   @override
   @mustCallSuper
   bool onComponentTypeCheck(PositionComponent other) {

--- a/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
@@ -214,6 +214,18 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   }
 
   @override
+  @mustCallSuper
+  bool onComponentTypeCheck(PositionComponent other) {
+    final myParent = parent;
+    final otherParent = other.parent;
+    if (myParent is CollisionCallbacks && otherParent is PositionComponent) {
+      return myParent.onComponentTypeCheck(otherParent);
+    }
+
+    return true;
+  }
+
+  @override
   CollisionCallback<ShapeHitbox>? onCollisionCallback;
 
   @override


### PR DESCRIPTION
# Description

`onComponentTypeCheck` was only supported for components but not for hitboxes, because ShapeHitbox implements `GenericCollisionCallbacks` instead `CollisionCallbacks`.

Specifying `onComponentTypeCheck` for individual hitboxes might be useful in cases where `Component` have hitboxes for collisions and also some utility hitboxes (for example, to check available directions for pathfinding). Colliding between this two types of hitboxes should not lead to movement restrictions and so on. But without `onComponentTypeCheck` in `ShapeHitbox` we can not to perform such check.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


