### PR TITLE
docs: Update example to not create Rect objects

### DIFF
--- a/packages/flame/example/lib/main.dart
+++ b/packages/flame/example/lib/main.dart
@@ -1,8 +1,8 @@
 import 'dart:math' as math;
 
 import 'package:flame/components.dart';
+import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 import 'package:flame/palette.dart';
 import 'package:flutter/material.dart';
 
@@ -17,38 +17,36 @@ void main() {
 /// This example simply adds a rotating white square on the screen.
 /// If you press on a square, it will be removed.
 /// If you press anywhere else, another square will be added.
-class MyGame extends FlameGame with HasTappables {
+class MyGame extends FlameGame with HasTappableComponents {
   @override
   Future<void> onLoad() async {
-    add(Square(Vector2(100, 200)));
+    add(Square(size / 2));
   }
 
   @override
-  void onTapUp(int id, TapUpInfo info) {
-    super.onTapUp(id, info);
-    if (!info.handled) {
-      final touchPoint = info.eventPosition.game;
+  void onTapDown(TapDownEvent event) {
+    super.onTapDown(event);
+    if (!event.handled) {
+      final touchPoint = event.canvasPosition;
       add(Square(touchPoint));
     }
   }
 }
 
-class Square extends PositionComponent with Tappable {
-  static const speed = 0.25;
+class Square extends RectangleComponent with TapCallbacks {
+  static const speed = 3;
   static const squareSize = 128.0;
+  static const indicatorSize = 6.0;
 
-  static Paint white = BasicPalette.white.paint();
   static Paint red = BasicPalette.red.paint();
   static Paint blue = BasicPalette.blue.paint();
 
-  Square(Vector2 position) : super(position: position);
-
-  @override
-  void render(Canvas c) {
-    c.drawRect(size.toRect(), white);
-    c.drawRect(const Rect.fromLTWH(0, 0, 3, 3), red);
-    c.drawRect(Rect.fromLTWH(width / 2, height / 2, 3, 3), blue);
-  }
+  Square(Vector2 position)
+      : super(
+          position: position,
+          size: Vector2.all(squareSize),
+          anchor: Anchor.center,
+        );
 
   @override
   void update(double dt) {
@@ -60,14 +58,25 @@ class Square extends PositionComponent with Tappable {
   @override
   Future<void> onLoad() async {
     super.onLoad();
-    size.setValues(squareSize, squareSize);
-    anchor = Anchor.center;
+    add(
+      RectangleComponent(
+        size: Vector2.all(indicatorSize),
+        paint: blue,
+      ),
+    );
+    add(
+      RectangleComponent(
+        position: size / 2,
+        size: Vector2.all(indicatorSize),
+        anchor: Anchor.center,
+        paint: red,
+      ),
+    );
   }
 
   @override
-  bool onTapUp(TapUpInfo info) {
+  void onTapDown(TapDownEvent event) {
     removeFromParent();
-    info.handled = true;
-    return true;
+    event.handled = true;
   }
 }


### PR DESCRIPTION
# Description

We shouldn't teach our users to create new `Rect` objects in `render`.
Also switching to `onTapDown` since `onTapUp` won't trigger if you move the mouse since it'll be a drag event instead.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
