### PR TITLE
fix: Melos sphinx scripts windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pubspec.lock
 packages/flame/doc/api/
 .flutter-plugins
 .vscode/
+.venv/
 **/.flutter-plugins
 **/.flutter-plugins-dependencies
 **/pubspec_overrides.yaml

--- a/melos.yaml
+++ b/melos.yaml
@@ -52,19 +52,19 @@ scripts:
     description: Run dartdoc checks for all packages.
 
   doc-build:
-    run: SOURCEDIR="$MELOS_ROOT_PATH/doc" && cd "$SOURCEDIR/_sphinx" && make html
+    run: cd "$MELOS_ROOT_PATH/doc/_sphinx" && make html
     description: Create the sphinx html docs.
 
   doc-build-live:
-    run: SOURCEDIR="$MELOS_ROOT_PATH/doc" && cd "$SOURCEDIR/_sphinx" && make livehtml
+    run: cd "$MELOS_ROOT_PATH/doc/_sphinx" && make livehtml
     description: Recompiles the docs enerytime there is a change in them and opens your browser.
 
   doc-clean:
-    run: SOURCEDIR="$MELOS_ROOT_PATH/doc" && cd "$SOURCEDIR/_sphinx" && make clean
+    run: cd "$MELOS_ROOT_PATH/doc/_sphinx" && make clean
     description: Removes all Sphinx's cached generated files.
 
   doc-linkcheck:
-    run: SOURCEDIR="$MELOS_ROOT_PATH/doc" && cd "$SOURCEDIR/_sphinx" && make linkcheck
+    run: cd "$MELOS_ROOT_PATH/doc/_sphinx" && make linkcheck
     description: Checks whether there are any broken links in the docs.
 
   test:select:


### PR DESCRIPTION
# Description
`melos doc-xyz` commands were not working on Windows as `SOURCEDIR` was not properly getting set. I tried changing it to use `set SOURCEDIR="$MELOS_ROOT_PATH/doc"` and `set SOURCEDIR="%MELOS_ROOT_PATH%/doc"`, but both didn't work. As `SOURCEDIR` isn't really necessary to be set for the commands to work, this PR remove that variable and directly using `$MELOS_ROOT_PATH/doc` in its place.

Additionally, this PR also adds `.venv` (a common folder storing virtual env) to gitignore.

## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues
NA

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
