### PR TITLE
docs: Formatting clean up in the flame_tiled docs

### DIFF
--- a/doc/_sphinx/conf.py
+++ b/doc/_sphinx/conf.py
@@ -30,14 +30,18 @@ extensions = [
 
 # Configuration options for MyST:
 # https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
-myst_enable_extensions = [
-    'dollarmath',
+myst_enable_extensions = [e.lower() for e in [
+    'colon_fence',
+    'dollarMath',
     'html_admonition',
     'html_image',
     'linkify',
     'replacements',
-    'smartquotes',
-]
+    'smartQuotes',
+    'strikethrough',
+    'substitution',
+    'taskList',
+]]
 
 # Auto-generate link anchors for headers at levels H1 and H2
 myst_heading_anchors = 4

--- a/doc/bridge_packages/flame_tiled/flame_tiled.md
+++ b/doc/bridge_packages/flame_tiled/flame_tiled.md
@@ -1,7 +1,9 @@
 # flame_tiled
 
-flame_tiled is the bridge package that connects the flame game engine to Tiled maps by parsing TMX
-(XML) files and accessing the tiles, objects, and everything in there.
+**flame_tiled** is the bridge package that connects the flame game engine to [Tiled] maps by parsing
+TMX (XML) files and accessing the tiles, objects, and everything in there.
+
+[Tiled]: https://www.mapeditor.org/
 
 ```{toctree}
 :hidden:

--- a/doc/bridge_packages/flame_tiled/layers.md
+++ b/doc/bridge_packages/flame_tiled/layers.md
@@ -14,15 +14,15 @@ These methods will either return the requested layer type or null if it does not
 
 ## Layer properties
 
-| Property              | Supported?  |
-| -----------           | ----------- |
-| Visible               | ✅          |
-| Opacity               | ✅          |
-| Tint color            | ❌          |
-| Horizontal offset     | ✅          |
-| Horizontal offset     | ✅          |
-| Parallax Factor       | ✅          |
-| Custom properties     | ✅          |
+The following Tiled properties are supported:
+
+- [x] Visible
+- [x] Opacity
+- [ ] Tint color
+- [x] Horizontal offset
+- [x] Vertical offset
+- [x] Parallax factor
+- [x] Custom properties
 
 
 ## Tiles properties

--- a/doc/bridge_packages/flame_tiled/tiled.md
+++ b/doc/bridge_packages/flame_tiled/tiled.md
@@ -2,20 +2,19 @@
 
 [Tiled] is a great tool to design levels and maps.  From [Tiled]'s documentation:
 
-```seealso
-Tiled is a 2D level editor that helps you develop the content of your game. Its
-primary feature is to edit tile maps of various forms, but it also supports
-free image placement as well as powerful ways to annotate your level with extra 
-information used by the game. Tiled focuses on general flexibility while trying
-to stay intuitive.
+> Tiled is a 2D level editor that helps you develop the content of your game. Its
+> primary feature is to edit tile maps of various forms, but it also supports
+> free image placement as well as powerful ways to annotate your level with extra
+> information used by the game. Tiled focuses on general flexibility while trying
+> to stay intuitive.
+>
+> In terms of tile maps, it supports straight rectangular tile layers, but also
+> projected isometric, staggered isometric and staggered hexagonal layers. A
+> tileset can be either a single image containing many tiles, or it can be a
+> collection of individual images. In order to support certain depth faking
+> techniques, tiles and layers can be offset by a custom distance and their
+> rendering order can be configured.
 
-In terms of tile maps, it supports straight rectangular tile layers, but also
-projected isometric, staggered isometric and staggered hexagonal layers. A
-tileset can be either a single image containing many tiles, or it can be a
-collection of individual images. In order to support certain depth faking
-techniques, tiles and layers can be offset by a custom distance and their
-rendering order can be configured.
-```
 
 ![Tiled Editor](../../images/TiledEditor.jpg)
 
@@ -35,6 +34,6 @@ into your game.  At its core, the [Tiled] map editor creates a TMX file that can
 within your game.
 
 
-[dart](https://pub.dev/packages/tiled)
-[flame_tiled](https://github.com/flame-engine/flame_tiled)
-[Tiled](https://www.mapeditor.org/)
+[dart]: https://pub.dev/packages/tiled
+[flame_tiled]: https://github.com/flame-engine/flame_tiled
+[Tiled]: https://www.mapeditor.org/


### PR DESCRIPTION
# Description

Some of the formatting was broken, so this PR fixes that.

Also enabled some new features of MyST that were added recently.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [x] No, this PR is not a breaking change.



<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
