### PR TITLE
fix: Buttons in ButtonComponents should not be final

### DIFF
--- a/packages/flame/lib/src/components/input/button_component.dart
+++ b/packages/flame/lib/src/components/input/button_component.dart
@@ -8,8 +8,8 @@ import 'package:meta/meta.dart';
 /// Note: You have to set the [button] in [onLoad] if you are not passing it in
 /// through the constructor.
 class ButtonComponent extends PositionComponent with Tappable {
-  late final PositionComponent? button;
-  late final PositionComponent? buttonDown;
+  PositionComponent? button;
+  PositionComponent? buttonDown;
 
   /// Callback for what should happen when the button is pressed.
   void Function()? onPressed;

--- a/packages/flame/test/components/hud_button_component_test.dart
+++ b/packages/flame/test/components/hud_button_component_test.dart
@@ -169,5 +169,23 @@ void main() {
       expect(releasedTimes, 1);
       expect(cancelledTimes, 1);
     });
+
+    testWithGame<GameWithTappables>(
+        'can set button and buttonDown in onLoad', GameWithTappables.new,
+        (game) async {
+      expect(
+        () => game.ensureAdd(_CustomHudButtonComponent()),
+        returnsNormally,
+      );
+    });
   });
+}
+
+class _CustomHudButtonComponent extends HudButtonComponent {
+  @override
+  Future<void> onLoad() async {
+    super.onLoad();
+    button = RectangleComponent(size: Vector2.all(10));
+    buttonDown = CircleComponent(radius: 10);
+  }
 }


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description

Since it should be possible to set `button` and `buttonDown` in `onLoad` they shouldn't be final.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
