### PR TITLE
test: Add test for two subsequent state changes to flame_multi_bloc_provider_test.dart

### DIFF
--- a/packages/flame_bloc/test/src/flame_multi_bloc_provider_test.dart
+++ b/packages/flame_bloc/test/src/flame_multi_bloc_provider_test.dart
@@ -182,6 +182,34 @@ void main() {
         expect(player.lastState, equals(PlayerState.sad));
         expect(inventory.lastState, equals(InventoryState.bow));
       });
+
+      testWithFlameGame(
+        'can listen to multiple subsequent state changes',
+        (game) async {
+          final playerCubit = PlayerCubit();
+          late PlayerListener player;
+
+          final provider = FlameMultiBlocProvider(
+            providers: [
+              FlameBlocProvider<PlayerCubit, PlayerState>.value(
+                value: playerCubit,
+              ),
+            ],
+            children: [
+              player = PlayerListener(),
+            ],
+          );
+          await game.ensureAdd(provider);
+
+          playerCubit.kill();
+          await Future<void>.microtask(() {});
+          expect(player.lastState, equals(PlayerState.dead));
+
+          playerCubit.riseFromTheDead();
+          await Future<void>.microtask(() {});
+          expect(player.lastState, equals(PlayerState.alive));
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
# Description

This is a cleanup identified on this issue: https://github.com/flame-engine/flame/issues/2308
Using an amazing unused-code tooling
Now, since Flame is a public API, unused code might not be trivial - it might just mean untested code.

In this case, it is a test file, so there should definitely be no unused code.
However analyzing the unused code revealed to me some intent of testing multiple subsequent state changes (dead -> raise from dead).
I believe such test was missing entirely, so I added it. I think it holds value, but lmk if you disagree I can just delete the test and the method.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md