### PR TITLE
style: Properly collapse left-side menu on the docs site

### DIFF
--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -317,7 +317,6 @@ div.nav-left ul {
   padding: 0 0 0 16px;
 }
 
-div.nav-left ul.current,
 div.nav-left > ul {
   display: block;
 }


### PR DESCRIPTION
# Description

Currently if you navigate to any inner page on the documentation site, say https://docs.flame-engine.org/main/tutorials/platformer/step_5.html, then the menus on the left that are currently collapsed can be expanded, but those that are already expanded cannot be collapsed (try clicking on the arrow next to "Tutorials" or "Ember Quest"). This PR fixes that.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.


## Breaking Change?

Hopefully not.
