### PR TITLE
fix: Override `remove()` method to fix the functionality issue in the `FlameMultiBlocProvider`

### DIFF
--- a/packages/flame_bloc/lib/src/flame_multi_bloc_provider.dart
+++ b/packages/flame_bloc/lib/src/flame_multi_bloc_provider.dart
@@ -44,4 +44,12 @@ class FlameMultiBlocProvider extends Component {
     }
     await _lastProvider?.add(component);
   }
+
+  @override
+  void remove(Component component) {
+    if (_lastProvider == null) {
+      super.remove(component);
+    }
+    _lastProvider?.remove(component);
+  }
 }

--- a/packages/flame_bloc/test/src/flame_multi_bloc_provider_test.dart
+++ b/packages/flame_bloc/test/src/flame_multi_bloc_provider_test.dart
@@ -90,6 +90,39 @@ void main() {
       expect(inventory.lastState, equals(InventoryState.bow));
     });
 
+    testWithFlameGame('Add and remove a child with two providers',
+        (game) async {
+      final inventoryCubit = InventoryCubit();
+      final playerCubit = PlayerCubit();
+
+      late FlameBlocProvider inventoryCubitProvider, playerCubitProvider;
+
+      final provider = FlameMultiBlocProvider(
+        providers: [
+          inventoryCubitProvider =
+              FlameBlocProvider<InventoryCubit, InventoryState>.value(
+            value: inventoryCubit,
+          ),
+          playerCubitProvider =
+              FlameBlocProvider<PlayerCubit, PlayerState>.value(
+            value: playerCubit,
+          ),
+        ],
+      );
+      await game.ensureAdd(provider);
+
+      final myTestComponent = PositionComponent(position: Vector2.all(10));
+
+      await provider.ensureAdd(myTestComponent);
+      expect(inventoryCubitProvider.children.length, 1);
+      expect(inventoryCubitProvider.firstChild(), playerCubitProvider);
+      expect(myTestComponent.parent, equals(playerCubitProvider));
+      expect(playerCubitProvider.firstChild(), equals(myTestComponent));
+      await provider.ensureRemove(myTestComponent);
+      expect(myTestComponent.parent, null);
+      expect(playerCubitProvider.children.length, 0);
+    });
+
     group('when using children on constructor', () {
       testWithFlameGame('Provides multiple blocs down on the tree',
           (game) async {

--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -27,6 +27,20 @@ extension FlameGameExtension on Component {
     await addAll(components);
     await (components.first.findGame()! as FlameGame).ready();
   }
+
+  /// Makes sure that the [component] is removed from the tree if you wait for
+  /// the returned future to resolve.
+  Future<void> ensureRemove(Component component) async {
+    remove(component);
+    await (component.findGame()! as FlameGame).ready();
+  }
+
+  /// Makes sure that the [components] are removed from the tree if you wait for
+  /// the returned future to resolve.
+  Future<void> ensureRemoveAll(Iterable<Component> components) async {
+    removeAll(components);
+    await (components.first.findGame()! as FlameGame).ready();
+  }
 }
 
 typedef GameCreateFunction<T extends Game> = T Function();


### PR DESCRIPTION
# Description
We overrode the `add()` method in the `FlameMultiBlocProvider` to handle a new functionality (add the new component to the last provider). We need to apply this functionality to the `remove()` method too. I just overrode the `remove()` method to apply that functionality.
In this way, both of `add()` and `remove()` methods work consistently.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [X] I have followed the [Contributor Guide] when preparing my PR.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.