### PR TITLE
fix: Removed component does not deleted from _broadphaseCheckCache

### DIFF
--- a/packages/flame/lib/src/collisions/broadphase/quadtree/quad_tree_broadphase.dart
+++ b/packages/flame/lib/src/collisions/broadphase/quadtree/quad_tree_broadphase.dart
@@ -125,6 +125,14 @@ class QuadTreeBroadphase<T extends Hitbox<T>> extends Broadphase<T> {
     if (item.collisionType == CollisionType.active) {
       activeCollisions.remove(item);
     }
+
+    final checkCache = _broadphaseCheckCache[item];
+    if (checkCache != null) {
+      for (final entry in checkCache.entries) {
+        _broadphaseCheckCache[entry.key]?.remove(item);
+      }
+      _broadphaseCheckCache.remove(item);
+    }
   }
 
   void clear() {


### PR DESCRIPTION

# Description
The QuadTreeBroadphase._broadphaseCheckCache did not get cleared from removed items and keeps dead components until clear() will be called explicitly.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

