### PR TITLE
fix: TextBoxComponent rendering for new line

### DIFF
--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -51,7 +51,8 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
   final TextBoxConfig _boxConfig;
   final double pixelRatio;
 
-  final List<String> _lines = [];
+  @visibleForTesting
+  final List<String> lines = [];
   double _maxLineWidth = 0.0;
   late double _lineHeight;
   late int _totalLines;
@@ -129,35 +130,35 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
   @override
   @internal
   void updateBounds() {
-    _lines.clear();
+    lines.clear();
     double? lineHeight;
     final maxBoxWidth = _fixedSize ? width : _boxConfig.maxWidth;
     text.split(' ').forEach((word) {
       final wordLines = word.split('\n');
       final possibleLine =
-          _lines.isEmpty ? wordLines[0] : '${_lines.last} ${wordLines[0]}';
+          lines.isEmpty ? wordLines[0] : '${lines.last} ${wordLines[0]}';
       lineHeight ??= textRenderer.measureTextHeight(possibleLine);
 
       final textWidth = textRenderer.measureTextWidth(possibleLine);
       _updateMaxWidth(textWidth);
       var canAppend = false;
       if (textWidth <= maxBoxWidth - _boxConfig.margins.horizontal) {
-        canAppend = _lines.isNotEmpty;
+        canAppend = lines.isNotEmpty;
       } else {
-        canAppend = _lines.isNotEmpty && _lines.last == '';
+        canAppend = lines.isNotEmpty && lines.last == '';
       }
 
       if (canAppend) {
-        _lines.last = '${_lines.last} ${wordLines[0]}';
+        lines.last = '${lines.last} ${wordLines[0]}';
         wordLines.removeAt(0);
         if (wordLines.isNotEmpty) {
-          _lines.addAll(wordLines);
+          lines.addAll(wordLines);
         }
       } else {
-        _lines.addAll(wordLines);
+        lines.addAll(wordLines);
       }
     });
-    _totalLines = _lines.length;
+    _totalLines = lines.length;
     _lineHeight = lineHeight ?? 0.0;
     size = _recomputeSize();
   }
@@ -173,7 +174,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
   bool get finished => _lifeTime > totalCharTime + _boxConfig.dismissDelay;
 
   int get _actualTextLength {
-    return _lines.map((e) => e.length).sum;
+    return lines.map((e) => e.length).sum;
   }
 
   int get currentChar => _boxConfig.timePerChar == 0.0
@@ -183,13 +184,13 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
   int get currentLine {
     var totalCharCount = 0;
     final _currentChar = currentChar;
-    for (var i = 0; i < _lines.length; i++) {
-      totalCharCount += _lines[i].length;
+    for (var i = 0; i < lines.length; i++) {
+      totalCharCount += lines[i].length;
       if (totalCharCount > _currentChar) {
         return i;
       }
     }
-    return _lines.length - 1;
+    return lines.length - 1;
   }
 
   double getLineWidth(String line, int charCount) {
@@ -206,7 +207,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
       var totalCharCount = 0;
       final _currentChar = currentChar;
       final _currentLine = currentLine;
-      final textWidth = _lines.sublist(0, _currentLine + 1).map((line) {
+      final textWidth = lines.sublist(0, _currentLine + 1).map((line) {
         final charCount =
             (i < _currentLine) ? line.length : (_currentChar - totalCharCount);
         totalCharCount += line.length;
@@ -215,7 +216,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
       }).reduce(math.max);
       return Vector2(
         textWidth + _boxConfig.margins.horizontal,
-        _lineHeight * _lines.length + _boxConfig.margins.vertical,
+        _lineHeight * lines.length + _boxConfig.margins.vertical,
       );
     } else {
       return Vector2(
@@ -258,7 +259,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
     final boxHeight = size.y - boxConfig.margins.vertical;
     var charCount = 0;
     for (var i = 0; i < nLines; i++) {
-      var line = _lines[i];
+      var line = lines[i];
       if (i == nLines - 1) {
         final nChars = math.min(currentChar - charCount, line.length);
         line = line.substring(0, nChars);
@@ -274,7 +275,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
               i * _lineHeight,
         ),
       );
-      charCount += _lines[i].length;
+      charCount += lines[i].length;
     }
   }
 

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -133,20 +133,28 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
     double? lineHeight;
     final maxBoxWidth = _fixedSize ? width : _boxConfig.maxWidth;
     text.split(' ').forEach((word) {
-      final possibleLine = _lines.isEmpty ? word : '${_lines.last} $word';
+      final wordLines = word.split('\n');
+      final possibleLine =
+          _lines.isEmpty ? wordLines[0] : '${_lines.last} ${wordLines[0]}';
       lineHeight ??= textRenderer.measureTextHeight(possibleLine);
 
       final textWidth = textRenderer.measureTextWidth(possibleLine);
+      _updateMaxWidth(textWidth);
+      var canAppend = false;
       if (textWidth <= maxBoxWidth - _boxConfig.margins.horizontal) {
-        if (_lines.isNotEmpty) {
-          _lines.last = possibleLine;
-        } else {
-          _lines.add(possibleLine);
-        }
-        _updateMaxWidth(textWidth);
+        canAppend = _lines.isNotEmpty;
       } else {
-        _lines.add(word);
-        _updateMaxWidth(textWidth);
+        canAppend = _lines.isNotEmpty && _lines.last == '';
+      }
+
+      if (canAppend) {
+        _lines.last = '${_lines.last} ${wordLines[0]}';
+        wordLines.removeAt(0);
+        if (wordLines.isNotEmpty) {
+          _lines.addAll(wordLines);
+        }
+      } else {
+        _lines.addAll(wordLines);
       }
     });
     _totalLines = _lines.length;

--- a/packages/flame/test/components/text_box_component_test.dart
+++ b/packages/flame/test/components/text_box_component_test.dart
@@ -21,6 +21,32 @@ void main() {
       expect(c.size.y, greaterThan(1));
     });
 
+    test('size is properly computed with new line character', () async {
+      final c = TextBoxComponent(
+        text: 'The quick brown fox \n jumps over the lazy dog.',
+        boxConfig: TextBoxConfig(
+          maxWidth: 100.0,
+        ),
+      );
+
+      expect(c.size.x, 100 + 2 * 8);
+      expect(c.size.y, 256);
+    });
+
+    test('lines are properly computed with new line character', () async {
+      final c = TextBoxComponent(
+        text: 'The quick brown fox \n jumps over the lazy dog.',
+        boxConfig: TextBoxConfig(
+          maxWidth: 400.0,
+        ),
+      );
+
+      expect(
+        c.lines,
+        ['The quick brown', 'fox ', ' jumps over the', 'lazy dog.'],
+      );
+    });
+
     testWithFlameGame('onLoad waits for cache to be done', (game) async {
       final c = TextBoxComponent(text: 'foo bar');
 


### PR DESCRIPTION
Initially the calculation of lines and updating accordingly ignores the case for a new line escape characters.
This PR changes how we calculate and update lines when checking for bounds.

# Description

**Before:**
When a text that contains `\n` character is given to the TextBox for example `Hello \n World`. It doesn't consider the new line and just appends the `\n` to the same line. This increases the lineHeight for that particular word (and won't be updated in this case). But, instead when there is a text `\nHello World`, then the initial lineHeight itself is twice than what it actually is.

So, the main problem here is that we are not considering (ignoring) the `\n` characters.

This can be solved by checking for any new lines in the split word (From `split(' ')`) by using `split('\n')` and adding the lines appropriately into the `_lines`.

**After**:
Now, whenever a `\n` is encountered, we respect both the new line and the spacing right after the `\n` character. This eliminates the improper rendering of the text. Also, `lineHeight` will always be same as expected and not more.

## Screenshots

Input1: `Hello \n something great World`
Output1:
<img width="197" alt="Screenshot 2023-03-17 at 15 18 54" src="https://user-images.githubusercontent.com/40348358/225870662-891e750f-b5c7-4324-b556-a32f0690e72e.png">

Input2: `\nHello\nsomething great World'`
Output2:
<img width="191" alt="Screenshot 2023-03-17 at 15 21 07" src="https://user-images.githubusercontent.com/40348358/225871191-9d09165d-f845-451a-acf1-b51f04c942c8.png">

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

### Migration instructions

- [-] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #1622 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
