### PR TITLE
feat: Added command <<visit>>

### DIFF
--- a/doc/other_modules/jenny/language/commands/commands.md
+++ b/doc/other_modules/jenny/language/commands/commands.md
@@ -38,6 +38,9 @@ scripts. For a full description of these commands, see the document on [user-def
 **[\<\<stop\>\>](stop.md)**
 : Stops executing the current node.
 
+**[\<\<visit\>\>](visit.md)**
+: Temporarily jumps to another node, and then comes back.
+
 **[\<\<wait\>\>](wait.md)**
 : Pauses the dialogue for the specified amount of time.
 
@@ -53,6 +56,7 @@ scripts. For a full description of these commands, see the document on [user-def
 <<local>>              <local.md>
 <<set>>                <set.md>
 <<stop>>               <stop.md>
+<<visit>>              <visit.md>
 <<wait>>               <wait.md>
 User-defined commands  <user_defined_commands.md>
 ```

--- a/doc/other_modules/jenny/language/commands/jump.md
+++ b/doc/other_modules/jenny/language/commands/jump.md
@@ -16,3 +16,9 @@ node ID, or as an expression in curly braces:
 
 If the expression evaluates at runtime to an unknown name, then a `NameError` exception will be
 thrown.
+
+
+## See Also
+
+- [\<\<visit\>\>](visit.md) command, which jumps into the destination node temporarily and then
+  returns to the same place in the dialogue as before.

--- a/doc/other_modules/jenny/language/commands/visit.md
+++ b/doc/other_modules/jenny/language/commands/visit.md
@@ -1,0 +1,38 @@
+# `<<visit>>`
+
+The **\<\<visit\>\>** command temporarily puts the current node on hold, executes the target node,
+and after it finishes, resumes execution of the previous node. This is similar to a function call
+in many programming languages.
+
+The `<<visit>>` command can be useful for splitting a large dialogue into several smaller nodes,
+or for reusing some common dialogue lines in several nodes. For example:
+
+```yarn
+title: RoamingTrader1
+---
+<<if $roaming_trader_introduced>>
+  Hello again, {$player}!
+<<else>>
+  <<visit RoamingTraderIntro>>
+<<endif>>
+
+-> What do you think about the Calamity?  <<if $calamity_started>>
+   <<visit RoamingTrader_Calamity>>
+-> Have you seen a weird-looking girl running by? <<if $quest_little_girl>>
+   <<visit RoamingTrader_LittleGirl>>
+-> What do you have for trade?
+   <<OpenTrade>>
+
+Pleasure doing business with you! #auto
+===
+```
+
+The argument of this command is the id of the node to jump to. It can be given either as a plain
+node ID, or as an expression in curly braces:
+
+```yarn
+<<visit {"RewardChoice_" + string($choice)}>>
+```
+
+If the expression evaluates at runtime to an unknown name, then a `NameError` exception will be
+thrown.

--- a/packages/flame_jenny/jenny/lib/src/command_storage.dart
+++ b/packages/flame_jenny/jenny/lib/src/command_storage.dart
@@ -104,6 +104,7 @@ class CommandStorage {
     'set',
     'stop',
     'stop',
+    'visit',
     'wait',
     'while',
   ];

--- a/packages/flame_jenny/jenny/lib/src/parse/token.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/token.dart
@@ -30,6 +30,7 @@ class Token {
   static const commandLocal = Token._(TokenType.commandLocal);
   static const commandSet = Token._(TokenType.commandSet);
   static const commandStop = Token._(TokenType.commandStop);
+  static const commandVisit = Token._(TokenType.commandVisit);
   static const commandWait = Token._(TokenType.commandWait);
   static const constFalse = Token._(TokenType.constFalse);
   static const constTrue = Token._(TokenType.constTrue);
@@ -129,6 +130,7 @@ enum TokenType {
   commandLocal, //           'local'
   commandSet, //             'set'
   commandStop, //            'stop'
+  commandVisit, //           'visit'
   commandWait, //            'wait'
   constFalse, //             'false'
   constTrue, //              'true'

--- a/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
@@ -239,7 +239,8 @@ class _Lexer {
                     (eatId() ||
                         (eatExpressionStart() &&
                             pushMode(modeTextExpression)) ||
-                        error('an ID or an expression expected'))) ||
+                        error('an ID or an expression in curly braces '
+                            'expected'))) ||
                 (tokens.last.isCommand && // user-defined commands
                     pushMode(modeCommandText)))) ||
         (eatCommandEnd() && popMode(modeCommand)) ||

--- a/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
@@ -35,7 +35,13 @@ class _Lexer {
         lineStart = 0,
         tokens = [],
         modeStack = [],
-        indentStack = [];
+        indentStack = [],
+        assert(
+          commandTokens.length ==
+              simpleCommands.length +
+                  bareExpressionCommands.length +
+                  nodeTargetingCommands.length,
+        );
 
   final String text;
   final List<Token> tokens;
@@ -229,7 +235,7 @@ class _Lexer {
                 (bareExpressionCommands.contains(tokens.last) &&
                     pushToken(Token.startExpression, position) &&
                     pushMode(modeCommandExpression)) ||
-                (tokens.last == Token.commandJump &&
+                (nodeTargetingCommands.contains(tokens.last) &&
                     (eatId() ||
                         (eatExpressionStart() &&
                             pushMode(modeTextExpression)) ||
@@ -973,6 +979,7 @@ class _Lexer {
     'local': Token.commandLocal,
     'set': Token.commandSet,
     'stop': Token.commandStop,
+    'visit': Token.commandVisit,
     'wait': Token.commandWait,
   };
 
@@ -991,6 +998,11 @@ class _Lexer {
     Token.commandLocal,
     Token.commandSet,
     Token.commandWait,
+  };
+
+  static final Set<Token> nodeTargetingCommands = {
+    Token.commandJump,
+    Token.commandVisit,
   };
 
   /// Throws a [SyntaxError] with the given [message], augmenting it with the

--- a/packages/flame_jenny/jenny/lib/src/structure/commands/visit_command.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/commands/visit_command.dart
@@ -1,0 +1,17 @@
+import 'package:jenny/src/dialogue_runner.dart';
+import 'package:jenny/src/structure/commands/command.dart';
+import 'package:jenny/src/structure/expressions/expression.dart';
+
+class VisitCommand extends Command {
+  VisitCommand(this.target);
+
+  final StringExpression target;
+
+  @override
+  Future<void> execute(DialogueRunner dialogue) {
+    return dialogue.visitNode(target.value);
+  }
+
+  @override
+  String get name => 'visit';
+}

--- a/packages/flame_jenny/jenny/test/dialogue_view_test.dart
+++ b/packages/flame_jenny/jenny/test/dialogue_view_test.dart
@@ -52,6 +52,62 @@ void main() {
       );
     });
 
+    test('jumps and visits', () async {
+      final yarn = YarnProject()
+        ..parse(
+          dedent('''
+            title: Start
+            ---
+            First line
+            <<visit AnotherNode>>
+            Second line
+            <<jump SomewhereElse>>
+            ===
+            title: AnotherNode
+            ---
+            Inside another node
+            <<jump SomewhereElse>>
+            ===
+            title: SomewhereElse
+            ---
+            This is nowhere...
+            ===
+          '''),
+        );
+      final view1 = _DefaultDialogueView();
+      final view2 = _RecordingDialogueView();
+      final dialogueRunner = DialogueRunner(
+        yarnProject: yarn,
+        dialogueViews: [view1, view2],
+      );
+      await dialogueRunner.startDialogue('Start');
+      expect(
+        view2.events,
+        const [
+          'onDialogueStart',
+          'onNodeStart(Start)',
+          'onLineStart(First line)',
+          'onLineFinish(First line)',
+          'onNodeStart(AnotherNode)',
+          'onLineStart(Inside another node)',
+          'onLineFinish(Inside another node)',
+          'onNodeFinish(AnotherNode)',
+          'onNodeStart(SomewhereElse)',
+          'onLineStart(This is nowhere...)',
+          'onLineFinish(This is nowhere...)',
+          'onNodeFinish(SomewhereElse)',
+          'onLineStart(Second line)',
+          'onLineFinish(Second line)',
+          'onNodeFinish(Start)',
+          'onNodeStart(SomewhereElse)',
+          'onLineStart(This is nowhere...)',
+          'onLineFinish(This is nowhere...)',
+          'onNodeFinish(SomewhereElse)',
+          'onDialogueFinish()',
+        ],
+      );
+    });
+
     test('stop line', () async {
       final yarn = YarnProject()
         ..parse(

--- a/packages/flame_jenny/jenny/test/parse/token_test.dart
+++ b/packages/flame_jenny/jenny/test/parse/token_test.dart
@@ -9,6 +9,7 @@ void main() {
       expect('${Token.colon}', 'Token.colon');
       expect('${Token.commandEndif}', 'Token.commandEndif');
       expect('${Token.commandLocal}', 'Token.commandLocal');
+      expect('${Token.commandVisit}', 'Token.commandVisit');
       expect('${Token.constTrue}', 'Token.constTrue');
       expect('${Token.endIndent}', 'Token.endIndent');
       expect('${Token.endMarkupTag}', 'Token.endMarkupTag');

--- a/packages/flame_jenny/jenny/test/structure/commands/jump_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/jump_command_test.dart
@@ -80,7 +80,7 @@ void main() {
             '===\n',
           ),
         hasSyntaxError(
-          'SyntaxError: an ID or an expression expected\n'
+          'SyntaxError: an ID or an expression in curly braces expected\n'
           '>  at line 3 column 8:\n'
           '>  <<jump 1>>\n'
           '>         ^\n',

--- a/packages/flame_jenny/jenny/test/structure/commands/visit_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/visit_command_test.dart
@@ -1,0 +1,35 @@
+
+import 'package:jenny/src/parse/token.dart';
+import 'package:jenny/src/parse/tokenize.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('VisitCommand', () {
+    test('tokenize bare-word node target', () {
+      expect(
+        tokenize('<<visit WhiteHouse>>'),
+        const [
+          Token.startCommand,
+          Token.commandVisit,
+          Token.id('WhiteHouse'),
+          Token.endCommand,
+        ],
+      );
+    });
+
+    test('tokenize expression node target', () {
+      expect(
+        tokenize(r'<<visit {$destination}>>'),
+        const [
+          Token.startCommand,
+          Token.commandVisit,
+          Token.startExpression,
+          Token.variable(r'$destination'),
+          Token.endExpression,
+          Token.endCommand,
+        ],
+      );
+    });
+
+  });
+}

--- a/packages/flame_jenny/jenny/test/structure/commands/visit_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/visit_command_test.dart
@@ -1,7 +1,11 @@
-
+import 'package:jenny/jenny.dart';
 import 'package:jenny/src/parse/token.dart';
 import 'package:jenny/src/parse/tokenize.dart';
+import 'package:jenny/src/structure/commands/visit_command.dart';
 import 'package:test/test.dart';
+
+import '../../test_scenario.dart';
+import '../../utils.dart';
 
 void main() {
   group('VisitCommand', () {
@@ -31,5 +35,189 @@ void main() {
       );
     });
 
+    test('<<visit>> command parsing', () {
+      final yarn = YarnProject()
+        ..variables.setVariable(r'$target', 'Y')
+        ..parse('title:A\n---\n'
+            '<<visit X>>\n'
+            '<<visit {\$target}>>\n'
+            '===\n');
+      final node = yarn.nodes['A']!;
+      expect(node.lines.length, 2);
+      expect(node.lines[0], isA<VisitCommand>());
+      expect(node.lines[1], isA<VisitCommand>());
+      expect((node.lines[0] as VisitCommand).target.value, 'X');
+      expect((node.lines[1] as VisitCommand).target.value, 'Y');
+    });
+
+    test('visiting another node', () async {
+      await testScenario(
+        input: '''
+          title: Start
+          ---
+          First line
+          <<visit Second>>
+          Second line
+          ===
+
+          title: Second
+          ---
+          Just visiting!
+          ===
+        ''',
+        testPlan: '''
+          line: First line
+          line: Just visiting!
+          line: Second line
+        ''',
+      );
+    });
+
+    test('nested visits', () async {
+      await testScenario(
+        input: '''
+          title: Start
+          ---
+          Alpha
+          <<visit V1>>
+          Beta
+          <<visit V2>>
+          Gamma
+          ===
+
+          title: V1
+          ---
+          Delta
+          <<visit V2>>
+          Eta
+          ===
+
+          title: V2
+          ---
+          <<visit V3>>
+          Omega
+          ===
+
+          title: V3
+          ---
+          Rho
+          ===
+        ''',
+        testPlan: '''
+          line: Alpha
+          line: Delta
+          line: Rho
+          line: Omega
+          line: Eta
+          line: Beta
+          line: Rho
+          line: Omega
+          line: Gamma
+        ''',
+      );
+    });
+
+    test('visit node from expression', () async {
+      await testScenario(
+        input: r'''
+          title: Start
+          ---
+          <<local $index = 2>>
+          Line before
+          <<visit {"Destination" + "_" + string($index)}>>
+          Line after
+          ===
+          ---
+          title: Destination_2
+          ---
+          Here
+          ===
+        ''',
+        testPlan: '''
+          line: Line before
+          line: Here
+          line: Line after
+        ''',
+      );
+    });
+
+    test('visit node with jumps', () async {
+      await testScenario(
+        input: '''
+          title: Start
+          ---
+          First line of <Start> node
+          <<visit Another>>
+          And we're back in the <Start> node
+          ===
+          --------------
+          title: Another
+          --------------
+          Inside <Another> node
+          <<jump Somewhere>>
+          This line shouldn't be seen...
+          ===
+          ----------------
+          title: Somewhere
+          ----------------
+          Reached <Somewhere> node
+          <<stop>>
+          ERROR!
+          ===
+        ''',
+        testPlan: '''
+          line: First line of <Start> node
+          line: Inside <Another> node
+          line: Reached <Somewhere> node
+          line: And we're back in the <Start> node
+        ''',
+      );
+    });
+
+    group('errors', () {
+      test('<<visit>> at root level', () {
+        expect(
+          () => YarnProject()..parse('<<visit Start>>\n'),
+          hasTypeError(
+            'TypeError: command <<visit>> is only allowed inside nodes\n'
+            '>  at line 1 column 1:\n'
+            '>  <<visit Start>>\n'
+            '>  ^\n',
+          ),
+        );
+      });
+
+      test('<<visit>> invalid syntax', () {
+        expect(
+          () => YarnProject()
+            ..parse(
+              'title:A\n---\n'
+              '<<visit "Target_\$index">>\n'
+              '===\n',
+            ),
+          hasSyntaxError(
+            'SyntaxError: an ID or an expression in curly braces expected\n'
+            '>  at line 3 column 9:\n'
+            '>  <<visit "Target_\$index">>\n'
+            '>          ^\n',
+          ),
+        );
+      });
+
+      test('<<visit>> with unknown destination', () async {
+        final yarn = YarnProject()
+          ..parse(
+            'title: A\n'
+            '---\n'
+            '<<visit Somewhere>>\n'
+            '===\n',
+          );
+        expect(
+          () => DialogueRunner(yarnProject: yarn, dialogueViews: [])
+              .startDialogue('A'),
+          hasNameError('NameError: Node "Somewhere" could not be found'),
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
# Description

The functionality of the `<<visit Target>>` command is that the dialogue runner will temporarily suspend execution of the current node and start executing Target, but then once that finishes it will resume executing the original node.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.



<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
