### PR TITLE
refactor: Use variable name on toString in component_test.dart

### DIFF
--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -62,8 +62,8 @@ void main() {
       testWithFlameGame(
         'component removed completes after changing parent',
         (game) async {
-          final parent = LifecycleComponent()..addToParent(game);
-          final child = LifecycleComponent()..addToParent(parent);
+          final parent = LifecycleComponent('parent')..addToParent(game);
+          final child = LifecycleComponent('child')..addToParent(parent);
           await game.ready();
           final removed = child.removed;
 
@@ -80,8 +80,8 @@ void main() {
 
       testWithFlameGame('remove parent of child that has removed set',
           (game) async {
-        final parent = LifecycleComponent()..addToParent(game);
-        final child = LifecycleComponent()..addToParent(parent);
+        final parent = LifecycleComponent('parent')..addToParent(game);
+        final child = LifecycleComponent('child')..addToParent(parent);
         await game.ready();
         final removed = child.removed;
 
@@ -94,8 +94,8 @@ void main() {
       testWithFlameGame(
         'component mounted completes when changing parent',
         (game) async {
-          final parent = LifecycleComponent();
-          final child = LifecycleComponent();
+          final parent = LifecycleComponent('parent');
+          final child = LifecycleComponent('child');
           parent.add(child);
           game.add(parent);
 
@@ -116,8 +116,8 @@ void main() {
       testWithFlameGame(
         'component mounted completes when changing parent from a null parent',
         (game) async {
-          final parent = LifecycleComponent();
-          final child = LifecycleComponent();
+          final parent = LifecycleComponent('parent');
+          final child = LifecycleComponent('child');
           game.add(parent);
 
           final mounted = child.mounted;
@@ -174,8 +174,8 @@ void main() {
       );
 
       testWithFlameGame('correct lifecycle on parent change', (game) async {
-        final parent = LifecycleComponent();
-        final child = LifecycleComponent();
+        final parent = LifecycleComponent('parent');
+        final child = LifecycleComponent('child');
         parent.add(child);
         game.add(parent);
         await game.ready();
@@ -232,8 +232,8 @@ void main() {
               ],
             ),
           );
-          final component1 = LifecycleComponent()..addToParent(game1);
-          final component2 = LifecycleComponent()..addToParent(game2);
+          final component1 = LifecycleComponent('A')..addToParent(game1);
+          final component2 = LifecycleComponent('B')..addToParent(game2);
           await game1.ready();
           await game2.ready();
           expect(
@@ -250,8 +250,8 @@ void main() {
       testWithFlameGame(
         'Remove and re-add component with children',
         (game) async {
-          final parent = LifecycleComponent();
-          final child = LifecycleComponent()..addToParent(parent);
+          final parent = LifecycleComponent('parent');
+          final child = LifecycleComponent('child')..addToParent(parent);
           await game.add(parent);
           await game.ready();
 
@@ -1149,8 +1149,9 @@ class TwoChildrenComponent extends Component {
 
 class LifecycleComponent extends Component {
   final List<String> events = [];
+  final String name;
 
-  LifecycleComponent();
+  LifecycleComponent([this.name = '']);
 
   int countEvents(String event) {
     return events.where((e) => e == event).length;
@@ -1187,6 +1188,9 @@ class LifecycleComponent extends Component {
     super.onGameResize(size);
     events.add('onGameResize $size');
   }
+
+  @override
+  String toString() => 'LifecycleComponent($name)';
 }
 
 class _SlowLoadingComponent extends Component {

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -33,7 +33,7 @@ void main() {
       testWithFlameGame(
         'component.removed completes if obtained before the game was ready',
         (game) async {
-          final component = LifecycleComponent('component');
+          final component = LifecycleComponent();
           final removed = component.removed;
           await game.add(component);
           await game.ready();
@@ -48,7 +48,7 @@ void main() {
       testWithFlameGame(
         'component removed completes when set after game is ready',
         (game) async {
-          final component = LifecycleComponent('component');
+          final component = LifecycleComponent();
           await game.add(component);
           await game.ready();
           final removed = component.removed;
@@ -62,8 +62,8 @@ void main() {
       testWithFlameGame(
         'component removed completes after changing parent',
         (game) async {
-          final parent = LifecycleComponent('parent')..addToParent(game);
-          final child = LifecycleComponent('child')..addToParent(parent);
+          final parent = LifecycleComponent()..addToParent(game);
+          final child = LifecycleComponent()..addToParent(parent);
           await game.ready();
           final removed = child.removed;
 
@@ -80,8 +80,8 @@ void main() {
 
       testWithFlameGame('remove parent of child that has removed set',
           (game) async {
-        final parent = LifecycleComponent('parent')..addToParent(game);
-        final child = LifecycleComponent('child')..addToParent(parent);
+        final parent = LifecycleComponent()..addToParent(game);
+        final child = LifecycleComponent()..addToParent(parent);
         await game.ready();
         final removed = child.removed;
 
@@ -94,8 +94,8 @@ void main() {
       testWithFlameGame(
         'component mounted completes when changing parent',
         (game) async {
-          final parent = LifecycleComponent('parent');
-          final child = LifecycleComponent('child');
+          final parent = LifecycleComponent();
+          final child = LifecycleComponent();
           parent.add(child);
           game.add(parent);
 
@@ -116,8 +116,8 @@ void main() {
       testWithFlameGame(
         'component mounted completes when changing parent from a null parent',
         (game) async {
-          final parent = LifecycleComponent('parent');
-          final child = LifecycleComponent('child');
+          final parent = LifecycleComponent();
+          final child = LifecycleComponent();
           game.add(parent);
 
           final mounted = child.mounted;
@@ -174,8 +174,8 @@ void main() {
       );
 
       testWithFlameGame('correct lifecycle on parent change', (game) async {
-        final parent = LifecycleComponent('parent');
-        final child = LifecycleComponent('child');
+        final parent = LifecycleComponent();
+        final child = LifecycleComponent();
         parent.add(child);
         game.add(parent);
         await game.ready();
@@ -232,8 +232,8 @@ void main() {
               ],
             ),
           );
-          final component1 = LifecycleComponent('A')..addToParent(game1);
-          final component2 = LifecycleComponent('B')..addToParent(game2);
+          final component1 = LifecycleComponent()..addToParent(game1);
+          final component2 = LifecycleComponent()..addToParent(game2);
           await game1.ready();
           await game2.ready();
           expect(
@@ -250,8 +250,8 @@ void main() {
       testWithFlameGame(
         'Remove and re-add component with children',
         (game) async {
-          final parent = LifecycleComponent('parent');
-          final child = LifecycleComponent('child')..addToParent(parent);
+          final parent = LifecycleComponent();
+          final child = LifecycleComponent()..addToParent(parent);
           await game.add(parent);
           await game.ready();
 
@@ -1149,9 +1149,8 @@ class TwoChildrenComponent extends Component {
 
 class LifecycleComponent extends Component {
   final List<String> events = [];
-  final String? name;
 
-  LifecycleComponent([this.name]);
+  LifecycleComponent();
 
   int countEvents(String event) {
     return events.where((e) => e == event).length;


### PR DESCRIPTION
# Description

This is a cleanup identified on this issue: https://github.com/flame-engine/flame/issues/2308
Using an amazing unused-code tooling
Now, since Flame is a public API, unused code might not be trivial - it might just mean untested code.

In this case, the unused code is in the tests, which likely means it is indeed necessary.
I tried to infer the intent of the author here, and even considered adding the names of the components to the events, but the events are already always per component, so that was meaningless. I also thought it might be a missing toString, that they would wish to show the component name for debugging purposes, but I didn't see any asserts/logs on the component objects themselves (just the events).
So I concluded there is no reason to keep this field, but lmk if anyone disagrees and I can bring it back and add some function to it.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md