### PR TITLE
fix: Incorrect JoystickComponent position in landscape mode #2387

### DIFF
--- a/packages/flame/lib/src/components/input/hud_margin_component.dart
+++ b/packages/flame/lib/src/components/input/hud_margin_component.dart
@@ -69,9 +69,7 @@ class HudMarginComponent<T extends FlameGame> extends PositionComponent
   @override
   void onGameResize(Vector2 gameSize) {
     super.onGameResize(gameSize);
-    if (isMounted) {
-      _updateMargins();
-    }
+    _updateMargins();
   }
 
   void _updateMargins() {

--- a/packages/flame/test/components/joystick_component_test.dart
+++ b/packages/flame/test/components/joystick_component_test.dart
@@ -10,47 +10,51 @@ class _GameHasDraggables extends FlameGame with HasDraggables {}
 void main() {
   group('JoystickDirection tests', () {
     testWithGame<_GameHasDraggables>(
-        'can convert angle to JoystickDirection', _GameHasDraggables.new,
-        (game) async {
-      final joystick = JoystickComponent(
-        knob: CircleComponent(radius: 5.0),
-        size: 20,
-        margin: const EdgeInsets.only(left: 20, bottom: 20),
-      );
-      await game.ensureAdd(joystick);
+      'can convert angle to JoystickDirection',
+      _GameHasDraggables.new,
+      (game) async {
+        final joystick = JoystickComponent(
+          knob: CircleComponent(radius: 5.0),
+          size: 20,
+          margin: const EdgeInsets.only(left: 20, bottom: 20),
+        );
+        await game.ensureAdd(joystick);
 
-      expect(joystick.direction, JoystickDirection.idle);
-      joystick.delta.setValues(1.0, 0.0);
-      expect(joystick.direction, JoystickDirection.right);
-      joystick.delta.setValues(0.0, -1.0);
-      expect(joystick.direction, JoystickDirection.up);
-      joystick.delta.setValues(1.0, -1.0);
-      expect(joystick.direction, JoystickDirection.upRight);
-      joystick.delta.setValues(-1.0, -1.0);
-      expect(joystick.direction, JoystickDirection.upLeft);
-      joystick.delta.setValues(-1.0, 0.0);
-      expect(joystick.direction, JoystickDirection.left);
-      joystick.delta.setValues(0.0, 1.0);
-      expect(joystick.direction, JoystickDirection.down);
-      joystick.delta.setValues(1.0, 1.0);
-      expect(joystick.direction, JoystickDirection.downRight);
-      joystick.delta.setValues(-1.0, 1.0);
-      expect(joystick.direction, JoystickDirection.downLeft);
-    });
+        expect(joystick.direction, JoystickDirection.idle);
+        joystick.delta.setValues(1.0, 0.0);
+        expect(joystick.direction, JoystickDirection.right);
+        joystick.delta.setValues(0.0, -1.0);
+        expect(joystick.direction, JoystickDirection.up);
+        joystick.delta.setValues(1.0, -1.0);
+        expect(joystick.direction, JoystickDirection.upRight);
+        joystick.delta.setValues(-1.0, -1.0);
+        expect(joystick.direction, JoystickDirection.upLeft);
+        joystick.delta.setValues(-1.0, 0.0);
+        expect(joystick.direction, JoystickDirection.left);
+        joystick.delta.setValues(0.0, 1.0);
+        expect(joystick.direction, JoystickDirection.down);
+        joystick.delta.setValues(1.0, 1.0);
+        expect(joystick.direction, JoystickDirection.downRight);
+        joystick.delta.setValues(-1.0, 1.0);
+        expect(joystick.direction, JoystickDirection.downLeft);
+      },
+    );
 
     testWithGame<_GameHasDraggables>(
-        'properly re-positions onGameSize', _GameHasDraggables.new,
-        (game) async {
-      game.onGameResize(Vector2(100, 200));
-      final joystick = JoystickComponent(
-        knob: CircleComponent(radius: 5.0),
-        size: 20,
-        margin: const EdgeInsets.only(left: 20, bottom: 20),
-      );
-      joystick.loaded.then((_) => game.onGameResize(Vector2(200, 100)));
-      await game.ensureAdd(joystick);
-      expect(joystick.position, Vector2(30, 70));
-    });
+      'properly re-positions onGameSize',
+      _GameHasDraggables.new,
+      (game) async {
+        game.onGameResize(Vector2(100, 200));
+        final joystick = JoystickComponent(
+          knob: CircleComponent(radius: 5.0),
+          size: 20,
+          margin: const EdgeInsets.only(left: 20, bottom: 20),
+        );
+        joystick.loaded.then((_) => game.onGameResize(Vector2(200, 100)));
+        await game.ensureAdd(joystick);
+        expect(joystick.position, Vector2(30, 70));
+      },
+    );
   });
 
   group('Joystick input tests', () {

--- a/packages/flame/test/components/joystick_component_test.dart
+++ b/packages/flame/test/components/joystick_component_test.dart
@@ -37,6 +37,20 @@ void main() {
       joystick.delta.setValues(-1.0, 1.0);
       expect(joystick.direction, JoystickDirection.downLeft);
     });
+
+    testWithGame<_GameHasDraggables>(
+        'properly re-positions onGameSize', _GameHasDraggables.new,
+        (game) async {
+      game.onGameResize(Vector2(100, 200));
+      final joystick = JoystickComponent(
+        knob: CircleComponent(radius: 5.0),
+        size: 20,
+        margin: const EdgeInsets.only(left: 20, bottom: 20),
+      );
+      joystick.loaded.then((_) => game.onGameResize(Vector2(200, 100)));
+      await game.ensureAdd(joystick);
+      expect(joystick.position, Vector2(30, 70));
+    });
   });
 
   group('Joystick input tests', () {


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
When in landscape mode, a Component will need to be repositioned based on the new canvas
dimensions. If a Component has not reached the mounted state when
HudMarginComponent.onGameResize is called, then _updateMargins will not be called, and
the position will not be updated.
This PR removes the check that the Component has reached the mounted state in
HudMarginComponent.onGameResize so that _updateMargins will always be called.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
