### PR TITLE
docs!: replace doc-build-live with doc-serve

### DIFF
--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -175,8 +175,10 @@ browser with the docs.
 melos doc-serve
 ```
 
-When using the **melos doc-serve** command, the **melos doc-build** need not be used every time,
-because it also compiles and then serves. This serves the site at `http://localhost:8000/`.
+When using the **melos doc-serve** command, the **melos doc-build** is only needed when
+there are changes to the sphinx theme. This is because **melos doc-serve** both automatically
+compiles the docs on changes and also hosts them locally. The docs are served at
+`http://localhost:8000/` by default.
 
 There are other make commands that you may find occasionally useful too:
 

--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -176,7 +176,7 @@ melos doc-serve
 ```
 
 When using the **melos doc-serve** command, the **melos doc-build** is only needed when
-there are changes to the sphinx theme. This is because **melos doc-serve** both automatically
+there are changes to the sphinx theme. This is because the serve command both automatically
 compiles the docs on changes and also hosts them locally. The docs are served at
 `http://localhost:8000/` by default.
 

--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -175,7 +175,8 @@ browser with the docs.
 melos doc-serve
 ```
 
-When using the **melos doc-serve** command, the **melos doc-build** need not be used every time, because it also compiles and then serves. This serves the site at `http://localhost:8000/`.
+When using the **melos doc-serve** command, the **melos doc-build** need not be used every time,
+because it also compiles and then serves. This serves the site at `http://localhost:8000/`.
 
 There are other make commands that you may find occasionally useful too:
 

--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -188,7 +188,8 @@ python -m http.server 8000 --directory doc/_build/html
 
 Then you can open the site at `http://localhost:8000/`.
 
-If you ever run the **melos doc-clean** command, the server will need to be restarted, because the clean command deletes the entire `html` directory.
+If you ever run the **melos doc-clean** command, the server will need to be restarted, because the
+clean command deletes the entire `html` directory.
 
 ```{note}
 Avoid having spaces in the paths to the docs since that will keep you from

--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -155,8 +155,8 @@ following:
       pip install -r doc/_sphinx/requirements.txt
       ```
 
-Once these prerequisites are met, you can build the documentation by switching to the `doc/_sphinx`
-directory and running `make html`, or use the built-in Melos target:
+Once these prerequisites are met, you can build the documentation by using the built-in Melos
+target:
 
 ```console
 melos doc-build
@@ -168,7 +168,7 @@ rebuild the documents that have changed since the previous run, so usually a reb
 a second or two.
 
 If you want to automatically recompile the docs every time there is a change to one of the files
-you can use the **melos doc-build-live** command, which will also serve and open your default
+you can use the **melos doc-serve** command, which will also serve and open your default
 browser with the docs.
 
 There are other make commands that you may find occasionally useful too:
@@ -180,7 +180,7 @@ state).
 The generated html files will be in the `doc/_build/html` directory, you can view them directly
 by opening the file `doc/_build/html/index.html` in your browser. The only drawback is that the
 browser won't allow any dynamic content in a file opened from a local drive. The solution to this
-is to either run **melos doc-build-live** or run your own local http server:
+is to either run **melos doc-serve** or run your own local http server:
 
 ```console
 python -m http.server 8000 --directory doc/_build/html
@@ -188,8 +188,7 @@ python -m http.server 8000 --directory doc/_build/html
 
 Then you can open the site at `http://localhost:8000/`.
 
-If you ever run the **melos doc-clean** or the **make clean** command, the server will need to be
-restarted, because the clean command deletes the entire `html` directory.
+If you ever run the **melos doc-clean** command, the server will need to be restarted, because the clean command deletes the entire `html` directory.
 
 ```{note}
 Avoid having spaces in the paths to the docs since that will keep you from

--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -168,8 +168,14 @@ rebuild the documents that have changed since the previous run, so usually a reb
 a second or two.
 
 If you want to automatically recompile the docs every time there is a change to one of the files
-you can use the **melos doc-serve** command, which will also serve and open your default
+you can use the the built-in Melos target below, which will also serve and open your default
 browser with the docs.
+
+```console
+melos doc-serve
+```
+
+When using the **melos doc-serve** command, the **melos doc-build** need not be used every time, because it also compiles and then serves. This serves the site at `http://localhost:8000/`.
 
 There are other make commands that you may find occasionally useful too:
 
@@ -180,13 +186,7 @@ state).
 The generated html files will be in the `doc/_build/html` directory, you can view them directly
 by opening the file `doc/_build/html/index.html` in your browser. The only drawback is that the
 browser won't allow any dynamic content in a file opened from a local drive. The solution to this
-is to either run **melos doc-serve** or run your own local http server:
-
-```console
-python -m http.server 8000 --directory doc/_build/html
-```
-
-Then you can open the site at `http://localhost:8000/`.
+is to run **melos doc-serve**.
 
 If you ever run the **melos doc-clean** command, the server will need to be restarted, because the
 clean command deletes the entire `html` directory.

--- a/melos.yaml
+++ b/melos.yaml
@@ -55,7 +55,7 @@ scripts:
     run: cd "$MELOS_ROOT_PATH/doc/_sphinx" && make html
     description: Create the sphinx html docs.
 
-  doc-build-live:
+  doc-serve:
     run: cd "$MELOS_ROOT_PATH/doc/_sphinx" && make livehtml
     description: Recompiles the docs enerytime there is a change in them and opens your browser.
 


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

This commit replaces the `melos doc-build-live` with `melos doc-serve`.

This also changes documentation for this while removing the mention of `make` commands in the documentation.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!-- Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below. -->

The users doesn't need to update anything. The only thing is that, when building documentation locally, the command `melos doc-build-live` won't work and instead have to use `melos doc-serve`

- [x] Yes, this PR is a breaking change.
- [-] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #2075 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
