### PR TITLE
docs: Fix invite link to Discord in docs top bar

### DIFF
--- a/doc/_sphinx/theme/layout.html
+++ b/doc/_sphinx/theme/layout.html
@@ -96,8 +96,8 @@
   <div class="expander"></div>
 
   <div class="versions-placeholder"></div>
-  <a href="https://discord.com/channels/509714518008528896/516639688581316629" id="discord-button"
-     class="btn" title="Flame Discord channel">
+  <a href="https://discord.com/invite/pxrBmy4" id="discord-button" class="btn"
+     title="Blue Fire Discord server">
     <i class="fab fa-discord"></i>
   </a>
   <a href="https://github.com/flame-engine/flame/" id="github-button" class="btn"


### PR DESCRIPTION
# Description

The link went directly to the Flame channel instead of being an invite link to the server, so it didn't work for people that weren't already on the server.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
