### PR TITLE
docs: BodyComponents should not be nested

### DIFF
--- a/doc/bridge_packages/flame_forge2d/forge2d.md
+++ b/doc/bridge_packages/flame_forge2d/forge2d.md
@@ -63,8 +63,8 @@ useful if you want to add for example animations or other components on top of y
 The body that you create in `createBody` should be defined according to Flame's coordinate system,
 not according to the coordinate system of Forge2D (where the Y-axis is flipped).
 
-:exclamation: In Forge2D (you shouldn't add any bodies as children to other components.
-Forge2D doesn't have a concept of nested bodies.
+:exclamation: In Forge2D you shouldn't add any bodies as children to other components,
+since Forge2D doesn't have a concept of nested bodies.
 So bodies should live on the top level in the physics world.
 Consequently, below is **wrong**
 

--- a/doc/bridge_packages/flame_forge2d/forge2d.md
+++ b/doc/bridge_packages/flame_forge2d/forge2d.md
@@ -91,7 +91,6 @@ So instead of `add(Bullet()))`, `parent?.add(Bullet())` should be used (as bello
 
 ```dart
 class Player extends BodyComponent  {
-
   @override
   Future<void> onLoad() async {
     parent?.add(Bullet());

--- a/doc/bridge_packages/flame_forge2d/forge2d.md
+++ b/doc/bridge_packages/flame_forge2d/forge2d.md
@@ -66,7 +66,7 @@ not according to the coordinate system of Forge2D (where the Y-axis is flipped).
 :exclamation: In Forge2D you shouldn't add any bodies as children to other components,
 since Forge2D doesn't have a concept of nested bodies.
 So bodies should live on the top level in the physics world.
-Consequently, below is **wrong**
+Instead of `add(Bullet()))`, `parent?.add(Bullet())` should be used (as bellow).
 
 ```dart
 class Bullet extends BodyComponent  {
@@ -78,17 +78,6 @@ class Bullet extends BodyComponent  {
   }
 }
 
-class Player extends BodyComponent  {
-  @override
-  Future<void> onLoad() async {
-    add(Bullet());
-  }
-}
-```
-
-So instead of `add(Bullet()))`, `parent?.add(Bullet())` should be used (as bellow).
-
-```dart
 class Player extends BodyComponent  {
   @override
   Future<void> onLoad() async {

--- a/doc/bridge_packages/flame_forge2d/forge2d.md
+++ b/doc/bridge_packages/flame_forge2d/forge2d.md
@@ -70,7 +70,6 @@ Consequently, below is **wrong**
 
 ```dart
 class Bullet extends BodyComponent  {
-
   @override
   Future<void> onLoad() async {
     ...

--- a/doc/bridge_packages/flame_forge2d/forge2d.md
+++ b/doc/bridge_packages/flame_forge2d/forge2d.md
@@ -63,6 +63,42 @@ useful if you want to add for example animations or other components on top of y
 The body that you create in `createBody` should be defined according to Flame's coordinate system,
 not according to the coordinate system of Forge2D (where the Y-axis is flipped).
 
+:exclamation: In Forge2D (you shouldn't add any bodies as children to other components.
+Forge2D doesn't have a concept of nested bodies.
+So bodies should live on the top level in the physics world.
+Consequently, below is **wrong**
+
+```dart
+class Bullet extends BodyComponent  {
+
+  @override
+  Future<void> onLoad() async {
+    ...
+    isBullet = true;
+    ...
+  }
+}
+
+class Player extends BodyComponent  {
+  @override
+  Future<void> onLoad() async {
+    add(Bullet());
+  }
+}
+```
+
+So instead of `add(Bullet()))`, `parent?.add(Bullet())` should be used (as bellow).
+
+```dart
+class Player extends BodyComponent  {
+
+  @override
+  Future<void> onLoad() async {
+    parent?.add(Bullet());
+  }
+}
+```
+
 
 ## Contact callbacks
 


### PR DESCRIPTION
Forge2D/Box2D doesn't have a concept of nested bodies and all bodies should live on a top level in the physics world. However, it's hard to know this for people who stat with Forge2d right away. It would be nice to have it clearly mentioned in the documentations.

Closes #2240