### PR TITLE
fix: Fix key input to work after restart

### DIFF
--- a/examples/games/padracing/lib/padracing_game.dart
+++ b/examples/games/padracing/lib/padracing_game.dart
@@ -239,9 +239,7 @@ class PadRacingGame extends Forge2DGame with KeyboardEvents {
 
   void reset() {
     _clearPressedKeys();
-    for (final keyMap in activeKeyMaps) {
-      keyMap.clear();
-    }
+    activeKeyMaps.clear();
     _timePassed = 0;
     overlays.remove('game_over');
     openMenu();


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description

The map with active keymaps should be cleared and not the maps in the map.
This made the game not taking input properly after restart.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2414 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
