### PR TITLE
refactor: Remove unused event "ScoreEventCleared" from flame_block example

### DIFF
--- a/packages/flame_bloc/example/lib/src/game_stats/bloc/game_stats_bloc.dart
+++ b/packages/flame_bloc/example/lib/src/game_stats/bloc/game_stats_bloc.dart
@@ -12,12 +12,6 @@ class GameStatsBloc extends Bloc<GameStatsEvent, GameStatsState> {
       ),
     );
 
-    on<ScoreEventCleared>(
-      (event, emit) => emit(
-        state.copyWith(score: 0),
-      ),
-    );
-
     on<PlayerRespawned>(
       (event, emit) => emit(
         state.copyWith(status: GameStatus.respawned),

--- a/packages/flame_bloc/example/lib/src/game_stats/bloc/game_stats_event.dart
+++ b/packages/flame_bloc/example/lib/src/game_stats/bloc/game_stats_event.dart
@@ -13,13 +13,6 @@ class ScoreEventAdded extends GameStatsEvent {
   List<Object?> get props => [score];
 }
 
-class ScoreEventCleared extends GameStatsEvent {
-  const ScoreEventCleared();
-
-  @override
-  List<Object?> get props => [];
-}
-
 class PlayerDied extends GameStatsEvent {
   const PlayerDied();
 


### PR DESCRIPTION
# Description

This is a cleanup identified on this issue: https://github.com/flame-engine/flame/issues/2308
Using an amazing unused-code tooling
Now, since Flame is a public API, unused code might not be trivial - it might just mean untested code.

Since this an example package, it definitely should never have unused code.
In this case, the constructor wasn't being used, but upon deeper investigation, that was because this particular event wasn't ever fired at all.
So I removed it entirely. If this was supposed to be fired somewhere by the example, please lmk and I can add the missing firing.
But as far as I can see, the event serves no purpose in this example.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md