### PR TITLE
fix!: PolygonComponent no longer modifies _vertices

### DIFF
--- a/packages/flame/lib/src/geometry/polygon_component.dart
+++ b/packages/flame/lib/src/geometry/polygon_component.dart
@@ -134,12 +134,6 @@ class PolygonComponent extends ShapeComponent {
         position = Anchor.topLeft.toOtherAnchorPosition(_topLeft, anchor, size);
       }
     }
-    _vertices.forEach((p) {
-      p.setValues(
-        p.x - _topLeft.x,
-        p.y - _topLeft.y,
-      );
-    });
   }
 
   /// gives back the shape vectors multiplied by the size and scale
@@ -156,6 +150,7 @@ class PolygonComponent extends ShapeComponent {
       vertices.forEachIndexed((i, vertex) {
         _globalVertices[i]
           ..setFrom(vertex)
+          ..sub(_topLeft)
           ..multiply(scale)
           ..add(position)
           ..rotate(angle, center: position);
@@ -254,7 +249,7 @@ class PolygonComponent extends ShapeComponent {
 
   Vector2 getVertex(int i, {List<Vector2>? vertices}) {
     vertices ??= globalVertices();
-    return vertices[i % vertices.length];
+    return vertices[i % vertices.length] - _topLeft;
   }
 
   void _reverseList(List<Object> list) {

--- a/packages/flame/lib/src/geometry/polygon_component.dart
+++ b/packages/flame/lib/src/geometry/polygon_component.dart
@@ -106,7 +106,8 @@ class PolygonComponent extends ShapeComponent {
 
   // Used to not create new Vector2 objects when calculating the top left of the
   // bounds of the polygon.
-  final _topLeft = Vector2.zero();
+  @internal
+  final topLeft = Vector2.zero();
 
   @protected
   void refreshVertices({required List<Vector2> newVertices}) {
@@ -114,24 +115,24 @@ class PolygonComponent extends ShapeComponent {
       newVertices.length == _vertices.length,
       'A polygon can not change their number of vertices',
     );
-    _topLeft.setFrom(newVertices[0]);
+    topLeft.setFrom(newVertices[0]);
     newVertices.forEachIndexed((i, _) {
       final newVertex = newVertices[i];
       _vertices[i].setFrom(newVertex);
-      _topLeft.x = min(_topLeft.x, newVertex.x);
-      _topLeft.y = min(_topLeft.y, newVertex.y);
+      topLeft.x = min(topLeft.x, newVertex.x);
+      topLeft.y = min(topLeft.y, newVertex.y);
     });
     _path
       ..reset()
       ..addPolygon(
-        vertices.map((p) => (p - _topLeft).toOffset()).toList(growable: false),
+        vertices.map((p) => (p - topLeft).toOffset()).toList(growable: false),
         true,
       );
     if (shrinkToBounds) {
       final bounds = _path.getBounds();
       size.setValues(bounds.width, bounds.height);
       if (!manuallyPositioned) {
-        position = Anchor.topLeft.toOtherAnchorPosition(_topLeft, anchor, size);
+        position = Anchor.topLeft.toOtherAnchorPosition(topLeft, anchor, size);
       }
     }
   }
@@ -150,7 +151,7 @@ class PolygonComponent extends ShapeComponent {
       vertices.forEachIndexed((i, vertex) {
         _globalVertices[i]
           ..setFrom(vertex)
-          ..sub(_topLeft)
+          ..sub(topLeft)
           ..multiply(scale)
           ..add(position)
           ..rotate(angle, center: position);
@@ -211,8 +212,9 @@ class PolygonComponent extends ShapeComponent {
     }
     for (var i = 0; i < _vertices.length; i++) {
       final edge = getEdge(i, vertices: vertices);
-      final isOutside = (edge.to.x - edge.from.x) * (point.y - edge.from.y) -
-              (point.x - edge.from.x) * (edge.to.y - edge.from.y) >
+      final isOutside = (edge.to.x - edge.from.x) *
+                  (point.y - edge.from.y + topLeft.y) -
+              (point.x - edge.from.x + topLeft.x) * (edge.to.y - edge.from.y) >
           0;
       if (isOutside) {
         return false;
@@ -249,7 +251,7 @@ class PolygonComponent extends ShapeComponent {
 
   Vector2 getVertex(int i, {List<Vector2>? vertices}) {
     vertices ??= globalVertices();
-    return vertices[i % vertices.length] - _topLeft;
+    return vertices[i % vertices.length];
   }
 
   void _reverseList(List<Object> list) {

--- a/packages/flame/lib/src/geometry/shape_intersections.dart
+++ b/packages/flame/lib/src/geometry/shape_intersections.dart
@@ -80,9 +80,10 @@ class CirclePolygonIntersections
       intersectionPoints.addAll(circle.lineSegmentIntersections(line));
     }
     if (intersectionPoints.isEmpty && (circle.isSolid || polygon.isSolid)) {
-      final outerShape = circle.containsPoint(polygon.vertices.first)
-          ? circle
-          : (polygon.containsPoint(circle.position) ? polygon : null);
+      final outerShape =
+          circle.containsPoint(polygon.vertices.first - polygon.topLeft)
+              ? circle
+              : (polygon.containsPoint(circle.position) ? polygon : null);
       if (outerShape != null && outerShape.isSolid) {
         final innerShape = outerShape == circle ? polygon : circle;
         return {innerShape.absoluteCenter};


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
PolygonComponent used to modify the contents of the _vertices list passed to it by offsetting them all by _topLeft. This prevented the user from using the same vertices list again, such as in another call to PolygonComponent. This PR stops PolygonComponent from directly modifying the list vectors and instead add the _topLeft offset where needed within internal code.

This is a breaking change since PolygonComponent's .vertices getter will now return the original, unmodified vertices rather than with the offset added.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->
Yes, to obtain the previous values of PolygonComponent .vertices subtract the polygon's top-left point vector from all vectors in the list returned the new output.

- [X] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
