### PR TITLE
docs: SpriteAnimation benchmark example

### DIFF
--- a/examples/lib/stories/animations/animations.dart
+++ b/examples/lib/stories/animations/animations.dart
@@ -3,6 +3,7 @@ import 'package:examples/commons/commons.dart';
 import 'package:examples/stories/animations/animation_group_example.dart';
 import 'package:examples/stories/animations/aseprite_example.dart';
 import 'package:examples/stories/animations/basic_animation_example.dart';
+import 'package:examples/stories/animations/benchmark_example.dart';
 import 'package:flame/game.dart';
 
 void addAnimationStories(Dashbook dashbook) {
@@ -24,5 +25,11 @@ void addAnimationStories(Dashbook dashbook) {
       (_) => GameWidget(game: AsepriteExample()),
       codeLink: baseLink('animations/aseprite_example.dart'),
       info: AsepriteExample.description,
+    )
+    ..add(
+      'Benchmark',
+      (_) => GameWidget(game: BenchmarkExample()),
+      codeLink: baseLink('animations/benchmark_example.dart'),
+      info: BenchmarkExample.description,
     );
 }

--- a/examples/lib/stories/animations/benchmark_example.dart
+++ b/examples/lib/stories/animations/benchmark_example.dart
@@ -1,0 +1,60 @@
+import 'dart:math';
+
+import 'package:examples/commons/ember.dart';
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame/input.dart';
+
+class BenchmarkExample extends FlameGame with TapDetector {
+  static const description = '''
+See how many SpriteAnimationComponent's your platform can handle before it
+starts to drop in FPS, this is without any sprite batching and such.
+100 animation components are added per tap.
+  ''';
+
+  final emberSize = Vector2.all(20);
+  late final TextComponent emberCounter;
+  final counterPrefix = 'Animations: ';
+  final Random random = Random();
+
+  @override
+  Future<void> onLoad() async {
+    await addAll([
+      FpsTextComponent(
+        position: size - Vector2(0, 50),
+        anchor: Anchor.bottomRight,
+      ),
+      emberCounter = TextComponent(
+        position: size - Vector2(0, 25),
+        anchor: Anchor.bottomRight,
+        priority: 1,
+      ),
+      Ember(size: emberSize, position: size / 2),
+    ]);
+    children.register<Ember>();
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    emberCounter.text = '$counterPrefix ${children.query<Ember>().length}';
+  }
+
+  @override
+  void onTapDown(TapDownInfo info) {
+    final halfWidth = emberSize.x / 2;
+    final halfHeight = emberSize.y / 2;
+    addAll(
+      List.generate(
+        100,
+        (_) => Ember(
+          size: emberSize,
+          position: Vector2(
+            halfWidth + (size.x - halfWidth) * random.nextDouble(),
+            halfHeight + (size.y - halfHeight) * random.nextDouble(),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Description

This adds an example so that you can test how many `SpriteAnimationComponent`s that you can add before starting to drop FPS on the platform that you are running the examples on.

It adds 100 embers per tap.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
