### PR TITLE
feat: Add children to `World` constructor

### DIFF
--- a/doc/flame/camera_component.md
+++ b/doc/flame/camera_component.md
@@ -41,6 +41,10 @@ and a single camera, then switching that camera's target from A to B will
 instantaneously switch the view to world B without having to unmount A and
 then mount B.
 
+Just like with most `Component`s, children can be added to `World` by using the
+`children` argument in its constructor, or by using the `add` or `addAll`
+methods.
+
 
 ## CameraComponent
 

--- a/packages/flame/lib/src/experimental/world.dart
+++ b/packages/flame/lib/src/experimental/world.dart
@@ -12,6 +12,8 @@ import 'package:vector_math/vector_math_64.dart';
 /// and allows itself to be rendered through a [CameraComponent] only. The
 /// updates proceed through the world tree normally.
 class World extends Component implements CoordinateTransform {
+  World({super.children});
+
   @override
   void renderTree(Canvas canvas) {}
 


### PR DESCRIPTION
# Description

With this `World` can make use of the `children` argument to `Component`.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
