### PR TITLE
docs: keep code block language position when scrolling

### DIFF
--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -597,15 +597,19 @@ pre {
   border-radius: 0.4em;
   box-shadow: 0px 0px 3px black;
   color: #888;
+  margin: 0;
+  padding: 10px;
+}
+
+div[class^="highlight-"] {
+  position: relative;
   font-family: var(--font-mono);
   font-size: 85%;
   line-height: 125%;
-  margin: 0;
-  padding: 10px;
-  position: relative;
 }
 
-div[class^="highlight-"] pre:before {
+
+div[class^="highlight-"]:before {
   background: black;
   border-bottom-left-radius: 5px;
   border-top-right-radius: 5px;
@@ -615,20 +619,21 @@ div[class^="highlight-"] pre:before {
   position: absolute;
   right: 0;
   top: 0;
+  z-index: 1;
 }
 
-div.highlight-console pre:before {
+div.highlight-console:before {
   content: "bash";
   color: #666;
 }
-div.highlight-dart pre:before {
+div.highlight-dart:before {
   content: "dart";
 }
-div.highlight-yaml pre:before {
+div.highlight-yaml:before {
   content: "yaml";
   color: #5f5;
 }
-div.highlight-text pre:before {
+div.highlight-text:before {
   content: "text";
   color: #666;
 }


### PR DESCRIPTION


# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

This bug is mainly relevant for mobile devices, to fix it we need to place the pseudo element with the code block language above the element `pre`.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

Fixes #2025

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
