### PR TITLE
feat: Added DialogueView.onNodeFinish event

### DIFF
--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -29,6 +29,6 @@ jobs:
             revert
             style
             test
-          subjectPattern: ^[A-Z]
+          subjectPattern: ^[A-Z].*
           subjectPatternError: |
             The subject of the PR must begin with an uppercase letter.

--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -2,7 +2,7 @@
 name: 'PR Title is Conventional'
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -2,7 +2,7 @@
 name: 'PR Title is Conventional'
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/doc/other_modules/jenny/runtime/dialogue_runner.md
+++ b/doc/other_modules/jenny/runtime/dialogue_runner.md
@@ -94,8 +94,8 @@ the sequence of emitted events will be as follows (assuming the second option is
 - `onDialogueFinish()`
 
 :::{note}
-Keep in mind that if a `DialogueError` is thrown while running the dialogue, then it will terminate
-immediately and none of the `*Finish` callbacks will run.
+Keep in mind that if a `DialogueError` is thrown while running the dialogue, then the dialogue will
+terminate immediately and none of the `*Finish` callbacks will run.
 :::
 
 

--- a/doc/other_modules/jenny/runtime/dialogue_runner.md
+++ b/doc/other_modules/jenny/runtime/dialogue_runner.md
@@ -36,7 +36,7 @@ The constructor takes two required parameters:
 
 ## Methods
 
-**runNode**(`String nodeName`)
+**startDialogue**(`String nodeName`)
 : Executes the node with the given name, and returns a future that completes only when the dialogue
   finishes running (which may be a while). A single `DialogueRunner` can only run one node at a
   time.

--- a/doc/other_modules/jenny/runtime/dialogue_runner.md
+++ b/doc/other_modules/jenny/runtime/dialogue_runner.md
@@ -93,6 +93,11 @@ the sequence of emitted events will be as follows (assuming the second option is
 - `onNodeFinish(Node("Away"))`
 - `onDialogueFinish()`
 
+:::{note}
+Keep in mind that if a `DialogueError` is thrown while running the dialogue, then it will terminate
+immediately and none of the `*Finish` callbacks will run.
+:::
+
 
 [DialogueChoice]: dialogue_choice.md
 [DialogueView]: dialogue_view.md

--- a/doc/other_modules/jenny/runtime/dialogue_view.md
+++ b/doc/other_modules/jenny/runtime/dialogue_view.md
@@ -46,7 +46,11 @@ simultaneously).
   `node`'s properties or metadata.
 
 **onNodeFinish**(`Node node`)
-: TODO
+: Called when the dialogue runner finishes executing the [Node], before **onDialogueFinish**. This
+  will also be called every time a node is exited via `<<stop>>` or a `<<jump>>` command (including
+  jumps from node to itself).
+
+  This callback can be used to clean up any preparations that were performed in `onNodeStart`.
 
 **onLineStart**(`DialogueLine line`) `-> bool`
 : Called when the next dialogue [line] should be presented to the user.

--- a/doc/other_modules/jenny/runtime/dialogue_view.md
+++ b/doc/other_modules/jenny/runtime/dialogue_view.md
@@ -39,9 +39,8 @@ simultaneously).
 : Called when the dialogue is about to finish.
 
 **onNodeStart**(`Node node`)
-: Called when the dialogue runner starts executing the [Node]. This will be called at the start of
-  `DialogueView.runNode()` (but after the **onDialogueStart**), and then each time the dialogue
-  jumps to another node.
+: Called when the dialogue runner starts executing the [Node]. This will be called right after the
+  **onDialogueStart** event, and then each time the dialogue jumps to another node.
 
   This method is a good place to perform node-specific initialization, for example by querying the
   `node`'s properties or metadata.

--- a/packages/flame_jenny/jenny/lib/src/dialogue_runner.dart
+++ b/packages/flame_jenny/jenny/lib/src/dialogue_runner.dart
@@ -47,7 +47,7 @@ class DialogueRunner {
 
   /// Executes the node with the given name, and returns a future that finishes
   /// once the dialogue stops running.
-  Future<void> runNode(String nodeName) async {
+  Future<void> startDialogue(String nodeName) async {
     try {
       if (_currentNodes.isNotEmpty) {
         throw DialogueError(
@@ -158,7 +158,7 @@ class DialogueRunner {
   @internal
   Future<void> jumpToNode(String nodeName) async {
     _finishCurrentNode();
-    return runNode(nodeName);
+    return startDialogue(nodeName);
   }
 
   @internal

--- a/packages/flame_jenny/jenny/lib/src/dialogue_runner.dart
+++ b/packages/flame_jenny/jenny/lib/src/dialogue_runner.dart
@@ -92,6 +92,8 @@ class DialogueRunner {
       await entry.processInDialogueRunner(this);
     }
     _incrementNodeVisitCount();
+    await _event((view) => view.onNodeFinish(node));
+
     _currentNode = null;
     _currentIterator = null;
   }
@@ -167,6 +169,9 @@ class DialogueRunner {
 
   /// Stops the current node, and then starts running [nodeName]. If [nodeName]
   /// is null, then stops the dialogue completely.
+  ///
+  /// This command is synchronous, i.e. it does not wait for the node to
+  /// *actually* finish (which calls the `onNodeFinish` callback).
   @internal
   void jumpToNode(String? nodeName) {
     _currentIterator = null;

--- a/packages/flame_jenny/jenny/lib/src/dialogue_view.dart
+++ b/packages/flame_jenny/jenny/lib/src/dialogue_view.dart
@@ -44,6 +44,14 @@ abstract class DialogueView {
   /// to complete before proceeding with the actual dialogue.
   FutureOr<void> onNodeStart(Node node) {}
 
+  /// Called when the dialogue exits the [node].
+  ///
+  /// For example, during a `<<jump>>` this callback will be called with the
+  /// current node, and then [onNodeStart] will be called with the new node.
+  /// Similarly, the command `<<stop>>` will trigger this callback too. At the
+  /// same time, during `<<visit>>` this callback will not be invoked.
+  FutureOr<void> onNodeFinish(Node node) {}
+
   /// Called when the next dialogue [line] should be presented to the user.
   ///
   /// The [DialogueView] may decide to present the [line] in whatever way it

--- a/packages/flame_jenny/jenny/lib/src/structure/commands/jump_command.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/commands/jump_command.dart
@@ -11,7 +11,7 @@ class JumpCommand extends Command {
   String get name => 'jump';
 
   @override
-  Future<void> execute(DialogueRunner dialogue) {
-    return dialogue.jumpToNode(target.value);
+  void execute(DialogueRunner dialogue) {
+    dialogue.jumpToNode(target.value);
   }
 }

--- a/packages/flame_jenny/jenny/lib/src/structure/commands/stop_command.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/commands/stop_command.dart
@@ -9,6 +9,6 @@ class StopCommand extends Command {
 
   @override
   void execute(DialogueRunner dialogue) {
-    dialogue.stop();
+    dialogue.jumpToNode(null);
   }
 }

--- a/packages/flame_jenny/jenny/test/dialogue_runner_test.dart
+++ b/packages/flame_jenny/jenny/test/dialogue_runner_test.dart
@@ -27,7 +27,7 @@ void main() {
         );
       final view = _RecordingDialogueView();
       final dialogue = DialogueRunner(yarnProject: yarn, dialogueViews: [view]);
-      await dialogue.runNode('Hamlet');
+      await dialogue.startDialogue('Hamlet');
       expect(
         view.events,
         [
@@ -93,7 +93,7 @@ void main() {
         yarnProject: yarn,
         dialogueViews: [view1, view2, view3],
       );
-      await dialogue.runNode('The Robot and the Mattress');
+      await dialogue.startDialogue('The Robot and the Mattress');
       expect(events, [
         '[A] onDialogueStart()',
         '[B] onDialogueStart()',
@@ -130,7 +130,7 @@ void main() {
             '===\n');
       final view = _RecordingDialogueView(choices: [1]);
       final dialogue = DialogueRunner(yarnProject: yarn, dialogueViews: [view]);
-      await dialogue.runNode('X');
+      await dialogue.startDialogue('X');
       expect(
         view.events,
         [
@@ -149,7 +149,7 @@ void main() {
 
       view.events.clear();
       view.choices.add(0);
-      await dialogue.runNode('X');
+      await dialogue.startDialogue('X');
       expect(
         view.events,
         [
@@ -174,11 +174,11 @@ void main() {
       final view = _RecordingDialogueView(choices: [2, 1]);
       final dialogue = DialogueRunner(yarnProject: yarn, dialogueViews: [view]);
       await expectLater(
-        () => dialogue.runNode('A'),
+        () => dialogue.startDialogue('A'),
         hasDialogueError('Invalid option index chosen in a dialogue: 2'),
       );
       await expectLater(
-        () => dialogue.runNode('A'),
+        () => dialogue.startDialogue('A'),
         hasDialogueError(
           'A dialogue view selected a disabled option: '
           'Option(Only two #disabled)',
@@ -193,7 +193,7 @@ void main() {
         dialogueViews: [_SimpleDialogueView(), _SimpleDialogueView()],
       );
       expect(
-        () => dialogue.runNode('A'),
+        () => dialogue.startDialogue('A'),
         hasDialogueError(
           'No dialogue views capable of making a dialogue choice',
         ),
@@ -327,9 +327,9 @@ void main() {
         );
       final view = _RecordingDialogueView();
       final dialogue = DialogueRunner(yarnProject: yarn, dialogueViews: [view]);
-      unawaited(dialogue.runNode('Start'));
+      unawaited(dialogue.startDialogue('Start'));
       expect(
-        () => dialogue.runNode('Other'),
+        () => dialogue.startDialogue('Other'),
         hasDialogueError(
           'Cannot run node "Other" because another node is currently running: '
           '"Start"',

--- a/packages/flame_jenny/jenny/test/dialogue_view_test.dart
+++ b/packages/flame_jenny/jenny/test/dialogue_view_test.dart
@@ -31,7 +31,7 @@ void main() {
         yarnProject: yarn,
         dialogueViews: [view1, view2],
       );
-      await dialogueRunner.runNode('Start');
+      await dialogueRunner.startDialogue('Start');
       expect(
         view2.events,
         const [
@@ -68,7 +68,7 @@ void main() {
         yarnProject: yarn,
         dialogueViews: [view1, view2, view3],
       );
-      await dialogueRunner.runNode('Start');
+      await dialogueRunner.startDialogue('Start');
       expect(
         view2.events,
         const [

--- a/packages/flame_jenny/jenny/test/dialogue_view_test.dart
+++ b/packages/flame_jenny/jenny/test/dialogue_view_test.dart
@@ -46,6 +46,7 @@ void main() {
           'onLineStart(Last line)',
           'onLineFinish(Last line)',
           'onCommand(<<Command(myCommand)>>)',
+          'onNodeFinish(Start)',
           'onDialogueFinish()',
         ],
       );
@@ -78,6 +79,7 @@ void main() {
           'onLineSignal(line="First line", signal=<I\'m a banana!>)',
           'onLineStop(First line)',
           'onLineFinish(First line)',
+          'onNodeFinish(Start)',
           'onDialogueFinish()',
         ],
       );
@@ -100,6 +102,11 @@ class _RecordingDialogueView extends DialogueView {
   @override
   FutureOr<void> onNodeStart(Node node) {
     events.add('onNodeStart(${node.title})');
+  }
+
+  @override
+  FutureOr<void> onNodeFinish(Node node) {
+    events.add('onNodeFinish(${node.title})');
   }
 
   @override

--- a/packages/flame_jenny/jenny/test/structure/commands/jump_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/jump_command_test.dart
@@ -114,7 +114,8 @@ void main() {
           '===\n',
         );
       expect(
-        () => DialogueRunner(yarnProject: yarn, dialogueViews: []).startDialogue('A'),
+        () => DialogueRunner(yarnProject: yarn, dialogueViews: [])
+            .startDialogue('A'),
         hasNameError('NameError: Node "Up" could not be found'),
       );
     });

--- a/packages/flame_jenny/jenny/test/structure/commands/jump_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/jump_command_test.dart
@@ -114,7 +114,7 @@ void main() {
           '===\n',
         );
       expect(
-        () => DialogueRunner(yarnProject: yarn, dialogueViews: []).runNode('A'),
+        () => DialogueRunner(yarnProject: yarn, dialogueViews: []).startDialogue('A'),
         hasNameError('NameError: Node "Up" could not be found'),
       );
     });

--- a/packages/flame_jenny/jenny/test/structure/commands/user_defined_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/user_defined_command_test.dart
@@ -142,7 +142,7 @@ void main() {
         dialogueViews: [view1, view2],
       );
 
-      await dialogueRunner.runNode('Start');
+      await dialogueRunner.startDialogue('Start');
       expect(fnCounter, 1);
       expect(view1.numCalled, 1);
       expect(view1.argumentString, 'a b 1');
@@ -151,7 +151,7 @@ void main() {
       expect(view2.argumentString, 'a b 1');
       expect(view2.arguments, ['a', 'b', '1']);
 
-      await dialogueRunner.runNode('Start');
+      await dialogueRunner.startDialogue('Start');
       expect(fnCounter, 2);
       expect(view2.numCalled, 2);
       expect(view2.argumentString, 'a b 2');

--- a/packages/flame_jenny/jenny/test/structure/expressions/functions/visit_count_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/expressions/functions/visit_count_test.dart
@@ -20,7 +20,7 @@ void main() {
           <<endif>>
           // Also let's make sure <<stop>> doesn't prevent calculation
           // of node visits
-          // <<stop>>
+          <<stop>>
           ===
         ''',
         testPlan: '''

--- a/packages/flame_jenny/jenny/test/structure/expressions/functions/visit_count_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/expressions/functions/visit_count_test.dart
@@ -18,6 +18,9 @@ void main() {
             jumping...
             <<jump Start>>
           <<endif>>
+          // Also let's make sure <<stop>> doesn't prevent calculation
+          // of node visits
+          // <<stop>>
           ===
         ''',
         testPlan: '''

--- a/packages/flame_jenny/jenny/test/test_scenario.dart
+++ b/packages/flame_jenny/jenny/test/test_scenario.dart
@@ -30,7 +30,7 @@ Future<void> testScenario({
       yarnProject: yarnProject,
       dialogueViews: [plan],
     );
-    await dialogue.runNode(plan.startNode);
+    await dialogue.startDialogue(plan.startNode);
     assert(
       plan.done,
       '\n'


### PR DESCRIPTION
# Description

- The `onNodeFinish` event is a counterpart to `onNodeStart`.
- This also fixes a small bug where node visit count was not properly incremented if the node was exited via a `<<stop>>`.
- The `DialogueRunner.runNode()` method renamed into `startDialogue()`.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Related Issues

Closes #2215


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
