### PR TITLE
docs: Interactive SizeEffect examples in doc.

### DIFF
--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -268,8 +268,19 @@ This effect will change the size of the target component, relative to its curren
 if the target has size `Vector2(100, 100)`, then after the following effect is applied and runs its
 course, the new size will be `Vector2(120, 50)`:
 
+ ```{flutter-app}
+ :sources: ../flame/examples
+ :page: size_by_effect
+ :show: widget code infobox
+ :width: 180
+ :height: 160
+ ```
+
 ```dart
-final effect = SizeEffect.by(Vector2(20, -50), EffectController(duration: 1));
+final effect = SizeEffect.by(
+  Vector2(20, 20),
+   EffectController(duration: 1),
+);
 ```
 
 The size of a `PositionComponent` cannot be negative. If an effect attempts to set the size to a
@@ -288,8 +299,20 @@ target component and its children.
 
 Changes the size of the target component to the specified size. Target size cannot be negative:
 
+
+ ```{flutter-app}
+ :sources: ../flame/examples
+ :page: size_to_effect
+ :show: widget code infobox
+ :width: 180
+ :height: 160
+ ```
+
 ```dart
-final effect = SizeEffect.to(Vector2(120, 120), EffectController(duration: 1));
+final effect = SizeEffect.to(
+  Vector2(80, 80),
+  EffectController(duration: 1),
+);
 ```
 
 

--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -278,7 +278,7 @@ course, the new size will be `Vector2(120, 50)`:
 
 ```dart
 final effect = SizeEffect.by(
-  Vector2(20, 20),
+   Vector2(-15, 30),
    EffectController(duration: 1),
 );
 ```
@@ -310,7 +310,7 @@ Changes the size of the target component to the specified size. Target size cann
 
 ```dart
 final effect = SizeEffect.to(
-  Vector2(80, 80),
+  Vector2(90, 80),
   EffectController(duration: 1),
 );
 ```

--- a/doc/flame/examples/lib/main.dart
+++ b/doc/flame/examples/lib/main.dart
@@ -20,6 +20,8 @@ import 'package:doc_flame_examples/router.dart';
 import 'package:doc_flame_examples/scale_by_effect.dart';
 import 'package:doc_flame_examples/scale_to_effect.dart';
 import 'package:doc_flame_examples/sequence_effect.dart';
+import 'package:doc_flame_examples/size_by_effect.dart';
+import 'package:doc_flame_examples/size_to_effect.dart';
 import 'package:doc_flame_examples/tap_events.dart';
 import 'package:doc_flame_examples/value_route.dart';
 import 'package:flame/game.dart';
@@ -50,6 +52,8 @@ void main() {
     'router': RouterGame.new,
     'scale_by_effect': ScaleByEffectGame.new,
     'scale_to_effect': ScaleToEffectGame.new,
+    'size_by_effect': SizeByEffectGame.new,
+    'size_to_effect': SizeToEffectGame.new,
     'sequence_effect': SequenceEffectGame.new,
     'tap_events': TapEventsGame.new,
     'value_route': ValueRouteExample.new,

--- a/doc/flame/examples/lib/size_by_effect.dart
+++ b/doc/flame/examples/lib/size_by_effect.dart
@@ -1,0 +1,33 @@
+import 'package:doc_flame_examples/flower.dart';
+import 'package:flame/effects.dart';
+import 'package:flame/experimental.dart';
+import 'package:flame/game.dart';
+
+class SizeByEffectGame extends FlameGame with HasTappableComponents {
+  bool reset = false;
+  @override
+  Future<void> onLoad() async {
+    final flower = Flower(
+      size: 60,
+      position: canvasSize / 2,
+      onTap: (flower) {
+        if (reset = !reset) {
+          flower.add(
+            SizeEffect.by(
+              Vector2(20, 20),
+              EffectController(duration: 1),
+            ),
+          );
+        } else {
+          flower.add(
+            SizeEffect.by(
+              Vector2(-20, -20),
+              EffectController(duration: 1),
+            ),
+          );
+        }
+      },
+    );
+    add(flower);
+  }
+}

--- a/doc/flame/examples/lib/size_by_effect.dart
+++ b/doc/flame/examples/lib/size_by_effect.dart
@@ -1,4 +1,5 @@
-import 'package:doc_flame_examples/flower.dart';
+import 'package:doc_flame_examples/ember.dart';
+import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
 import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
@@ -7,27 +8,28 @@ class SizeByEffectGame extends FlameGame with HasTappableComponents {
   bool reset = false;
   @override
   Future<void> onLoad() async {
-    final flower = Flower(
-      size: 60,
-      position: canvasSize / 2,
-      onTap: (flower) {
+    final ember = EmberPlayer(
+      position: size / 2,
+      size: Vector2(45, 40),
+      onTap: (ember) {
         if (reset = !reset) {
-          flower.add(
+          ember.add(
             SizeEffect.by(
-              Vector2(20, 20),
-              EffectController(duration: 1),
+              Vector2(-15, 30),
+              EffectController(duration: 0.75),
             ),
           );
         } else {
-          flower.add(
+          ember.add(
             SizeEffect.by(
-              Vector2(-20, -20),
-              EffectController(duration: 1),
+              Vector2(15, -30),
+              EffectController(duration: 0.75),
             ),
           );
         }
       },
-    );
-    add(flower);
+    )..anchor = Anchor.center;
+
+    add(ember);
   }
 }

--- a/doc/flame/examples/lib/size_to_effect.dart
+++ b/doc/flame/examples/lib/size_to_effect.dart
@@ -1,0 +1,33 @@
+import 'package:doc_flame_examples/flower.dart';
+import 'package:flame/effects.dart';
+import 'package:flame/experimental.dart';
+import 'package:flame/game.dart';
+
+class SizeToEffectGame extends FlameGame with HasTappableComponents {
+  bool reset = false;
+  @override
+  Future<void> onLoad() async {
+    final flower = Flower(
+      size: 40,
+      position: canvasSize / 2,
+      onTap: (flower) {
+        if (reset = !reset) {
+          flower.add(
+            SizeEffect.to(
+              Vector2(80, 80),
+              EffectController(duration: 1),
+            ),
+          );
+        } else {
+          flower.add(
+            SizeEffect.to(
+              Vector2(60, 60),
+              EffectController(duration: 1),
+            ),
+          );
+        }
+      },
+    );
+    add(flower);
+  }
+}

--- a/doc/flame/examples/lib/size_to_effect.dart
+++ b/doc/flame/examples/lib/size_to_effect.dart
@@ -1,4 +1,5 @@
-import 'package:doc_flame_examples/flower.dart';
+import 'package:doc_flame_examples/ember.dart';
+import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
 import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
@@ -7,27 +8,28 @@ class SizeToEffectGame extends FlameGame with HasTappableComponents {
   bool reset = false;
   @override
   Future<void> onLoad() async {
-    final flower = Flower(
-      size: 40,
-      position: canvasSize / 2,
-      onTap: (flower) {
+    final ember = EmberPlayer(
+      position: size / 2,
+      size: Vector2(45, 40),
+      onTap: (ember) {
         if (reset = !reset) {
-          flower.add(
+          ember.add(
             SizeEffect.to(
-              Vector2(80, 80),
-              EffectController(duration: 1),
+              Vector2(90, 80),
+              EffectController(duration: 0.75),
             ),
           );
         } else {
-          flower.add(
+          ember.add(
             SizeEffect.to(
-              Vector2(60, 60),
-              EffectController(duration: 1),
+              Vector2(45, 40),
+              EffectController(duration: 0.75),
             ),
           );
         }
       },
-    );
-    add(flower);
+    )..anchor = Anchor.center;
+
+    add(ember);
   }
 }


### PR DESCRIPTION
# Description
Doc examples for SizeEffect.to and SizeEffect.by.
I used the Ember because the Flower gave script errors when trying to size.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #1952

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
