### PR TITLE
test: Fix a test for a component with hitboxes

### DIFF
--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -275,6 +275,7 @@ void main() {
               ]),
             );
           await game.ready();
+          expect(component.children.length, 1);
 
           expect(component.containsPoint(Vector2.all(1.1)), false);
           expect(component.containsPoint(Vector2.all(1.4)), false);

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -258,23 +258,32 @@ void main() {
         expect(component.containsPoint(Vector2(1.1, 3.1)), false);
       });
 
-      test('component with hitbox does not contains point', () {
-        final component = _MyHitboxComponent();
-        component.position.setValues(1.0, 1.0);
-        component.anchor = Anchor.topLeft;
-        component.size.setValues(2.0, 2.0);
-        component.add(
-          PolygonHitbox([
-            Vector2(1, 0),
-            Vector2(0, -1),
-            Vector2(-1, 0),
-            Vector2(0, 1),
-          ]),
-        );
+      testWithFlameGame(
+        'component with hitbox does not contain point',
+        (game) async {
+          final component = _MyHitboxComponent()
+            ..addToParent(game)
+            ..position.setValues(1.0, 1.0)
+            ..anchor = Anchor.topLeft
+            ..size.setValues(2.0, 2.0)
+            ..add(
+              PolygonHitbox([
+                Vector2(1, 0),
+                Vector2(0, 1),
+                Vector2(1, 2),
+                Vector2(2, 1),
+              ]),
+            );
+          await game.ready();
 
-        final point = Vector2(1.1, 1.1);
-        expect(component.containsPoint(point), false);
-      });
+          expect(component.containsPoint(Vector2.all(1.1)), false);
+          expect(component.containsPoint(Vector2.all(1.4)), false);
+          expect(component.containsPoint(Vector2.all(2.0)), true);
+          expect(component.containsPoint(Vector2.all(2.6)), false);
+          expect(component.containsPoint(Vector2.all(2.9)), false);
+          expect(component.containsPoint(Vector2(2.6, 1.5)), false);
+        },
+      );
 
       test('component with zero size does not contain point', () {
         final component = PositionComponent();


### PR DESCRIPTION
# Description

In the test, the component was not properly added to a game instance, and as a result its hitbox was never mounted. In addition, the hitbox polygon used negative coordinates, which caused to be outside of the parent shape, which was counterintuitive.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [x] No, this PR is not a breaking change.


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
