### PR TITLE
fix: Camera no longer "sticks" to boundary with BoundedPositionBehavior

### DIFF
--- a/packages/flame/lib/src/camera/behaviors/bounded_position_behavior.dart
+++ b/packages/flame/lib/src/camera/behaviors/bounded_position_behavior.dart
@@ -74,18 +74,9 @@ class BoundedPositionBehavior extends Component {
     if (isValidPoint(currentPosition)) {
       _previousPosition.setFrom(currentPosition);
     } else {
-      var inBoundsPoint = _previousPosition;
-      var outOfBoundsPoint = currentPosition;
-      while (inBoundsPoint.taxicabDistanceTo(outOfBoundsPoint) > _precision) {
-        final newPoint = (inBoundsPoint + outOfBoundsPoint)..scale(0.5);
-        if (isValidPoint(newPoint)) {
-          inBoundsPoint = newPoint;
-        } else {
-          outOfBoundsPoint = newPoint;
-        }
-      }
-      _previousPosition.setFrom(inBoundsPoint);
-      _target!.position = inBoundsPoint;
+      final closestBoundaryPoint = _bounds.nearestPoint(currentPosition);
+      _previousPosition.setFrom(closestBoundaryPoint);
+      _target!.position = closestBoundaryPoint;
     }
   }
 }

--- a/packages/flame/lib/src/experimental/geometry/shapes/circle.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/circle.dart
@@ -83,5 +83,15 @@ class Circle extends Shape {
   }
 
   @override
+  Vector2 nearestPoint(Vector2 point) {
+    if (_radius == 0) {
+      return _center;
+    }
+    final vectorToPoint = point - _center;
+    final distance = vectorToPoint.length;
+    return _center + vectorToPoint * (_radius/distance);
+  }
+
+  @override
   String toString() => 'Circle([${_center.x}, ${_center.y}], $_radius)';
 }

--- a/packages/flame/lib/src/experimental/geometry/shapes/circle.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/circle.dart
@@ -89,7 +89,7 @@ class Circle extends Shape {
     }
     final vectorToPoint = point - _center;
     final distance = vectorToPoint.length;
-    return _center + vectorToPoint * (_radius/distance);
+    return _center + vectorToPoint * (_radius / distance);
   }
 
   @override

--- a/packages/flame/lib/src/experimental/geometry/shapes/polygon.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/polygon.dart
@@ -217,7 +217,21 @@ class Polygon extends Shape {
 
   @override
   Vector2 nearestPoint(Vector2 point) {
-    throw UnimplementedError();
+    final result = Vector2.zero();
+    var shortestDistance2 = double.infinity;
+    for (var i = 0; i < _vertices.length; i++) {
+      final vertex = _vertices[i];
+      final edge = _edges[i];
+      final dotProduct = (point - vertex).dot(edge);
+      final t = (dotProduct / edge.length2).clamp(-1.0, 0.0);
+      final edgePoint = vertex + edge * t;
+      final distance2 = (edgePoint - point).length2;
+      if (distance2 < shortestDistance2) {
+        shortestDistance2 = distance2;
+        result.setFrom(edgePoint);
+      }
+    }
+    return result;
   }
 
   @override

--- a/packages/flame/lib/src/experimental/geometry/shapes/polygon.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/polygon.dart
@@ -216,5 +216,10 @@ class Polygon extends Shape {
   }
 
   @override
+  Vector2 nearestPoint(Vector2 point) {
+    throw UnimplementedError();
+  }
+
+  @override
   String toString() => 'Polygon($vertices)';
 }

--- a/packages/flame/lib/src/experimental/geometry/shapes/rectangle.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/rectangle.dart
@@ -124,5 +124,12 @@ class Rectangle extends Shape {
   }
 
   @override
+  Vector2 nearestPoint(Vector2 point) {
+    final xx = (point.x).clamp(_left, _right);
+    final yy = (point.y).clamp(_top, _bottom);
+    return Vector2(xx, yy);
+  }
+
+  @override
   String toString() => 'Rectangle([$_left, $_top], [$_right, $_bottom])';
 }

--- a/packages/flame/lib/src/experimental/geometry/shapes/rounded_rectangle.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/rounded_rectangle.dart
@@ -172,6 +172,11 @@ class RoundedRectangle extends Shape {
   }
 
   @override
+  Vector2 nearestPoint(Vector2 point) {
+    throw UnimplementedError();
+  }
+
+  @override
   String toString() =>
       'RoundedRectangle([$_left, $_top], [$_right, $_bottom], $_radius)';
 }

--- a/packages/flame/lib/src/experimental/geometry/shapes/rounded_rectangle.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/rounded_rectangle.dart
@@ -173,7 +173,20 @@ class RoundedRectangle extends Shape {
 
   @override
   Vector2 nearestPoint(Vector2 point) {
-    throw UnimplementedError();
+    final xx = (point.x).clamp(_left, _right);
+    final yy = (point.y).clamp(_top, _bottom);
+    final result = Vector2(xx, yy);
+    if (containsPoint(result)) {
+      return result;
+    }
+    final center = result
+      ..setValues(
+        result.x <= _left + _radius ? _left + _radius : _right - _radius,
+        result.y <= _top + _radius ? _top + _radius : _bottom - _radius,
+      );
+    final vectorToPoint = point - center;
+    final distance = vectorToPoint.length;
+    return center..addScaled(vectorToPoint, _radius / distance);
   }
 
   @override

--- a/packages/flame/lib/src/experimental/geometry/shapes/shape.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/shape.dart
@@ -82,4 +82,11 @@ abstract class Shape {
   ///
   /// This method is only used for convex shapes.
   Vector2 support(Vector2 direction);
+
+  /// Returns a point on the shape's boundary which is closest to the given
+  /// [externalPoint].
+  ///
+  /// The [externalPoint] must lie outside of the shape. If there are multiple
+  /// nearest points, any one can be returned.
+  Vector2 nearestPoint(Vector2 externalPoint);
 }

--- a/packages/flame/test/camera/behaviors/bounded_position_behavior_test.dart
+++ b/packages/flame/test/camera/behaviors/bounded_position_behavior_test.dart
@@ -26,7 +26,7 @@ void main() {
       expect(component.position, Vector2(0, 3));
       component.position = Vector2(-1, 2);
       game.update(0);
-      expect(component.position, Vector2(0, 3));
+      expect(component.position, Vector2(0, 2));
     });
 
     test('bad precision', () {

--- a/packages/flame/test/camera/camera_component_test.dart
+++ b/packages/flame/test/camera/camera_component_test.dart
@@ -150,8 +150,10 @@ void main() {
 
       camera.moveTo(Vector2(-20, 0), speed: 10);
       for (var i = 0; i < 20; i++) {
-        expect(camera.viewfinder.position, closeToVector(Vector2(0, 10), 0.5));
-        game.update(0.5);
+        expect(camera.viewfinder.position,
+            closeToVector(Vector2(0, 10 - i * 0.45), 0.5),
+        );
+        game.update(0.1);
       }
 
       expect(

--- a/packages/flame/test/camera/camera_component_test.dart
+++ b/packages/flame/test/camera/camera_component_test.dart
@@ -150,8 +150,9 @@ void main() {
 
       camera.moveTo(Vector2(-20, 0), speed: 10);
       for (var i = 0; i < 20; i++) {
-        expect(camera.viewfinder.position,
-            closeToVector(Vector2(0, 10 - i * 0.45), 0.5),
+        expect(
+          camera.viewfinder.position,
+          closeToVector(Vector2(0, 10 - i * 0.45), 0.5),
         );
         game.update(0.1);
       }

--- a/packages/flame/test/experimental/geometry/shapes/circle_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/circle_test.dart
@@ -147,5 +147,21 @@ void main() {
         closeToVector(Vector2(2 - 20 / sqrt(5), 1 - 10 / sqrt(5))),
       );
     });
+
+    test('nearestPoint', () {
+      final circle = Circle(Vector2(1, 1), 1);
+      const a = 0.7071067811865475; // sqrt(1/2)
+      expect(circle.nearestPoint(Vector2(0, 0)), Vector2.all(1 - a));
+      expect(circle.nearestPoint(Vector2(1, 0)), Vector2(1, 0));
+      expect(circle.nearestPoint(Vector2(2, 0)), Vector2(1 + a, 1 - a));
+      expect(circle.nearestPoint(Vector2(2, 2)), Vector2(1 + a, 1 + a));
+    });
+
+    test('nearestPoint for zero-radius circle', () {
+      final circle = Circle(Vector2(3, 4), 0);
+      expect(circle.nearestPoint(Vector2(3, 4)), Vector2(3, 4));
+      expect(circle.nearestPoint(Vector2(5, 7)), Vector2(3, 4));
+      expect(circle.nearestPoint(Vector2(0, 0)), Vector2(3, 4));
+    });
   });
 }

--- a/packages/flame/test/experimental/geometry/shapes/polygon_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/polygon_test.dart
@@ -271,5 +271,29 @@ void main() {
       expect(result.edges, [z, z, z, z, z]);
       expect(result.isConvex, true);
     });
+
+    test('nearestPoint', () {
+      final polygon = Polygon([
+        Vector2(10, 10),
+        Vector2(20, 30),
+        Vector2(10, 40),
+        Vector2(40, 40),
+        Vector2(50, 0),
+      ]);
+
+      expect(polygon.nearestPoint(Vector2(0, 0)), Vector2(10, 10));
+      expect(
+        polygon.nearestPoint(Vector2(10, 0)),
+        Vector2(12.352941176470589, 9.411764705882353),
+      );
+      expect(polygon.nearestPoint(Vector2(60, 0)), Vector2(50, 0));
+      expect(polygon.nearestPoint(Vector2(10, 30)), Vector2(15, 35));
+      expect(polygon.nearestPoint(Vector2(30, 50)), Vector2(30, 40));
+      expect(polygon.nearestPoint(Vector2(50, 50)), Vector2(40, 40));
+      expect(
+        polygon.nearestPoint(Vector2(50, 20)),
+        Vector2(45.294117647058826, 18.823529411764707),
+      );
+    });
   });
 }

--- a/packages/flame/test/experimental/geometry/shapes/rectangle_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/rectangle_test.dart
@@ -208,5 +208,20 @@ void main() {
       );
       expect(rectangle.support(Vector2(9, -200)), closeToVector(Vector2(9, 2)));
     });
+
+    test('nearestPoint', () {
+      final rectangle = Rectangle.fromLTRB(0, 0, 5, 4);
+
+      expect(rectangle.nearestPoint(Vector2(0, 0)), Vector2(0, 0));
+      expect(rectangle.nearestPoint(Vector2(1, -1)), Vector2(1, 0));
+      expect(rectangle.nearestPoint(Vector2(-1, -1)), Vector2(0, 0));
+      expect(rectangle.nearestPoint(Vector2(-3, 2)), Vector2(0, 2));
+      expect(rectangle.nearestPoint(Vector2(-3, 7)), Vector2(0, 4));
+      expect(rectangle.nearestPoint(Vector2(-3, 7)), Vector2(0, 4));
+      expect(rectangle.nearestPoint(Vector2(3, 7)), Vector2(3, 4));
+      expect(rectangle.nearestPoint(Vector2(7, 7)), Vector2(5, 4));
+      expect(rectangle.nearestPoint(Vector2(17, 1)), Vector2(5, 1));
+      expect(rectangle.nearestPoint(Vector2(8, -2)), Vector2(5, 0));
+    });
   });
 }

--- a/packages/flame/test/experimental/geometry/shapes/rounded_rectangle_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/rounded_rectangle_test.dart
@@ -228,5 +228,27 @@ void main() {
         throwsUnimplementedError,
       );
     });
+
+    test('nearestPoint', () {
+      final rrect = RoundedRectangle.fromLTRBR(0, 0, 50, 30, 10);
+
+      expect(
+        rrect.nearestPoint(Vector2(0, 0)),
+        Vector2(2.9289321881345254, 2.9289321881345254),
+      );
+      expect(
+        rrect.nearestPoint(Vector2(0, -10)),
+        Vector2(5.52786404500042, 1.0557280900008408),
+      );
+      expect(rrect.nearestPoint(Vector2(10, -10)), Vector2(10, 0));
+      expect(rrect.nearestPoint(Vector2(30, -10)), Vector2(30, 0));
+      expect(
+        rrect.nearestPoint(Vector2(55, 5)),
+        Vector2(49.48683298050514, 6.83772233983162),
+      );
+      expect(rrect.nearestPoint(Vector2(60, 15)), Vector2(50, 15));
+      expect(rrect.nearestPoint(Vector2(20, 150)), Vector2(20, 30));
+      expect(rrect.nearestPoint(Vector2(100, 100)), Vector2(46, 28));
+    });
   });
 }


### PR DESCRIPTION
# Description

Previously, when using BoundedPositionBehavior, the camera would "stick" to the world boundary as soon as the target moves outside. With this PR, the camera will now try to keep as close to the target as possible, even if it moves outside of the world boundary. Thus, the camera will now behave as if the boundary became "slippery".

Also added method `nearestPoint()` in class `Shape`.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #1905


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
