### PR TITLE
fix: [flame_rive] fixed null exception when no artboard with specified name is exists

### DIFF
--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -159,7 +159,8 @@ class RiveArtboardRenderer {
 /// Loads the Artboard from the specified Rive File.
 ///
 /// When [artboardName] is not null it returns the artboard with the specified
-/// name, an assertion is triggered if no artboard with that name exists in the file.
+/// name, an assertion is triggered if no artboard with that name exists in the
+/// file.
 Future<Artboard> loadArtboard(
   FutureOr<RiveFile> file, {
   String? artboardName,

--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -156,10 +156,10 @@ class RiveArtboardRenderer {
   }
 }
 
-/// loads the Artboard from the specified Rive File
+/// Loads the Artboard from the specified Rive File.
 ///
-/// when [artboardName] is not null, Returns an artboard from the specified
-/// name, or [AssertionError] if no artboard with that name exists in the file
+/// When [artboardName] is not null it returns the artboard with the specified
+/// name, an assertion is triggered if no artboard with that name exists in the file.
 Future<Artboard> loadArtboard(
   FutureOr<RiveFile> file, {
   String? artboardName,

--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -156,12 +156,23 @@ class RiveArtboardRenderer {
   }
 }
 
+/// loads the Artboard from the specified Rive File
+///
+/// when [artboardName] is not null, Returns an artboard from the specified
+/// name, or [AssertionError] if no artboard with that name exists in the file
 Future<Artboard> loadArtboard(
   FutureOr<RiveFile> file, {
   String? artboardName,
 }) async {
   final loaded = await file;
-  return artboardName == null
-      ? loaded.mainArtboard.instance()
-      : loaded.artboardByName(artboardName)!.instance();
+  if (artboardName == null) {
+    return loaded.mainArtboard.instance();
+  } else {
+    final artboard = loaded.artboardByName(artboardName)?.instance();
+    assert(
+      artboard != null,
+      'No artboard with the specified name exists in the RiveFile',
+    );
+    return artboard!;
+  }
 }

--- a/packages/flame_rive/test/flame_rive_test.dart
+++ b/packages/flame_rive/test/flame_rive_test.dart
@@ -33,7 +33,7 @@ void main() {
         expect(artboard.name, artboardName);
       });
 
-      test('Load the Specified Artboard that does not exist', () async {
+      test('Load an artboard that does not exist', () async {
         expect(
           () => loadArtboard(
             riveFile,

--- a/packages/flame_rive/test/flame_rive_test.dart
+++ b/packages/flame_rive/test/flame_rive_test.dart
@@ -32,6 +32,16 @@ void main() {
         );
         expect(artboard.name, artboardName);
       });
+
+      test('Load the Specified Artboard that does not exist', () async {
+        expect(
+          () => loadArtboard(
+            riveFile,
+            artboardName: 'Empty',
+          ),
+          throwsA(isA<AssertionError>()),
+        );
+      });
     });
 
     group('RiveComponent', () {


### PR DESCRIPTION
# Description
Fixed null exception when no artboard with specified name is exists and added necessary test.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #2043 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
