### PR TITLE
fix: Build flame-docs-site on push

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,9 +22,7 @@ jobs:
 
     steps:
       - name: Trigger building the docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.docs_token }}
         run: |
-          curl -XPOST -u "${{ secrets.GIT_CREDENTIALS }}" \
-          -H "Accept:application/vnd.github" \
-          -H "Content-Type:application/json" \
-          https://api.github.com/flame-engine/flame-docs-site/actions/workflows/gh-pages.yml/dispatches \
-          --data '{"ref": "main" }'
+          gh workflow run 13757924 -R flame-engine/flame-docs-site


### PR DESCRIPTION
# Description
Instead of the curl command, it uses the integrated [gh cli tool](https://cli.github.com/).

The workflow ID corresponds to the flame-docs-site's gh-pages.yml. 
You can get the workflow id running the gh tool on your computer, via
gh workflow list  -R flame-engine/flame-docs-site

This pr assumes that a personal access token, `docs_token`, can access the flame-docs-site repository and trigger workflows.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
