### PR TITLE
docs: make the language tag non moving in code blocks

### DIFF
--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -599,6 +599,8 @@ div.document :is(h1, h2, h3, h4) > code {
   position: relative;
   overflow-x: auto;
   padding: 2px;
+  padding-top: 18px;
+  margin-top: -18px;
 }
 
 pre {
@@ -612,18 +614,18 @@ pre {
   line-height: 125%;
   margin: 0;
   padding: 10px;
-  padding-right: 41px;
+  border-top-right-radius: 0;
 }
 
 div[class^="highlight-"] pre:before {
   background: black;
-  border-bottom-left-radius: 5px;
+  border-top-left-radius: 5px;
   border-top-right-radius: 5px;
   color: #58d0ff;
   font-size: 80%;
   padding: 1px 8px;
   position: absolute;
-  right: 0;
+  right: 1px;
   top: 0;
 }
 

--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -607,7 +607,6 @@ pre {
   margin: 0;
   padding: 10px;
   padding-right: 41px;
-  position: unset;
 }
 
 div[class^="highlight-"] pre:before {

--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -593,6 +593,7 @@ div.document :is(h1, h2, h3, h4) > code {
 
  div[class^="highlight-"] {
   position: relative;
+  overflow-x: auto;
 }
 
 pre {

--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -591,6 +591,10 @@ div.document :is(h1, h2, h3, h4) > code {
  * Code
  *----------------------------------------------------------------------------*/
 
+ div[class^="highlight-"] {
+  position: relative;
+}
+
 pre {
   background: #202020;
   border: none;
@@ -602,7 +606,8 @@ pre {
   line-height: 125%;
   margin: 0;
   padding: 10px;
-  position: relative;
+  padding-right: 41px;
+  position: unset;
 }
 
 div[class^="highlight-"] pre:before {

--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -623,7 +623,7 @@ div[class^="highlight-"] pre:before {
   font-size: 80%;
   padding: 1px 8px;
   position: absolute;
-  right: 1px;
+  right: 0;
   top: 0;
 }
 

--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -594,6 +594,7 @@ div.document :is(h1, h2, h3, h4) > code {
  div[class^="highlight-"] {
   position: relative;
   overflow-x: auto;
+  padding: 2px;
 }
 
 pre {

--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -599,8 +599,8 @@ div.document :is(h1, h2, h3, h4) > code {
   position: relative;
   overflow-x: auto;
   padding: 2px;
-  padding-top: 18px;
-  margin-top: -18px;
+  padding-top: 11px;
+  margin-top: -11px;
 }
 
 pre {
@@ -614,13 +614,11 @@ pre {
   line-height: 125%;
   margin: 0;
   padding: 10px;
-  border-top-right-radius: 0;
 }
 
 div[class^="highlight-"] pre:before {
   background: black;
-  border-top-left-radius: 5px;
-  border-top-right-radius: 5px;
+  border-radius: 5px;
   color: #58d0ff;
   font-size: 80%;
   padding: 1px 8px;


### PR DESCRIPTION
the language tag for code blocks used to move along with scroll of code. Now, with this commit, the tag will be fixed at the top and doesn't move with scroll

# Description

This commit makes a few css style changes in order that the language tags for code blocks in documentation site remains same even when horizontally scrolled.

Along with the above, this commit adds right padding to the code as to not come under the language tag when reaching the end.

Screenrecording:

https://user-images.githubusercontent.com/40348358/194294111-2d966f9e-2600-45b6-ab25-b15bf9d57770.mov

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [-] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #2025

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
