### PR TITLE
docs: Fixed linked joints examples

### DIFF
--- a/doc/_sphinx/extensions/flutter_app.py
+++ b/doc/_sphinx/extensions/flutter_app.py
@@ -44,6 +44,9 @@ class FlutterAppDirective(SphinxDirective):
         In addition, the "code" run mode will try to locate a file or a folder
         with the matching name.
 
+      :subfolder: - optional parameter, needed if the app page is not located in the lib folder.
+      The value of the parameter should be the path from the lib folder to the page source file.
+
       :show: - a list of one or more run modes, which could include "widget",
         "popup", "code", and "infobox". Each of these modes produces a different
         output:
@@ -65,6 +68,7 @@ class FlutterAppDirective(SphinxDirective):
     option_spec = {
         'sources': directives.unchanged,
         'page': directives.unchanged,
+        'subfolder': directives.unchanged,
         'show': directives.unchanged,
         'width': directives.unchanged,
         'height': directives.unchanged,
@@ -222,7 +226,10 @@ class FlutterAppDirective(SphinxDirective):
             out.write('</body>\n</html>\n')
 
     def _generate_code_listings(self, code_id):
-        code_dir = self.source_dir + '/lib/' + self.options.get('page', '')
+        subfolder = self.options.get('subfolder', '')
+        if subfolder and not subfolder.endswith('/'):
+            subfolder += '/'
+        code_dir = self.source_dir + '/lib/' +  subfolder + self.options.get('page', '')
         if os.path.isdir(code_dir):
             files = glob.glob(code_dir + '/**', recursive=True)
         elif os.path.isfile(code_dir + '.dart'):

--- a/doc/bridge_packages/flame_forge2d/joints.md
+++ b/doc/bridge_packages/flame_forge2d/joints.md
@@ -39,14 +39,6 @@ another.
 
 It can for example be useful when simulating "soft-bodies".
 
-```{flutter-app}
-:sources: ../../examples
-:page: constant_volume_joint
-:show: widget code infobox
-:width: 200
-:height: 200
-```
-
 ```dart
   final constantVolumeJoint = ConstantVolumeJointDef()
     ..frequencyHz = 10
@@ -57,6 +49,13 @@ It can for example be useful when simulating "soft-bodies".
   });
     
   world.createJoint(ConstantVolumeJoint(world, constantVolumeJoint));
+```
+
+```{flutter-app}
+:sources: ../../examples
+:subfolder: stories/bridge_libraries/forge2d/joints
+:page: constant_volume_joint
+:show: code popup
 ```
 
 `ConstantVolumeJointDef` requires at least 3 bodies to be added using the `addBody` method. It also
@@ -75,14 +74,6 @@ A `DistanceJoint` constrains two points on two bodies to remain at a fixed dista
 
 You can view this as a massless, rigid rod.
 
-```{flutter-app}
-:sources: ../../examples
-:page: distance_joint
-:show: widget code infobox
-:width: 200
-:height: 200
-```
-
 ```dart
 final distanceJointDef = DistanceJointDef()
   ..initialize(firstBody, secondBody, firstBody.worldCenter, secondBody.worldCenter)
@@ -91,6 +82,13 @@ final distanceJointDef = DistanceJointDef()
   ..dampingRatio = 0.2;
 
 world.createJoint(DistanceJoint(distanceJointDef));
+```
+
+```{flutter-app}
+:sources: ../../examples
+:page: distance_joint
+:subfolder: stories/bridge_libraries/forge2d/joints
+:show: code popup
 ```
 
 To create a `DistanceJointDef`, you can use the `initialize` method, which requires two bodies and a
@@ -132,14 +130,6 @@ applied. In most cases, it would be the center of the first object. However, for
 physics interactions between bodies, you can set the `anchor` point to a specific location on one or
 both of the bodies.
 
-```{flutter-app}
-:sources: ../../examples
-:page: friction_joint
-:show: widget code infobox
-:width: 200
-:height: 200
-```
-
 ```dart
 final frictionJointDef = FrictionJointDef()
   ..initialize(ballBody, floorBody, ballBody.worldCenter)
@@ -147,6 +137,13 @@ final frictionJointDef = FrictionJointDef()
   ..maxTorque = 50;
 
   world.createJoint(FrictionJoint(frictionJointDef));
+```
+
+```{flutter-app}
+:sources: ../../examples
+:page: friction_joint
+:subfolder: stories/bridge_libraries/forge2d/joints
+:show: code popup
 ```
 
 When creating a `FrictionJoint`, simulated friction can be applied via maximum force and torque


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

Embedded flutter-app joints examples didn't work, because flutter-app script expects the example page to be located in the lib folder of a module. Introduced a new subfolder param, to specify where to find the example page.

Verified joints examples apps and code button on the doc page work; Also verified the same for the effects page.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [-] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

PR 5/X for #2005

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
