### PR TITLE
test: Add test for the intersections test helper method

### DIFF
--- a/packages/flame/test/collisions/collision_type_test.dart
+++ b/packages/flame/test/collisions/collision_type_test.dart
@@ -27,6 +27,23 @@ void main() {
         expect(blockA.activeCollisions.length, 1);
         expect(blockB.activeCollisions.length, 1);
       },
+      'intersections are returned': (game) async {
+        final blockA = TestBlock(
+          Vector2.zero(),
+          Vector2.all(10),
+        );
+        final blockB = TestBlock(
+          Vector2.all(1),
+          Vector2.all(10),
+        );
+        await game.ensureAddAll([blockA, blockB]);
+        game.update(0);
+
+        final points = blockA.intersections(blockB);
+        expect(points.length, 2);
+        expect(points, contains(Vector2(1, 10)));
+        expect(points, contains(Vector2(10, 1)));
+      },
       'passives do not collide': (game) async {
         final blockA = TestBlock(
           Vector2.zero(),


### PR DESCRIPTION
# Description

This is a cleanup identified on this issue: https://github.com/flame-engine/flame/issues/2308
Using an amazing unused-code tooling
Now, since Flame is a public API, unused code might not be trivial - it might just mean untested code.

In this case, we have a test helper, which is a public function we expose to help people write better tests.
Which means that the function could be useful, it was just lacking a test -- so I added it.
That being said, if this method is deemed unnecessary for users, I can just remove it instead - lmk.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md