### PR TITLE
test: Widget tests for Event Mixins - `DragCallbacks` and `TapCallbacks`

### DIFF
--- a/packages/flame/test/events/game_mixins/multi_touch_tap_detector_test.dart
+++ b/packages/flame/test/events/game_mixins/multi_touch_tap_detector_test.dart
@@ -23,7 +23,7 @@ void main() {
     );
 
     withMultiTouchTapDetector.testGameWidget(
-      'render canvas and taps are delivered',
+      'update game and render canvas',
       verify: (game, tester) async {
         await tester.pumpWidget(GameWidget(game: game));
         await tester.pump();

--- a/packages/flame_test/lib/flame_test.dart
+++ b/packages/flame_test/lib/flame_test.dart
@@ -6,6 +6,7 @@ export 'src/fails_assert.dart';
 export 'src/flame_test.dart';
 export 'src/mock_gesture_events.dart';
 export 'src/mock_image.dart';
+export 'src/mock_tap_drag_events.dart';
 export 'src/random_test.dart';
 export 'src/test_flame_game.dart';
 export 'src/test_golden.dart' show testGolden;

--- a/packages/flame_test/lib/src/mock_tap_drag_events.dart
+++ b/packages/flame_test/lib/src/mock_tap_drag_events.dart
@@ -1,0 +1,64 @@
+import 'package:flame/experimental.dart';
+import 'package:flutter/gestures.dart';
+
+TapDownEvent createTapDownEvents({
+  int? pointerId,
+  PointerDeviceKind? kind,
+  Offset? globalPosition,
+  Offset? localPosition,
+}) {
+  return TapDownEvent(
+    pointerId ?? 1,
+    TapDownDetails(
+      localPosition: localPosition ?? Offset.zero,
+      globalPosition: globalPosition ?? Offset.zero,
+      kind: kind ?? PointerDeviceKind.touch,
+    ),
+  );
+}
+
+TapUpEvent createTapUpEvents({
+  int? pointerId,
+  PointerDeviceKind? kind,
+  Offset? globalPosition,
+  Offset? localPosition,
+}) {
+  return TapUpEvent(
+    pointerId ?? 1,
+    TapUpDetails(
+      localPosition: localPosition ?? Offset.zero,
+      globalPosition: globalPosition ?? Offset.zero,
+      kind: kind ?? PointerDeviceKind.touch,
+    ),
+  );
+}
+
+DragStartEvent createDragStartEvents({
+  int? pointerId,
+  PointerDeviceKind? kind,
+  Offset? globalPosition,
+  Offset? localPosition,
+}) {
+  return DragStartEvent(
+    pointerId ?? 1,
+    DragStartDetails(
+      localPosition: localPosition ?? Offset.zero,
+      globalPosition: globalPosition ?? Offset.zero,
+    ),
+  );
+}
+
+DragUpdateEvent createDragUpdateEvents({
+  int? pointerId,
+  PointerDeviceKind? kind,
+  Offset? globalPosition,
+  Offset? localPosition,
+}) {
+  return DragUpdateEvent(
+    pointerId ?? 1,
+    DragUpdateDetails(
+      localPosition: localPosition ?? Offset.zero,
+      globalPosition: globalPosition ?? Offset.zero,
+    ),
+  );
+}


### PR DESCRIPTION
# Description
- 🚨 Widget test for `DragCallbacks` and `TapCallbacks`
- Added some common function in separate file for common use case
- Minor test case description changed for `MultiTouchTapDetector`


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

## Note
- Added some common function in 1 file, not sure it's breaking change or not
