### PR TITLE
docs: Link CONTRIBUTING file into the docs

### DIFF
--- a/doc/development/contributing.md
+++ b/doc/development/contributing.md
@@ -1,0 +1,2 @@
+```{include} ../../CONTRIBUTING.md
+```

--- a/doc/development/development.md
+++ b/doc/development/development.md
@@ -3,6 +3,7 @@
 ```{toctree}
 :maxdepth: 2
 
+Contributing   <contributing.md>
 Documentation  <documentation.md>
 Style Guide    <style_guide.md>
 Tests Guide    <testing_guide.md>


### PR DESCRIPTION
# Description

As discussed in #2045, this PR makes the CONTRIBUTING doc also visible from the main documentation site.


## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [-] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.



<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
