### PR TITLE
feat: Add scroll to right side nav

### DIFF
--- a/doc/_sphinx/theme/flames.css
+++ b/doc/_sphinx/theme/flames.css
@@ -396,12 +396,17 @@ div.nav-left li.current > ul {
  *----------------------------------------------------------------------------*/
 
 div.sidebar-right {
-  flex: 5;
+  flex: 5 1 auto;
   height: calc(100vh - 25px - var(--top-menu-height));
-  margin-right: 20px;
+  margin-right: -28px;
   max-width: var(--right-menu-width);
   position: sticky;
   top: calc(25px + var(--top-menu-height));
+  overflow: hidden;
+}
+
+div.sidebar-right:hover {
+  overflow-y: auto;
 }
 
 @media (max-width: 1200px) {


### PR DESCRIPTION
when overflow-y, the scroll will be enabled on hover that makes us scroll through the contents and click what's below

# Description

Initially, the contents section (the right side nav) doesn't scroll when overflow. This PR adds the functionality to scroll when it overflows vertically.

Working video:

https://user-images.githubusercontent.com/40348358/227519288-805ae943-0c23-4220-8224-fec168bae599.mov

### a small case to consider

This commit had some complications like having to compromise with having shrink width. It doesn't much shrink, but does slightly does.

Before this PR:
<img width="1237" alt="Screenshot 2023-03-24 at 17 43 18" src="https://user-images.githubusercontent.com/40348358/227519653-84c503a2-8ab4-460a-96b7-17c31d60ce62.png">

After this PR:
<img width="1238" alt="Screenshot 2023-03-24 at 17 42 54" src="https://user-images.githubusercontent.com/40348358/227519701-bce512d7-e6df-459b-a3a1-5762a05f2934.png">

But, I am thinking this can be considered as the readability isn't effected much as this sidebar only is visible when there is enough space (more width).

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [-] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2423 
