### PR TITLE
ci: Remove lint rule invariant_booleans

### DIFF
--- a/packages/flame_lint/lib/analysis_options.yaml
+++ b/packages/flame_lint/lib/analysis_options.yaml
@@ -61,7 +61,6 @@ linter:
     - flutter_style_todos
     - hash_and_equals
     - implementation_imports
-    - invariant_booleans
     - iterable_contains_unrelated_type
     - join_return_with_assignment
     - library_names


### PR DESCRIPTION
The rule is deprecated, and is scheduled for removal in a future version of Dart linter: https://dart-lang.github.io/linter/lints/invariant_booleans.html