### PR TITLE
docs: Fix actual typos that made into our dictionary

### DIFF
--- a/.github/.cspell/flame_dictionary.txt
+++ b/.github/.cspell/flame_dictionary.txt
@@ -7,7 +7,6 @@ Dashbook
 Fireslime
 Hermione
 Kawabunga
-Kinect
 Klingsbo
 Lukas
 Nakama

--- a/.github/.cspell/gamedev_dictionary.txt
+++ b/.github/.cspell/gamedev_dictionary.txt
@@ -94,7 +94,6 @@ prerender
 prerendered
 pressable
 proxying
-pubdev
 pubspec
 queryable
 raycast
@@ -118,7 +117,6 @@ respawn
 respawned
 rrect
 rrects
-rsts
 scos
 serializable
 socio

--- a/doc/bridge_packages/flame_svg/svg.md
+++ b/doc/bridge_packages/flame_svg/svg.md
@@ -9,7 +9,7 @@ Svg support is provided by the `flame_svg` bridge package, be sure to put it in 
 to use it.
 
 If you want to know more about the installation visit
-[flame_svg on pubdev](https://pub.dev/packages/flame_svg/install).
+[flame_svg on pub.dev](https://pub.dev/packages/flame_svg/install).
 
 
 ## How to use flame_svg

--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -771,7 +771,7 @@ following effects qualify: [`MoveByEffect`](#movebyeffect), [`MoveToEffect`](#mo
 [`RotateEffect.to`](#rotateeffectto).
 
 The parameter `speed` is in units per second, where the notion of a "unit" depends on the target
-effect. For example, for move effects, they refer to the distance travelled; for rotation effects
+effect. For example, for move effects, they refer to the distance traveled; for rotation effects
 the units are radians.
 
 ```dart

--- a/doc/other_modules/jenny/language/commands/declare.md
+++ b/doc/other_modules/jenny/language/commands/declare.md
@@ -79,7 +79,7 @@ the same as `TYPE`, and will throw a compile-time error otherwise.
 <<declare $been_to_hell = false>>
 
 <<declare $name as String>>
-<<declare $distanceTravelled as Number>>
+<<declare $distanceTraveled as Number>>
 
 <<declare $birthDay = randomRange(1, 365) as Number>>
 <<declare $vulgarity = GetObscenitySetting() as Bool>>

--- a/doc/tutorials/platformer/step_3.md
+++ b/doc/tutorials/platformer/step_3.md
@@ -422,7 +422,7 @@ with a `passive` `CollisionType`.  Collisions will be explained more in a later 
 #### Display the Platform
 
 In our `loadGameSegments` method from earlier, we will need to add the call to add our block.  We
-will need to define `gridPosition` and `xOffset` to be passed in.  `gridPostion` will be a
+will need to define `gridPosition` and `xOffset` to be passed in.  `gridPosition` will be a
 `Vector2` and `xOffset` is a double as that will be used to calculate the x-axis offset for
 the block in a `Vector2`.  So add the following to your `loadGameSegments` method:
 

--- a/examples/games/trex/lib/trex_game.dart
+++ b/examples/games/trex/lib/trex_game.dart
@@ -42,7 +42,7 @@ class TRexGame extends FlameGame
   String scoreString(int score) => score.toString().padLeft(5, '0');
 
   /// Used for score calculation
-  double _distanceTravelled = 0;
+  double _distanceTraveled = 0;
 
   @override
   Future<void> onLoad() async {
@@ -128,7 +128,7 @@ class TRexGame extends FlameGame
       _highscore = score;
     }
     score = 0;
-    _distanceTravelled = 0;
+    _distanceTraveled = 0;
   }
 
   @override
@@ -140,8 +140,8 @@ class TRexGame extends FlameGame
 
     if (isPlaying) {
       timePlaying += dt;
-      _distanceTravelled += dt * currentSpeed;
-      score = _distanceTravelled ~/ 50;
+      _distanceTraveled += dt * currentSpeed;
+      score = _distanceTraveled ~/ 50;
 
       if (currentSpeed < maxSpeed) {
         currentSpeed += acceleration * dt;

--- a/packages/flame/lib/src/text/formatters/sprite_font_text_formatter.dart
+++ b/packages/flame/lib/src/text/formatters/sprite_font_text_formatter.dart
@@ -51,7 +51,7 @@ class SpriteFontTextFormatter extends TextFormatter {
   @override
   TextElement format(String text) {
     var rects = Float32List(text.length * 4);
-    var rsts = Float32List(text.length * 4);
+    var transforms = Float32List(text.length * 4);
     var j = 0;
     var x0 = 0.0;
     for (final glyph in font.textToGlyphs(text)) {
@@ -59,20 +59,20 @@ class SpriteFontTextFormatter extends TextFormatter {
       rects[j + 1] = glyph.srcTop;
       rects[j + 2] = glyph.srcRight;
       rects[j + 3] = glyph.srcBottom;
-      rsts[j + 0] = scale;
-      rsts[j + 1] = 0;
-      rsts[j + 2] = x0 + (glyph.srcLeft - glyph.left) * scale;
-      rsts[j + 3] = (glyph.srcTop - glyph.top - font.ascent) * scale;
+      transforms[j + 0] = scale;
+      transforms[j + 1] = 0;
+      transforms[j + 2] = x0 + (glyph.srcLeft - glyph.left) * scale;
+      transforms[j + 3] = (glyph.srcTop - glyph.top - font.ascent) * scale;
       j += 4;
       x0 += glyph.width * scale + letterSpacing;
     }
     if (j < text.length * 4) {
       rects = rects.sublist(0, j);
-      rsts = rsts.sublist(0, j);
+      transforms = transforms.sublist(0, j);
     }
     return SpriteFontTextElement(
       source: font.source,
-      transforms: rsts,
+      transforms: transforms,
       rects: rects,
       paint: paint,
       metrics: LineMetrics(

--- a/packages/flame_bloc/example/lib/src/inventory/view/inventory.dart
+++ b/packages/flame_bloc/example/lib/src/inventory/view/inventory.dart
@@ -19,7 +19,7 @@ class Inventory extends StatelessWidget {
   String _mapWeaponName(Weapon weapon) {
     switch (weapon) {
       case Weapon.bullet:
-        return 'Kinect';
+        return 'Kinetic';
       case Weapon.laser:
         return 'Laser';
       case Weapon.plasma:


### PR DESCRIPTION
# Description

I am on a crusade to improve our spellchecking. I have a big PR that I am now going to break down into very small chunks to for review.

This one I am fixing actual typos that made it despite our current settings. Hopefully this one won't be controversial (yet).

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
