### PR TITLE
fix: Re-use paint object in ImageParticle

### DIFF
--- a/packages/flame/lib/src/particles/image_particle.dart
+++ b/packages/flame/lib/src/particles/image_particle.dart
@@ -8,15 +8,17 @@ import 'package:flame/src/particles/particle.dart';
 class ImageParticle extends Particle {
   /// dart.ui [Image] to draw
   Image image;
+  Paint paint;
 
   late Rect src;
   late Rect dest;
 
   ImageParticle({
     required this.image,
+    Paint? paint,
     Vector2? size,
     super.lifespan,
-  }) {
+  }) : paint = paint ?? Paint() {
     final srcWidth = image.width.toDouble();
     final srcHeight = image.height.toDouble();
     final destWidth = size?.x ?? srcWidth;
@@ -29,6 +31,6 @@ class ImageParticle extends Particle {
 
   @override
   void render(Canvas canvas) {
-    canvas.drawImageRect(image, src, dest, Paint());
+    canvas.drawImageRect(image, src, dest, paint);
   }
 }


### PR DESCRIPTION
# Description

Since it is very bad to create paint-objects in the render loop this PR moves out the paint object and lets the user set the paint object manually.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
