### PR TITLE
style: Remove unused typedef in jenny's parser

### DIFF
--- a/packages/flame_jenny/jenny/lib/src/parse/parse.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/parse.dart
@@ -965,12 +965,6 @@ class _Parser {
   }
 }
 
-typedef FunctionBuilder = Expression Function(
-  List<FunctionArgument>,
-  YarnProject,
-  ErrorFn,
-);
-
 class _NodeHeader {
   _NodeHeader(this.title, this.tags);
   String? title;


### PR DESCRIPTION

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [x] No, this PR is not a breaking change.


## Related Issues

Reported in #2308


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
