### PR TITLE
docs: Fix component diagram text styling

### DIFF
--- a/doc/flame/diagrams/component.md
+++ b/doc/flame/diagrams/component.md
@@ -3,7 +3,7 @@
   graph TD  
 
     %% Node Color %%
-    classDef yellow fill:#F6BE00,stroke:#F6BE00,stroke-width:4px,color:#000 ;
+    classDef yellow fill:#F6BE00,stroke:#F6BE00,stroke-width:4px,color:#AAA ;
     classDef default fill:#282828,stroke:#F6BE00;
     
     %% Nodes %%
@@ -15,45 +15,58 @@
 
 ```{mermaid}
 %%{init: { 'theme': 'dark'  } }%%
-
 graph TD
     %% Node Color %%
-    classDef yellow fill:#F6BE00,stroke:#F6BE00,stroke-width:4px,color:#000 ;
+    classDef yellow fill:#F6BE00,stroke:#F6BE00,stroke-width:4px,color:#AAA;
     classDef default fill:#282828,stroke:#F6BE00;
     
     %% Nodes %%
        
-    Component[Component]
-    TimerComponent(TimerComponent <br/>ParticleComponent <br>SpriteBatchComponent)
-    Effects("Effects <br/> (See the effects section)"):::yellow
-    FlameGame(Flame Game)
+    Component(Component)
+    Misc("
+        TimerComponent
+        ParticleComponent
+        SpriteBatchComponent
+    ")
+    Effects("Effects<br/>(See the effects section)"):::yellow
+    Game(Game)
+    FlameGame(FlameGame)
     PositionComponent(PositionComponent)
    
-    SpriteComponent("SpriteComponent  <br/> SpriteGroupComponent 
-    <br/> SpriteAnimationComponent <br/> 
-    SpriteAnimationGroupComponent <br/> ParallaxComponent 
-    <br/> IsoMetricTileMapComponent")
+    Sprites("
+        SpriteComponent
+        SpriteGroupComponent 
+        SpriteAnimationComponent
+        SpriteAnimationGroupComponent
+        ParallaxComponent 
+        IsoMetricTileMapComponent
+    ")
     
     HudMarginComponent(HudMarginComponent)
-    HudButtonComponent(HudButtonComponent  <br/> JoystickComponent)
+    HudComponents("
+        HudButtonComponent
+        JoystickComponent
+    ")
     
-    ButtonComponent("ButtonComponent <br/> CustomPainterComponent 
-    <br/> ShapeComponent <br/> SpriteButtonComponent 
-    <br/> TextComponent <br/> TextBoxComponent 
-    <br/> NineTileBoxComponent")
-    
-    Loadable("Loadable (Mixin)"):::yellow
-    
+    OtherPositionComponents("
+        ButtonComponent
+        CustomPainterComponent
+        ShapeComponent
+        SpriteButtonComponent
+        TextComponent
+        TextBoxComponent
+        NineTileBoxComponent
+    ")
+        
     %% Flow %%
-    Component --> TimerComponent
+    Component --> Misc
     Component --> Effects
     Component --> PositionComponent
     Component --> FlameGame
    
-    Loadable --> FlameGame
-    PositionComponent --> SpriteComponent
+    Game --> FlameGame
+    PositionComponent --> Sprites
     PositionComponent --> HudMarginComponent
-    PositionComponent --> ButtonComponent
-    HudMarginComponent --> HudButtonComponent
-    
+    PositionComponent --> OtherPositionComponents
+    HudMarginComponent --> HudComponents    
 ```


### PR DESCRIPTION
# Description

The text on the abstract classes wasn't readable on the old one and loadable doesn't exist anymore, this is the new one:
![image](https://user-images.githubusercontent.com/744771/203504201-48345ee2-bb46-4438-bcab-cefd985c0347.png)

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
