### PR TITLE
feat: Added escape sequence \- in yarn language

### DIFF
--- a/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
@@ -603,6 +603,7 @@ class _Lexer {
         if (cu == $backslash ||
             cu == $slash ||
             cu == $hash ||
+            cu == $minus ||
             cu == $lessThan ||
             cu == $greaterThan ||
             cu == $leftBrace ||

--- a/packages/flame_jenny/jenny/test/parse/tokenize_test.dart
+++ b/packages/flame_jenny/jenny/test/parse/tokenize_test.dart
@@ -537,6 +537,7 @@ void main() {
               'very long \\\n'
               '  text\n'
               'line with a newline:\\n ok\n'
+              '\\-> text with arrow\n'
               '===\n'),
           const [
             Token.startHeader,
@@ -554,6 +555,9 @@ void main() {
             Token.text('line with a newline:'),
             Token.text('\n'),
             Token.text(' ok'),
+            Token.newline,
+            Token.text('-'),
+            Token.text('> text with arrow'),
             Token.newline,
             Token.endBody,
           ],

--- a/packages/flame_jenny/jenny/test/structure/dialogue_choice_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/dialogue_choice_test.dart
@@ -66,12 +66,14 @@ void main() {
           ------------
           -> Hi, My name is [bold]{$player}[/bold]
           -> I can give you only {$money / 2} coins -- that's all I have
+          \-> Not an option!
           ===
         ''',
         testPlan: '''
           option: Hi, My name is Steve
           option: I can give you only 50.0 coins -- that's all I have
           select: 1
+          line: -> Not an option!
         ''',
       );
     });


### PR DESCRIPTION
# Description

Escape sequence `\-` allows to escape an option arrow "->" at the start of a line.



## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2219

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
