### PR TITLE
chore: Update rive package to 0.10.2

### DIFF
--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flame_rive: ^1.6.0
   flutter:
     sdk: flutter
-  rive: 0.9.0
+  rive: 0.10.2
 
 dev_dependencies:
   flame_lint: ^0.2.0

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flame_rive: ^1.6.0
   flutter:
     sdk: flutter
-  rive: 0.10.2
+  rive: 0.9.0
 
 dev_dependencies:
   flame_lint: ^0.2.0

--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -6,7 +6,7 @@ import 'package:flame/components.dart';
 import 'package:flutter/rendering.dart';
 import 'package:rive/rive.dart';
 
-import 'package:rive/src';
+import 'package:rive/math.dart';
 
 class RiveComponent extends PositionComponent {
   final Artboard artboard;

--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -6,7 +6,7 @@ import 'package:flame/components.dart';
 import 'package:flutter/rendering.dart';
 import 'package:rive/rive.dart';
 
-import 'package:rive/math.dart';
+import 'package:rive/src';
 
 class RiveComponent extends PositionComponent {
   final Artboard artboard;

--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -4,9 +4,8 @@ import 'dart:ui' as ui;
 
 import 'package:flame/components.dart';
 import 'package:flutter/rendering.dart';
-import 'package:rive/rive.dart';
-
 import 'package:rive/math.dart';
+import 'package:rive/rive.dart';
 
 class RiveComponent extends PositionComponent {
   final Artboard artboard;

--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -5,10 +5,8 @@ import 'dart:ui' as ui;
 import 'package:flame/components.dart';
 import 'package:flutter/rendering.dart';
 import 'package:rive/rive.dart';
-// ignore_for_file: implementation_imports
-import 'package:rive/src/rive_core/math/aabb.dart';
-import 'package:rive/src/rive_core/math/mat2d.dart';
-import 'package:rive/src/rive_core/math/vec2d.dart';
+
+import 'package:rive/math.dart';
 
 class RiveComponent extends PositionComponent {
   final Artboard artboard;

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flame: ^1.6.0
   flutter:
     sdk: flutter
-  rive: ^0.9.0
+  rive: ^0.10.2
 
 dev_dependencies:
   dartdoc: ^6.0.1

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flame: ^1.6.0
   flutter:
     sdk: flutter
-  rive: ^0.10.2
+  rive: ^0.9.0
 
 dev_dependencies:
   dartdoc: ^6.0.1

--- a/packages/flame_rive/test/flame_rive_test.dart
+++ b/packages/flame_rive/test/flame_rive_test.dart
@@ -79,7 +79,7 @@ void main() {
         await game.ready();
 
         // Check if the current artboard has animation
-        expect(riveComponent.animations.isNotEmpty, isTrue);
+        expect(riveComponent.artboard.animations.isNotEmpty, isTrue);
         // Check if this artboard is attach to any RiveAnimationController
         expect(riveComponent.artboard.animationControllers.isEmpty, isTrue);
       });
@@ -94,7 +94,7 @@ void main() {
         await game.ready();
 
         // Check if this artboard has animation
-        expect(riveComponent.animations.isNotEmpty, isTrue);
+        expect(riveComponent.artboard.animations.isNotEmpty, isTrue);
         // Check if this artboard is attach to any RiveAnimationController
         expect(riveComponent.artboard.animationControllers.isEmpty, isFalse);
         // Check if the attach RiveAnimationController is active

--- a/packages/flame_rive/test/flame_rive_test.dart
+++ b/packages/flame_rive/test/flame_rive_test.dart
@@ -79,7 +79,7 @@ void main() {
         await game.ready();
 
         // Check if the current artboard has animation
-        expect(riveComponent.artboard.hasAnimations, isTrue);
+        expect(riveComponent.animations.isNotEmpty, isTrue);
         // Check if this artboard is attach to any RiveAnimationController
         expect(riveComponent.artboard.animationControllers.isEmpty, isTrue);
       });
@@ -94,7 +94,7 @@ void main() {
         await game.ready();
 
         // Check if this artboard has animation
-        expect(riveComponent.artboard.hasAnimations, isTrue);
+        expect(riveComponent.animations.isNotEmpty, isTrue);
         // Check if this artboard is attach to any RiveAnimationController
         expect(riveComponent.artboard.animationControllers.isEmpty, isFalse);
         // Check if the attach RiveAnimationController is active


### PR DESCRIPTION
0.10.2: 

Performance improvement: No longer drawing components with an opacity of 0.
Updated example, see "Skinning Demo".
Support for negative speeds on linear animations when played back in state machines.
Support for overriding speed on animation states.


- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.
