### PR TITLE
ci: Trigger docs build on merge

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,3 +16,8 @@ jobs:
         with:
           workingDir: examples
           webRenderer: canvaskit
+
+  build-docs:
+  - name: Trigger building the docs
+      run: |
+        curl -XPOST -u "${{ secrets.GIT_CREDENTIALS }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/flame-engine/flame-docs-site/actions/workflows/gh-pages.yml/dispatches --data '{"ref": "main" }'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,5 +19,5 @@ jobs:
 
   build-docs:
   - name: Trigger building the docs
-      run: |
-        curl -XPOST -u "${{ secrets.GIT_CREDENTIALS }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/flame-engine/flame-docs-site/actions/workflows/gh-pages.yml/dispatches --data '{"ref": "main" }'
+    run: |
+      curl -XPOST -u "${{ secrets.GIT_CREDENTIALS }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/flame-engine/flame-docs-site/actions/workflows/gh-pages.yml/dispatches --data '{"ref": "main" }'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Trigger building the docs
         run: |
-          curl -XPOST -u "${{ secrets.GIT_CREDENTIALS }}"
+          curl -XPOST -u "${{ secrets.GIT_CREDENTIALS }}" \
           -H "Accept:application/vnd.github" \
           -H "Content-Type:application/json" \
           https://api.github.com/flame-engine/flame-docs-site/actions/workflows/gh-pages.yml/dispatches \

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,6 +18,13 @@ jobs:
           webRenderer: canvaskit
 
   build-docs:
-  - name: Trigger building the docs
-    run: |
-      curl -XPOST -u "${{ secrets.GIT_CREDENTIALS }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/flame-engine/flame-docs-site/actions/workflows/gh-pages.yml/dispatches --data '{"ref": "main" }'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger building the docs
+        run: |
+          curl -XPOST -u "${{ secrets.GIT_CREDENTIALS }}"
+          -H "Accept:application/vnd.github" \
+          -H "Content-Type:application/json" \
+          https://api.github.com/flame-engine/flame-docs-site/actions/workflows/gh-pages.yml/dispatches \
+          --data '{"ref": "main" }'


### PR DESCRIPTION
# Description

This should trigger the documentation build to run, so that we don't have to trigger it manually.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
