### PR TITLE
perf: Avoid Vector2 creation in `Sprite.render`

### DIFF
--- a/packages/flame/lib/src/sprite.dart
+++ b/packages/flame/lib/src/sprite.dart
@@ -107,11 +107,7 @@ class Sprite {
       _tmpRenderPosition.setZero();
     }
 
-    if (size != null) {
-      _tmpRenderSize.setFrom(size);
-    } else {
-      _tmpRenderSize.setFrom(srcSize);
-    }
+    _tmpRenderSize.setFrom(size ?? srcSize);
 
     _tmpRenderPosition.setValues(
       _tmpRenderPosition.x - (anchor.x * _tmpRenderSize.x),

--- a/packages/flame/lib/src/sprite.dart
+++ b/packages/flame/lib/src/sprite.dart
@@ -82,8 +82,8 @@ class Sprite {
   }
 
   // Used to avoid the creation of new Vector2 objects in render.
-  late final _tmpRenderPosition = Vector2.zero();
-  late final _tmpRenderSize = Vector2.zero();
+  static final _tmpRenderPosition = Vector2.zero();
+  static final _tmpRenderSize = Vector2.zero();
 
   /// Renders this sprite onto the [canvas].
   ///

--- a/packages/flame/lib/src/sprite.dart
+++ b/packages/flame/lib/src/sprite.dart
@@ -81,6 +81,10 @@ class Sprite {
     );
   }
 
+  // Used to avoid the creation of new Vector2 objects in render.
+  late final _tmpRenderPosition = Vector2.zero();
+  late final _tmpRenderSize = Vector2.zero();
+
   /// Renders this sprite onto the [canvas].
   ///
   /// * [position]: x,y coordinates where it will be drawn; default to origin.
@@ -97,18 +101,30 @@ class Sprite {
     Anchor anchor = Anchor.topLeft,
     Paint? overridePaint,
   }) {
-    final drawPosition = position ?? Vector2.zero();
-    final drawSize = size ?? srcSize;
+    if (position != null) {
+      _tmpRenderPosition.setFrom(position);
+    } else {
+      _tmpRenderPosition.setZero();
+    }
 
-    final delta = anchor.toVector2()..multiply(drawSize);
-    final drawRect = (drawPosition - delta).toPositionedRect(drawSize);
+    if (size != null) {
+      _tmpRenderSize.setFrom(size);
+    } else {
+      _tmpRenderSize.setFrom(srcSize);
+    }
 
+    _tmpRenderPosition.setValues(
+      _tmpRenderPosition.x - (anchor.x * _tmpRenderSize.x),
+      _tmpRenderPosition.y - (anchor.y * _tmpRenderSize.y),
+    );
+
+    final drawRect = _tmpRenderPosition.toPositionedRect(_tmpRenderSize);
     final drawPaint = overridePaint ?? paint;
 
     canvas.drawImageRect(image, src, drawRect, drawPaint);
   }
 
-  /// Return a new Image based on the [src] of the Sprite.
+  /// Return a new [Image] based on the [src] of the Sprite.
   ///
   /// **Note:** This is a heavy async operation and should not be called inside
   /// the game loop. Remember to call dispose on the [Image] object once you


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description

This creates two new private vector2 objects that can be re-used inside of `Sprite.render` so that we don't have to create new objects in there.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
