### PR TITLE
docs: Update broken fireslime references

### DIFF
--- a/.github/.cspell/flame_dictionary.txt
+++ b/.github/.cspell/flame_dictionary.txt
@@ -4,7 +4,6 @@ Audioplayers
 BGUG
 Bodymovin
 Dashbook
-Fireslime
 Hermione
 Kawabunga
 Klingsbo

--- a/packages/flame_flare/README.md
+++ b/packages/flame_flare/README.md
@@ -68,7 +68,7 @@ See the example app for a slightly more complex usage.
 The simplest way to show us your support is by giving the project a star.
 
 You can also support us by becoming a patron on Patreon:
-[![Patreon](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/fireslime)
+[![Patreon](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/bluefireoss)
 
 Or by making a single donation by buying us a coffee:
-[![Buy Me A Coffee](https://user-images.githubusercontent.com/835641/60540201-fcd7fa00-9ce4-11e9-87ec-1e98568e9f58.png)](https://www.buymeacoffee.com/fireslime)
+[![Buy Me A Coffee](https://user-images.githubusercontent.com/835641/60540201-fcd7fa00-9ce4-11e9-87ec-1e98568e9f58.png)](https://www.buymeacoffee.com/bluefire)


### PR DESCRIPTION
# Description

I am on a crusade to improve our spellchecking. I have a big PR that I am now going to break down into very small chunks to for review.

This is another hopefully not controversial one - broken links referencing the old Fire Slime.
Updating the links means we no longer need that word in our dictionary file.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
