### PR TITLE
fix: Ignore the build directories for sphinx builds

### DIFF
--- a/doc/_sphinx/Makefile
+++ b/doc/_sphinx/Makefile
@@ -14,7 +14,7 @@ help:
 .PHONY: help Makefile
 
 livehtml:
-	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) --open-browser
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) --ignore "**/.*" --ignore "*build*" --open-browser
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -192,6 +192,7 @@ If you ever run the **melos doc-clean** or the **make clean** command, the serve
 restarted, because the clean command deletes the entire `html` directory.
 
 ```note
-Avoid having spaces in the paths to the docs since that will keep you from building the project due
-to [this bug](https://github.com/ipython/ipython/pull/13765).
+Avoid having spaces in the paths to the docs since that will keep you from
+building the project due to
+[this bug](https://github.com/ipython/ipython/pull/13765).
 ```

--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -190,3 +190,8 @@ Then you can open the site at `http://localhost:8000/`.
 
 If you ever run the **melos doc-clean** or the **make clean** command, the server will need to be
 restarted, because the clean command deletes the entire `html` directory.
+
+```note
+Avoid having spaces in the paths to the docs since that will keep you from building the project due
+to [this bug](https://github.com/ipython/ipython/pull/13765).
+```


### PR DESCRIPTION
# Description

If we don't ignore the build directories it will build multiple times unnecessarily when doing the live build.

Also tried to solve the "spaces in path" problem, but that is blocked by this:
https://github.com/ipython/ipython/pull/13765

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
