### PR TITLE
docs: Add warning to version-specific docunmentation pages

### DIFF
--- a/doc/_sphinx/scripts/versions.js
+++ b/doc/_sphinx/scripts/versions.js
@@ -33,8 +33,13 @@ function convertVersionsToHtmlLinks(versionsList, currentVersion) {
   return out;
 }
 
-function maybeAddWarning(currentVersion) {
-  if (currentVersion !== 'main') {
+function maybeAddWarning(versions, currentVersion) {
+  const specialVersions = ['main', 'local'];
+  const latestVersion = versions.filter(e => !specialVersions.includes(e))[0];
+  const nonWarningVersions = [...specialVersions, latestVersion];
+  const showWarning = !nonWarningVersions.includes(currentVersion);
+  console.log(nonWarningVersions, showWarning);
+  if (showWarning) {
     $('#version-warning')
       .find('.version').text(currentVersion).end()
       .removeClass('hidden');
@@ -42,8 +47,9 @@ function maybeAddWarning(currentVersion) {
 }
 
 function buildVersionsMenu(data) {
+  const versions = data.split('\n');
   const currentVersion = getCurrentDocVersion();
-  const versionButtons = convertVersionsToHtmlLinks(data.split('\n'), currentVersion);
+  const versionButtons = convertVersionsToHtmlLinks(versions, currentVersion);
   $('div.versions-placeholder').append(`
     <div id="versions-menu" tabindex="-1">
       <div class="btn">
@@ -63,7 +69,7 @@ function buildVersionsMenu(data) {
     setTimeout(() => $(this).removeClass("active"), 200);
   });
 
-  maybeAddWarning(currentVersion);
+  maybeAddWarning(versions, currentVersion);
 }
 
 // Start loading the versions list as soon as possible, don't wait for DOM

--- a/doc/_sphinx/scripts/versions.js
+++ b/doc/_sphinx/scripts/versions.js
@@ -33,6 +33,14 @@ function convertVersionsToHtmlLinks(versionsList, currentVersion) {
   return out;
 }
 
+function maybeAddWarning(currentVersion) {
+  if (currentVersion !== 'main') {
+    $('#version-warning')
+      .find('.version').text(currentVersion).end()
+      .removeClass('hidden');
+  }
+}
+
 function buildVersionsMenu(data) {
   const currentVersion = getCurrentDocVersion();
   const versionButtons = convertVersionsToHtmlLinks(data.split('\n'), currentVersion);
@@ -54,6 +62,8 @@ function buildVersionsMenu(data) {
     // A timeout ensures that `click` can propagate to child <A/> elements.
     setTimeout(() => $(this).removeClass("active"), 200);
   });
+
+  maybeAddWarning(currentVersion);
 }
 
 // Start loading the versions list as soon as possible, don't wait for DOM

--- a/doc/_sphinx/scripts/versions.js
+++ b/doc/_sphinx/scripts/versions.js
@@ -38,7 +38,6 @@ function maybeAddWarning(versions, currentVersion) {
   const latestVersion = versions.filter(e => !specialVersions.includes(e))[0];
   const nonWarningVersions = [...specialVersions, latestVersion];
   const showWarning = !nonWarningVersions.includes(currentVersion);
-  console.log(nonWarningVersions, showWarning);
   if (showWarning) {
     $('#version-warning')
       .find('.version').text(currentVersion).end()

--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -473,6 +473,24 @@ div.document-wrapper {
   margin-top: 25px;
 }
 
+div.warning {
+  background: #9b6814;
+  color: white;
+  border-radius: 2pt;
+  box-shadow: 2px 2px 3px #ffc43c;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+div.warning .version {
+  font-style: italic;
+  text-decoration: dashed underline;
+}
+
+.hidden {
+  display: none;
+}
+
 div.document {
   background-color: #282828;
   color: #b0b0b0;

--- a/doc/_sphinx/theme/layout.html
+++ b/doc/_sphinx/theme/layout.html
@@ -125,9 +125,10 @@
 <div class="main-area">
   <div class="document-wrapper">
     <div class="warning hidden" id="version-warning">
-      <p><strong>Warning:</strong> you are currently viewing the docs for a specific
+      <p><strong>Warning:</strong> you are currently viewing the docs for an older
       version <span class="version"></span> of Flame.</p>
-      <p>Please <a href="/main">click here</a> to go see the most up-to-date documentation.</p>
+      <p>Please <a href="/">click here</a> to go see the documentation for the latest
+      released version.</p>
     </div>
     <div class="document" role="main">
       {% block body %} {% endblock %}

--- a/doc/_sphinx/theme/layout.html
+++ b/doc/_sphinx/theme/layout.html
@@ -124,6 +124,11 @@
 
 <div class="main-area">
   <div class="document-wrapper">
+    <div class="warning hidden" id="version-warning">
+      <p><strong>Warning:</strong> you are currently viewing the docs for a specific
+      version <span class="version"></span> of Flame.</p>
+      <p>Please <a href="/main">click here</a> to go see the most up-to-date documentation.</p>
+    </div>
     <div class="document" role="main">
       {% block body %} {% endblock %}
     </div>


### PR DESCRIPTION
# Description

See details on issue #2214
Basically, we want to make users more aware they are looking at old version of the docs.

![image](https://user-images.githubusercontent.com/882703/210159642-008ccf39-2d26-48cb-8f51-a65ee72a90fe.png)


## Checklist

- [X] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Related Issues

Fixes #2214

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
