### PR TITLE
fix: OpacityEffect custom paint override

### DIFF
--- a/packages/flame/lib/src/components/mixins/has_paint.dart
+++ b/packages/flame/lib/src/components/mixins/has_paint.dart
@@ -64,7 +64,7 @@ mixin HasPaint<T extends Object> on Component {
       throw ArgumentError('Opacity needs to be between 0 and 1');
     }
 
-    getPaint(paintId).color = paint.color.withOpacity(opacity);
+    setColor(getPaint(paintId).color.withOpacity(opacity), paintId: paintId);
   }
 
   /// Returns the current opacity.
@@ -78,7 +78,7 @@ mixin HasPaint<T extends Object> on Component {
       throw ArgumentError('Alpha needs to be between 0 and 255');
     }
 
-    getPaint(paintId).color = paint.color.withAlpha(alpha);
+    setColor(getPaint(paintId).color.withAlpha(alpha), paintId: paintId);
   }
 
   /// Returns the current opacity.

--- a/packages/flame/test/effects/opacity_effect_test.dart
+++ b/packages/flame/test/effects/opacity_effect_test.dart
@@ -3,10 +3,20 @@ import 'dart:math';
 import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
 import 'package:flame/game.dart';
+import 'package:flame/palette.dart';
 import 'package:flame_test/flame_test.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _PaintComponent extends Component with HasPaint {}
+
+class _CustomPaintComponent extends Component with HasPaint<String> {
+  _CustomPaintComponent(Map<String, Paint> paints) {
+    for (final p in paints.entries) {
+      setPaint(p.key, p.value);
+    }
+  }
+}
 
 void main() {
   const _epsilon = 0.004; // 1/255, since alpha only holds 8 bits
@@ -185,6 +195,29 @@ void main() {
           game.update(3);
           expectDouble(component.getOpacity(), 0.0);
         }
+      },
+    );
+
+    flameGame.test(
+      'on custom paint',
+      (game) async {
+        final component =
+            _CustomPaintComponent({'bluePaint': BasicPalette.blue.paint()});
+        await game.ensureAdd(component);
+
+        await component.add(
+          OpacityEffect.fadeOut(
+            EffectController(duration: 1),
+            paintId: 'bluePaint',
+          ),
+        );
+
+        game.update(1);
+
+        // RGB components shouldn't be affected after opacity efffect.
+        expect(component.getPaint('bluePaint').color.blue, 255);
+        expect(component.getPaint('bluePaint').color.red, 0);
+        expect(component.getPaint('bluePaint').color.green, 0);
       },
     );
 


### PR DESCRIPTION
# Description

When applying OpacityEffect to a specific `paintId`, the paint at that id was accidently getting replaced with the default `paint`. This PR makes sure that color from the provided `paintId` is used while modifying `alpha` and `opacity` in `HasPaint` mixin.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2055 
