### PR TITLE
fix: Exception when having multiple calls to dispose() function of a Svg instance

### DIFF
--- a/packages/flame/lib/src/cache/memory_cache.dart
+++ b/packages/flame/lib/src/cache/memory_cache.dart
@@ -19,6 +19,16 @@ class MemoryCache<K, V> {
     }
   }
 
+  /// Removes the value from the cache.
+  void clear(K key) {
+    _cache.remove(key);
+  }
+
+  /// Removes all the values from the cache.
+  void clearCache() {
+    _cache.clear();
+  }
+
   V? getValue(K key) => _cache[key];
 
   bool containsKey(K key) => _cache.containsKey(key);

--- a/packages/flame/test/cache/memory_cache_test.dart
+++ b/packages/flame/test/cache/memory_cache_test.dart
@@ -28,5 +28,28 @@ void main() {
       expect(cache.getValue(1), 'ble');
       expect(cache.size, 1);
     });
+
+    test('clear', () async {
+      final cache = MemoryCache<int, String>();
+      cache.setValue(0, 'bla');
+      expect(cache.containsKey(0), true);
+      expect(cache.size, 1);
+      cache.clear(0);
+      expect(cache.containsKey(0), false);
+      expect(cache.size, 0);
+    });
+
+    test('clearCache', () async {
+      final cache = MemoryCache<int, String>();
+      cache.setValue(0, 'bla');
+      cache.setValue(1, 'ble');
+      expect(cache.containsKey(0), true);
+      expect(cache.containsKey(1), true);
+      expect(cache.size, 2);
+      cache.clearCache();
+      expect(cache.containsKey(0), false);
+      expect(cache.containsKey(1), false);
+      expect(cache.size, 0);
+    });
   });
 }

--- a/packages/flame_svg/lib/svg.dart
+++ b/packages/flame_svg/lib/svg.dart
@@ -102,6 +102,7 @@ class Svg {
     _imageCache.keys.forEach((key) {
       _imageCache.getValue(key)?.dispose();
     });
+    _imageCache.clearCache();
   }
 }
 

--- a/packages/flame_svg/test/_resources/android.svg
+++ b/packages/flame_svg/test/_resources/android.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 105">
+  <g fill="#97C024" stroke="#97C024" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M14,40v24M81,40v24M38,68v24M57,68v24M28,42v31h39v-31z" stroke-width="12"/>
+    <path d="M32,5l5,10M64,5l-6,10 " stroke-width="2"/>
+  </g>
+  <path d="M22,35h51v10h-51zM22,33c0-31,51-31,51,0" fill="#97C024"/>
+  <g fill="#FFF">
+    <circle cx="36" cy="22" r="2"/>
+    <circle cx="59" cy="22" r="2"/>
+  </g>
+</svg>

--- a/packages/flame_svg/test/svg_test.dart
+++ b/packages/flame_svg/test/svg_test.dart
@@ -24,48 +24,68 @@ class SvgPainter extends CustomPainter {
 }
 
 void main() {
-  testWidgets(
-    'render sharply',
-    (tester) async {
-      final svgRoot = await svg.fromSvgString(
-        File('test/_resources/hand.svg').readAsStringSync(),
-        'hand',
-      );
-      final flameSvg = flame_svg.Svg(svgRoot);
-      flameSvg.render(Canvas(PictureRecorder()), Vector2.all(300));
-      await tester.binding.setSurfaceSize(const Size(800, 600));
-      tester.binding.window.devicePixelRatioTestValue = 3;
-      await tester.pumpWidget(
-        MaterialApp(
-          debugShowCheckedModeBanner: false,
-          home: Scaffold(
-            body: Column(
-              children: [
-                Expanded(
-                  child: Center(
-                    child: SvgPicture.string(
-                      File('test/_resources/hand.svg').readAsStringSync(),
-                      width: 300,
-                      height: 300,
-                    ),
-                  ),
-                ),
-                Expanded(
-                  child: CustomPaint(
-                    size: const Size(300, 300),
-                    painter: SvgPainter(flameSvg),
-                  ),
-                )
-              ],
-            ),
-          ),
+  group('Svg', () {
+    late flame_svg.Svg svgInstance;
+
+    setUp(() async {
+      svgInstance = flame_svg.Svg(
+        await svg.fromSvgString(
+          File('test/_resources/android.svg').readAsStringSync(),
+          'svg',
         ),
       );
-      await tester.pumpAndSettle();
-      await expectLater(
-        find.byType(MaterialApp),
-        matchesGoldenFile('./_goldens/render_sharply.png'),
-      );
-    },
-  );
+    });
+
+    test('multiple calls to dispose should not throw error', () async {
+      svgInstance.render(Canvas(PictureRecorder()), Vector2.all(100));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      svgInstance.dispose();
+      svgInstance.dispose();
+    });
+
+    testWidgets(
+      'render sharply',
+      (tester) async {
+        final svgRoot = await svg.fromSvgString(
+          File('test/_resources/hand.svg').readAsStringSync(),
+          'hand',
+        );
+        final flameSvg = flame_svg.Svg(svgRoot);
+        flameSvg.render(Canvas(PictureRecorder()), Vector2.all(300));
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        tester.binding.window.devicePixelRatioTestValue = 3;
+        await tester.pumpWidget(
+          MaterialApp(
+            debugShowCheckedModeBanner: false,
+            home: Scaffold(
+              body: Column(
+                children: [
+                  Expanded(
+                    child: Center(
+                      child: SvgPicture.string(
+                        File('test/_resources/hand.svg').readAsStringSync(),
+                        width: 300,
+                        height: 300,
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: CustomPaint(
+                      size: const Size(300, 300),
+                      painter: SvgPainter(flameSvg),
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await expectLater(
+          find.byType(MaterialApp),
+          matchesGoldenFile('./_goldens/render_sharply.png'),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
### Existing behavior:

<details>
<summary>Run this minimal example:</summary>

```
import 'package:flame/game.dart';
import 'package:flame_svg/flame_svg.dart';
import 'package:flutter/material.dart';

void main() {
  final game = MyGame();
  runApp(
    MaterialApp(
      home: Scaffold(
        floatingActionButton: FloatingActionButton(
          onPressed: game.removeSvgs,
        ),
        body: GameWidget(
          game: game,
        ),
      ),
    ),
  );
}

class MyGame extends FlameGame {
  late Svg svgInstance;

  void removeSvgs() {
    removeAll(children.query<SvgComponent>());
  }

  @override
  Future<void> onLoad() async {
    await super.onLoad();
    svgInstance = await loadSvg('android.svg');
    addAll(
      List.generate(
        2,
        (index) => SvgComponent(
          svg: svgInstance,
          position: Vector2.all(100 + index * 100),
          size: Vector2.all(100 + index * 100),
        ),
      ),
    );
  }
}

```

</details>

Tap on the floating action button to remove 2 Svg components.
<details>
<summary>It throws this exception:</summary>

```
The following assertion was thrown during a scheduler callback:
'dart:ui/painting.dart': Failed assertion: line 1681 pos 12: '<optimized out>': is not true.

When the exception was thrown, this was the stack
#2      Image.dispose (dart:ui/painting.dart:1681:12)
#3      Svg.dispose.<anonymous closure>
package:flame_svg/svg.dart:84
#4      Iterable.forEach (dart:core/iterable.dart:325:35)
#5      Svg.dispose
package:flame_svg/svg.dart:83
#6      SvgComponent.onRemove
package:flame_svg/svg_component.dart:40
#7      Component._remove.<anonymous closure>
package:flame/…/core/component.dart:810
#8      Iterable.every (dart:core/iterable.dart:403:16)
#9      Component.propagateToChildren
package:flame/…/core/component.dart:344
#10     Component._remove
package:flame/…/core/component.dart:808
#11     _LifecycleManager._processRemovalQueue
package:flame/…/core/component.dart:997
#12     _LifecycleManager.processQueues
package:flame/…/core/component.dart:974
#13     FlameGame.updateTree
package:flame/…/game/flame_game.dart:77
#14     FlameGame.update
package:flame/…/game/flame_game.dart:70
#15     GameRenderBox.gameLoopCallback
package:flame/…/game/game_render_box.dart:53
#16     GameLoop._tick
package:flame/…/game/game_loop.dart:46
#17     Ticker._tick
package:flutter/…/scheduler/ticker.dart:249
#18     SchedulerBinding._invokeFrameCallback
package:flutter/…/scheduler/binding.dart:1175
#19     SchedulerBinding.handleBeginFrame.<anonymous closure>
package:flutter/…/scheduler/binding.dart:1079
#20     _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:617:13)
#21     SchedulerBinding.handleBeginFrame
package:flutter/…/scheduler/binding.dart:1077
#22     SchedulerBinding._handleBeginFrame
package:flutter/…/scheduler/binding.dart:994
#23     _invoke1 (dart:ui/hooks.dart:167:13)
#24     PlatformDispatcher._beginFrame (dart:ui/platform_dispatcher.dart:296:5)
#25     _beginFrame (dart:ui/hooks.dart:104:31)
(elided 2 frames from class _AssertionError)
```
</details>

### Reason:
Image caches have already been disposed, so the later call throws the above exception.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
