### PR TITLE
refactor: Remove unused variable "tapTimes" from multi_touch_tap_detector_test.dart

### DIFF
--- a/packages/flame/test/events/game_mixins/multi_touch_tap_detector_test.dart
+++ b/packages/flame/test/events/game_mixins/multi_touch_tap_detector_test.dart
@@ -88,7 +88,6 @@ void main() {
 }
 
 class _GameWithMultiTouchTapDetector extends Game with MultiTouchTapDetector {
-  int tapTimes = 0;
   bool updated = false;
   bool rendered = false;
 


### PR DESCRIPTION
# Description

This is a cleanup identified on this issue: https://github.com/flame-engine/flame/issues/2308
Using an amazing unused-code tooling
Now, since Flame is a public API, unused code might not be trivial - it might just mean untested code.

This one was a no-brainer -- the variable was clearly replaced by specific counters during the writing of the test and forgotten there:

```
  int nOnTapDown = 0;
  int nOnLongTapDown = 0;
  int nOnTapUp = 0;
  int nOnTap = 0;
  int nOnTapCancel = 0;
```

It wasn't even increment and the taps are already thoroughly tested more granularly.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md