### PR TITLE
docs: Update cspell github action and configuration

### DIFF
--- a/.github/.cspell/gamedev_dictionary.txt
+++ b/.github/.cspell/gamedev_dictionary.txt
@@ -1,3 +1,4 @@
+AABB # axis-aligned bounding box
 AHSL
 AHSV
 ARGB

--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -2,7 +2,12 @@
   "version": "0.2",
   "language": "en",
   "flagWords": ["teh", "hte"],
-  "ignorePaths": ["**/media/**", "**/assets/**", "**/test/**"],
+  "ignorePaths": [
+    "**/media/**",
+    "**/assets/**",
+    "**/test/**",
+    "CHANGELOG.md"
+  ],
   "ignoreRegExpList": [
       "@[\\w\\-]+",
       "\\$\\w+",

--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -6,7 +6,7 @@
     "**/media/**",
     "**/assets/**",
     "**/test/**",
-    "CHANGELOG.md"
+    "**/CHANGELOG.md"
   ],
   "ignoreRegExpList": [
       "@[\\w\\-]+",

--- a/.github/workflows/spell_checker.yml
+++ b/.github/workflows/spell_checker.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: streetsidesoftware/cspell-action@v2
         with:
           files: "**/*.{md,dart}"

--- a/.github/workflows/spell_checker.yml
+++ b/.github/workflows/spell_checker.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: zwaldowski/cspell-action@v1
+      - uses: streetsidesoftware/cspell-action@v2
         with:
-          paths: "**/*.{md,dart}"
+          files: "**/*.{md,dart}"
+          incremental_files_only: false
           config: .github/cspell.json
-          exclude: ".gitignore,CHANGELOG.md"

--- a/packages/flame/lib/src/extensions/color.dart
+++ b/packages/flame/lib/src/extensions/color.dart
@@ -37,6 +37,9 @@ extension ColorExtension on Color {
     );
   }
 
+  // used as an example hex color code on the documentation below
+  // cSpell:ignore fccc
+
   /// Parses an RGB color from a valid hex string (e.g. #1C1C1C).
   ///
   /// The `#` is optional.

--- a/packages/flame/lib/src/extensions/paint.dart
+++ b/packages/flame/lib/src/extensions/paint.dart
@@ -42,6 +42,9 @@ extension PaintExtension on Paint {
     return Paint()..color = color;
   }
 
+  // used as an example hex color code on the documentation below
+  // cSpell:ignore fccc
+
   /// Parses an ARGB color from a valid hex string (e.g. #1C1C1C).
   ///
   /// The `#` is optional.


### PR DESCRIPTION
# Description

I am on a crusade to improve our spellchecking. I have a big PR that I am now going to break down into very small chunks to for review.

[zwaldowski's cspell-action](https://github.com/zwaldowski/cspell-action) has been deprecated in favor of streetsidesoftware/cspell-action.

This PR:

* updates to use the new recommended cspell action
* update to use checkout v3, because why not
* fixes a few violations the new action caught

Note: I think we should make a distinction between things that should be in a dictionary (e.g. `AABB`, a standard industry acronym that we expect people to know what it is) and specific edge-cases/ignore rules for specific parts of specific files (e.g. something like `fccc` which is meaningless outside of the very specific context in which it is used). For the latter, I believe we should use case-by case exceptions.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
