### PR TITLE
docs: Fix broken image link on flame_tiled pub

### DIFF
--- a/packages/flame_tiled/README.md
+++ b/packages/flame_tiled/README.md
@@ -30,10 +30,10 @@ Adds support for <a href="https://www.mapeditor.org/">Tiled</a>'s tile maps to y
 Package to bridge the `tiled` library into easy-to-use Flame components.
 
 <p align="center">
-    <img alt="flame_tiled example" width="200px" src="/packages/flame_tiled/example/screenshot.png">
+    <img alt="flame_tiled example" width="500px" src="https://raw.githubusercontent.com/flame-engine/flame/master/packages/flame_tiled/example/screenshot.png">
 </p>
 
-More [here](https://docs.flame-engine.org/main/tiled.html).
+More documentation can be found [here](https://docs.flame-engine.org/main/tiled.html).
 
 
 ## Contributors (before the package moved into the monorepo)


### PR DESCRIPTION
# Description

Fix broken image link on flame_tiled pub.
Sadly the repo relative link works on GitHub but not on pub.
This replaces it with an equivalent githubusercontent URL.
This is how it is done by other packages and recommended on Stack Overflow according to my research (but open to other better solutions).

![image](https://user-images.githubusercontent.com/882703/225175465-ad6fd53c-0318-43eb-8ac5-d60f25d763e9.png)

I also made the image a bit bigger bc it was small and hard to see (to me).

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
