### PR TITLE
feat(jenny): Trim whitespace at the end of dialogue lines

### DIFF
--- a/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
@@ -651,6 +651,7 @@ class _Lexer {
   /// Emits the text token corresponding to the text processed.
   bool eatPlainText() {
     final position0 = position;
+    var positionBeforeWhitespace = position;
     while (!eof) {
       final cu = currentCodeUnit;
       if (cu == $lessThan || cu == $slash) {
@@ -661,12 +662,17 @@ class _Lexer {
         }
       } else if (cu == $carriageReturn ||
           cu == $lineFeed ||
-          cu == $hash ||
           cu == $backslash ||
           cu == $leftBrace) {
         break;
+      } else if (cu == $hash) {
+        position = positionBeforeWhitespace;
+        break;
       }
       position += 1;
+      if (!(cu == $space || cu == $tab)) {
+        positionBeforeWhitespace = position;
+      }
     }
     if (position > position0) {
       pushToken(Token.text(text.substring(position0, position)), position0);

--- a/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
@@ -77,7 +77,11 @@ class _Lexer {
 
   /// Returns the integer code unit at the current parse position, or -1 if we
   /// reached the end of input.
-  int get currentCodeUnit => eof ? -1 : text.codeUnitAt(position);
+  int get currentCodeUnit =>
+      position < text.length ? text.codeUnitAt(position) : -1;
+
+  int get nextCodeUnit =>
+      position < text.length - 1 ? text.codeUnitAt(position + 1) : -1;
 
   /// Pushes a new mode into the mode stack and returns `true`.
   bool pushMode(_ModeFn mode) {
@@ -654,19 +658,15 @@ class _Lexer {
     var positionBeforeWhitespace = position;
     while (!eof) {
       final cu = currentCodeUnit;
-      if (cu == $lessThan || cu == $slash) {
-        position += 1;
-        if (currentCodeUnit == cu) {
-          position -= 1;
-          break;
-        }
-      } else if (cu == $carriageReturn ||
-          cu == $lineFeed ||
+      if ((cu == $slash && nextCodeUnit == $slash) ||
+          cu == $hash ||
+          cu == $carriageReturn ||
+          cu == $lineFeed) {
+        position = positionBeforeWhitespace;
+        break;
+      } else if ((cu == $lessThan && nextCodeUnit == $lessThan) ||
           cu == $backslash ||
           cu == $leftBrace) {
-        break;
-      } else if (cu == $hash) {
-        position = positionBeforeWhitespace;
         break;
       }
       position += 1;

--- a/packages/flame_jenny/jenny/test/parse/tokenize_test.dart
+++ b/packages/flame_jenny/jenny/test/parse/tokenize_test.dart
@@ -494,13 +494,13 @@ void main() {
         expect(
           tokenize('---\n---\n'
               'some text // here be dragons\n'
-              'other text\n'
+              'other text   \t\n'
               '===\n'),
           const [
             Token.startHeader,
             Token.endHeader,
             Token.startBody,
-            Token.text('some text '),
+            Token.text('some text'),
             Token.newline,
             Token.text('other text'),
             Token.newline,
@@ -563,7 +563,6 @@ void main() {
             Token.startBody,
             Token.startExpression,
             Token.endExpression,
-            Token.text(' '),
             Token.newline,
             Token.endBody,
           ],
@@ -849,6 +848,22 @@ void main() {
             Token.number('33'),
             Token.endExpression,
             Token.hashtag('#here-be-dragons'),
+            Token.newline,
+            Token.endBody,
+          ],
+        );
+      });
+
+      test('comments in lines', () {
+        expect(
+          tokenize('---\n---\n'
+              'line1 // whatever\n'
+              '===\n'),
+          const [
+            Token.startHeader,
+            Token.endHeader,
+            Token.startBody,
+            Token.text('line1'),
             Token.newline,
             Token.endBody,
           ],

--- a/packages/flame_jenny/jenny/test/parse/tokenize_test.dart
+++ b/packages/flame_jenny/jenny/test/parse/tokenize_test.dart
@@ -470,6 +470,23 @@ void main() {
           ],
         );
       });
+
+      test('line with hash tags', () {
+        expect(
+          tokenize('---\n---\n'
+              'Some text #with-tag\n'
+              '===\n'),
+          const [
+            Token.startHeader,
+            Token.endHeader,
+            Token.startBody,
+            Token.text('Some text'),
+            Token.hashtag('#with-tag'),
+            Token.newline,
+            Token.endBody,
+          ],
+        );
+      });
     });
 
     group('modeText', () {
@@ -823,7 +840,7 @@ void main() {
             Token.startHeader,
             Token.endHeader,
             Token.startBody,
-            Token.text('line1 '),
+            Token.text('line1'),
             Token.hashtag('#tag'),
             Token.hashtag('#some:other@tag!'),
             Token.newline,
@@ -831,7 +848,6 @@ void main() {
             Token.startExpression,
             Token.number('33'),
             Token.endExpression,
-            Token.text(' '),
             Token.hashtag('#here-be-dragons'),
             Token.newline,
             Token.endBody,
@@ -887,6 +903,24 @@ void main() {
             Token.commandStop,
             Token.endCommand,
             Token.hashtag('#four'),
+            Token.newline,
+            Token.endBody,
+          ],
+        );
+      });
+
+      test('text with escaped content', () {
+        expect(
+          tokenize('---\n---\n'
+              'One \\{ two\n'
+              '===\n'),
+          const [
+            Token.startHeader,
+            Token.endHeader,
+            Token.startBody,
+            Token.text('One '),
+            Token.text('{'),
+            Token.text(' two'),
             Token.newline,
             Token.endBody,
           ],


### PR DESCRIPTION
# Description

The whitespace will now be trimmed at the end of expressions like
```
Line1 #foo
Line2 // bar
Line3\s+
```


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [x] No, this PR is not a breaking change.



<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
