### PR TITLE
feat: Added the <<character>> command to Jenny

### DIFF
--- a/doc/_sphinx/extensions/yarn_lexer.py
+++ b/doc/_sphinx/extensions/yarn_lexer.py
@@ -152,7 +152,7 @@ class YarnLexer(RegexLexer):
             (r'\$\w+', Name.Variable),
             (r'([+\-*/%><=]=?)', Operator),
             (r'\d+(?:\.\d+)?(?:[eE][+\-]?\d+)?', Number),
-            (r'[(),]', Punctuation),
+            (r'[(),]|\.\.\.', Punctuation),
             (r'"', String.Delimeter, 'string'),
             (r'\w+', Name.Function),
             (r'.', Error),

--- a/doc/other_modules/jenny/language/commands/character.md
+++ b/doc/other_modules/jenny/language/commands/character.md
@@ -1,0 +1,60 @@
+# `<<character>>`
+
+The **\<\<character\>\>** command declares a character with the given name, and one or more aliases
+that can be used in the scripts.
+
+The command has several purposes:
+
+- it protects you from accidentally misspelling a character's name in your script;
+- it allows a character to have *full name*, which doesn't have to be an ID;
+- it allows declaring multiple aliases for the same character, which can be used in different
+  nodes (an alias may even be in a different language than the full name);
+- you can associate additional data with each character, which will then be available at runtime.
+
+This format of this command is the following:
+
+```yarn
+<<character "FULL NAME" alias1 alias2...>>
+```
+
+The *full name* here is optional: if optional, it will be considered *the* name of the character.
+However, if the name is omitted then the first alias will be considered the true character's name.
+Each *alias* must be a valid ID, and at least one alias must be provided. For example:
+
+```yarn
+// A well-mannered seven-year-old girl, who nevertheless always gets into
+// all kinds of zany adventures.
+<<character Alice>>
+
+// A magical cat known for his ability to grin majestically, and partially
+// vanish. He is mad (by his own admission).
+<<character "Cheshire Cat" Cat Cheshire>>
+
+// A foul-tempered Queen, who is also a playing card. Described as
+// "a blind fury", her favorite saying is "Off with their heads!".
+// Not to be confused with Red Queen.
+<<character "Queen of Hearts" Queen QoH QH>>
+```
+
+After a character is declared, any of its aliases can be used in the script: they will all refer
+to the same `Character` object. At the same time, using a character without declaring it first is
+not allowed (unless a special flag in `YarnProject` is set to allow this).
+
+```yarn
+title: Alice_and_the_Cat
+---
+Alice: But I don't want to go among mad people.
+Cat:   Oh, you can't help that, we're all mad here. I'm mad. You're mad.
+Alice: How do you know I'm mad?
+Cat:   You must be, or you wouldn't have come here.
+Alice: And how do you know that you're mad?
+Cat:   To begin with, a dog's not mad. You grant that?
+Alice: I suppose so.
+Cat:   Well then, you see a dog growls when it's angry, and wags its tail \
+       when it's pleased.
+Cat:   Now, [i]I[/i] growl when I'm pleased, and wag my tail when I'm angry. \
+       Therefore, I'm mad.
+Alice: [i]I[/i] call it purring, not growling.
+Cat:   Call it what you like.
+===
+```

--- a/doc/other_modules/jenny/language/commands/character.md
+++ b/doc/other_modules/jenny/language/commands/character.md
@@ -11,14 +11,14 @@ The command has several purposes:
   nodes (an alias may even be in a different language than the full name);
 - you can associate additional data with each character, which will then be available at runtime.
 
-This format of this command is the following:
+The format of this command is the following:
 
 ```yarn
 <<character "FULL NAME" alias1 alias2...>>
 ```
 
-The *full name* here is optional: if optional, it will be considered *the* name of the character.
-However, if the name is omitted then the first alias will be considered the true character's name.
+The *full name* here is optional: if given, it will be considered *the* name of the character.
+However, if the name is omitted, then the first alias will be considered the true character's name.
 Each *alias* must be a valid ID, and at least one alias must be provided. For example:
 
 ```yarn

--- a/doc/other_modules/jenny/language/commands/commands.md
+++ b/doc/other_modules/jenny/language/commands/commands.md
@@ -16,6 +16,9 @@ scripts. For a full description of these commands, see the document on [user-def
 
 ### Variables
 
+**[\<\<character\>\>](character.md)**
+: Declares a character (person).
+
 **[\<\<declare\>\>](declare.md)**
 : Declares a global variable.
 
@@ -50,6 +53,7 @@ scripts. For a full description of these commands, see the document on [user-def
 ```{toctree}
 :hidden:
 
+<<character>>          <character.md>
 <<declare>>            <declare.md>
 <<if>>                 <if.md>
 <<jump>>               <jump.md>

--- a/doc/other_modules/jenny/language/lines.md
+++ b/doc/other_modules/jenny/language/lines.md
@@ -188,7 +188,6 @@ This line is so long that it becomes uncomfortable to read in a text editor. \
 ```
 
 
-[\<\<character\>\>]: commands/character.md
 [node body]: nodes.md#body
 [DialogueLine]: ../runtime/dialogue_line.md
 [Expressions]: expressions/expressions.md

--- a/doc/other_modules/jenny/language/lines.md
+++ b/doc/other_modules/jenny/language/lines.md
@@ -15,9 +15,6 @@ in a [node body]. A line may contain the following elements:
 
 A **line** is represented with the [DialogueLine] class in Jenny runtime.
 
-[node body]: nodes.md#body
-[DialogueLine]: ../runtime/dialogue_line.md
-
 
 ## Character ID
 
@@ -62,6 +59,11 @@ Attention\: The cake is NOT a lie
 ===
 ```
 
+```{note}
+All characters must be **declared** using the [\<\<character\>\>] command
+before they can be used in a script.
+```
+
 
 ## Interpolated expressions
 
@@ -101,7 +103,7 @@ further processing. Which means that the text of the expression may contain spec
 (such as `[`, `]`, `{`, `}`, `\`, etc), and they don't need to be escaped. It also means that the
 expression cannot contain markup, or produce a hashtag, etc.
 
-Read more about expressions in the [Expressions](expressions/expressions.md) section.
+Read more about expressions in the [Expressions] section.
 
 
 ## Markup
@@ -122,7 +124,7 @@ additional information attached to the line that shows that the last 17 characte
 the `em` tag.
 
 Markup tags can be nested, or be zero-width, they can also include parameters whose values can be
-dynamic. Read more about this in the [Markup](markup.md) document.
+dynamic. Read more about this in the [Markup] document.
 
 
 ## Hashtags
@@ -184,3 +186,10 @@ This line is so long that it becomes uncomfortable to read in a text editor. \
     text.
 ===
 ```
+
+
+[\<\<character\>\>]: commands/character.md
+[node body]: nodes.md#body
+[DialogueLine]: ../runtime/dialogue_line.md
+[Expressions]: expressions/expressions.md
+[Markup]: markup.md

--- a/doc/other_modules/jenny/runtime/character.md
+++ b/doc/other_modules/jenny/runtime/character.md
@@ -1,0 +1,29 @@
+# Character
+
+A **Character** represents a person who is speaking a particular line in a dialogue. This object
+is available as the `.character` property of a [DialogueLine] delivered to your [DialogueView].
+
+
+## Properties
+
+**name** `String`
+: The canonical name of the character, as declared by the [\<\<character\>\>] command.
+
+**aliases** `List<String>`
+: Additional names (IDs) that may be used for this character in yarn scripts.
+
+**data** `Map<String, dynamic>`
+: Extra information that you can associate with this character. This may include their short bio,
+  portrait, affiliation, color, etc. This information must be stored for each character manually,
+  and then it will be accessible from [DialogueView]s.
+
+
+## See Also
+
+- [CharacterStorage]: the container where all Character objects within a YarnProject are cached.
+
+
+[\<\<character\>\>]: ../language/commands/character.md
+[CharacterStorage]: character_storage.md
+[DialogueView]: dialogue_view.md
+[DialogueLine]: dialogue_line.md

--- a/doc/other_modules/jenny/runtime/character_storage.md
+++ b/doc/other_modules/jenny/runtime/character_storage.md
@@ -1,0 +1,22 @@
+# CharacterStorage
+
+The **CharacterStorage** object is a cache of all [Character]s declared in yarn scripts. Typically,
+this cache will be populated with the help of the [\<\<character\>\>] commands. Adding characters
+manually is possible but not recommended.
+
+
+## Methods
+
+**contains**(`String name`) → `bool`
+: Returns `true` if a character with the given name or alias was defined.
+
+**operator[]**(`String name`) → `Character?`
+: Returns the [Character] object with the given name/alias, or `null` if this character was not
+  defined.
+
+**add**(`Character character`)
+: Adds a new `Character` object into the storage.
+
+
+[\<\<character\>\>]: ../language/commands/character.md
+[Character]: character.md

--- a/doc/other_modules/jenny/runtime/dialogue_line.md
+++ b/doc/other_modules/jenny/runtime/dialogue_line.md
@@ -7,7 +7,7 @@ The **DialogueLine** class represents a single [Line] of text in the `.yarn` scr
 
 ## Properties
 
-**character** `String?`
+**character** `Character?`
 : The name of the character who is speaking the line, or `null` if the line has no speaker.
 
 **text** `String`

--- a/doc/other_modules/jenny/runtime/dialogue_option.md
+++ b/doc/other_modules/jenny/runtime/dialogue_option.md
@@ -25,5 +25,6 @@ options will be grouped into [DialogueChoice] objects.
 **isDisabled** `bool`
 : Same as `!isAvailable`.
 
+
 [Option]: ../language/options.md
 [DialogueChoice]: dialogue_choice.md

--- a/doc/other_modules/jenny/runtime/index.md
+++ b/doc/other_modules/jenny/runtime/index.md
@@ -3,6 +3,8 @@
 ```{toctree}
 :hidden:
 
+Character          <character.md>
+CharacterStorage   <character_storage.md>
 CommandStorage     <command_storage.md>
 DialogueChoice     <dialogue_choice.md>
 DialogueLine       <dialogue_line.md>

--- a/doc/other_modules/jenny/runtime/yarn_project.md
+++ b/doc/other_modules/jenny/runtime/yarn_project.md
@@ -63,6 +63,15 @@ final yarn = YarnProject()
 
   All custom commands must be added before they can be used in the dialogue script.
 
+**characters** `CharacterStorage`
+: The [container][CharacterStorage] for all [Character] objects declared in your yarn scripts.
+
+**strictCharacterNames** `bool`
+: If `true` (default), the validity of character names will be strictly enforced. That is, all
+  characters must be declared before they can be used, using the [\<\<character\>\>] commands. If
+  this property is set to false, then new [Character] objects will be created automatically as
+  they are encountered in scripts.
+
 **trueValues**, **falseValues** `Set<String>`
 : The strings that can be recognized as `true`/`false` values respectively.
 
@@ -77,6 +86,9 @@ final yarn = YarnProject()
   existing ones.
 
 
+[\<\<character\>\>]: ../language/commands/character.md
+[Character]: character.md
+[CharacterStorage]: character_storage.md
 [CommandStorage]: command_storage.md
 [FunctionStorage]: function_storage.md
 [Node]: node.md

--- a/packages/flame_jenny/jenny/lib/jenny.dart
+++ b/packages/flame_jenny/jenny/lib/jenny.dart
@@ -1,3 +1,4 @@
+export 'src/character_storage.dart' show Character, CharacterStorage;
 export 'src/dialogue_runner.dart' show DialogueRunner;
 export 'src/dialogue_view.dart' show DialogueView;
 export 'src/errors.dart' show SyntaxError, NameError, TypeError, DialogueError;

--- a/packages/flame_jenny/jenny/lib/jenny.dart
+++ b/packages/flame_jenny/jenny/lib/jenny.dart
@@ -1,4 +1,5 @@
-export 'src/character_storage.dart' show Character, CharacterStorage;
+export 'src/character.dart' show Character;
+export 'src/character_storage.dart' show CharacterStorage;
 export 'src/dialogue_runner.dart' show DialogueRunner;
 export 'src/dialogue_view.dart' show DialogueView;
 export 'src/errors.dart' show SyntaxError, NameError, TypeError, DialogueError;

--- a/packages/flame_jenny/jenny/lib/src/character.dart
+++ b/packages/flame_jenny/jenny/lib/src/character.dart
@@ -1,0 +1,18 @@
+/// A [Character] represents a particular person who is speaking a line in a
+/// dialogue. All characters must be declared with the help of the
+/// `<<character>>` command.
+class Character {
+  Character(this.name, {List<String>? aliases}) : aliases = aliases ?? [];
+
+  /// The canonical name of the character
+  final String name;
+
+  /// The list of aliases
+  final List<String> aliases;
+  Map<String, dynamic>? _data;
+
+  Map<String, dynamic> get data => _data ??= <String, dynamic>{};
+
+  @override
+  String toString() => 'Character($name)';
+}

--- a/packages/flame_jenny/jenny/lib/src/character.dart
+++ b/packages/flame_jenny/jenny/lib/src/character.dart
@@ -4,13 +4,17 @@
 class Character {
   Character(this.name, {List<String>? aliases}) : aliases = aliases ?? [];
 
+  Map<String, dynamic>? _data;
+
   /// The canonical name of the character
   final String name;
 
   /// The list of aliases
   final List<String> aliases;
-  Map<String, dynamic>? _data;
 
+  /// Additional information associated with this character.
+  ///
+  /// You can store any key-value pairs here that you want, or nothing at all.
   Map<String, dynamic> get data => _data ??= <String, dynamic>{};
 
   @override

--- a/packages/flame_jenny/jenny/lib/src/character_storage.dart
+++ b/packages/flame_jenny/jenny/lib/src/character_storage.dart
@@ -1,3 +1,5 @@
+import 'package:jenny/src/character.dart';
+
 class CharacterStorage {
   final Map<String, Character> _cache = {};
 
@@ -9,21 +11,9 @@ class CharacterStorage {
   Character? operator [](String name) => _cache[name];
 
   void add(Character character) {
+    _cache[character.name] = character;
     for (final alias in character.aliases) {
       _cache[alias] = character;
     }
   }
-}
-
-class Character {
-  Character(this.name, {List<String>? aliases}) : aliases = aliases ?? [];
-
-  final String name;
-  final List<String> aliases;
-  Map<String, dynamic>? _data;
-
-  Map<String, dynamic> get data => _data ??= <String, dynamic>{};
-
-  @override
-  String toString() => 'Character($name)';
 }

--- a/packages/flame_jenny/jenny/lib/src/character_storage.dart
+++ b/packages/flame_jenny/jenny/lib/src/character_storage.dart
@@ -1,0 +1,30 @@
+
+class CharacterStorage {
+  final Map<String, Character> _cache = {};
+
+  bool get isEmpty => _cache.isEmpty;
+  bool get isNotEmpty => _cache.isNotEmpty;
+
+  bool contains(String name) => _cache.containsKey(name);
+
+  Character? operator[](String name) => _cache[name];
+
+  void add(Character character) {
+    for (final alias in character.aliases) {
+      _cache[alias] = character;
+    }
+  }
+}
+
+class Character {
+  Character({required this.name, required this.aliases});
+
+  final String name;
+  final List<String> aliases;
+  Map<String, dynamic>? _data;
+
+  Map<String, dynamic> get data => _data ??= <String, dynamic>{};
+
+  @override
+  String toString() => 'Character($name)';
+}

--- a/packages/flame_jenny/jenny/lib/src/character_storage.dart
+++ b/packages/flame_jenny/jenny/lib/src/character_storage.dart
@@ -1,15 +1,24 @@
 import 'package:jenny/src/character.dart';
 
+/// The container for all [Character]s defined in your yarn scripts. This
+/// container is populated as the YarnProject parses the input scripts.
 class CharacterStorage {
   final Map<String, Character> _cache = {};
 
   bool get isEmpty => _cache.isEmpty;
   bool get isNotEmpty => _cache.isNotEmpty;
 
+  /// Was the character with the given name or alias added to this container?
   bool contains(String name) => _cache.containsKey(name);
 
+  /// Retrieves the character given its name/alias, or returns `null` if such
+  /// character is not present.
   Character? operator [](String name) => _cache[name];
 
+  /// Adds a new [character] to the container.
+  ///
+  /// This is mostly intended for internal use; in yarn scripts use command
+  /// `<<character>>` to declare characters.
   void add(Character character) {
     _cache[character.name] = character;
     for (final alias in character.aliases) {

--- a/packages/flame_jenny/jenny/lib/src/character_storage.dart
+++ b/packages/flame_jenny/jenny/lib/src/character_storage.dart
@@ -1,4 +1,3 @@
-
 class CharacterStorage {
   final Map<String, Character> _cache = {};
 
@@ -7,7 +6,7 @@ class CharacterStorage {
 
   bool contains(String name) => _cache.containsKey(name);
 
-  Character? operator[](String name) => _cache[name];
+  Character? operator [](String name) => _cache[name];
 
   void add(Character character) {
     for (final alias in character.aliases) {
@@ -17,7 +16,7 @@ class CharacterStorage {
 }
 
 class Character {
-  Character({required this.name, required this.aliases});
+  Character(this.name, {List<String>? aliases}) : aliases = aliases ?? [];
 
   final String name;
   final List<String> aliases;

--- a/packages/flame_jenny/jenny/lib/src/parse/parse.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/parse.dart
@@ -411,6 +411,8 @@ class _Parser {
       return parseCommandSet();
     } else if (token == Token.commandDeclare || token == Token.commandLocal) {
       return parseCommandDeclareOrLocal();
+    } else if (token == Token.commandCharacter) {
+      return parseCommandCharacter();
     } else if (token == Token.commandElseif ||
         token == Token.commandElse ||
         token == Token.commandEndif) {
@@ -673,6 +675,28 @@ class _Parser {
       project.variables.setVariable(variableName, expression.value);
       return const DeclareCommand();
     }
+  }
+
+  Command parseCharacterCommand() {
+    take(Token.startCommand);
+    take(Token.commandCharacter);
+    take(Token.startExpression);
+    String? realName;
+    if (peekToken().isString) {
+      realName = peekToken().content;
+      position += 1;
+    }
+    final aliases = <String>[];
+    while (peekToken().isId) {
+      aliases.add(peekToken().content);
+      position += 1;
+    }
+    if (aliases.isEmpty) {
+      syntaxError('at least one character id is required');
+    }
+    take(Token.endExpression);
+    take(Token.endCommand);
+    takeNewline();
   }
 
   Command parseUserDefinedCommand() {

--- a/packages/flame_jenny/jenny/lib/src/parse/parse.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/parse.dart
@@ -10,7 +10,6 @@ import 'package:jenny/src/structure/commands/jump_command.dart';
 import 'package:jenny/src/structure/commands/local_command.dart';
 import 'package:jenny/src/structure/commands/set_command.dart';
 import 'package:jenny/src/structure/commands/stop_command.dart';
-import 'package:jenny/src/structure/commands/user_defined_command.dart';
 import 'package:jenny/src/structure/commands/visit_command.dart';
 import 'package:jenny/src/structure/commands/wait_command.dart';
 import 'package:jenny/src/structure/dialogue_entry.dart';
@@ -23,7 +22,6 @@ import 'package:jenny/src/structure/expressions/operators/_common.dart'
 import 'package:jenny/src/structure/expressions/operators/negate.dart';
 import 'package:jenny/src/structure/expressions/operators/not.dart';
 import 'package:jenny/src/structure/line_content.dart';
-import 'package:jenny/src/structure/markup_attribute.dart';
 import 'package:meta/meta.dart';
 
 @internal

--- a/packages/flame_jenny/jenny/lib/src/parse/parse.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/parse.dart
@@ -141,9 +141,11 @@ class _Parser {
       } else if (nextToken == Token.startCommand) {
         final position0 = position;
         final command = parseCommand();
-        if (command is DeclareCommand) {
-          position = position0;
-          syntaxError('<<declare>> command cannot be used inside a node');
+        if (command is DeclareCommand || command is CharacterCommand) {
+          syntaxError(
+            '<<${command.name}>> command cannot be used inside a node',
+            position0,
+          );
         }
         lines.add(command);
       } else if (nextToken.isText ||

--- a/packages/flame_jenny/jenny/lib/src/parse/parse.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/parse.dart
@@ -2,6 +2,7 @@ import 'package:jenny/src/errors.dart';
 import 'package:jenny/src/parse/token.dart';
 import 'package:jenny/src/parse/tokenize.dart';
 import 'package:jenny/src/structure/block.dart';
+import 'package:jenny/src/structure/commands/character_command.dart';
 import 'package:jenny/src/structure/commands/command.dart';
 import 'package:jenny/src/structure/commands/declare_command.dart';
 import 'package:jenny/src/structure/commands/if_command.dart';
@@ -677,7 +678,7 @@ class _Parser {
     }
   }
 
-  Command parseCharacterCommand() {
+  Command parseCommandCharacter() {
     take(Token.startCommand);
     take(Token.commandCharacter);
     take(Token.startExpression);
@@ -691,12 +692,13 @@ class _Parser {
       aliases.add(peekToken().content);
       position += 1;
     }
+    take(Token.endExpression);
     if (aliases.isEmpty) {
       syntaxError('at least one character id is required');
     }
-    take(Token.endExpression);
     take(Token.endCommand);
     takeNewline();
+    return const CharacterCommand();
   }
 
   Command parseUserDefinedCommand() {

--- a/packages/flame_jenny/jenny/lib/src/parse/parse.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/parse.dart
@@ -204,12 +204,16 @@ class _Parser {
     );
   }
 
-  String? maybeParseLinePerson() {
+  Character? maybeParseLinePerson() {
     final token = peekToken();
     if (token.isPerson) {
       takePerson();
       take(Token.colon);
-      return token.content;
+      final name = token.content;
+      if (project.strictCharacterNames && !project.characters.contains(name)) {
+        nameError('unknown character "$name"', position - 2);
+      }
+      return project.characters[name] ?? Character(name);
     }
     return null;
   }
@@ -697,10 +701,7 @@ class _Parser {
     }
     take(Token.endCommand);
     takeNewline();
-    final character = Character(
-      name: realName ?? aliases.first,
-      aliases: aliases,
-    );
+    final character = Character(realName ?? aliases.first, aliases: aliases);
     project.characters.add(character);
     return const CharacterCommand();
   }

--- a/packages/flame_jenny/jenny/lib/src/parse/parse.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/parse.dart
@@ -701,9 +701,13 @@ class _Parser {
     if (aliases.isEmpty) {
       syntaxError('at least one character id is required');
     }
+    if (realName == null) {
+      realName = aliases.first;
+      aliases.removeAt(0);
+    }
     take(Token.endCommand);
     takeNewline();
-    final character = Character(realName ?? aliases.first, aliases: aliases);
+    final character = Character(realName, aliases: aliases);
     project.characters.add(character);
     return const CharacterCommand();
   }

--- a/packages/flame_jenny/jenny/lib/src/parse/token.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/token.dart
@@ -21,6 +21,7 @@ class Token {
   static const closeMarkupTag = Token._(TokenType.closeMarkupTag);
   static const colon = Token._(TokenType.colon);
   static const comma = Token._(TokenType.comma);
+  static const commandCharacter = Token._(TokenType.commandCharacter);
   static const commandDeclare = Token._(TokenType.commandDeclare);
   static const commandElse = Token._(TokenType.commandElse);
   static const commandElseif = Token._(TokenType.commandElseif);
@@ -121,6 +122,7 @@ enum TokenType {
   closeMarkupTag, //         '/'  (e.g. in "[br/]")
   colon, //                  ':'
   comma, //                  ','
+  commandCharacter, //       'character'
   commandDeclare, //         'declare'
   commandElse, //            'else'
   commandElseif, //          'elseif'

--- a/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
@@ -980,6 +980,7 @@ class _Lexer {
     ')': Token.endParenthesis,
   };
   static const Map<String, Token> commandTokens = {
+    'character': Token.commandCharacter,
     'declare': Token.commandDeclare,
     'else': Token.commandElse,
     'elseif': Token.commandElseif,
@@ -1002,6 +1003,7 @@ class _Lexer {
 
   /// Built-in commands that are followed by an expression (without `{}`).
   static final Set<Token> bareExpressionCommands = {
+    Token.commandCharacter,
     Token.commandDeclare,
     Token.commandElseif,
     Token.commandIf,

--- a/packages/flame_jenny/jenny/lib/src/structure/commands/character_command.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/commands/character_command.dart
@@ -1,0 +1,12 @@
+import 'package:jenny/src/dialogue_runner.dart';
+import 'package:jenny/src/structure/commands/command.dart';
+
+class CharacterCommand extends Command {
+  const CharacterCommand();
+
+  @override
+  String get name => 'character';
+
+  @override
+  void execute(DialogueRunner dialogue) => throw AssertionError();
+}

--- a/packages/flame_jenny/jenny/lib/src/structure/dialogue_line.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/dialogue_line.dart
@@ -1,5 +1,4 @@
 import 'package:jenny/jenny.dart';
-import 'package:jenny/src/dialogue_runner.dart';
 import 'package:jenny/src/structure/dialogue_entry.dart';
 import 'package:jenny/src/structure/line_content.dart';
 import 'package:jenny/src/structure/markup_attribute.dart';
@@ -41,21 +40,21 @@ import 'package:jenny/src/structure/markup_attribute.dart';
 class DialogueLine extends DialogueEntry {
   DialogueLine({
     required LineContent content,
-    String? character,
+    Character? character,
     List<String>? tags,
   })  : _content = content,
         _character = character,
         _tags = tags,
         _value = content.isConst ? content.text : null;
 
-  final String? _character;
+  final Character? _character;
   final List<String>? _tags;
   final LineContent _content;
   String? _value;
 
-  /// The name of the character who is speaking the line. This can be null if
-  /// the line does not contain a speaker.
-  String? get character => _character;
+  /// The character who is speaking the line. This can be null if the line does
+  /// not contain a speaker.
+  Character? get character => _character;
 
   /// The computed text of the line, after substituting all inline expressions.
   ///
@@ -90,7 +89,7 @@ class DialogueLine extends DialogueEntry {
 
   @override
   String toString() {
-    final prefix = character == null ? '' : '$character: ';
+    final prefix = character == null ? '' : '${character!.name}: ';
     final text = _value ?? '<unevaluated>';
     return 'DialogueLine($prefix$text)';
   }

--- a/packages/flame_jenny/jenny/lib/src/structure/dialogue_option.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/dialogue_option.dart
@@ -26,7 +26,7 @@ class DialogueOption extends DialogueLine {
 
   @override
   String toString() {
-    final prefix = character == null ? '' : '$character: ';
+    final prefix = character == null ? '' : '${character!.name}: ';
     final suffix = _available ? '' : ' #disabled';
     return 'Option($prefix$text$suffix)';
   }

--- a/packages/flame_jenny/jenny/lib/src/yarn_project.dart
+++ b/packages/flame_jenny/jenny/lib/src/yarn_project.dart
@@ -46,6 +46,8 @@ class YarnProject {
 
   final CharacterStorage characters;
 
+  bool strictCharacterNames = true;
+
   /// Tokens that represent valid true/false values when converting an argument
   /// into a boolean. These sets can be modified by the user.
   static Set<String> trueValues = {'true', 'yes', 'on', '+', 'T', '1'};

--- a/packages/flame_jenny/jenny/lib/src/yarn_project.dart
+++ b/packages/flame_jenny/jenny/lib/src/yarn_project.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:jenny/src/character_storage.dart';
 import 'package:jenny/src/command_storage.dart';
 import 'package:jenny/src/errors.dart';
 import 'package:jenny/src/function_storage.dart';
@@ -23,6 +24,7 @@ class YarnProject {
         variables = VariableStorage(),
         functions = FunctionStorage(),
         commands = CommandStorage(),
+        characters = CharacterStorage(),
         random = Random() {
     locale = 'en';
   }
@@ -32,6 +34,8 @@ class YarnProject {
   /// All parsed [Node]s, keyed by their titles.
   final Map<String, Node> nodes;
 
+  /// All global variables accessible within the yarn scripts are stored here.
+  /// In addition, this also keeps information about node visit counts.
   final VariableStorage variables;
 
   /// User-defined functions are stored here.
@@ -39,6 +43,8 @@ class YarnProject {
 
   /// Repository for user-defined commands.
   final CommandStorage commands;
+
+  final CharacterStorage characters;
 
   /// Tokens that represent valid true/false values when converting an argument
   /// into a boolean. These sets can be modified by the user.

--- a/packages/flame_jenny/jenny/test/dialogue_runner_test.dart
+++ b/packages/flame_jenny/jenny/test/dialogue_runner_test.dart
@@ -10,6 +10,7 @@ void main() {
   group('DialogueRunner', () {
     test('plain dialogue', () async {
       final yarn = YarnProject()
+        ..strictCharacterNames = false
         ..parse(
           '-------------\n'
           'title: Hamlet\n'
@@ -65,6 +66,7 @@ void main() {
 
     test('DialogueViews with delays', () async {
       final yarn = YarnProject()
+        ..strictCharacterNames = false
         ..parse('title: The Robot and the Mattress\n'
             '---\n'
             'Zem: Hello, robot\n'

--- a/packages/flame_jenny/jenny/test/parse/parse_test.dart
+++ b/packages/flame_jenny/jenny/test/parse/parse_test.dart
@@ -205,10 +205,12 @@ void main() {
     group('parseDialogueLine', () {
       test('line with a speaker', () {
         final yarn = YarnProject()
+          ..strictCharacterNames = false
           ..parse('title:A\n---\nMrGoo: whatever\n===\n');
         expect(yarn.nodes['A']!.lines.first, isA<DialogueLine>());
         final line = yarn.nodes['A']!.lines[0] as DialogueLine;
-        expect(line.character, 'MrGoo');
+        expect(line.character, isA<Character>());
+        expect(line.character!.name, 'MrGoo');
         expect(line.text, 'whatever');
       });
 
@@ -290,6 +292,7 @@ void main() {
 
       test('speakers in options', () {
         final yarn = YarnProject()
+          ..strictCharacterNames = false
           ..parse('title:A\n---\n'
               '-> Alice: Hello!\n'
               '-> Bob: Hi: there!\n'
@@ -298,8 +301,9 @@ void main() {
         final choice = node.lines[0] as DialogueChoice;
         final option0 = choice.options[0];
         final option1 = choice.options[1];
-        expect(option0.character, 'Alice');
-        expect(option1.character, 'Bob');
+        expect(option0.character, isA<Character>());
+        expect(option0.character!.name, 'Alice');
+        expect(option1.character!.name, 'Bob');
         expect(option0.text, 'Hello!');
         expect(option1.text, 'Hi: there!');
       });
@@ -648,11 +652,13 @@ void main() {
 
       test('parse nested tags', () {
         final yarn = YarnProject()
+          ..strictCharacterNames = false
           ..parse('title: A\n---\n'
               'Warning: [a]Spinning [b][c]Je[/c]nny[/b][/a]\n'
               '===\n');
         final line = yarn.nodes['A']!.lines[0] as DialogueLine;
-        expect(line.character, 'Warning');
+        expect(line.character, isA<Character>());
+        expect(line.character!.name, 'Warning');
         expect(line.text, 'Spinning Jenny');
 
         expect(line.attributes.length, 3);

--- a/packages/flame_jenny/jenny/test/parse/token_test.dart
+++ b/packages/flame_jenny/jenny/test/parse/token_test.dart
@@ -7,6 +7,7 @@ void main() {
       expect('${Token.asType}', 'Token.asType');
       expect('${Token.closeMarkupTag}', 'Token.closeMarkupTag');
       expect('${Token.colon}', 'Token.colon');
+      expect('${Token.commandCharacter}', 'Token.commandCharacter');
       expect('${Token.commandEndif}', 'Token.commandEndif');
       expect('${Token.commandLocal}', 'Token.commandLocal');
       expect('${Token.commandVisit}', 'Token.commandVisit');

--- a/packages/flame_jenny/jenny/test/structure/commands/character_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/character_command_test.dart
@@ -54,6 +54,10 @@ void main() {
       expect(harry.data['age'], 11);
       expect(harry.data['affiliation'], 'Dumbledore');
 
+      final peeves = yarn.characters['Peeves']!;
+      expect(peeves.name, 'Peeves');
+      expect(peeves.aliases, isEmpty);
+
       expect(yarn.characters['Hermione'], isNotNull);
       expect(yarn.characters['Voldemort'], isNull);
     });

--- a/packages/flame_jenny/jenny/test/structure/commands/character_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/character_command_test.dart
@@ -1,0 +1,28 @@
+
+import 'package:jenny/src/parse/token.dart';
+import 'package:jenny/src/parse/tokenize.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CharacterCommand', () {
+    test('tokenize <<character>> command', () {
+      expect(
+        tokenize('<<character "Agent Smith" Smith AgSmith>>'),
+        const [
+          Token.startCommand,
+          Token.commandCharacter,
+          Token.startExpression,
+          Token.string('Agent Smith'),
+          Token.id('Smith'),
+          Token.id('AgSmith'),
+          Token.endExpression,
+          Token.endCommand,
+        ],
+      );
+    });
+
+    group('errors', () {
+
+    });
+  });
+}

--- a/packages/flame_jenny/jenny/test/structure/commands/character_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/character_command_test.dart
@@ -1,7 +1,9 @@
-
 import 'package:jenny/src/parse/token.dart';
 import 'package:jenny/src/parse/tokenize.dart';
+import 'package:jenny/src/yarn_project.dart';
 import 'package:test/test.dart';
+
+import '../../utils.dart';
 
 void main() {
   group('CharacterCommand', () {
@@ -22,7 +24,35 @@ void main() {
     });
 
     group('errors', () {
+      test('invalid syntax', () {
+        expect(
+          () => YarnProject()..parse(r'<<character "Me" = $foo>>'),
+          hasSyntaxError('SyntaxError: unexpected token\n'
+              '>  at line 1 column 18:\n'
+              '>  <<character "Me" = \$foo>>\n'
+              '>                   ^\n'),
+        );
+      });
 
+      test('no character name or ids', () {
+        expect(
+          () => YarnProject()..parse('<<character>>'),
+          hasSyntaxError('SyntaxError: at least one character id is required\n'
+              '>  at line 1 column 12:\n'
+              '>  <<character>>\n'
+              '>             ^\n'),
+        );
+      });
+
+      test('only character name', () {
+        expect(
+          () => YarnProject()..parse('<<character "Bozo">>'),
+          hasSyntaxError('SyntaxError: at least one character id is required\n'
+              '>  at line 1 column 19:\n'
+              '>  <<character "Bozo">>\n'
+              '>                    ^\n'),
+        );
+      });
     });
   });
 }

--- a/packages/flame_jenny/jenny/test/structure/commands/character_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/character_command_test.dart
@@ -23,6 +23,40 @@ void main() {
       );
     });
 
+    test('<<character>> command declares new characters', () {
+      final yarn = YarnProject();
+      yarn.parse(
+        '<<character "Harry Potter" Harry HP>>\n'
+        '<<character "Hermione Granger" Hermione HG>>\n'
+        '<<character "Ron Weasley" Ron RW>>\n'
+        '<<character Peeves>>\n',
+      );
+      expect(yarn.characters.isEmpty, false);
+      expect(yarn.characters.isNotEmpty, true);
+
+      expect(yarn.characters.contains('HP'), true);
+      expect(yarn.characters.contains('HG'), true);
+      expect(yarn.characters.contains('RW'), true);
+      expect(yarn.characters.contains('HW'), false);
+      expect(yarn.characters.contains('Hermione'), true);
+      expect(yarn.characters.contains('Peeves'), true);
+      expect(yarn.characters.contains('Harry'), true);
+      expect(yarn.characters.contains('Ron'), true);
+      expect(yarn.characters.contains('harry'), false);
+
+      final harry = yarn.characters['Harry']!;
+      expect(harry.name, 'Harry Potter');
+      expect(harry.aliases, ['Harry', 'HP']);
+      expect(harry.data, isEmpty);
+      harry.data['age'] = 11;
+      harry.data['affiliation'] = 'Dumbledore';
+      expect(harry.data['age'], 11);
+      expect(harry.data['affiliation'], 'Dumbledore');
+
+      expect(yarn.characters['Hermione'], isNotNull);
+      expect(yarn.characters['Voldemort'], isNull);
+    });
+
     group('errors', () {
       test('invalid syntax', () {
         expect(
@@ -51,6 +85,23 @@ void main() {
               '>  at line 1 column 19:\n'
               '>  <<character "Bozo">>\n'
               '>                    ^\n'),
+        );
+      });
+
+      test('duplicate character id', () {
+        expect(
+          () => YarnProject()
+            ..parse(
+              '<<character "Fancy Bob" FancyBob bob>>\n'
+              '<<character "Lame Bob" LameBob bob>>\n',
+            ),
+          hasNameError(
+            'NameError: character "bob" was already defined: Character(Fancy '
+            'Bob)\n'
+            '>  at line 2 column 32:\n'
+            '>  <<character "Lame Bob" LameBob bob>>\n'
+            '>                                 ^\n',
+          ),
         );
       });
     });

--- a/packages/flame_jenny/jenny/test/structure/commands/set_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/set_command_test.dart
@@ -64,7 +64,7 @@ void main() {
           <<if $foo is 54>>
               haha nice now 'set' works even when deeply nested
           <<else>>
-              aaargh :(
+              aaargh >:(
           <<endif>>
           ===
         ''',

--- a/packages/flame_jenny/jenny/test/structure/dialogue_line_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/dialogue_line_test.dart
@@ -17,12 +17,12 @@ void main() {
 
     test('line with meta information', () {
       final line = DialogueLine(
-        character: 'Bob',
+        character: Character('Bob'),
         content: LineContent('Hello!'),
         tags: ['#red', '#fast'],
       );
       expect(line.text, 'Hello!');
-      expect(line.character, 'Bob');
+      expect(line.character!.name, 'Bob');
       expect(line.tags, ['#red', '#fast']);
       expect('$line', 'DialogueLine(Bob: Hello!)');
     });

--- a/packages/flame_jenny/jenny/test/structure/dialogue_option_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/dialogue_option_test.dart
@@ -1,4 +1,4 @@
-import 'package:jenny/src/structure/dialogue_option.dart';
+import 'package:jenny/jenny.dart';
 import 'package:jenny/src/structure/expressions/literal.dart';
 import 'package:jenny/src/structure/line_content.dart';
 import 'package:test/test.dart';
@@ -21,11 +21,11 @@ void main() {
     test('simple option', () {
       final option = DialogueOption(
         content: LineContent('me'),
-        character: 'Rook',
+        character: Character('Rook'),
         condition: constFalse,
       );
       option.evaluate();
-      expect(option.character, 'Rook');
+      expect(option.character!.name, 'Rook');
       expect(option.tags, isEmpty);
       expect(option.attributes, isEmpty);
       expect(option.text, 'me');

--- a/packages/flame_jenny/jenny/test/test_scenario.dart
+++ b/packages/flame_jenny/jenny/test/test_scenario.dart
@@ -20,7 +20,8 @@ Future<void> testScenario({
   List<String>? commands,
   YarnProject? yarn,
 }) async {
-  final yarnProject = yarn ?? YarnProject();
+  final yarnProject = yarn ?? YarnProject()
+    ..strictCharacterNames = false;
   commands?.forEach(yarnProject.commands.addOrphanedCommand);
 
   Future<void> testBody() async {
@@ -108,7 +109,7 @@ class _TestPlan extends DialogueView {
         : '${expected.character}: ${expected.text}';
     final text2 = (line.character == null)
         ? line.text
-        : '${line.character}: ${line.text}';
+        : '${line.character!.name}: ${line.text}';
     assert(
       text1 == text2,
       'Expected line: "$text1"\n'
@@ -145,7 +146,7 @@ class _TestPlan extends DialogueView {
               option1.text +
               (option1.enabled ? '' : ' [disabled]');
       final text2 =
-          (option2.character == null ? '' : '${option2.character}: ') +
+          (option2.character == null ? '' : '${option2.character!.name}: ') +
               option2.text +
               (option2.isAvailable ? '' : ' [disabled]');
       assert(


### PR DESCRIPTION
# Description

The new command allows pre-declaring the characters that will be seen in the yarn scripts, and provides a place to store any additional information associated with each character.

The `DialogueLine.character` property now returns a `Character` object, instead of a `String`.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2273


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
