### PR TITLE
docs: Fix broken markdown on docs readme file

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -53,8 +53,9 @@ There is a set of tutorials that you can follow to get started in the
 Simple examples for all features can be found in the
 [examples folder](https://github.com/flame-engine/flame/tree/main/examples).
 
-You can also check out the [awesome flame repository], it contains quite a lot of good tutorials and
-articles written by the community to get you started with Flame.
+You can also check out the 
+[awesome flame repository](https://github.com/flame-engine/awesome-flame#user-content-articles--tutorials), 
+it contains quite a lot of good tutorials and articles written by the community to get you started with Flame.
 
 
 ## Outside of the scope of the engine
@@ -89,6 +90,3 @@ Here are some suggestions for http client packages:
 
 - [http](https://pub.dev/packages/http): A simple package for performing http requests.
 - [Dio](https://pub.dev/packages/dio): A popular and powerful package for performing http requests.
-
-[awesome flame
-repository](https://github.com/flame-engine/awesome-flame#user-content-articles--tutorials)

--- a/doc/README.md
+++ b/doc/README.md
@@ -53,9 +53,10 @@ There is a set of tutorials that you can follow to get started in the
 Simple examples for all features can be found in the
 [examples folder](https://github.com/flame-engine/flame/tree/main/examples).
 
-You can also check out the 
-[awesome flame repository](https://github.com/flame-engine/awesome-flame#user-content-articles--tutorials), 
-it contains quite a lot of good tutorials and articles written by the community to get you started with Flame.
+You can also check out the [awesome flame
+repository](https://github.com/flame-engine/awesome-flame#user-content-articles--tutorials),
+it contains quite a lot of good tutorials and articles written by the community
+to get you started with Flame.
 
 
 ## Outside of the scope of the engine


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/882703/210155162-610ef923-95d6-42f8-9fc5-76c30edafb69.png)


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
