### PR TITLE
ci: Replace "flutter format" with "dart format" in Melos scripts

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -32,12 +32,12 @@ scripts:
     description: Run `flutter analyze` for all packages.
 
   format:
-    run: melos exec flutter format . --fix
-    description: Run `flutter format` for all packages.
+    run: melos exec dart format . --fix
+    description: Run `dart format` for all packages.
 
   format-check:
     run: melos exec flutter format . --set-exit-if-changed
-    description: Run `flutter format` checks for all packages.
+    description: Run `dart format` checks for all packages.
 
   markdown-check:
     run: markdownlint . --ignore-path .markdownlintignore --config .markdownlint.yaml


### PR DESCRIPTION
This fixes the following warning when running our CI workflows:
```
[!] The "format" command is deprecated and will be removed in a future version of
Flutter. Please use the "dart format" sub-command instead, which takes all of the
same command-line arguments as "flutter format".
```