### PR TITLE
test: Unit tests for event mixins - `DragCallbacks` and `TapCallbacks`

### DIFF
--- a/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
@@ -1,0 +1,183 @@
+import 'package:flame/components.dart';
+import 'package:flame/experimental.dart';
+import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/gestures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DragCallbacks', () {
+    testWithGame<_GameWithHasDraggableComponents>(
+      'make sure they can be added to game with HasDraggableComponents',
+      _GameWithHasDraggableComponents.new,
+      (game) async {
+        await game.add(_DragCallbacksComponent());
+        await game.ready();
+      },
+    );
+
+    testWithFlameGame(
+      'make sure DragCallbacks cannot be added to invalid games',
+      (game) async {
+        expect(
+          () => game.ensureAdd(_DragCallbacksComponent()),
+          failsAssert(
+            'The components with DragCallbacks can only be added to a '
+            'FlameGame with '
+            'the HasDraggableComponents mixin',
+          ),
+        );
+      },
+    );
+
+    testWithGame<_GameWithHasDraggableComponents>(
+      'drag event start',
+      _GameWithHasDraggableComponents.new,
+      (game) async {
+        final component = _DragCallbacksComponent()
+          ..x = 10
+          ..y = 10
+          ..width = 10
+          ..height = 10;
+
+        await game.ensureAdd(component);
+        game.onDragStart(
+          DragStartEvent(
+            1,
+            DragStartDetails(
+              localPosition: const Offset(12, 12),
+              globalPosition: const Offset(12, 12),
+            ),
+          ),
+        );
+        expect(component.containsLocalPoint(Vector2(10, 10)), false);
+        expect(game.dragStartEvent, 1);
+      },
+    );
+
+    testWithGame<_GameWithHasDraggableComponents>(
+      'drag event start, update and cancel',
+      _GameWithHasDraggableComponents.new,
+      (game) async {
+        final component = _DragCallbacksComponent()
+          ..x = 10
+          ..y = 10
+          ..width = 10
+          ..height = 10;
+
+        await game.ensureAdd(component);
+        expect(game.dragStartEvent, 0);
+        game.onDragStart(
+          DragStartEvent(
+            1,
+            DragStartDetails(
+              localPosition: const Offset(12, 12),
+              globalPosition: const Offset(12, 12),
+            ),
+          ),
+        );
+        expect(game.dragStartEvent, 1);
+        expect(game.dragUpdateEvent, 0);
+        expect(game.dragEndEvent, 0);
+
+        game.onDragUpdate(
+          DragUpdateEvent(
+            1,
+            DragUpdateDetails(
+              localPosition: const Offset(15, 15),
+              globalPosition: const Offset(15, 15),
+            ),
+          ),
+        );
+
+        expect(game.containsLocalPoint(Vector2(9, 9)), true);
+        expect(game.dragUpdateEvent, 1);
+
+        game.onDragEnd(
+          DragEndEvent(
+            1,
+            DragEndDetails(),
+          ),
+        );
+
+        expect(game.dragEndEvent, 1);
+      },
+    );
+
+    testWithGame<_GameWithHasDraggableComponents>(
+      'drag event update not called without onDragStart',
+      _GameWithHasDraggableComponents.new,
+      (game) async {
+        final component = _DragCallbacksComponent()
+          ..x = 10
+          ..y = 10
+          ..width = 10
+          ..height = 10;
+
+        await game.ensureAdd(component);
+        expect(game.dragStartEvent, 0);
+        expect(game.dragUpdateEvent, 0);
+
+        game.onDragUpdate(
+          DragUpdateEvent(
+            1,
+            DragUpdateDetails(
+              localPosition: const Offset(15, 15),
+              globalPosition: const Offset(15, 15),
+            ),
+          ),
+        );
+
+        expect(game.dragUpdateEvent, 0);
+      },
+    );
+  });
+}
+
+class _GameWithHasDraggableComponents extends FlameGame
+    with HasDraggableComponents {
+  int dragStartEvent = 0;
+  int dragUpdateEvent = 0;
+  int dragEndEvent = 0;
+
+  @override
+  void onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
+    if (event.handled) {
+      dragStartEvent++;
+    }
+  }
+
+  @override
+  void onDragUpdate(DragUpdateEvent event) {
+    super.onDragUpdate(event);
+    if (event.handled) {
+      dragUpdateEvent++;
+    }
+  }
+
+  @override
+  void onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
+    if (event.handled) {
+      dragEndEvent++;
+    }
+  }
+}
+
+class _DragCallbacksComponent extends PositionComponent with DragCallbacks {
+  @override
+  void onDragStart(DragStartEvent event) {
+    event.handled = true;
+  }
+
+  @override
+  void onDragUpdate(DragUpdateEvent event) {
+    event.handled = true;
+  }
+
+  @override
+  void onDragEnd(DragEndEvent event) {
+    event.handled = true;
+  }
+}

--- a/packages/flame/test/events/component_mixins/tap_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/tap_callbacks_test.dart
@@ -1,0 +1,253 @@
+import 'package:canvas_test/canvas_test.dart';
+import 'package:flame/components.dart';
+import 'package:flame/experimental.dart';
+import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final withHasTappableComponents =
+      FlameTester(_GameWithHasTappableComponents.new);
+
+  group('TapCallbacks', () {
+    withHasTappableComponents
+        .test('make sure they can be added to game with HasTappableComponents',
+            (game) async {
+      await game.ensureAdd(_TapCallbacksComponent());
+    });
+
+    testWithFlameGame(
+      'make sure TapCallbacks cannot be added to invalid games',
+      (game) async {
+        expect(
+          () => game.ensureAdd(_TapCallbacksComponent()),
+          failsAssert(
+            'The components with TapCallbacks can only be added to a '
+            'FlameGame with '
+            'the HasTappableComponents mixin',
+          ),
+        );
+      },
+    );
+
+    testWithGame<_GameWithHasTappableComponents>(
+      'tap up, down event',
+      _GameWithHasTappableComponents.new,
+      (game) async {
+        final component = _TapCallbacksComponent()
+          ..x = 10
+          ..y = 10
+          ..width = 10
+          ..height = 10;
+
+        await game.ensureAdd(component);
+
+        // [onTapUp] will call, if there was an [onTapDown] event before
+        game.onTapUp(
+          TapUpEvent(
+            1,
+            TapUpDetails(
+              kind: PointerDeviceKind.touch,
+              localPosition: const Offset(12, 12),
+              globalPosition: const Offset(12, 12),
+            ),
+          ),
+        );
+        expect(game.tapUpEvent, 0);
+
+        game.onTapDown(
+          TapDownEvent(
+            1,
+            TapDownDetails(
+              kind: PointerDeviceKind.touch,
+              localPosition: const Offset(12, 12),
+              globalPosition: const Offset(12, 12),
+            ),
+          ),
+        );
+        expect(component.containsLocalPoint(Vector2(10, 10)), false);
+        expect(game.tapDownEvent, 1);
+
+        // [onTapUp] will call, if there was an [onTapDown] event before
+        game.onTapUp(
+          TapUpEvent(
+            1,
+            TapUpDetails(
+              kind: PointerDeviceKind.touch,
+              localPosition: const Offset(12, 12),
+              globalPosition: const Offset(12, 12),
+            ),
+          ),
+        );
+        expect(component.containsLocalPoint(Vector2(9, 9)), true);
+        expect(game.tapUpEvent, 1);
+
+        // [onTapCancel] will call, when there was an [onTapDown] event
+        // previously, but the [onTapUp] can no longer occur.
+        game.onTapCancel(
+          TapCancelEvent(
+            1,
+          ),
+        );
+        expect(game.tapCancelEvent, 0);
+      },
+    );
+
+    testWithGame<_GameWithHasTappableComponents>(
+      'longTapDown and tapCancel event',
+      _GameWithHasTappableComponents.new,
+      (game) async {
+        final component = _TapCallbacksComponent()
+          ..x = 10
+          ..y = 10
+          ..width = 10
+          ..height = 10;
+
+        await game.ensureAdd(component);
+
+        game.onTapDown(
+          TapDownEvent(
+            1,
+            TapDownDetails(
+              kind: PointerDeviceKind.touch,
+              localPosition: const Offset(12, 12),
+              globalPosition: const Offset(12, 12),
+            ),
+          ),
+        );
+        expect(game.tapDownEvent, 1);
+
+        // [onLongTapDown] will call, if there was an [onTapDown] event before
+        // ,and who remain at the point where the user is touching the screen.
+        game.onLongTapDown(
+          TapDownEvent(
+            1,
+            TapDownDetails(
+              kind: PointerDeviceKind.touch,
+              localPosition: const Offset(12, 12),
+              globalPosition: const Offset(12, 12),
+            ),
+          ),
+        );
+        expect(game.longTapDownEvent, 1);
+
+        // [onTapCancel] will call, when there was an [onTapDown] event
+        // previously, but the [onTapUp] can no longer occur.
+        game.onTapCancel(
+          TapCancelEvent(
+            1,
+          ),
+        );
+        expect(game.tapCancelEvent, 1);
+      },
+    );
+
+    testWithGame<_GameWithHasTappableComponents>(
+      'updates and renders children',
+      _GameWithHasTappableComponents.new,
+      (game) async {
+        final child = _MyTapComponent();
+        final parent = Component()..add(child);
+        game.add(parent);
+        await game.ready();
+
+        game.update(0);
+        expect(child.updated, true);
+        game.render(MockCanvas());
+        expect(child.rendered, true);
+      },
+    );
+  });
+}
+
+class _GameWithHasTappableComponents extends FlameGame
+    with HasTappableComponents {
+  int tapDownEvent = 0;
+  int longTapDownEvent = 0;
+  int tapUpEvent = 0;
+  int tapCancelEvent = 0;
+
+  @override
+  void onTapDown(TapDownEvent event) {
+    super.onTapDown(event);
+    if (event.handled) {
+      tapDownEvent++;
+    }
+  }
+
+  @override
+  void onLongTapDown(TapDownEvent event) {
+    super.onLongTapDown(event);
+    if (event.handled) {
+      longTapDownEvent++;
+    }
+  }
+
+  @override
+  void onTapUp(TapUpEvent event) {
+    super.onTapUp(event);
+    if (event.handled) {
+      tapUpEvent++;
+    }
+  }
+
+  @override
+  void onTapCancel(TapCancelEvent event) {
+    super.onTapCancel(event);
+    if (event.handled) {
+      tapCancelEvent++;
+    }
+  }
+}
+
+class _TapCallbacksComponent extends PositionComponent with TapCallbacks {
+  @override
+  void onTapDown(TapDownEvent event) {
+    event.handled = true;
+  }
+
+  @override
+  void onLongTapDown(TapDownEvent event) {
+    event.handled = true;
+  }
+
+  @override
+  void onTapUp(TapUpEvent event) {
+    event.handled = true;
+  }
+
+  @override
+  void onTapCancel(TapCancelEvent event) {
+    event.handled = true;
+  }
+}
+
+class _MyTapComponent extends PositionComponent with TapCallbacks {
+  late Vector2 gameSize;
+
+  int tapTimes = 0;
+
+  bool get tapped => tapTimes > 0;
+  bool updated = false;
+  bool rendered = false;
+
+  @override
+  void update(double dt) => updated = true;
+
+  @override
+  void render(Canvas canvas) => rendered = true;
+
+  @override
+  void onGameResize(Vector2 gameSize) {
+    super.onGameResize(gameSize);
+    this.gameSize = gameSize;
+  }
+
+  @override
+  bool onTapDown(_) {
+    ++tapTimes;
+    return false;
+  }
+}

--- a/packages/flame/test/events/game_mixins/multi_touch_drag_detector_test.dart
+++ b/packages/flame/test/events/game_mixins/multi_touch_drag_detector_test.dart
@@ -1,0 +1,112 @@
+import 'dart:ui';
+
+import 'package:canvas_test/canvas_test.dart';
+import 'package:flame/events.dart';
+import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final withMultiTouchFragDetector =
+      GameTester(_MultiTouchDragDetectorGame.new);
+
+  group('MultiTouchDragDetector', () {
+    testWidgets(
+      'Game can have MultiTouchDragDetector',
+      (tester) async {
+        await tester.pumpWidget(
+          GameWidget(
+            game: _MultiTouchDragDetectorGame(),
+          ),
+        );
+        expect(tester.takeException(), null);
+      },
+    );
+
+    withMultiTouchFragDetector.testGameWidget(
+      'update game and render canvas',
+      verify: (game, tester) async {
+        await tester.pumpWidget(GameWidget(game: game));
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+        expect(game.nOnDragStart, 0);
+        game.update(0);
+        expect(game.updated, true);
+        game.render(MockCanvas());
+        expect(game.rendered, true);
+      },
+    );
+
+    withMultiTouchFragDetector.testGameWidget(
+      'drags are delivered',
+      verify: (game, tester) async {
+        await tester.pumpWidget(GameWidget(game: game));
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+        expect(game.nOnDragStart, 0);
+        game.render(MockCanvas());
+        expect(game.rendered, true);
+
+        // regular drag
+        await tester.timedDragFrom(
+          const Offset(50, 50),
+          const Offset(20, 0),
+          const Duration(milliseconds: 100),
+        );
+        expect(game.nOnDragStart, 1);
+        expect(game.nOnDragUpdate, 8);
+        expect(game.nOnDragEnd, 1);
+        expect(game.nOnDragCancel, 0);
+
+        // cancelled drag
+        final gesture = await tester.startGesture(const Offset(50, 50));
+        await gesture.moveBy(const Offset(10, 10));
+        await gesture.cancel();
+        await tester.pump(const Duration(seconds: 1));
+        expect(game.nOnDragStart, 2);
+        expect(game.nOnDragEnd, 1);
+        expect(game.nOnDragCancel, 1);
+      },
+    );
+  });
+}
+
+class _MultiTouchDragDetectorGame extends Game with MultiTouchDragDetector {
+  bool updated = false;
+  bool rendered = false;
+
+  int nOnDragStart = 0;
+  int nOnDragUpdate = 0;
+  int nOnDragEnd = 0;
+  int nOnDragCancel = 0;
+
+  @override
+  void render(Canvas canvas) => rendered = true;
+
+  @override
+  void update(double dt) => updated = true;
+
+  @override
+  void onDragCancel(int pointerId) {
+    super.onDragCancel(pointerId);
+    nOnDragCancel++;
+  }
+
+  @override
+  void onDragEnd(int pointerId, DragEndInfo info) {
+    super.onDragEnd(pointerId, info);
+    nOnDragEnd++;
+  }
+
+  @override
+  void onDragUpdate(int pointerId, DragUpdateInfo info) {
+    super.onDragUpdate(pointerId, info);
+    nOnDragUpdate++;
+  }
+
+  @override
+  void onDragStart(int pointerId, DragStartInfo info) {
+    super.onDragStart(pointerId, info);
+    nOnDragStart++;
+  }
+}

--- a/packages/flame/test/events/game_mixins/multi_touch_tap_detector_test.dart
+++ b/packages/flame/test/events/game_mixins/multi_touch_tap_detector_test.dart
@@ -1,0 +1,136 @@
+import 'package:canvas_test/canvas_test.dart';
+import 'package:flame/events.dart';
+import 'package:flame/extensions.dart';
+import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final withMultiTouchTapDetector =
+      GameTester(_GameWithMultiTouchTapDetector.new);
+
+  group('MultiTouchTapDetector', () {
+    testWidgets(
+      'Game can have MultiTouchTapDetector',
+      (tester) async {
+        await tester.pumpWidget(
+          GameWidget(
+            game: _GameWithMultiTouchTapDetector(),
+          ),
+        );
+        expect(tester.takeException(), null);
+      },
+    );
+
+    withMultiTouchTapDetector.testGameWidget(
+      'render canvas and taps are delivered',
+      verify: (game, tester) async {
+        await tester.pumpWidget(GameWidget(game: game));
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+        expect(game.nOnTapDown, 0);
+        game.update(0);
+        expect(game.updated, true);
+        game.render(MockCanvas());
+        expect(game.rendered, true);
+      },
+    );
+
+    withMultiTouchTapDetector.testGameWidget(
+      'render canvas and taps are delivered',
+      verify: (game, tester) async {
+        await tester.pumpWidget(GameWidget(game: game));
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+        expect(game.nOnTapDown, 0);
+        game.render(MockCanvas());
+        expect(game.rendered, true);
+
+        // regular tap
+        await tester.tapAt(const Offset(100, 100));
+        await tester.pump(const Duration(milliseconds: 100));
+        expect(game.nOnTapDown, 1);
+        expect(game.nOnTapUp, 1);
+        expect(game.nOnTap, 1);
+        expect(game.nOnLongTapDown, 0);
+        expect(game.nOnTapCancel, 0);
+
+        // long tap
+        await tester.longPressAt(const Offset(100, 100));
+        await tester.pump(const Duration(seconds: 1));
+        expect(game.nOnTapDown, 2);
+        expect(game.nOnTapUp, 2);
+        expect(game.nOnTap, 2);
+        expect(game.nOnLongTapDown, 1);
+        expect(game.nOnTapCancel, 0);
+
+        // cancelled tap
+        var gesture = await tester.startGesture(const Offset(100, 100));
+        await gesture.cancel();
+        await tester.pump(const Duration(seconds: 1));
+        expect(game.nOnTapDown, 3);
+        expect(game.nOnTapUp, 2);
+        expect(game.nOnTap, 2);
+        expect(game.nOnTapCancel, 1);
+
+        // tap cancelled via movement
+        gesture = await tester.startGesture(const Offset(100, 100));
+        await gesture.moveBy(const Offset(20, 20));
+        await tester.pump(const Duration(seconds: 1));
+        expect(game.nOnTapDown, 4);
+        expect(game.nOnTapUp, 2);
+        expect(game.nOnTap, 2);
+        expect(game.nOnLongTapDown, 1);
+        expect(game.nOnTapCancel, 2);
+      },
+    );
+  });
+}
+
+class _GameWithMultiTouchTapDetector extends Game with MultiTouchTapDetector {
+  int tapTimes = 0;
+  bool updated = false;
+  bool rendered = false;
+
+  int nOnTapDown = 0;
+  int nOnLongTapDown = 0;
+  int nOnTapUp = 0;
+  int nOnTap = 0;
+  int nOnTapCancel = 0;
+
+  @override
+  void render(Canvas canvas) => rendered = true;
+
+  @override
+  void update(double dt) => updated = true;
+
+  @override
+  void onTapDown(int pointerId, TapDownInfo info) {
+    super.onTapDown(pointerId, info);
+    nOnTapDown++;
+  }
+
+  @override
+  void onLongTapDown(int pointerId, TapDownInfo info) {
+    super.onLongTapDown(pointerId, info);
+    nOnLongTapDown++;
+  }
+
+  @override
+  void onTapUp(int pointerId, TapUpInfo info) {
+    super.onTapUp(pointerId, info);
+    nOnTapUp++;
+  }
+
+  @override
+  void onTapCancel(int pointerId) {
+    super.onTapCancel(pointerId);
+    nOnTapCancel++;
+  }
+
+  @override
+  void onTap(int pointerId) {
+    super.onTap(pointerId);
+    nOnTap++;
+  }
+}


### PR DESCRIPTION
# Description
- 🐛 fix: #2017: Unit tests for event mixins
-  Unit and Widget tests for Event Mixin
    - `DragCallbacks`
    - `TapCallbacks`
    - `MultiTouchDragDetector`
    - `MultiTouchTapDetector`


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #2017 

## Note:
- I will add more widget test in next PR