### PR TITLE
docs: Add "teh" as a flag word in spellchecker

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -1,7 +1,7 @@
 {
   "version": "0.2",
   "language": "en",
-  "flagWords": [],
+  "flagWords": ["teh", "hte"],
   "ignorePaths": ["**/media/**", "**/assets/**", "**/test/**"],
   "ignoreRegExpList": [
       "@[\\w\\-]+",


### PR DESCRIPTION
# Description

This prevents the same typo happening again.
Followup for #2225.


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
