### PR TITLE
docs: Fix documentation auto re-build

### DIFF
--- a/doc/_sphinx/Makefile
+++ b/doc/_sphinx/Makefile
@@ -2,7 +2,7 @@
 
 # You can set these variables from the command line.
 # SPHINXOPTS and SPHINXBUILD can also be set from the environment.
-SOURCEDIR     = "$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/.."
+SOURCEDIR     = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/..
 SPHINXOPTS    ?= -c "${SOURCEDIR}/_sphinx"
 SPHINXBUILD   ?= sphinx-build
 BUILDDIR      = "${SOURCEDIR}/_build"
@@ -14,7 +14,7 @@ help:
 .PHONY: help Makefile
 
 livehtml:
-	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) --ignore "**/.*" --ignore "*build*" --open-browser
+	sphinx-autobuild $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(O) --ignore "**/.*" --ignore "*build*" --open-browser
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
# Description

Previously it didn't work properly with the live examples.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2079


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
