### PR TITLE
fix: EventComponentMixins missing `@mustCallSuper` added

### DIFF
--- a/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
@@ -5,6 +5,7 @@ import 'package:flame/src/events/messages/drag_cancel_event.dart';
 import 'package:flame/src/events/messages/drag_end_event.dart';
 import 'package:flame/src/events/messages/drag_start_event.dart';
 import 'package:flame/src/events/messages/drag_update_event.dart';
+import 'package:meta/meta.dart';
 
 /// This mixin can be added to a [Component] allowing it to receive drag events.
 ///
@@ -53,6 +54,7 @@ mixin DragCallbacks on Component {
   void onDragCancel(DragCancelEvent event) => onDragEnd(event.toDragEnd());
 
   @override
+  @mustCallSuper
   void onMount() {
     super.onMount();
     assert(

--- a/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
@@ -4,6 +4,7 @@ import 'package:flame/src/events/flame_game_mixins/has_tappable_components.dart'
 import 'package:flame/src/events/messages/tap_cancel_event.dart';
 import 'package:flame/src/events/messages/tap_down_event.dart';
 import 'package:flame/src/events/messages/tap_up_event.dart';
+import 'package:meta/meta.dart';
 
 /// This mixin can be added to a [Component] allowing it to receive tap events.
 ///
@@ -22,6 +23,7 @@ mixin TapCallbacks on Component {
   void onTapCancel(TapCancelEvent event) {}
 
   @override
+  @mustCallSuper
   void onMount() {
     super.onMount();
     assert(


### PR DESCRIPTION
# Description
- 🐛 Event component_mixins missing `@mustCallSuper` added


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
