### PR TITLE
fix: Update MoveAlongPathEffect

### DIFF
--- a/packages/flame/lib/src/effects/move_along_path_effect.dart
+++ b/packages/flame/lib/src/effects/move_along_path_effect.dart
@@ -78,20 +78,18 @@ class MoveAlongPathEffect extends MoveEffect {
   void onStart() {
     _lastOffset = Vector2.zero();
     _lastAngle = 0;
+    final start = _pathMetric.getTangentForOffset(0)!;
     if (_followDirection) {
       assert(
         target is AngleProvider,
         'An `oriented` MoveAlongPathEffect cannot be applied to a target that '
         'does not support rotation',
       );
+      (target as AngleProvider).angle = _lastAngle = -start.angle;
     }
     if (_isAbsolute) {
-      final start = _pathMetric.getTangentForOffset(0)!;
       target.position.x = _lastOffset.x = start.position.dx;
       target.position.y = _lastOffset.y = start.position.dy;
-      if (_followDirection) {
-        (target as AngleProvider).angle = _lastAngle = -start.angle;
-      }
     }
   }
 

--- a/packages/flame/test/effects/move_along_path_effect_test.dart
+++ b/packages/flame/test/effects/move_along_path_effect_test.dart
@@ -159,7 +159,6 @@ void main() {
       }
     });
 
-
     test('errors', () {
       final controller = LinearEffectController(0);
       expect(

--- a/packages/flame/test/effects/move_along_path_effect_test.dart
+++ b/packages/flame/test/effects/move_along_path_effect_test.dart
@@ -121,6 +121,45 @@ void main() {
       },
     );
 
+    testWithFlameGame('non-absolute oriented path', (game) async {
+      final component = PositionComponent(
+        position: Vector2.zero(),
+        angle: -30.5,
+      );
+      game.add(component);
+      game.update(0);
+
+      component.add(
+        MoveAlongPathEffect(
+          Path() // pythagorean triangle, perimeter=600
+            ..moveTo(200, 200)
+            ..lineTo(290, 80)
+            ..lineTo(450, 200)
+            ..lineTo(200, 200),
+          EffectController(duration: 6),
+          oriented: true,
+        ),
+      );
+      game.update(0);
+      for (var i = 0; i < 60; i++) {
+        if (i <= 15) {
+          expect(component.position.x, closeTo(200 + 6 * i, 1e-10));
+          expect(component.position.y, closeTo(200 - 8 * i, 1e-10));
+          expect(component.angle, closeTo(-asin(0.8), 1e-7));
+        } else if (i <= 35) {
+          expect(component.position.x, closeTo(290 + 8 * (i - 15), 1e-10));
+          expect(component.position.y, closeTo(80 + 6 * (i - 15), 1e-10));
+          expect(component.angle, closeTo(asin(0.6), 1e-7));
+        } else {
+          expect(component.position.x, closeTo(450 - 10 * (i - 35), 1e-10));
+          expect(component.position.y, closeTo(200, 1e-10));
+          expect(component.angle, closeTo(pi, 1e-7));
+        }
+        game.update(0.1);
+      }
+    });
+
+
     test('errors', () {
       final controller = LinearEffectController(0);
       expect(


### PR DESCRIPTION
# Description
Updated `MoveAlongPathEffect` class to ensure target angle is initiated when oriented is set to true for either absolute or non-absolute paths.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
Not that I know of but flame team would be best placed to say yes/no to this.

### Migration instructions
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
