### PR TITLE
feat: Change `HasCollisionDetection` to be on `Component`

### DIFF
--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -51,7 +51,7 @@ within one `FlameGame`.
 Example:
 
 ```dart
-class CollidableWorld extends World with HasCollisionDetection {}
+class CollisionDetectionWorld extends World with HasCollisionDetection {}
 ```
 
 ```{note}

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -42,6 +42,23 @@ class MyGame extends FlameGame with HasCollisionDetection {
 Now when you add `ShapeHitbox`s to components that are then added to the game, they will
 automatically be checked for collisions.
 
+You can also add `HasCollisionDetection` directly to another `Component` instead of the `FlameGame`,
+for example to the `World` that is used for the `CameraComponent`.
+If that is done, hitboxes that are added in that component's tree will only be compared to other
+hitboxes in that subtree, which makes it possible to have several worlds with collision detection
+within one `FlameGame`.
+
+Example:
+
+```dart
+class CollidableWorld extends World with HasCollisionDetection {}
+```
+
+```{note}
+Hitboxes will only be connected to one collision detection system and that is the closest parent
+that has the `HasCollisionDetection` mixin.
+```
+
 
 ### CollisionCallbacks
 

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -55,8 +55,8 @@ class CollisionDetectionWorld extends World with HasCollisionDetection {}
 ```
 
 ```{note}
-Hitboxes will only be connected to one collision detection system and that is the closest parent
-that has the `HasCollisionDetection` mixin.
+Hitboxes will only be connected to one collision detection system and that is
+the closest parent that has the `HasCollisionDetection` mixin.
 ```
 
 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -44,3 +44,4 @@ app.*.symbols
 # Obfuscation related
 app.*.map.json
 .vscode/
+pubspec.lock

--- a/examples/lib/stories/collision_detection/collision_detection.dart
+++ b/examples/lib/stories/collision_detection/collision_detection.dart
@@ -4,6 +4,7 @@ import 'package:examples/stories/collision_detection/bouncing_ball_example.dart'
 import 'package:examples/stories/collision_detection/circles_example.dart';
 import 'package:examples/stories/collision_detection/collidable_animation_example.dart';
 import 'package:examples/stories/collision_detection/multiple_shapes_example.dart';
+import 'package:examples/stories/collision_detection/multiple_worlds_example.dart';
 import 'package:examples/stories/collision_detection/quadtree_example.dart';
 import 'package:examples/stories/collision_detection/raycast_example.dart';
 import 'package:examples/stories/collision_detection/raycast_light_example.dart';
@@ -37,6 +38,12 @@ void addCollisionDetectionStories(Dashbook dashbook) {
       (_) => GameWidget(game: MultipleShapesExample()),
       codeLink: baseLink('collision_detection/multiple_shapes_example.dart'),
       info: MultipleShapesExample.description,
+    )
+    ..add(
+      'Multiple worlds',
+      (_) => GameWidget(game: MultipleWorldsExample()),
+      codeLink: baseLink('collision_detection/multiple_worlds_example.dart'),
+      info: MultipleWorldsExample.description,
     )
     ..add(
       'QuadTree collision',

--- a/examples/lib/stories/collision_detection/multiple_worlds_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_worlds_example.dart
@@ -5,11 +5,8 @@ import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
 import 'package:flame/experimental.dart';
-import 'package:flame/extensions.dart' show OffsetExtension;
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/painting.dart';
 
 class MultipleWorldsExample extends FlameGame {
   static const description = '''

--- a/examples/lib/stories/collision_detection/multiple_worlds_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_worlds_example.dart
@@ -1,0 +1,84 @@
+import 'dart:math';
+
+import 'package:examples/commons/ember.dart';
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
+import 'package:flame/experimental.dart';
+import 'package:flame/extensions.dart' show OffsetExtension;
+import 'package:flame/game.dart';
+import 'package:flame/input.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/painting.dart';
+
+class MultipleWorldsExample extends FlameGame {
+  static const description = '''
+    This example shows how multiple worlds can have discrete collision
+    detection.
+    
+    The top two Embers live in one world and turn green when they collide and
+    the bottom two embers live in another world and turn red when they collide,
+    you can see that when one of the top ones collide with one of the bottom
+    ones, neither change their colors since they are in different worlds.
+  ''';
+
+  @override
+  Future<void> onLoad() async {
+    final world1 = CollisionDetectionWorld();
+    final world2 = CollisionDetectionWorld();
+    final camera1 = CameraComponent(world: world1);
+    final camera2 = CameraComponent(world: world2);
+    await addAll([world1, world2, camera1, camera2]);
+    final ember1 = CollidableEmber(position: Vector2(75, 75));
+    final ember2 = CollidableEmber(position: Vector2(-75, 75));
+    final ember3 = CollidableEmber(position: Vector2(75, -75));
+    final ember4 = CollidableEmber(position: Vector2(-75, -75));
+    world1.addAll([ember1, ember2]);
+    world2.addAll([ember3, ember4]);
+  }
+}
+
+class CollisionDetectionWorld extends World with HasCollisionDetection {}
+
+class CollidableEmber extends Ember with CollisionCallbacks {
+  CollidableEmber({super.position});
+
+  static final Random _rng = Random();
+  int get index =>
+      (position.x.isNegative ? 1 : 0) + (position.y.isNegative ? 2 : 0);
+
+  @override
+  Future<void> onLoad() async {
+    super.onLoad();
+    add(CircleHitbox());
+    add(
+      MoveToEffect(
+        Vector2.zero(),
+        EffectController(
+          duration: 0.5 + _rng.nextDouble(),
+          infinite: true,
+          alternate: true,
+        ),
+      ),
+    );
+  }
+
+  @override
+  void onCollisionStart(
+    Set<Vector2> intersectionPoints,
+    PositionComponent other,
+  ) {
+    super.onCollisionStart(intersectionPoints, other);
+
+    add(
+      ColorEffect(
+        index < 2 ? Colors.red : Colors.green,
+        const Offset(0, 0.9),
+        EffectController(
+          duration: 0.2,
+          alternate: true,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flame/lib/src/collisions/has_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/has_collision_detection.dart
@@ -1,9 +1,10 @@
 import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 
 /// Keeps track of all the [ShapeHitbox]s in the component tree and initiates
 /// collision detection every tick.
-mixin HasCollisionDetection<B extends Broadphase<ShapeHitbox>> on FlameGame {
+mixin HasCollisionDetection<B extends Broadphase<ShapeHitbox>> on Component {
   CollisionDetection<ShapeHitbox, B> _collisionDetection =
       StandardCollisionDetection();
   CollisionDetection<ShapeHitbox, B> get collisionDetection =>
@@ -27,7 +28,7 @@ mixin HasCollisionDetection<B extends Broadphase<ShapeHitbox>> on FlameGame {
 /// Do note that [collisionDetection] has to be initialized before the game
 /// starts the update loop for the collision detection to work.
 mixin HasGenericCollisionDetection<T extends Hitbox<T>, B extends Broadphase<T>>
-    on FlameGame {
+    on Component {
   CollisionDetection<T, B>? _collisionDetection;
   CollisionDetection<T, B> get collisionDetection => _collisionDetection!;
 

--- a/packages/flame/lib/src/collisions/has_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/has_collision_detection.dart
@@ -1,6 +1,5 @@
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
-import 'package:flame/game.dart';
 
 /// Keeps track of all the [ShapeHitbox]s in the component tree and initiates
 /// collision detection every tick.

--- a/packages/flame/lib/src/collisions/has_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/has_collision_detection.dart
@@ -1,8 +1,12 @@
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 
-/// Keeps track of all the [ShapeHitbox]s in the component tree and initiates
+/// Keeps track of all the [ShapeHitbox]s in the component's tree and initiates
 /// collision detection every tick.
+///
+/// Hitboxes are only part of the collision detection performed by its closest
+/// parent with the [HasCollisionDetection] mixin, if there are multiple nested
+/// classes that has [HasCollisionDetection].
 mixin HasCollisionDetection<B extends Broadphase<ShapeHitbox>> on Component {
   CollisionDetection<ShapeHitbox, B> _collisionDetection =
       StandardCollisionDetection();

--- a/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
@@ -96,9 +96,9 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
 
     // This should be placed after the hitbox parent listener
     // since the correct hitbox size is required by the QuadTree.
-    final parentGame = findParent<FlameGame>();
-    if (parentGame is HasCollisionDetection) {
-      _collisionDetection = parentGame.collisionDetection;
+    final parent = findParent<HasCollisionDetection>();
+    if (parent is HasCollisionDetection) {
+      _collisionDetection = parent.collisionDetection;
       _collisionDetection?.add(this);
     }
   }

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -300,8 +300,11 @@ class Component {
 
   /// Returns the closest parent further up the hierarchy that satisfies type=T,
   /// or null if no such parent can be found.
-  T? findParent<T extends Component>() {
-    return ancestors().whereType<T>().firstOrNull;
+  ///
+  /// If [includeSelf] is set to true (default is false) then the component
+  /// which the call is made for is also included in the search.
+  T? findParent<T extends Component>({bool includeSelf = false}) {
+    return ancestors(includeSelf: includeSelf).whereType<T>().firstOrNull;
   }
 
   /// Returns the first child that matches the given type [T], or null if there

--- a/packages/flame/test/collisions/collision_callback_benchmark_test.dart
+++ b/packages/flame/test/collisions/collision_callback_benchmark_test.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
+import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
@@ -41,7 +42,8 @@ class _TestBlock extends PositionComponent with CollisionCallbacks {
 void main() {
   group('Benchmark collision detection', () {
     runCollisionTestRegistry({
-      'collidable callbacks are called': (game) async {
+      'collidable callbacks are called': (collisionSystem) async {
+        final game = collisionSystem as FlameGame;
         final rng = Random(0);
         final blocks = List.generate(
           100,

--- a/packages/flame/test/collisions/collision_detection_test.dart
+++ b/packages/flame/test/collisions/collision_detection_test.dart
@@ -1,5 +1,6 @@
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
+import 'package:flame/game.dart';
 import 'package:flame/geometry.dart';
 import 'package:flame/geometry.dart' as geometry;
 import 'package:flame_test/flame_test.dart';
@@ -969,7 +970,8 @@ void main() {
 
   group('Raycasting', () {
     runCollisionTestRegistry({
-      'one hitbox': (game) async {
+      'one hitbox': (collisionSystem) async {
+        final game = collisionSystem as FlameGame;
         await game.ensureAdd(
           PositionComponent(
             children: [RectangleHitbox()],
@@ -984,12 +986,13 @@ void main() {
           origin: Vector2.zero(),
           direction: Vector2(1, 0),
         );
-        final result = game.collisionDetection.raycast(ray);
+        final result = collisionSystem.collisionDetection.raycast(ray);
         expect(result?.hitbox?.parent, game.children.first);
         expect(result?.reflectionRay?.origin, closeToVector(Vector2(50, 0)));
         expect(result?.reflectionRay?.direction, closeToVector(Vector2(-1, 0)));
       },
-      'multiple hitboxes after each other': (game) async {
+      'multiple hitboxes after each other': (collisionSystem) async {
+        final game = collisionSystem as FlameGame;
         await game.ensureAddAll([
           for (var i = 0.0; i < 10; i++)
             PositionComponent(
@@ -1003,7 +1006,7 @@ void main() {
           origin: Vector2.zero(),
           direction: Vector2.all(1)..normalize(),
         );
-        final result = game.collisionDetection.raycast(ray);
+        final result = collisionSystem.collisionDetection.raycast(ray);
         expect(result?.hitbox?.parent, game.children.first);
         expect(result?.reflectionRay?.origin, closeToVector(Vector2.all(90)));
         expect(
@@ -1011,7 +1014,9 @@ void main() {
           closeToVector(Vector2(-1, 1)..normalize()),
         );
       },
-      'multiple hitboxes after each other with one ignored': (game) async {
+      'multiple hitboxes after each other with one ignored':
+          (collisionSystem) async {
+        final game = collisionSystem as FlameGame;
         await game.ensureAddAll([
           for (var i = 0.0; i < 10; i++)
             PositionComponent(
@@ -1025,7 +1030,7 @@ void main() {
           origin: Vector2.zero(),
           direction: Vector2.all(1)..normalize(),
         );
-        final result = game.collisionDetection.raycast(
+        final result = collisionSystem.collisionDetection.raycast(
           ray,
           ignoreHitboxes: [
             game.children.first.children.first as ShapeHitbox,
@@ -1041,7 +1046,8 @@ void main() {
           closeToVector(Vector2(-1, 1)..normalize()),
         );
       },
-      'ray with origin on hitbox corner': (game) async {
+      'ray with origin on hitbox corner': (collisionSystem) async {
+        final game = collisionSystem as FlameGame;
         await game.ensureAddAll([
           PositionComponent(
             position: Vector2.all(10),
@@ -1053,7 +1059,7 @@ void main() {
           origin: Vector2.all(10),
           direction: Vector2.all(1)..normalize(),
         );
-        final result = game.collisionDetection.raycast(ray);
+        final result = collisionSystem.collisionDetection.raycast(ray);
         expect(result?.hitbox?.parent, game.children.first);
         expect(result?.reflectionRay?.origin, closeToVector(Vector2(20, 20)));
         expect(
@@ -1061,7 +1067,8 @@ void main() {
           closeToVector(Vector2(1, -1)..normalize()),
         );
       },
-      'raycast with maxDistance': (game) async {
+      'raycast with maxDistance': (collisionSystem) async {
+        final game = collisionSystem as FlameGame;
         await game.ensureAddAll([
           PositionComponent(
             position: Vector2.all(20),
@@ -1078,7 +1085,7 @@ void main() {
         final result = RaycastResult<ShapeHitbox>();
 
         // No hit cast
-        game.collisionDetection.raycast(
+        collisionSystem.collisionDetection.raycast(
           ray,
           maxDistance: Vector2.all(9).length,
           out: result,
@@ -1086,7 +1093,7 @@ void main() {
         expect(result.hitbox?.parent, isNull);
 
         // Extended cast
-        game.collisionDetection.raycast(
+        collisionSystem.collisionDetection.raycast(
           ray,
           maxDistance: Vector2.all(10).length,
           out: result,
@@ -1097,7 +1104,8 @@ void main() {
 
     group('Rectangle hitboxes', () {
       runCollisionTestRegistry({
-        'ray from within RectangleHitbox': (game) async {
+        'ray from within RectangleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.all(0),
@@ -1109,7 +1117,7 @@ void main() {
             origin: Vector2.all(5),
             direction: Vector2.all(1)..normalize(),
           );
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.normal, closeToVector(Vector2(0, -1)));
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(10, 10)));
@@ -1118,7 +1126,8 @@ void main() {
             closeToVector(Vector2(1, -1)..normalize()),
           );
         },
-        'ray from the left of RectangleHitbox': (game) async {
+        'ray from the left of RectangleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1127,7 +1136,7 @@ void main() {
           ]);
           await game.ready();
           final ray = Ray2(origin: Vector2(-5, 5), direction: Vector2(1, 0));
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(0, 5)));
           expect(
@@ -1135,7 +1144,8 @@ void main() {
             closeToVector(Vector2(-1, 0)),
           );
         },
-        'ray from the top of RectangleHitbox': (game) async {
+        'ray from the top of RectangleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1144,7 +1154,7 @@ void main() {
           ]);
           await game.ready();
           final ray = Ray2(origin: Vector2(5, -5), direction: Vector2(0, 1));
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(5, 0)));
           expect(
@@ -1152,7 +1162,8 @@ void main() {
             closeToVector(Vector2(0, -1)),
           );
         },
-        'ray from the right of RectangleHitbox': (game) async {
+        'ray from the right of RectangleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1161,7 +1172,7 @@ void main() {
           ]);
           await game.ready();
           final ray = Ray2(origin: Vector2(15, 5), direction: Vector2(-1, 0));
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(10, 5)));
           expect(
@@ -1169,7 +1180,8 @@ void main() {
             closeToVector(Vector2(1, 0)),
           );
         },
-        'ray from the bottom of RectangleHitbox': (game) async {
+        'ray from the bottom of RectangleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1178,7 +1190,7 @@ void main() {
           ]);
           await game.ready();
           final ray = Ray2(origin: Vector2(5, 15), direction: Vector2(0, -1));
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(5, 10)));
           expect(
@@ -1191,7 +1203,8 @@ void main() {
 
     group('Circle hitboxes', () {
       runCollisionTestRegistry({
-        'ray from top to bottom within CircleHitbox': (game) async {
+        'ray from top to bottom within CircleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1200,7 +1213,7 @@ void main() {
           ]);
           await game.ready();
           final ray = Ray2(origin: Vector2(5, 4), direction: Vector2(0, 1));
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.normal, closeToVector(Vector2(0, -1)));
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(5, 10)));
@@ -1209,7 +1222,9 @@ void main() {
             closeToVector(Vector2(0, -1)),
           );
         },
-        'ray from bottom-right to top-left within CircleHitbox': (game) async {
+        'ray from bottom-right to top-left within CircleHitbox':
+            (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1221,7 +1236,7 @@ void main() {
             origin: Vector2.all(6),
             direction: Vector2.all(-1)..normalize(),
           );
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.normal, closeToVector(Vector2.all(0.707106781186547)));
           expect(
@@ -1233,7 +1248,9 @@ void main() {
             closeToVector(Vector2.all(1)..normalize()),
           );
         },
-        'ray from bottom within CircleHitbox going down': (game) async {
+        'ray from bottom within CircleHitbox going down':
+            (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1243,7 +1260,7 @@ void main() {
           await game.ready();
           final direction = Vector2(0, 1);
           final ray = Ray2(origin: Vector2(5, 6), direction: direction);
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.normal, closeToVector(Vector2(0, -1)));
           expect(
@@ -1255,7 +1272,8 @@ void main() {
             closeToVector(direction.inverted()),
           );
         },
-        'ray from the left of CircleHitbox': (game) async {
+        'ray from the left of CircleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1264,7 +1282,7 @@ void main() {
           ]);
           await game.ready();
           final ray = Ray2(origin: Vector2(-5, 5), direction: Vector2(1, 0));
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(0, 5)));
           expect(
@@ -1272,7 +1290,8 @@ void main() {
             closeToVector(Vector2(-1, 0)),
           );
         },
-        'ray from the top of CircleHitbox': (game) async {
+        'ray from the top of CircleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1281,7 +1300,7 @@ void main() {
           ]);
           await game.ready();
           final ray = Ray2(origin: Vector2(5, -5), direction: Vector2(0, 1));
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(5, 0)));
           expect(
@@ -1289,7 +1308,8 @@ void main() {
             closeToVector(Vector2(0, -1)),
           );
         },
-        'ray from the right of CircleHitbox': (game) async {
+        'ray from the right of CircleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1298,7 +1318,7 @@ void main() {
           ]);
           await game.ready();
           final ray = Ray2(origin: Vector2(15, 5), direction: Vector2(-1, 0));
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(10, 5)));
           expect(
@@ -1306,7 +1326,8 @@ void main() {
             closeToVector(Vector2(1, 0)),
           );
         },
-        'ray from the bottom of CircleHitbox': (game) async {
+        'ray from the bottom of CircleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2.zero(),
@@ -1315,7 +1336,7 @@ void main() {
           ]);
           await game.ready();
           final ray = Ray2(origin: Vector2(5, 15), direction: Vector2(0, -1));
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, game.children.first);
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(5, 10)));
           expect(
@@ -1323,7 +1344,8 @@ void main() {
             closeToVector(Vector2(0, 1)),
           );
         },
-        'ray from the center of CircleHitbox': (game) async {
+        'ray from the center of CircleHitbox': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           final positionComponent = PositionComponent(
             position: Vector2.zero(),
             size: Vector2.all(10),
@@ -1335,7 +1357,7 @@ void main() {
             origin: positionComponent.absoluteCenter,
             direction: Vector2(0, -1),
           );
-          final result = game.collisionDetection.raycast(ray);
+          final result = collisionSystem.collisionDetection.raycast(ray);
           expect(result?.hitbox?.parent, positionComponent);
           expect(result?.reflectionRay?.origin, closeToVector(Vector2(5, 0)));
           expect(
@@ -1348,7 +1370,8 @@ void main() {
 
     group('raycastAll', () {
       runCollisionTestRegistry({
-        'All directions and all hits': (game) async {
+        'All directions and all hits': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2(10, 0),
@@ -1369,14 +1392,15 @@ void main() {
           ]);
           await game.ready();
           final origin = Vector2.all(15);
-          final results = game.collisionDetection.raycastAll(
+          final results = collisionSystem.collisionDetection.raycastAll(
             origin,
             numberOfRays: 4,
           );
           expect(results.every((r) => r.isActive), isTrue);
           expect(results.length, 4);
         },
-        'raycastAll with maxDistance': (game) async {
+        'raycastAll with maxDistance': (collisionSystem) async {
+          final game = collisionSystem as FlameGame;
           await game.ensureAddAll([
             PositionComponent(
               position: Vector2(10, 0),
@@ -1399,7 +1423,7 @@ void main() {
           final origin = Vector2.all(15);
 
           // No hit
-          final results1 = game.collisionDetection.raycastAll(
+          final results1 = collisionSystem.collisionDetection.raycastAll(
             origin,
             maxDistance: 4,
             numberOfRays: 4,
@@ -1407,7 +1431,7 @@ void main() {
           expect(results1.length, isZero);
 
           // Hit all four
-          final results2 = game.collisionDetection.raycastAll(
+          final results2 = collisionSystem.collisionDetection.raycastAll(
             origin,
             maxDistance: 5,
             numberOfRays: 4,
@@ -1418,7 +1442,8 @@ void main() {
     });
 
     runCollisionTestRegistry({
-      'All directions and all hits': (game) async {
+      'All directions and all hits': (collisionSystem) async {
+        final game = collisionSystem as FlameGame;
         await game.ensureAddAll([
           PositionComponent(
             position: Vector2(10, 0),
@@ -1440,7 +1465,7 @@ void main() {
         await game.ready();
         final origin = Vector2.all(15);
         final ignoreHitbox = game.children.first.children.first as ShapeHitbox;
-        final results = game.collisionDetection.raycastAll(
+        final results = collisionSystem.collisionDetection.raycastAll(
           origin,
           numberOfRays: 4,
           ignoreHitboxes: [ignoreHitbox],
@@ -1454,7 +1479,8 @@ void main() {
 
   group('Raytracing', () {
     runCollisionTestRegistry({
-      'on single circle': (game) async {
+      'on single circle': (collisionSystem) async {
+        final game = collisionSystem as FlameGame;
         final circle = CircleComponent(
           radius: 10.0,
           position: Vector2.all(20),
@@ -1465,7 +1491,7 @@ void main() {
           origin: Vector2(0, 10),
           direction: Vector2.all(1.0)..normalize(),
         );
-        final results = game.collisionDetection.raytrace(ray);
+        final results = collisionSystem.collisionDetection.raytrace(ray);
         expect(results.length, 1);
         expect(results.first.isActive, isTrue);
         expect(results.first.isInsideHitbox, isFalse);

--- a/packages/flame/test/collisions/collision_test_helpers.dart
+++ b/packages/flame/test/collisions/collision_test_helpers.dart
@@ -1,5 +1,6 @@
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
+import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
 import 'package:flame/image_composition.dart';
 import 'package:flame_test/flame_test.dart';
@@ -9,6 +10,8 @@ class HasCollidablesGame extends FlameGame with HasCollisionDetection {}
 
 class HasQuadTreeCollidablesGame extends FlameGame
     with HasQuadTreeCollisionDetection {}
+
+class CollisionDetectionWorld extends World with HasCollisionDetection {}
 
 @isTest
 Future<void> testCollisionDetectionGame(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: conventional_commit
-      sha256: "40321e55c2416c0940a846bf938c0a70efaf9eb72da042d5ea76b79b6f5045ee"
+      sha256: "8eee25c315cf1946215d02d598402ca75cfee8a8ab482f3fac34cb0717323afa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0-dev.0"
+    version: "0.6.0"
   file:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "739431cbc88d802dc215c0a7bac6e48a9a7fe2c42ef15cbe2f8c54433e6588d6"
+      sha256: cd8e7db0250ee822c5354a8214afc751b6c1c41aadfbbef927456d509d953244
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-dev.0"
+    version: "3.0.0"
   meta:
     dependency: transitive
     description:


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description

This change makes it possible to have the collision detection system further down in the tree than on the `FlameGame`, this enables you to have collision detection on the `World` component for example. 
Today it doesn't work if you have several worlds where the components are overlapping across the worlds, since the hitboxes live on top level.

So now you can use a `World` like this:
```dart
class CollisionDetectionWorld extends World with HasCollisionDetection {}
```
and all hitboxes added in there will only react with other hitboxes added to that world.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
