### PR TITLE
feat: add onCancelled to ButtonComponent and HudButtonComponent

### DIFF
--- a/packages/flame/lib/src/components/input/button_component.dart
+++ b/packages/flame/lib/src/components/input/button_component.dart
@@ -64,7 +64,10 @@ class ButtonComponent extends PositionComponent with Tappable {
   @override
   @mustCallSuper
   bool onTapUp(TapUpInfo info) {
-    onTapCancel();
+    if (buttonDown != null) {
+      buttonDown!.removeFromParent();
+      button!.parent = this;
+    }
     onReleased?.call();
     return true;
   }

--- a/packages/flame/lib/src/components/input/button_component.dart
+++ b/packages/flame/lib/src/components/input/button_component.dart
@@ -12,20 +12,20 @@ class ButtonComponent extends PositionComponent with Tappable {
   late final PositionComponent? buttonDown;
 
   /// Callback for what should happen when the button is pressed.
-  /// If you want to interact with [onTapCancel] it is recommended
-  /// to extend [ButtonComponent].
   void Function()? onPressed;
 
   /// Callback for what should happen when the button is released.
-  /// If you want to interact with [onTapCancel] it is recommended
-  /// to extend [ButtonComponent].
   void Function()? onReleased;
+
+  /// Callback for what should happen when the button is cancelled.
+  void Function()? onCancelled;
 
   ButtonComponent({
     this.button,
     this.buttonDown,
     this.onPressed,
     this.onReleased,
+    this.onCancelled,
     super.position,
     Vector2? size,
     super.scale,
@@ -76,6 +76,7 @@ class ButtonComponent extends PositionComponent with Tappable {
       buttonDown!.removeFromParent();
       button!.parent = this;
     }
+    onCancelled?.call();
     return false;
   }
 }

--- a/packages/flame/lib/src/components/input/hud_button_component.dart
+++ b/packages/flame/lib/src/components/input/hud_button_component.dart
@@ -15,6 +15,7 @@ class HudButtonComponent extends ButtonComponent
     EdgeInsets? margin,
     Function()? super.onPressed,
     Function()? super.onReleased,
+    Function()? super.onCancelled,
     super.position,
     Vector2? size,
     super.scale,

--- a/packages/flame/test/components/button_component_test.dart
+++ b/packages/flame/test/components/button_component_test.dart
@@ -72,8 +72,15 @@ void main() {
       expect(releasedTimes, 1);
       expect(cancelledTimes, 0);
 
+      game.onTapDown(
+        1,
+        createTapDownEvent(
+          game,
+          globalPosition: buttonPosition.toOffset(),
+        ),
+      );
       game.onTapCancel(1);
-      expect(pressedTimes, 1);
+      expect(pressedTimes, 2);
       expect(releasedTimes, 1);
       expect(cancelledTimes, 1);
     });
@@ -125,8 +132,15 @@ void main() {
       expect(releasedTimes, 1);
       expect(cancelledTimes, 0);
 
+      game.onTapDown(
+        1,
+        createTapDownEvent(
+          game,
+          globalPosition: previousPosition,
+        ),
+      );
       game.onTapCancel(1);
-      expect(pressedTimes, 1);
+      expect(pressedTimes, 2);
       expect(releasedTimes, 1);
       expect(cancelledTimes, 1);
     });

--- a/packages/flame/test/components/button_component_test.dart
+++ b/packages/flame/test/components/button_component_test.dart
@@ -94,6 +94,7 @@ void main() {
           button: RectangleComponent(size: componentSize),
           onPressed: () => pressedTimes++,
           onReleased: () => releasedTimes++,
+          onCancelled: () => cancelledTimes++,
           position: buttonPosition,
           size: componentSize,
         ),

--- a/packages/flame/test/components/button_component_test.dart
+++ b/packages/flame/test/components/button_component_test.dart
@@ -13,6 +13,7 @@ void main() {
         'correctly registers taps', GameWithTappables.new, (game) async {
       var pressedTimes = 0;
       var releasedTimes = 0;
+      var cancelledTimes = 0;
       final initialGameSize = Vector2.all(100);
       final componentSize = Vector2.all(10);
       final buttonPosition = Vector2.all(100);
@@ -23,6 +24,7 @@ void main() {
           button: RectangleComponent(size: componentSize),
           onPressed: () => pressedTimes++,
           onReleased: () => releasedTimes++,
+          onCancelled: () => cancelledTimes++,
           position: buttonPosition,
           size: componentSize,
         ),
@@ -30,10 +32,12 @@ void main() {
 
       expect(pressedTimes, 0);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapDown(1, createTapDownEvent(game));
       expect(pressedTimes, 0);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapUp(
         1,
@@ -44,6 +48,7 @@ void main() {
       );
       expect(pressedTimes, 0);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapDown(
         1,
@@ -54,6 +59,7 @@ void main() {
       );
       expect(pressedTimes, 1);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapUp(
         1,
@@ -64,6 +70,12 @@ void main() {
       );
       expect(pressedTimes, 1);
       expect(releasedTimes, 1);
+      expect(cancelledTimes, 0);
+
+      game.onTapCancel(1);
+      expect(pressedTimes, 1);
+      expect(releasedTimes, 1);
+      expect(cancelledTimes, 1);
     });
 
     testWithGame<GameWithTappables>(
@@ -71,6 +83,7 @@ void main() {
         (game) async {
       var pressedTimes = 0;
       var releasedTimes = 0;
+      var cancelledTimes = 0;
       final initialGameSize = Vector2.all(100);
       final componentSize = Vector2.all(10);
       final buttonPosition = Vector2.all(100);
@@ -98,6 +111,7 @@ void main() {
       );
       expect(pressedTimes, 1);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapUp(
         1,
@@ -108,6 +122,12 @@ void main() {
       );
       expect(pressedTimes, 1);
       expect(releasedTimes, 1);
+      expect(cancelledTimes, 0);
+
+      game.onTapCancel(1);
+      expect(pressedTimes, 1);
+      expect(releasedTimes, 1);
+      expect(cancelledTimes, 1);
     });
 
     testWidgets(

--- a/packages/flame/test/components/hud_button_component_test.dart
+++ b/packages/flame/test/components/hud_button_component_test.dart
@@ -13,6 +13,7 @@ void main() {
         'correctly registers taps', GameWithTappables.new, (game) async {
       var pressedTimes = 0;
       var releasedTimes = 0;
+      var cancelledTimes = 0;
       final initialGameSize = Vector2.all(100);
       final componentSize = Vector2.all(10);
       const margin = EdgeInsets.only(bottom: 10, right: 10);
@@ -23,6 +24,7 @@ void main() {
           button: RectangleComponent(size: componentSize),
           onPressed: () => pressedTimes++,
           onReleased: () => releasedTimes++,
+          onCancelled: () => cancelledTimes++,
           size: componentSize,
           margin: margin,
         ),
@@ -30,10 +32,12 @@ void main() {
 
       expect(pressedTimes, 0);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapDown(1, createTapDownEvent(game));
       expect(pressedTimes, 0);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapUp(
         1,
@@ -44,6 +48,7 @@ void main() {
       );
       expect(pressedTimes, 0);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapDown(
         1,
@@ -56,6 +61,7 @@ void main() {
       );
       expect(pressedTimes, 1);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapUp(
         1,
@@ -66,6 +72,12 @@ void main() {
       );
       expect(pressedTimes, 1);
       expect(releasedTimes, 1);
+      expect(cancelledTimes, 0);
+
+      game.onTapCancel(1);
+      expect(pressedTimes, 1);
+      expect(releasedTimes, 1);
+      expect(cancelledTimes, 1);
     });
 
     testWithGame<GameWithTappables>(
@@ -73,6 +85,7 @@ void main() {
         (game) async {
       var pressedTimes = 0;
       var releasedTimes = 0;
+      var cancelledTimes = 0;
       final initialGameSize = Vector2.all(100);
       final componentSize = Vector2.all(10);
       const margin = EdgeInsets.only(bottom: 10, right: 10);
@@ -107,6 +120,7 @@ void main() {
       );
       expect(pressedTimes, 0);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapDown(
         1,
@@ -118,6 +132,7 @@ void main() {
       );
       expect(pressedTimes, 1);
       expect(releasedTimes, 0);
+      expect(cancelledTimes, 0);
 
       game.onTapUp(
         1,
@@ -129,6 +144,12 @@ void main() {
       );
       expect(pressedTimes, 1);
       expect(releasedTimes, 1);
+      expect(cancelledTimes, 0);
+
+      game.onTapCancel(1);
+      expect(pressedTimes, 1);
+      expect(releasedTimes, 1);
+      expect(cancelledTimes, 1);
     });
   });
 }

--- a/packages/flame/test/components/hud_button_component_test.dart
+++ b/packages/flame/test/components/hud_button_component_test.dart
@@ -96,6 +96,7 @@ void main() {
           button: RectangleComponent(size: componentSize),
           onPressed: () => pressedTimes++,
           onReleased: () => releasedTimes++,
+          onCancelled: () => cancelledTimes++,
           size: componentSize,
           margin: margin,
         ),

--- a/packages/flame/test/components/hud_button_component_test.dart
+++ b/packages/flame/test/components/hud_button_component_test.dart
@@ -74,8 +74,17 @@ void main() {
       expect(releasedTimes, 1);
       expect(cancelledTimes, 0);
 
+      game.onTapDown(
+        1,
+        createTapDownEvent(
+          game,
+          globalPosition: initialGameSize.toOffset() +
+              margin.bottomRight -
+              const Offset(1, 1),
+        ),
+      );
       game.onTapCancel(1);
-      expect(pressedTimes, 1);
+      expect(pressedTimes, 2);
       expect(releasedTimes, 1);
       expect(cancelledTimes, 1);
     });
@@ -147,8 +156,16 @@ void main() {
       expect(releasedTimes, 1);
       expect(cancelledTimes, 0);
 
+      game.onTapDown(
+        1,
+        createTapDownEvent(
+          game,
+          globalPosition:
+              game.size.toOffset() + margin.bottomRight - const Offset(1, 1),
+        ),
+      );
       game.onTapCancel(1);
-      expect(pressedTimes, 1);
+      expect(pressedTimes, 2);
       expect(releasedTimes, 1);
       expect(cancelledTimes, 1);
     });


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

Adds `onCancelled` to `ButtonComponent` and `HudButtonComponent`

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

No

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

https://github.com/flame-engine/flame/issues/2191#issuecomment-1328051507
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
