### PR TITLE
docs: Add Flame Zapp link to bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug.md
+++ b/.github/ISSUE_TEMPLATE/1_bug.md
@@ -19,7 +19,7 @@ assignees: ''
 # Steps to reproduce
 <!-- This one is very important, please be very precise in how we can reproduce this bug -->
 <!-- If possible please report steps based on the example from this plugin! -->
-<!-- If you can make a minimal reproducible example it is incredibly helpful, the simplest is to share a link to https://zapp.run, you can start from https://zapp.run/edit/flame-zh006agh106 where all dependencies are already set up. -->
+<!-- If you can make a minimal reproducible example it is incredibly helpful, the simplest is to share a link to https://zapp.run, you can start from https://zapp.run/edit/flame where all dependencies are already set up. -->
 
 # Flutter doctor output
 <!-- Execute in a terminal and put output into code block below -->

--- a/.github/ISSUE_TEMPLATE/1_bug.md
+++ b/.github/ISSUE_TEMPLATE/1_bug.md
@@ -19,6 +19,7 @@ assignees: ''
 # Steps to reproduce
 <!-- This one is very important, please be very precise in how we can reproduce this bug -->
 <!-- If possible please report steps based on the example from this plugin! -->
+<!-- If you can make a minimal reproducible example it is incredibly helpful, the simplest is to share a link to https://zapp.run, you can start from https://zapp.run/edit/flame-zh006agh106 where all dependencies are already set up. -->
 
 # Flutter doctor output
 <!-- Execute in a terminal and put output into code block below -->

--- a/.github/ISSUE_TEMPLATE/1_bug.md
+++ b/.github/ISSUE_TEMPLATE/1_bug.md
@@ -19,7 +19,7 @@ assignees: ''
 # Steps to reproduce
 <!-- This one is very important, please be very precise in how we can reproduce this bug -->
 <!-- If possible please report steps based on the example from this plugin! -->
-<!-- If you can make a minimal reproducible example it is incredibly helpful, the simplest is to share a link to https://zapp.run, you can start from https://zapp.run/edit/flame where all dependencies are already set up. -->
+<!-- If you can make a minimal reproducible example it is incredibly helpful, the simplest way is to share a link to https://zapp.run, you can start from https://zapp.run/edit/flame where all dependencies are already set up. -->
 
 # Flutter doctor output
 <!-- Execute in a terminal and put output into code block below -->


### PR DESCRIPTION
# Description

Adds a link to https://zapp.run/edit/flame-zh006agh106 in the issue template, since Flame is already set up in there it is incredibly easy to share and run MREs from there.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
