### PR TITLE
docs: fix move effect interactive examples reset

### DIFF
--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -111,7 +111,10 @@ offset is relative to the current position of the target:
 ```
 
 ```dart
-final effect = MoveByEffect(Vector2(0, -10), EffectController(duration: 0.5));
+final effect = MoveByEffect(
+  Vector2(0, -10),
+  EffectController(duration: 0.5),
+);
 ```
 
 If the component is currently at `Vector2(250, 200)`, then at the end of the effect its position
@@ -135,7 +138,10 @@ point in a straight line.
 ```
 
 ```dart
-final effect = MoveToEffect(Vector2(100, 500), EffectController(duration: 3));
+final effect = MoveToEffect(
+  Vector2(100, 500),
+  EffectController(duration: 3),
+);
 ```
 
 It is possible, but not recommended to attach multiple such effects to the same component.

--- a/doc/flame/examples/lib/move_along_path_effect.dart
+++ b/doc/flame/examples/lib/move_along_path_effect.dart
@@ -22,9 +22,9 @@ class MoveAlongPathEffectGame extends FlameGame with HasTappableComponents {
           );
         } else {
           flower.add(
-            MoveEffect.by(
-              size / 2,
-              EffectController(duration: 1.0),
+            MoveAlongPathEffect(
+              Path()..quadraticBezierTo(-100, 0, -50, 50),
+              EffectController(duration: 1.5),
             ),
           );
         }

--- a/doc/flame/examples/lib/move_by_effect.dart
+++ b/doc/flame/examples/lib/move_by_effect.dart
@@ -21,7 +21,7 @@ class MoveByEffectGame extends FlameGame with HasTappableComponents {
         } else {
           flower.add(
             MoveEffect.by(
-              size / 2,
+              Vector2(-30, -30),
               EffectController(duration: 1.0),
             ),
           );


### PR DESCRIPTION
# Description

This commit fixes the interactive examples of move effect (by and along path). The were not coming to their original position. This commit fixes the flower to come to original position when clicked 2nd time.

This also arranges the code in multi line for the move effects in documentation.

Screen Recordings:

https://user-images.githubusercontent.com/40348358/194905713-3265a3a3-0557-4153-93dc-a81314087720.mov

https://user-images.githubusercontent.com/40348358/194905753-405e673c-0f19-4e19-b200-9e5835ff6d20.mov


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [-] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Not related to any issue. But, is a fix for bugs found in #2052

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
