### PR TITLE
chore: Mark GlowEffect as experimental

### DIFF
--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -194,7 +194,7 @@ clockwise:
 
 ```dart
 final effect = RotateEffect.by(
-  tau/4, 
+  tau/4,
   EffectController(duration: 2),
 );
 ```
@@ -215,7 +215,7 @@ target to look east (0º is north, 90º=[tau]/4 east, 180º=tau/2 south, and 270
 
 ```dart
 final effect = RotateEffect.to(
-  tau/4, 
+  tau/4,
   EffectController(duration: 2),
 );
 ```
@@ -331,7 +331,7 @@ using `AnchorEffect.by()`.
 
 ```dart
 final effect = AnchorByEffect(
-  Vector2(0.1, 0.1), 
+  Vector2(0.1, 0.1),
   EffectController(speed: 1),
 );
 ```
@@ -352,7 +352,7 @@ Changes the location of the target's anchor. This effect can also be created usi
 
 ```dart
 final effect = AnchorToEffect(
-  Anchor.center, 
+  Anchor.center,
   EffectController(speed: 1),
 );
 ```
@@ -433,6 +433,10 @@ uses multiple paints, the effect can target any individual color using the `pain
 
 ### GlowEffect
 
+```{note}
+This effect is currently experimental, and its API may change in the future.
+```
+
 This effect will apply the glowing shade around target relative to the specified
 `glow-strength`. The color of shade will be targets paint color. For example, the following effect
 will apply the glowing shade around target by strength of `10`:
@@ -474,20 +478,20 @@ backward); and also repeat a certain predetermined number of times, or infinitel
 ```dart
 final effect = SequenceEffect([
   ScaleEffect.by(
-    Vector2.all(1.5), 
+    Vector2.all(1.5),
     EffectController(
-      duration: 0.2, 
+      duration: 0.2,
       alternate: true,
     ),
   ),
   MoveEffect.by(
-    Vector2(30, -50), 
+    Vector2(30, -50),
     EffectController(
       duration: 0.5,
     ),
   ),
   OpacityEffect.to(
-    0, 
+    0,
     EffectController(
       duration: 0.3,
     ),

--- a/packages/flame/lib/src/effects/glow_effect.dart
+++ b/packages/flame/lib/src/effects/glow_effect.dart
@@ -2,12 +2,14 @@ import 'dart:ui';
 
 import 'package:flame/effects.dart';
 import 'package:flame/src/effects/provider_interfaces.dart';
+import 'package:meta/meta.dart';
 
 /// Change the MaskFilter on Paint of a component over time.
 ///
 /// This effect applies incremental changes to the MaskFilter on Paint of a
 /// component and requires that any other effect or update logic applied to the
 /// same component also used incremental updates.
+@experimental
 class GlowEffect extends Effect with EffectTarget<PaintProvider> {
   GlowEffect(this.strength, super.controller, {this.style = BlurStyle.outer});
 


### PR DESCRIPTION
# Description

This PR marks the recently added `GlowEffect` as experimental, indicating that we will likely need to change its API soon.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
