### PR TITLE
refactor: Remove "items" variable from core Broadphase class.

### DIFF
--- a/packages/flame/lib/src/collisions/broadphase/broadphase.dart
+++ b/packages/flame/lib/src/collisions/broadphase/broadphase.dart
@@ -6,9 +6,9 @@ import 'package:meta/meta.dart';
 /// actual intersections are calculated.
 ///
 /// Currently there are two implementations of [Broadphase]:
-/// - [Sweep] - simplest but slowest system, yet nice for small count of objects
-/// - [QuadTree] - work faster but requires additional setup and works only
-///   with fixed-size maps. See [HasQuadTreeCollisionDetection] for details
+/// - [Sweep] is the simplest but slowest system, yet nice for small amounts of hitboxes.
+/// - [QuadTree] usually works faster, but requires additional setup and works only
+///   with fixed-size maps. See [HasQuadTreeCollisionDetection] for details.
 abstract class Broadphase<T extends Hitbox<T>> {
   Broadphase();
 

--- a/packages/flame/lib/src/collisions/broadphase/broadphase.dart
+++ b/packages/flame/lib/src/collisions/broadphase/broadphase.dart
@@ -6,9 +6,11 @@ import 'package:meta/meta.dart';
 /// actual intersections are calculated.
 ///
 /// Currently there are two implementations of [Broadphase]:
-/// - [Sweep] is the simplest but slowest system, yet nice for small amounts of hitboxes.
-/// - [QuadTree] usually works faster, but requires additional setup and works only
-///   with fixed-size maps. See [HasQuadTreeCollisionDetection] for details.
+/// - [Sweep] is the simplest but slowest system, yet nice for small amounts of
+///   hitboxes.
+/// - [QuadTree] usually works faster, but requires additional setup and works
+///   only with fixed-size maps. See [HasQuadTreeCollisionDetection] for
+///   details.
 abstract class Broadphase<T extends Hitbox<T>> {
   Broadphase();
 

--- a/packages/flame/lib/src/collisions/broadphase/broadphase.dart
+++ b/packages/flame/lib/src/collisions/broadphase/broadphase.dart
@@ -8,13 +8,27 @@ import 'package:meta/meta.dart';
 /// Currently there is only one implementation of [Broadphase] and that is
 /// [Sweep].
 abstract class Broadphase<T extends Hitbox<T>> {
-  final List<T> items;
-
-  Broadphase({List<T>? items}) : items = items ?? [];
+  Broadphase();
 
   /// This method can be used if there are things that needs to be prepared in
   /// each tick.
   void update() {}
+
+  /// Returns a flat List of items regardless of what data structure is used to
+  /// store collision information
+  List<T> get items;
+
+  /// Add item to broadphase. Should be called in [CollisionDetection] class
+  /// while adding a hitbox into collision detection system
+  void add(T item);
+
+  void addAll(Iterable<T> items) => items.forEach(add);
+
+  /// Remove item from broadphase. Should be called in [CollisionDetection]
+  /// class while removing a hitbox into collision detection system
+  void remove(T item);
+
+  void removeAll(Iterable<T> items) => items.forEach(remove);
 
   /// Returns the potential hitbox collisions
   Set<CollisionProspect<T>> query();

--- a/packages/flame/lib/src/collisions/broadphase/broadphase.dart
+++ b/packages/flame/lib/src/collisions/broadphase/broadphase.dart
@@ -5,8 +5,10 @@ import 'package:meta/meta.dart';
 /// by doing a rough estimation of which hitboxes that can collide before their
 /// actual intersections are calculated.
 ///
-/// Currently there is only one implementation of [Broadphase] and that is
-/// [Sweep].
+/// Currently there are two implementations of [Broadphase]:
+/// - [Sweep] - simplest but slowest system, yet nice for small count of objects
+/// - [QuadTree] - work faster but requires additional setup and works only
+///   with fixed-size maps. See [HasQuadTreeCollisionDetection] for details
 abstract class Broadphase<T extends Hitbox<T>> {
   Broadphase();
 

--- a/packages/flame/lib/src/collisions/broadphase/broadphase.dart
+++ b/packages/flame/lib/src/collisions/broadphase/broadphase.dart
@@ -17,17 +17,19 @@ abstract class Broadphase<T extends Hitbox<T>> {
   void update() {}
 
   /// Returns a flat List of items regardless of what data structure is used to
-  /// store collision information
+  /// store collision information.
   List<T> get items;
 
-  /// Add item to broadphase. Should be called in [CollisionDetection] class
-  /// while adding a hitbox into collision detection system
+  /// Adds an item to the broadphase. Should be called in a
+  /// [CollisionDetection] class while adding a hitbox into its collision
+  /// detection system.
   void add(T item);
 
   void addAll(Iterable<T> items) => items.forEach(add);
 
-  /// Remove item from broadphase. Should be called in [CollisionDetection]
-  /// class while removing a hitbox into collision detection system
+  /// Removes an item from the broadphase. Should be called in a
+  /// [CollisionDetection] class while removing a hitbox from its collision
+  /// detection system.
   void remove(T item);
 
   void removeAll(Iterable<T> items) => items.forEach(remove);

--- a/packages/flame/lib/src/collisions/broadphase/quadtree/quad_tree_broadphase.dart
+++ b/packages/flame/lib/src/collisions/broadphase/quadtree/quad_tree_broadphase.dart
@@ -20,7 +20,6 @@ typedef ExternalMinDistanceCheck = bool Function(
 /// detailed description of its initialization parameters.
 class QuadTreeBroadphase<T extends Hitbox<T>> extends Broadphase<T> {
   QuadTreeBroadphase({
-    super.items,
     required Rect mainBoxSize,
     required this.broadphaseCheck,
     required this.minimumDistanceCheck,
@@ -32,7 +31,7 @@ class QuadTreeBroadphase<T extends Hitbox<T>> extends Broadphase<T> {
           maxDepth: maxDepth,
         );
 
-  final QuadTree tree;
+  final QuadTree<T> tree;
 
   final activeCollisions = HashSet<T>();
 
@@ -44,6 +43,9 @@ class QuadTreeBroadphase<T extends Hitbox<T>> extends Broadphase<T> {
 
   final _potentials = HashSet<CollisionProspect<T>>();
   final _potentialsTmp = <List<ShapeHitbox>>[];
+
+  @override
+  List<T> get items => tree.hitboxes;
 
   @override
   HashSet<CollisionProspect<T>> query() {
@@ -84,7 +86,7 @@ class QuadTreeBroadphase<T extends Hitbox<T>> extends Broadphase<T> {
           continue;
         }
 
-        _potentialsTmp.add([asShapeItem, potential]);
+        _potentialsTmp.add([asShapeItem, asShapePotential]);
       }
     }
 
@@ -111,6 +113,7 @@ class QuadTreeBroadphase<T extends Hitbox<T>> extends Broadphase<T> {
     tree.add(item);
   }
 
+  @override
   void add(T hitbox) {
     tree.add(hitbox);
     if (hitbox.collisionType == CollisionType.active) {
@@ -119,6 +122,7 @@ class QuadTreeBroadphase<T extends Hitbox<T>> extends Broadphase<T> {
     _cacheCenterOfHitbox(hitbox as ShapeHitbox);
   }
 
+  @override
   void remove(T item) {
     tree.remove(item);
     _cachedCenters.remove(item);

--- a/packages/flame/lib/src/collisions/broadphase/quadtree/quadtree_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/broadphase/quadtree/quadtree_collision_detection.dart
@@ -28,8 +28,6 @@ class QuadTreeCollisionDetection
 
   @override
   void add(ShapeHitbox item) {
-    super.add(item);
-
     item.onAabbChanged = () => _scheduledUpdate.add(item);
     // ignore: prefer_function_declarations_over_variables
     final listenerCollisionType = () {
@@ -44,7 +42,7 @@ class QuadTreeCollisionDetection
     item.collisionTypeNotifier.addListener(listenerCollisionType);
     _listenerCollisionType[item] = listenerCollisionType;
 
-    broadphase.add(item);
+    super.add(item);
   }
 
   @override
@@ -61,7 +59,6 @@ class QuadTreeCollisionDetection
       _listenerCollisionType.remove(item);
     }
 
-    broadphase.remove(item);
     super.remove(item);
   }
 

--- a/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
+++ b/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
@@ -1,10 +1,19 @@
 import 'package:flame/collisions.dart';
 
 class Sweep<T extends Hitbox<T>> extends Broadphase<T> {
-  Sweep({super.items});
+  Sweep({List<T>? items}) : items = items ?? [];
+
+  @override
+  final List<T> items;
 
   late final List<T> _active = [];
   late final Set<CollisionProspect<T>> _potentials = {};
+
+  @override
+  void add(T item) => items.add(item);
+
+  @override
+  void remove(T item) => items.remove(item);
 
   @override
   void update() {

--- a/packages/flame/lib/src/collisions/collision_detection.dart
+++ b/packages/flame/lib/src/collisions/collision_detection.dart
@@ -10,18 +10,20 @@ import 'package:flame/geometry.dart';
 abstract class CollisionDetection<T extends Hitbox<T>,
     B extends Broadphase<T>> {
   final B broadphase;
+
   List<T> get items => broadphase.items;
   final Set<CollisionProspect<T>> _lastPotentials = {};
 
   CollisionDetection({required this.broadphase});
 
-  void add(T item) => items.add(item);
+  void add(T item) => broadphase.add(item);
+
   void addAll(Iterable<T> items) => items.forEach(add);
 
   /// Removes the [item] from the collision detection, if you just want
   /// to temporarily inactivate it you can set
   /// `collisionType = CollisionType.inactive;` instead.
-  void remove(T item) => items.remove(item);
+  void remove(T item) => broadphase.remove(item);
 
   /// Removes all [items] from the collision detection, see [remove].
   void removeAll(Iterable<T> items) => items.forEach(remove);
@@ -64,8 +66,11 @@ abstract class CollisionDetection<T extends Hitbox<T>,
   /// Check what the intersection points of two items are,
   /// returns an empty list if there are no intersections.
   Set<Vector2> intersections(T itemA, T itemB);
+
   void handleCollisionStart(Set<Vector2> intersectionPoints, T itemA, T itemB);
+
   void handleCollision(Set<Vector2> intersectionPoints, T itemA, T itemB);
+
   void handleCollisionEnd(T itemA, T itemB);
 
   /// Returns the first hitbox that the given [ray] hits and the associated


### PR DESCRIPTION
# Description
`items` variable from core `Broadphase` class is replaced to abstract getter. Also methods for adding and removing items are added. All this together allows to preserve backward compatibility and allow broadphase / collision detection  developer to specify own algorithm of adding/removing hitboxes and algorithm of accessing a full list of hitboxes.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2283
