### PR TITLE
docs: Fix examples folder README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,9 @@
 [![Powered by Flame](https://img.shields.io/badge/Powered%20by-%F0%9F%94%A5-orange.svg)](https://flame-engine.org)
-![Test](https://github.com/flame-engine/flame_example/workflows/Test/badge.svg?branch=main&event=push)
 [![Discord](https://img.shields.io/discord/509714518008528896.svg)](https://discord.gg/pxrBmy4)
 
+# Flame Examples
 
-# Flame examples
-
-This is a set of small examples showcasing specific features of the Flame Engine, it's a great
+This is a set of small examples showcasing specific features of the Flame Engine; it's a great
 source of learning how to use certain things.
 [See it live here](https://examples.flame-engine.org/).
 
@@ -13,13 +11,8 @@ This app is composed of a main menu in which you can select one of the examples 
 Each example is a standalone game and is contained within its own file, so you can easily checkout
 the code and see how it works.
 
-For a very simple but complete game in Flame, check the
+For a very simple, but complete game in Flame, check the
 [example folder inside the Flame package](https://github.com/flame-engine/flame/tree/main/packages/flame/example).
-
-These examples are kept up-to-date with the `main` branch of Flame. We are still working on v1 and
-these will be the official examples when we launch, but for now it is a playground for us to test
-release candidates and make sure that it all works as intended.
-
 
 ## Help
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 [![Powered by Flame](https://img.shields.io/badge/Powered%20by-%F0%9F%94%A5-orange.svg)](https://flame-engine.org)
 [![Discord](https://img.shields.io/discord/509714518008528896.svg)](https://discord.gg/pxrBmy4)
 
+
 # Flame Examples
 
 This is a set of small examples showcasing specific features of the Flame Engine; it's a great
@@ -13,6 +14,7 @@ the code and see how it works.
 
 For a very simple, but complete game in Flame, check the
 [example folder inside the Flame package](https://github.com/flame-engine/flame/tree/main/packages/flame/example).
+
 
 ## Help
 


### PR DESCRIPTION
# Description

Noticed the `examples` folder README was a bit outdated:

1. it was still linked to the old repo build
![image](https://user-images.githubusercontent.com/882703/198842022-538710ac-9c2f-4f45-ba99-52ce6c09c9a7.png)
2. it still mentioned v1 migration

I also improved punctuation.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
