### PR TITLE
docs: Fix broken links in Component Notifier examples

### DIFF
--- a/examples/lib/stories/components/components.dart
+++ b/examples/lib/stories/components/components.dart
@@ -64,7 +64,8 @@ void addComponentsStories(Dashbook dashbook) {
     ..add(
       'Component Notifier (with provider)',
       (_) => const ComponentsNotifierProviderExampleWidget(),
-      codeLink: baseLink('components/components_notifier_provider_example.dart'),
+      codeLink:
+          baseLink('components/components_notifier_provider_example.dart'),
       info: ComponentsNotifierProviderExampleWidget.description,
     );
 }

--- a/examples/lib/stories/components/components.dart
+++ b/examples/lib/stories/components/components.dart
@@ -58,13 +58,13 @@ void addComponentsStories(Dashbook dashbook) {
     ..add(
       'Component Notifier',
       (_) => const ComponentsNotifierExampleWidget(),
-      codeLink: baseLink('components/component_notifier_example.dart'),
+      codeLink: baseLink('components/components_notifier_example.dart'),
       info: ComponentsNotifierExampleWidget.description,
     )
     ..add(
       'Component Notifier (with provider)',
       (_) => const ComponentsNotifierProviderExampleWidget(),
-      codeLink: baseLink('components/component_notifier_provider_example.dart'),
+      codeLink: baseLink('components/components_notifier_provider_example.dart'),
       info: ComponentsNotifierProviderExampleWidget.description,
     );
 }


### PR DESCRIPTION
# Description
Current source code links for `Component Notifier` and `Component Notifier (with provider)` return 404, this PR fixes it.


## Checklist
- [X] I have followed the [Contributor Guide] when preparing my PR.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
