### PR TITLE
feat: OnDialogueChoice now returns null by default

### DIFF
--- a/doc/other_modules/jenny/runtime/dialogue_view.md
+++ b/doc/other_modules/jenny/runtime/dialogue_view.md
@@ -116,9 +116,11 @@ simultaneously).
 
   An error will be thrown if:
 
+  <!-- markdownlint-disable MD006 MD007 -->
   - None of the views return a valid selection (i.e. all return `null`);
   - The returned index is invalid for the `choice` list;
   - The selected option is marked as disabled.
+  <!-- markdownlint-enable MD006 MD007 -->
 
 **onChoiceFinish**(`DialogueOption option`)
 : Called when the choice has been made, and an [option] has been selected.

--- a/doc/other_modules/jenny/runtime/dialogue_view.md
+++ b/doc/other_modules/jenny/runtime/dialogue_view.md
@@ -106,11 +106,22 @@ simultaneously).
   Some dialogue views may need to clear their display when this event happens, or make some other
   preparations to receive the next dialogue line.
 
-**onChoiceStart**(`DialogueChoice choice`) `-> int`
-: TODO
+**onChoiceStart**(`DialogueChoice choice`) → `FutureOr<int?>`
+: Called when the dialogue enters a [choice]: the player needs to select among several presented
+  [option]s.
+
+  This callback is invoked on all dialogue views, however, normally only one of them should be
+  making a selection. A view that performs the actual selection should return a future that resolves
+  with the index of the chosen option; all other views should return `null`.
+
+  An error will be thrown if:
+
+  - None of the views return a valid selection (i.e. all return `null`);
+  - The returned index is invalid for the `choice` list;
+  - The selected option is marked as disabled.
 
 **onChoiceFinish**(`DialogueOption option`)
-: Called when the choice has been made, and the [option] has been selected.
+: Called when the choice has been made, and an [option] has been selected.
 
   The `option` will be the one returned from the **onChoiceStart** method by one of the dialogue
   views.
@@ -130,6 +141,7 @@ simultaneously).
 [DialogueRunner]: dialogue_runner.md
 [Node]: node.md
 [YarnProject]: yarn_project.md
+[choice]: dialogue_choice.md
 [command]: user_defined_command.md
 [line]: dialogue_line.md
 [option]: dialogue_option.md

--- a/packages/flame_jenny/jenny/lib/src/dialogue_view.dart
+++ b/packages/flame_jenny/jenny/lib/src/dialogue_view.dart
@@ -132,20 +132,14 @@ abstract class DialogueView {
   /// make a choice on how to proceed. If a dialogue view presents this choice
   /// to the player and allows them to make a selection, then it must return a
   /// future that completes when the choice is made. If the dialogue view does
-  /// not display menu choice, then it should return a future that never
-  /// completes (which is the default implementation).
-  ///
-  /// The dialogue runner will assume the choice has been made whenever any of
-  /// the dialogue views will have completed their futures. If none of the
-  /// dialogue views are capable of making a choice, then the dialogue will get
-  /// stuck.
+  /// not display menu choice, then it should return `null`.
   ///
   /// The future returned by this method should deliver an integer value of the
   /// index of the option that was selected. This index must not exceed the
   /// length of the [choice] list, and the indicated option must not be marked
   /// as "unavailable". If these conditions are violated, an exception will be
   /// raised.
-  Future<int> onChoiceStart(DialogueChoice choice) => never;
+  FutureOr<int?> onChoiceStart(DialogueChoice choice) => null;
 
   /// Called when the choice has been made, and the [option] was selected.
   ///
@@ -158,8 +152,4 @@ abstract class DialogueView {
   /// If this method returns a future, the dialogue runner will wait for that
   /// future to complete before proceeding with the dialogue.
   FutureOr<void> onCommand(UserDefinedCommand command) {}
-
-  /// A future that never completes.
-  @internal
-  static Future<Never> never = Completer<Never>().future;
 }

--- a/packages/flame_jenny/jenny/test/dialogue_runner_test.dart
+++ b/packages/flame_jenny/jenny/test/dialogue_runner_test.dart
@@ -194,9 +194,7 @@ void main() {
       );
       expect(
         () => dialogue.startDialogue('A'),
-        hasDialogueError(
-          'No dialogue views capable of making a dialogue choice',
-        ),
+        hasDialogueError('No option selected in a DialogueChoice'),
       );
     });
 


### PR DESCRIPTION
# Description

Previously, `onDialogueChoice` was returning a never-completing future, which is both more error-prone, and prevents a use-case where a dialogue view would perform some async action without ultimately making a selection.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.


## Breaking Change?

- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2216


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
