### PR TITLE
docs: Small anchor confusion in the components doc

### DIFF
--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -385,18 +385,19 @@ as the point within the component by which Flame "grabs" it.
 
 All children of the `PositionComponent` will be transformed in relation to the parent, which means
 that the `position`, `angle` and `scale` will be relative to the parents state.
-So if you, for example, wanted to position a child 50 logical pixels above the center of the parent
-you would do this:
+So if you, for example, wanted to position a child in the center of the parent you would do this:
 
 ```dart
 Future<void> onLoad() async {
   final parent = PositionComponent(
     position: Vector2(100, 100),
     size: Vector2(100, 100),
+  );
+  final child = PositionComponent(
+    position: parent.size / 2,
     anchor: Anchor.center,
   );
-  final child = PositionComponent(position: Vector2(0, -50));
-  await parent.add(child);
+  parent.add(child);
 }
 ```
 


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description

Seems to have been some confusion about the anchor from the one that wrote these docs, the sentence that described the code was wrong.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues

https://stackoverflow.com/questions/75493256/confusion-on-anchor-argument-of-position-component
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
