### PR TITLE
docs: Fix non-markdown section of README files

### DIFF
--- a/packages/flame_bloc/README.md
+++ b/packages/flame_bloc/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Offers a simple and natural way to use <a href="https://github.com/felangel/bloc">`flutter_bloc`</a> inside <a href="https://github.com/flame-engine/flame">Flame</a>.
+Offers a simple and natural way to use <a href="https://github.com/felangel/bloc">flutter_bloc</a> inside <a href="https://github.com/flame-engine/flame">Flame</a>.
 </p>
 
 <p align="center">

--- a/packages/flame_fire_atlas/README.md
+++ b/packages/flame_fire_atlas/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for <a href="https://github.com/flame-engine/fire-atlas">`fire_atlas`</a>-based sprite sheets inside <a href="https://github.com/flame-engine/flame">Flame</a>.
+Adds support for <a href="https://github.com/flame-engine/fire-atlas">fire_atlas</a>-based sprite sheets inside <a href="https://github.com/flame-engine/flame">Flame</a>.
 </p>
 
 <p align="center">

--- a/packages/flame_flare/README.md
+++ b/packages/flame_flare/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for [Flare animations](https://rive.app/explore/popular/trending/all) to your [Flame](https://github.com/flame-engine/flame) games.
+Adds support for <a href="https://rive.app/explore/popular/trending/all">Flare animations</a> to your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">

--- a/packages/flame_forge2d/README.md
+++ b/packages/flame_forge2d/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for [Forge2d](https://github.com/flame-engine/forge2d), the Box2d-based physics engine, to your [Flame](https://github.com/flame-engine/flame) games.
+Adds support for <a href="https://github.com/flame-engine/forge2d">Forge2d</a>, the Box2d-based physics engine, to your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">

--- a/packages/flame_isolate/README.md
+++ b/packages/flame_isolate/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for [integral_isolates](https://pub.dev/packages/integral_isolates) to your [Flame](https://github.com/flame-engine/flame) games.
+Adds support for <a href="https://pub.dev/packages/integral_isolates">integral_isolates</a> to your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">

--- a/packages/flame_jenny/README.md
+++ b/packages/flame_jenny/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for [jenny](https://pub.dev/packages/jenny), the Dart port of [YarnSpinner], to your [Flame](https://github.com/flame-engine/flame) games.
+Adds support for <a href="https://pub.dev/packages/jenny">jenny</a>, the Dart port of <a href="https://yarnspinner.dev/">YarnSpinner</a>, to your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">

--- a/packages/flame_lint/README.md
+++ b/packages/flame_lint/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-A strict and satisfying lint for any [Flame](https://github.com/flame-engine/flame), Flutter or Dart project.
+A strict and satisfying lint for any <a href="https://github.com/flame-engine/flame">Flame</a>, Flutter or Dart project.
 </p>
 
 <p align="center">

--- a/packages/flame_lottie/README.md
+++ b/packages/flame_lottie/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for [Lottie animations](https://github.com/airbnb/lottie-android) to your [Flame](https://github.com/flame-engine/flame) games.
+Adds support for <a href="https://github.com/airbnb/lottie-android">Lottie animations</a> to your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">

--- a/packages/flame_oxygen/README.md
+++ b/packages/flame_oxygen/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for [Oxygen](https://github.com/flame-engine/oxygen), an alternative ECS written by the Flame Team, to your [Flame](https://github.com/flame-engine/flame) games.
+Adds support for <a href="https://github.com/flame-engine/oxygen">Oxygen</a>, an alternative ECS written by the Flame Team, to your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">

--- a/packages/flame_rive/README.md
+++ b/packages/flame_rive/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for [Rive animations](https://github.com/rive-app/rive-flutter) to your [Flame](https://github.com/flame-engine/flame) games.
+Adds support for <a href="https://github.com/rive-app/rive-flutter">Rive animations</a> to your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">

--- a/packages/flame_svg/README.md
+++ b/packages/flame_svg/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for rendering SVG (using the [flutter_svg](https://github.com/dnfield/flutter_svg) library) to your [Flame](https://github.com/flame-engine/flame) games.
+Adds support for rendering SVG (using the <a href="https://github.com/dnfield/flutter_svg">flutter_svg</a> library) to your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">

--- a/packages/flame_test/README.md
+++ b/packages/flame_test/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-A set of useful helpers and utilities for testing your [Flame](https://github.com/flame-engine/flame) games.
+A set of useful helpers and utilities for testing your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">

--- a/packages/flame_tiled/README.md
+++ b/packages/flame_tiled/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-Adds support for [Tiled](https://www.mapeditor.org/)'s tile maps to your [Flame](https://github.com/flame-engine/flame) games.
+Adds support for <a href="https://www.mapeditor.org/">Tiled</a>'s tile maps to your <a href="https://github.com/flame-engine/flame">Flame</a> games.
 </p>
 
 <p align="center">


### PR DESCRIPTION
# Description

Apparently my previous change broke a lot of the README files because I used markdown on the HTML-only zone. It started all right but at some point after I started testing I accidentally switched.

The backticks also don't work well with links, so I removed them.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
