### PR TITLE
test: Added test for accessing children in onMount

### DIFF
--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -4,6 +4,8 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../custom_component.dart';
+
 void main() {
   group('Component', () {
     group('Lifecycle', () {
@@ -996,6 +998,29 @@ void main() {
           expect(component2.value, 3);
           expect(component1.value, 4);
           expect(order, 5);
+        },
+      );
+
+      testWithFlameGame(
+        'Components added in onLoad can be accessed in onMount',
+        (game) async {
+          final component = CustomComponent(
+            onLoad: (self) {
+              self.add(Component());
+              self.add(_SlowLoadingComponent());
+              self.add(Component());
+            },
+            onMount: (self) {
+              expect(self.children.length, 3);
+              self.children.elementAt(0).add(Component());
+            },
+          );
+          game.add(component);
+          await game.ready();
+
+          expect(component.isMounted, true);
+          expect(component.children.length, 3);
+          expect(component.children.first.children.length, 1);
         },
       );
     });

--- a/packages/flame/test/custom_component.dart
+++ b/packages/flame/test/custom_component.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:flame/components.dart';
+
+/// A component where all event handlers can be provided as parameters in the
+/// constructor.
+class CustomComponent extends Component {
+  CustomComponent({
+    void Function(CustomComponent, Vector2)? onGameResize,
+    FutureOr<void> Function(CustomComponent)? onLoad,
+    void Function(CustomComponent)? onMount,
+    void Function(CustomComponent)? onRemove,
+  })  : _onGameResize = onGameResize,
+        _onLoad = onLoad,
+        _onMount = onMount,
+        _onRemove = onRemove;
+
+  final void Function(CustomComponent, Vector2)? _onGameResize;
+  final FutureOr<void> Function(CustomComponent)? _onLoad;
+  final void Function(CustomComponent)? _onMount;
+  final void Function(CustomComponent)? _onRemove;
+
+  @override
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    _onGameResize?.call(this, size);
+  }
+
+  @override
+  FutureOr<void> onLoad() => _onLoad?.call(this);
+
+  @override
+  void onMount() => _onMount?.call(this);
+
+  @override
+  void onRemove() => _onRemove?.call(this);
+}


### PR DESCRIPTION
# Description

Since we started using ComponentTreeRoot, the children of an unmounted component are stored in its `children` container -- which means the components added during `onLoad` are now accessible during `onMount` via `children` (even though they are still unmounted).

This PR adds a test for that.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #1945

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
