### PR TITLE
ci: Added Melos command "doc-setup"

### DIFF
--- a/doc/_sphinx/requirements.txt
+++ b/doc/_sphinx/requirements.txt
@@ -4,3 +4,4 @@ Pygments==2.12.0
 Sphinx==5.0.2
 sphinxcontrib-mermaid==0.7.1
 sphinx-autobuild==2021.3.14
+jinja2==3.1.2

--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -170,24 +170,18 @@ following:
 
 1. A working **Flutter** installation, accessible from the command line;
 
-2. A **Python** environment, with python version 3.8+ or higher;
-    - You can verify this by running `python --version` from the command line;
-    - Having a dedicated python virtual environment is recommended but not required;
+2. **Melos** command-line tool, as per the [contributing] guide.
 
-3. A set of python **modules** listed in the `doc/_sphinx/requirements.txt` file;
-    - The easiest way to install these is to run
+3. A **Python** environment, with python version 3.8+ or higher. Having a dedicated python
+   virtual environment is recommended but not required;
 
-      ```console
-      pip install -r doc/_sphinx/requirements.txt
-      ```
-
-    - Verify that all packages were installed correctly, otherwise, an error may occur.
-
-4. Melos as per the [contributing](contributing.md#environment-setup) guide.
+4. Install the remaining requirements using the command
+   ```console
+    melos run doc-setup
+   ```
 
 Once these prerequisites are met, you can build the documentation by using the built-in Melos
 target:
-
 
 ```console
 melos doc-build
@@ -230,3 +224,6 @@ Avoid having spaces in the paths to the docs since that will keep you from
 building the project due to
 [this bug](https://github.com/ipython/ipython/pull/13765).
 ```
+
+
+[contributing]: contributing.md#environment-setup

--- a/doc/development/documentation.md
+++ b/doc/development/documentation.md
@@ -176,6 +176,7 @@ following:
    virtual environment is recommended but not required;
 
 4. Install the remaining requirements using the command
+
    ```console
     melos run doc-setup
    ```

--- a/melos.yaml
+++ b/melos.yaml
@@ -51,6 +51,19 @@ scripts:
     run: melos exec flutter pub run dartdoc
     description: Run dartdoc checks for all packages.
 
+  doc-setup:
+    run: |
+      echo '\033[1;32mChecking python version:\033[m' &&
+      python --version &&
+      echo '\n\033[1;32mInstalling required python modules:\033[m' &&
+      (python -c 'import sys; sys.exit(0 if sys.version_info>=(3,8) else 2)' ||
+       (echo '\033[1;31mError: Python 3.8+ is required\033[m' && false)) &&
+      python -m pip install -r "$MELOS_ROOT_PATH/doc/_sphinx/requirements.txt" &&
+      echo '\n\033[1;32mInstalling dartdoc_json:\033[m' &&
+      dart pub global activate dartdoc_json &&
+      echo '\n\033[1;32mDone.\033[m'
+    description: Prepares the environment for documentation development.
+
   doc-build:
     run: cd "$MELOS_ROOT_PATH/doc/_sphinx" && make html
     description: Create the sphinx html docs.

--- a/melos.yaml
+++ b/melos.yaml
@@ -55,9 +55,9 @@ scripts:
     run: |
       echo '\033[1;32mChecking python version:\033[m' &&
       python --version &&
-      echo '\n\033[1;32mInstalling required python modules:\033[m' &&
       (python -c 'import sys; sys.exit(0 if sys.version_info>=(3,8) else 2)' ||
        (echo '\033[1;31mError: Python 3.8+ is required\033[m' && false)) &&
+      echo '\n\033[1;32mInstalling required python modules:\033[m' &&
       python -m pip install -r "$MELOS_ROOT_PATH/doc/_sphinx/requirements.txt" &&
       echo '\n\033[1;32mInstalling dartdoc_json:\033[m' &&
       dart pub global activate dartdoc_json &&


### PR DESCRIPTION
# Description

* The purpose of this new command is to make it easier to install things needed for doc development.
* Also added `jinja2` into the requirements file -- currently it is installed manually by the doc-publish script (https://github.com/flame-engine/flame-docs-site/blob/main/publish.sh#L58)


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [x] No, this PR is not a breaking change.



<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
