### PR TITLE
refactor: Component rebalancing is now performed via a global queue

### DIFF
--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -96,9 +96,10 @@ class MyGame extends FlameGame {
 ```
 
 To update the priority of a component you have to set it to a new value, like
-`component.priority = 2`, and it will be updated in the next tick.
+`component.priority = 2`, and it will be updated in the current tick before the rendering stage.
 
-Example:
+In the following example we first initialize the component with priority 1, and then when the 
+user taps the component we change its priority to 2:
 
 ```dart
 class MyComponent extends PositionComponent with Tappable {
@@ -111,9 +112,6 @@ class MyComponent extends PositionComponent with Tappable {
   }
 }
 ```
-
-In the example above we first initialize the component with priority 1, and then when the user taps
-the component we change the priority to 2.
 
 
 ### Composability of components

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -98,7 +98,7 @@ class MyGame extends FlameGame {
 To update the priority of a component you have to set it to a new value, like
 `component.priority = 2`, and it will be updated in the current tick before the rendering stage.
 
-In the following example we first initialize the component with priority 1, and then when the 
+In the following example we first initialize the component with priority 1, and then when the
 user taps the component we change its priority to 2:
 
 ```dart

--- a/examples/lib/stories/components/priority_example.dart
+++ b/examples/lib/stories/components/priority_example.dart
@@ -33,7 +33,7 @@ class Square extends RectangleComponent
   bool onTapDown(TapDownInfo info) {
     final topComponent = gameRef.children.last;
     if (topComponent != this) {
-      gameRef.children.changePriority(this, topComponent.priority + 1);
+      priority = topComponent.priority + 1;
     }
     return false;
   }

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -489,7 +489,6 @@ class Component {
   /// children according to their [priority] order, relative to the
   /// priority of the direct siblings, not the children or the ancestors.
   void updateTree(double dt) {
-    _children?.updateComponentList();
     update(dt);
     _children?.forEach((c) => c.updateTree(dt));
   }
@@ -728,28 +727,26 @@ class Component {
   int get priority => _priority;
   int _priority;
   set priority(int newPriority) {
-    _priority = newPriority;
-    final game = findGame();
-    if (game != null && _parent != null) {
-      (game as FlameGame).enqueueRebalance(_parent!);
+    if (_priority != newPriority) {
+      _priority = newPriority;
+      final game = findGame();
+      if (game != null && _parent != null) {
+        (game as FlameGame).enqueueRebalance(_parent!);
+      }
     }
-
-    // if (parent == null) {
-    //   _priority = newPriority;
-    // } else {
-    //   parent!.children.changePriority(this, newPriority);
-    // }
   }
 
   /// Usually this is not something that the user would want to call since the
   /// component list isn't re-ordered when it is called.
   /// See FlameGame.changePriority instead.
+  @Deprecated('Will be removed in 1.8.0. Use priority setter instead.')
   void changePriorityWithoutResorting(int priority) => _priority = priority;
 
   /// Call this if any of this component's children priorities have changed
   /// at runtime.
   ///
   /// This will call [ComponentSet.rebalanceAll] on the [children] ordered set.
+  @Deprecated('Will be removed in 1.8.0.')
   void reorderChildren() => _children?.rebalanceAll();
 
   //#endregion

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -728,11 +728,17 @@ class Component {
   int get priority => _priority;
   int _priority;
   set priority(int newPriority) {
-    if (parent == null) {
-      _priority = newPriority;
-    } else {
-      parent!.children.changePriority(this, newPriority);
+    _priority = newPriority;
+    final game = findGame();
+    if (game != null && _parent != null) {
+      (game as FlameGame).enqueueRebalance(_parent!);
     }
+
+    // if (parent == null) {
+    //   _priority = newPriority;
+    // } else {
+    //   parent!.children.changePriority(this, newPriority);
+    // }
   }
 
   /// Usually this is not something that the user would want to call since the

--- a/packages/flame/lib/src/components/core/component_set.dart
+++ b/packages/flame/lib/src/components/core/component_set.dart
@@ -67,14 +67,6 @@ class ComponentSet extends QueryableOrderedSet<Component> {
   @override
   bool get isNotEmpty => !isEmpty;
 
-  /// Call this on your update method.
-  ///
-  /// This method effectuates any pending operations of insertion or removal,
-  /// and thus actually modifies the components set.
-  /// Note: do not call this while iterating the set.
-  @Deprecated('Will be removed in 1.8.0.')
-  void updateComponentList() {}
-
   /// Sorts the components according to their `priority`s. This method is
   /// invoked by the framework when it knows that the priorities of the
   /// components in this set has changed.
@@ -85,6 +77,14 @@ class ComponentSet extends QueryableOrderedSet<Component> {
     super.clear();
     elements.forEach(super.add);
   }
+
+  /// Call this on your update method.
+  ///
+  /// This method effectuates any pending operations of insertion or removal,
+  /// and thus actually modifies the components set.
+  /// Note: do not call this while iterating the set.
+  @Deprecated('Will be removed in 1.8.0.')
+  void updateComponentList() {}
 
   @Deprecated('Will be removed in 1.8.0.')
   @override

--- a/packages/flame/lib/src/components/core/component_set.dart
+++ b/packages/flame/lib/src/components/core/component_set.dart
@@ -75,14 +75,20 @@ class ComponentSet extends QueryableOrderedSet<Component> {
   @Deprecated('Will be removed in 1.8.0.')
   void updateComponentList() {}
 
-  @Deprecated('Will be made internal in 1.8.0.')
-  @override
-  void rebalanceAll() {
+  /// Sorts the components according to their `priority`s. This method is
+  /// invoked by the framework when it knows that the priorities of the
+  /// components in this set has changed.
+  @internal
+  void reorder() {
     final elements = toList();
     // bypass the wrapper because the components are already added
     super.clear();
     elements.forEach(super.add);
   }
+
+  @Deprecated('Will be removed in 1.8.0.')
+  @override
+  void rebalanceAll() => reorder();
 
   @Deprecated('Will be removed in 1.8.0.')
   @override

--- a/packages/flame/lib/src/components/core/component_set.dart
+++ b/packages/flame/lib/src/components/core/component_set.dart
@@ -73,8 +73,7 @@ class ComponentSet extends QueryableOrderedSet<Component> {
   /// and thus actually modifies the components set.
   /// Note: do not call this while iterating the set.
   @Deprecated('Will be removed in 1.8.0.')
-  void updateComponentList() {
-  }
+  void updateComponentList() {}
 
   @Deprecated('Will be made internal in 1.8.0.')
   @override

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -110,8 +110,7 @@ class ComponentTreeRoot extends Component {
 
   void processRebalanceEvents() {
     for (final component in _componentsToRebalance) {
-      // ignore: deprecated_member_use_from_same_package
-      component.children.rebalanceAll();
+      component.children.reorder();
     }
     _componentsToRebalance.clear();
   }

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -12,10 +12,12 @@ import 'package:vector_math/vector_math_64.dart';
 class ComponentTreeRoot extends Component {
   ComponentTreeRoot({super.children})
       : _queue = RecycledQueue(_LifecycleEvent.new),
-        _blocked = <int>{};
+        _blocked = <int>{},
+        _componentsToRebalance = <Component>{};
 
   final RecycledQueue<_LifecycleEvent> _queue;
   final Set<int> _blocked;
+  final Set<Component> _componentsToRebalance;
 
   @internal
   void enqueueAdd(Component child, Component parent) {
@@ -54,6 +56,11 @@ class ComponentTreeRoot extends Component {
       ..kind = _LifecycleEventKind.move
       ..child = child
       ..parent = newParent;
+  }
+
+  @internal
+  void enqueueRebalance(Component parent) {
+    _componentsToRebalance.add(parent);
   }
 
   bool get hasLifecycleEvents => _queue.isNotEmpty;
@@ -99,6 +106,13 @@ class ComponentTreeRoot extends Component {
       }
       _blocked.clear();
     }
+  }
+
+  void processRebalanceEvents() {
+    for (final component in _componentsToRebalance) {
+      component.children.rebalanceAll();
+    }
+    _componentsToRebalance.clear();
   }
 
   @mustCallSuper

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -110,6 +110,7 @@ class ComponentTreeRoot extends Component {
 
   void processRebalanceEvents() {
     for (final component in _componentsToRebalance) {
+      // ignore: deprecated_member_use_from_same_package
       component.children.rebalanceAll();
     }
     _componentsToRebalance.clear();

--- a/packages/flame/lib/src/components/router_component.dart
+++ b/packages/flame/lib/src/components/router_component.dart
@@ -273,9 +273,8 @@ class RouterComponent extends Component {
 
   void _adjustRoutesOrder() {
     for (var i = 0; i < _routeStack.length; i++) {
-      _routeStack[i].changePriorityWithoutResorting(i);
+      _routeStack[i].priority = i;
     }
-    reorderChildren();
   }
 
   void _adjustRoutesVisibility() {

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -85,7 +85,6 @@ class FlameGame extends ComponentTreeRoot with Game {
   @override
   void updateTree(double dt) {
     processLifecycleEvents();
-    children.updateComponentList();
     if (parent != null) {
       update(dt);
     }

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -90,6 +90,7 @@ class FlameGame extends ComponentTreeRoot with Game {
       update(dt);
     }
     children.forEach((c) => c.updateTree(dt));
+    processRebalanceEvents();
   }
 
   /// This passes the new size along to every component in the tree via their

--- a/packages/flame/test/components/priority_test.dart
+++ b/packages/flame/test/components/priority_test.dart
@@ -1,6 +1,10 @@
+import 'dart:ui';
+
 import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
+
+import '../custom_component.dart';
 // ignore_for_file: deprecated_member_use_from_same_package
 
 void main() {
@@ -202,6 +206,42 @@ void main() {
         componentsSorted(c.children);
       },
     );
+
+    testWithFlameGame('child can update priority of its parent', (game) async {
+      final renderEvents = <String>[];
+
+      final parent = CustomComponent(
+        priority: 0,
+        onRender: (self, canvas) {
+          renderEvents.add('render:parent');
+        },
+      );
+      final child = CustomComponent(
+        onUpdate: (self, dt) {
+          self.parent!.priority = 10;
+        },
+      );
+      parent.add(child);
+      game.add(parent);
+      game.add(
+        CustomComponent(
+          priority: 1,
+          onRender: (self, canvas) {
+            renderEvents.add('render:another');
+          },
+        ),
+      );
+      await game.ready();
+
+      expect(parent.priority, 0);
+      expect(child.priority, 0);
+      game.update(0.1);
+      expect(parent.priority, 10);
+      expect(child.priority, 0);
+      expect(renderEvents, isEmpty);
+      game.render(Canvas(PictureRecorder()));
+      expect(renderEvents, ['render:another', 'render:parent']);
+    });
   });
 }
 

--- a/packages/flame/test/components/priority_test.dart
+++ b/packages/flame/test/components/priority_test.dart
@@ -249,9 +249,9 @@ class _SpyComponentSet extends ComponentSet {
   int callCount = 0;
 
   @override
-  void rebalanceAll() {
+  void reorder() {
     callCount++;
-    super.rebalanceAll();
+    super.reorder();
   }
 }
 

--- a/packages/flame/test/components/priority_test.dart
+++ b/packages/flame/test/components/priority_test.dart
@@ -1,27 +1,7 @@
 import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
-
-class _PriorityComponent extends Component {
-  _PriorityComponent(int priority) : super(priority: priority);
-}
-
-class _ParentWithReorderSpy extends Component {
-  int callCount = 0;
-
-  _ParentWithReorderSpy(int priority) : super(priority: priority);
-
-  @override
-  void reorderChildren() {
-    callCount++;
-    super.reorderChildren();
-  }
-
-  void assertCalled(int n) {
-    expect(callCount, n);
-    callCount = 0;
-  }
-}
+// ignore_for_file: deprecated_member_use_from_same_package
 
 void main() {
   void componentsSorted(Iterable<Component> components) {
@@ -223,4 +203,31 @@ void main() {
       },
     );
   });
+}
+
+class _SpyComponentSet extends ComponentSet {
+  int callCount = 0;
+
+  @override
+  void rebalanceAll() {
+    callCount++;
+    super.rebalanceAll();
+  }
+}
+
+class _PriorityComponent extends Component {
+  _PriorityComponent(int priority) : super(priority: priority);
+}
+
+class _ParentWithReorderSpy extends Component {
+  _ParentWithReorderSpy(int priority) : super(priority: priority);
+
+  @override
+  ComponentSet createComponentSet() => _SpyComponentSet();
+
+  void assertCalled(int n) {
+    final componentSet = children as _SpyComponentSet;
+    expect(componentSet.callCount, n);
+    componentSet.callCount = 0;
+  }
 }

--- a/packages/flame/test/custom_component.dart
+++ b/packages/flame/test/custom_component.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:flame/components.dart';
 
@@ -10,15 +11,23 @@ class CustomComponent extends Component {
     FutureOr<void> Function(CustomComponent)? onLoad,
     void Function(CustomComponent)? onMount,
     void Function(CustomComponent)? onRemove,
+    void Function(CustomComponent, double)? onUpdate,
+    void Function(CustomComponent, Canvas)? onRender,
+    super.priority,
+    super.children,
   })  : _onGameResize = onGameResize,
         _onLoad = onLoad,
         _onMount = onMount,
-        _onRemove = onRemove;
+        _onRemove = onRemove,
+        _onUpdate = onUpdate,
+        _onRender = onRender;
 
   final void Function(CustomComponent, Vector2)? _onGameResize;
   final FutureOr<void> Function(CustomComponent)? _onLoad;
   final void Function(CustomComponent)? _onMount;
   final void Function(CustomComponent)? _onRemove;
+  final void Function(CustomComponent, double)? _onUpdate;
+  final void Function(CustomComponent, Canvas)? _onRender;
 
   @override
   void onGameResize(Vector2 size) {
@@ -34,4 +43,10 @@ class CustomComponent extends Component {
 
   @override
   void onRemove() => _onRemove?.call(this);
+
+  @override
+  void update(double dt) => _onUpdate?.call(this, dt);
+
+  @override
+  void render(Canvas canvas) => _onRender?.call(this, canvas);
 }


### PR DESCRIPTION
# Description

This PR ensures that all component rebalancing operations are resolved from a single location, after the `update` stage but before the `render` stage (thus, components may get reordered during the update, and these changes will go into effect during the rendering step on the same game tick).

This also fixes the problem where the child changing the priorities of its parent would cause a ConcurrentModificationError.

A number of methods that were used to handle rebalancing are now marked as deprecated. From the user's perspective, the only API they should be using is the `.priority` setter.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [-] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2263


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
