### PR TITLE
fix: TextBoxComponent's boxConfig timePerChar generates "Optimized Out" error

### DIFF
--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -270,14 +270,20 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
     }
   }
 
+  final Set<Image> cachedToRemove = {};
+
   Future<void> redraw() async {
     final newSize = _recomputeSize();
     final cachedImage = cache;
-    if (cachedImage != null) {
+    if (cachedImage != null && !cachedToRemove.contains(cachedImage)) {
+      cachedToRemove.add(cachedImage);
       // Do not dispose of the cached image immediately, since it may have been
       // sent into the rendering pipeline where it is still pending to be used.
       // See issue #1618 for details.
-      Future.delayed(const Duration(milliseconds: 100), cachedImage.dispose);
+      Future.delayed(const Duration(milliseconds: 100), () {
+        cachedToRemove.remove(cachedImage);
+        cachedImage.dispose();
+      });
     }
     cache = await _fullRenderAsImage(newSize);
     size = newSize;


### PR DESCRIPTION
…t" error #2143

# Description
Error was happening because cachedImage.dispose(); was called multiple times on the same object.

https://github.com/flame-engine/flame/issues/2143

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #2143
