### PR TITLE
feat: Add replaceChild and replaceAll methods [WIP]

### DIFF
--- a/doc/flame/game.md
+++ b/doc/flame/game.md
@@ -53,6 +53,9 @@ To remove components from the list on a `FlameGame` the `remove` or `removeAll` 
 The first can be used if you just want to remove one component, and the second can be used when you
 want to remove a list of components.
 
+If you want to replace a component with another, utility methods `replaceChild` and `replaceAll` are
+available (which are equivalent to removing the original and then adding the new replacement).
+
 
 ## Game Loop
 

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -619,6 +619,24 @@ class Component {
     parent = newParent;
   }
 
+  /// Replaces a [replaceFrom] child of this component with [replaceWith].
+  /// I.e., removes [replaceFrom], and adds [replaceWith] instead.
+  FutureOr<void> replaceChild(Component replaceFrom, Component replaceWith) {
+    if (replaceFrom == replaceWith) {
+      // nothing to do
+      return Future.value();
+    }
+    remove(replaceFrom);
+    return add(replaceWith);
+  }
+
+  /// Same as [replaceChild], but takes a map of replacements.
+  /// Removes the key and adds the value instead.
+  FutureOr<void> replaceAll(Map<Component, Component> replacements) {
+    removeAll(replacements.keys);
+    return addAll(replacements.values);
+  }
+
   //#endregion
 
   //#region Hit Testing

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -652,6 +652,55 @@ void main() {
       );
     });
 
+    group('Replacing components', () {
+      testWithFlameGame('replaces single child', (game) async {
+        final child1 = Component();
+        final child2 = Component();
+
+        final parent = Component();
+        await game.ensureAdd(parent);
+        expect(parent.isMounted, true);
+
+        await parent.add(child1);
+        game.update(0); // children are only updated on the next tick
+        expect(parent.contains(child1), true);
+        expect(parent.contains(child2), false);
+
+        parent.replaceChild(child1, child2);
+        game.update(0); // children are only updated on the next tick
+        expect(parent.contains(child1), false);
+        expect(parent.contains(child2), true);
+      });
+
+      testWithFlameGame('replaces a map', (game) async {
+        final child1 = Component();
+        final child2 = Component();
+        final child3 = Component();
+        final child4 = Component();
+        final child5 = Component();
+
+        final parent = Component();
+        await game.ensureAdd(parent);
+        expect(parent.isMounted, true);
+
+        await parent.addAll([child1, child2, child3]);
+        game.update(0); // children are only updated on the next tick
+        expect(parent.contains(child1), true);
+        expect(parent.contains(child2), true);
+        expect(parent.contains(child3), true);
+        expect(parent.contains(child4), false);
+        expect(parent.contains(child5), false);
+
+        parent.replaceAll({child1: child5, child3: child4});
+        game.update(0); // children are only updated on the next tick
+        expect(parent.contains(child1), false);
+        expect(parent.contains(child2), true);
+        expect(parent.contains(child3), false);
+        expect(parent.contains(child4), true);
+        expect(parent.contains(child5), true);
+      });
+    });
+
     group('descendants()', () {
       testWithFlameGame(
         'descendants in a deep component tree',
@@ -810,8 +859,8 @@ void main() {
       );
 
       testWithFlameGame(
-        'after adding several childs using addAll the method onChildrenChanged '
-        'should be called list.length times',
+        'after adding several children using addAll the method '
+        'onChildrenChanged should be called list.length times',
         (game) async {
           final list = [Component(), Component()];
           final parent = _OnChildrenChangedComponent();


### PR DESCRIPTION
# Description

This adds two utility methods, `replaceChild` and `replaceAll`, as per suggested:
![image](https://user-images.githubusercontent.com/882703/215278457-34d9d927-df9b-4c3e-ba3f-72e05b842df5.png)

There are some points to consider about the implementation:

* should we wait for the removal? remove methods are not awaitable currently
* what if we are trying to replace something with itself?
* what if the removal portion fails (component doesn't exist as child, etc)?
* what if the addition portion fails (component already child of someone else, etc)

@erickzanardo what do you think of the questions above, since you had the idea originally?

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
