### PR TITLE
fix: sprite_button_component.dart_missing_mustcallsuper added

### DIFF
--- a/packages/flame/lib/src/components/input/sprite_button_component.dart
+++ b/packages/flame/lib/src/components/input/sprite_button_component.dart
@@ -1,4 +1,5 @@
 import 'package:flame/components.dart';
+import 'package:meta/meta.dart';
 
 enum ButtonState {
   up,
@@ -50,18 +51,21 @@ class SpriteButtonComponent extends SpriteGroupComponent<ButtonState>
   }
 
   @override
+  @mustCallSuper
   bool onTapDown(_) {
     current = ButtonState.down;
     return false;
   }
 
   @override
+  @mustCallSuper
   bool onTapUp(_) {
     onTapCancel();
     return false;
   }
 
   @override
+  @mustCallSuper
   bool onTapCancel() {
     current = ButtonState.up;
     onPressed?.call();


### PR DESCRIPTION
# Description
`sprite_button_component.dart` missing @mustcallsuper added on method


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
