### PR TITLE
feat: onComponentTypeCheck for Sweep

### DIFF
--- a/packages/flame/lib/src/collisions/broadphase/quadtree/has_quadtree_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/broadphase/quadtree/has_quadtree_collision_detection.dart
@@ -66,6 +66,7 @@ mixin HasQuadTreeCollisionDetection on FlameGame
             (activeItemCenter.y - potentialCenter.y).abs() > minimumDistance!);
   }
 
+  @override
   bool onComponentTypeCheck(PositionComponent one, PositionComponent another) {
     var checkParent = false;
     if (one is GenericCollisionCallbacks) {

--- a/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
+++ b/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
@@ -31,6 +31,9 @@ class Sweep<T extends Hitbox<T>> extends Broadphase<T> {
       final currentMin = currentBox.min.x;
       for (var i = _active.length - 1; i >= 0; i--) {
         final activeItem = _active[i];
+        if (_broadphaseCheckCache[activeItem]?[item] == false) {
+          continue;
+        }
         final activeBox = activeItem.aabb;
         if (activeBox.max.x >= currentMin) {
           if (item.collisionType == CollisionType.active ||

--- a/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
+++ b/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
@@ -1,10 +1,14 @@
 import 'package:flame/collisions.dart';
 
 class Sweep<T extends Hitbox<T>> extends Broadphase<T> {
-  Sweep({super.items});
+  Sweep({super.items, this.broadphaseCheck});
 
   late final List<T> _active = [];
   late final Set<CollisionProspect<T>> _potentials = {};
+  final _potentialsTmp = <List<T>>[];
+
+  ExternalBroadphaseCheck? broadphaseCheck;
+  final _broadphaseCheckCache = <T, Map<T, bool>>{};
 
   @override
   void update() {
@@ -31,13 +35,40 @@ class Sweep<T extends Hitbox<T>> extends Broadphase<T> {
         if (activeBox.max.x >= currentMin) {
           if (item.collisionType == CollisionType.active ||
               activeItem.collisionType == CollisionType.active) {
-            _potentials.add(CollisionProspect<T>(item, activeItem));
+            // _potentials.add(CollisionProspect<T>(item, activeItem));
+
+            _potentialsTmp.add([item, activeItem]);
           }
         } else {
           _active.remove(activeItem);
         }
       }
       _active.add(item);
+    }
+    if (_potentialsTmp.isNotEmpty) {
+      for (var i = 0; i < _potentialsTmp.length; i++) {
+        final item0 = _potentialsTmp[i].first;
+        final item1 = _potentialsTmp[i].last;
+        final checkFunction = broadphaseCheck;
+        var checkSuccess = false;
+        if (checkFunction != null &&
+            item0 is ShapeHitbox &&
+            item1 is ShapeHitbox) {
+          final asShapeHitbox0 = item0 as ShapeHitbox;
+          final asShapeHitbox1 = item1 as ShapeHitbox;
+          checkSuccess = checkFunction(asShapeHitbox0, asShapeHitbox1);
+          if (checkSuccess) {
+            _potentials.add(CollisionProspect(item0, item1));
+          }
+        }
+
+        if (!checkSuccess) {
+          if (_broadphaseCheckCache[item0] == null) {
+            _broadphaseCheckCache[item0] = {};
+          }
+          _broadphaseCheckCache[item0]![item1] = false;
+        }
+      }
     }
     return _potentials;
   }

--- a/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
+++ b/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
@@ -60,6 +60,8 @@ class Sweep<T extends Hitbox<T>> extends Broadphase<T> {
           if (checkSuccess) {
             _potentials.add(CollisionProspect(item0, item1));
           }
+        } else {
+          _potentials.add(CollisionProspect(item0, item1));
         }
 
         if (!checkSuccess) {

--- a/packages/flame/lib/src/collisions/has_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/has_collision_detection.dart
@@ -1,11 +1,13 @@
 import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 
 /// Keeps track of all the [ShapeHitbox]s in the component tree and initiates
 /// collision detection every tick.
 mixin HasCollisionDetection<B extends Broadphase<ShapeHitbox>> on FlameGame {
   CollisionDetection<ShapeHitbox, B> _collisionDetection =
-      StandardCollisionDetection();
+      StandardCollisionDetection(onComponentTypeCheck: _onComponentTypeCheck);
+
   CollisionDetection<ShapeHitbox, B> get collisionDetection =>
       _collisionDetection;
 
@@ -14,11 +16,38 @@ mixin HasCollisionDetection<B extends Broadphase<ShapeHitbox>> on FlameGame {
     _collisionDetection = cd;
   }
 
+  bool onComponentTypeCheck(PositionComponent one, PositionComponent another) =>
+      _onComponentTypeCheck(one, another);
+
   @override
   void update(double dt) {
     super.update(dt);
     collisionDetection.run();
   }
+}
+
+bool _onComponentTypeCheck(PositionComponent one, PositionComponent another) {
+  var checkParent = false;
+  if (one is GenericCollisionCallbacks) {
+    if (!(one as GenericCollisionCallbacks).onComponentTypeCheck(another)) {
+      return false;
+    }
+  } else {
+    checkParent = true;
+  }
+
+  if (another is GenericCollisionCallbacks) {
+    if (!(another as GenericCollisionCallbacks).onComponentTypeCheck(one)) {
+      return false;
+    }
+  } else {
+    checkParent = true;
+  }
+
+  if (checkParent && one is ShapeHitbox && another is ShapeHitbox) {
+    return _onComponentTypeCheck(one.hitboxParent, another.hitboxParent);
+  }
+  return true;
 }
 
 /// This mixin is useful if you have written your own collision detection which
@@ -29,6 +58,7 @@ mixin HasCollisionDetection<B extends Broadphase<ShapeHitbox>> on FlameGame {
 mixin HasGenericCollisionDetection<T extends Hitbox<T>, B extends Broadphase<T>>
     on FlameGame {
   CollisionDetection<T, B>? _collisionDetection;
+
   CollisionDetection<T, B> get collisionDetection => _collisionDetection!;
 
   set collisionDetection(CollisionDetection<T, B> cd) {

--- a/packages/flame/lib/src/collisions/has_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/has_collision_detection.dart
@@ -6,7 +6,9 @@ import 'package:flame/game.dart';
 /// collision detection every tick.
 mixin HasCollisionDetection<B extends Broadphase<ShapeHitbox>> on FlameGame {
   CollisionDetection<ShapeHitbox, B> _collisionDetection =
-      StandardCollisionDetection(onComponentTypeCheck: _onComponentTypeCheck);
+      StandardCollisionDetection(
+    broadphase: Sweep<ShapeHitbox>(broadphaseCheck: _onComponentTypeCheck) as B,
+  );
 
   CollisionDetection<ShapeHitbox, B> get collisionDetection =>
       _collisionDetection;

--- a/packages/flame/lib/src/collisions/standard_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/standard_collision_detection.dart
@@ -10,13 +10,8 @@ import 'package:flame/geometry.dart';
 /// passing in another [Broadphase] to the constructor.
 class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
     extends CollisionDetection<ShapeHitbox, B> {
-  StandardCollisionDetection({
-    B? broadphase,
-    ExternalBroadphaseCheck? onComponentTypeCheck,
-  }) : super(
-          broadphase: broadphase ??
-              Sweep<ShapeHitbox>(broadphaseCheck: onComponentTypeCheck) as B,
-        );
+  StandardCollisionDetection({B? broadphase})
+      : super(broadphase: broadphase ?? Sweep<ShapeHitbox>() as B);
 
   /// Check what the intersection points of two collidables are,
   /// returns an empty list if there are no intersections.

--- a/packages/flame/lib/src/collisions/standard_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/standard_collision_detection.dart
@@ -10,8 +10,13 @@ import 'package:flame/geometry.dart';
 /// passing in another [Broadphase] to the constructor.
 class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
     extends CollisionDetection<ShapeHitbox, B> {
-  StandardCollisionDetection({B? broadphase})
-      : super(broadphase: broadphase ?? Sweep<ShapeHitbox>() as B);
+  StandardCollisionDetection({
+    B? broadphase,
+    ExternalBroadphaseCheck? onComponentTypeCheck,
+  }) : super(
+          broadphase: broadphase ??
+              Sweep<ShapeHitbox>(broadphaseCheck: onComponentTypeCheck) as B,
+        );
 
   /// Check what the intersection points of two collidables are,
   /// returns an empty list if there are no intersections.


### PR DESCRIPTION
# Description

Add onComponentTypeCheck functionality to Sweep.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

This is a quession for discussion. I pushed not best impllementation but it avoids breaking changes. We should to decide here, what to do.

- [ ] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.
