### PR TITLE
ci: Fix title validator

### DIFF
--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -29,6 +29,6 @@ jobs:
             revert
             style
             test
-          subjectPattern: ^[A-Z]
+          subjectPattern: ^[A-Z].+$
           subjectPatternError: |
             The subject of the PR must begin with an uppercase letter.


### PR DESCRIPTION
This (hopefully) fixes bad configuration for title validator, pushed in PR #2227.

Looks like the title validator is configured to always use the configuration from main instead of the current branch, which means we can only know if it works after pushing it to main:
> Also if you change the configuration in a PR, the changes will not be reflected for the current PR – only subsequent ones after the changes are in the main branch.