### PR TITLE
fix: Auto-resize `SpriteComponent` on sprite change

### DIFF
--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -22,8 +22,8 @@ class SpriteComponent extends PositionComponent
   /// Returns current value of auto resize flag.
   bool get autoResize => _autoResize;
 
-  /// Sets the given value of autoResize flag.
-  /// Will update the size if new value is true.
+  /// Sets the given value of autoResize flag. Will update the [size]
+  /// to fit srcSize of [sprite] if set to  true.
   set autoResize(bool value) {
     _autoResize = value;
     if (value) {
@@ -38,7 +38,7 @@ class SpriteComponent extends PositionComponent
   Sprite? get sprite => _sprite;
 
   /// Sets the given sprite as the new [sprite] of this component.
-  /// Will update the size is [autoResize] is set to true.
+  /// Will update the size if [autoResize] is set to true.
   set sprite(Sprite? value) {
     _sprite = value;
 
@@ -65,10 +65,9 @@ class SpriteComponent extends PositionComponent
     super.children,
     super.priority,
   })  : assert(
-          ((size == null) && (autoResize ?? true)) ||
-              ((size != null) && !(autoResize ?? false)),
-          '''If size is set, autoResize should be false and vice versa or
-          size should be null when autoResize is true''',
+          (size == null && (autoResize ?? true)) ||
+              (size != null && !(autoResize ?? false)),
+          '''If size is set, autoResize should be false or size should be null when autoResize is true.''',
         ),
         _autoResize = autoResize ?? size == null,
         _sprite = sprite,

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -27,7 +27,11 @@ class SpriteComponent extends PositionComponent
   set autoResize(bool value) {
     _autoResize = value;
     if (value) {
-      size.setFrom(sprite?.srcSize ?? Vector2.zero());
+      if (_sprite != null) {
+        size.setFrom(_sprite!.srcSize);
+      } else {
+        size.setZero();
+      }
     }
   }
 
@@ -65,8 +69,7 @@ class SpriteComponent extends PositionComponent
     super.children,
     super.priority,
   })  : assert(
-          (size == null && (autoResize ?? true)) ||
-              (size != null && !(autoResize ?? false)),
+          (size == null) == (autoResize ?? size == null),
           '''If size is set, autoResize should be false or size should be null when autoResize is true.''',
         ),
         _autoResize = autoResize ?? size == null,

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -15,12 +15,46 @@ export '../sprite.dart';
 class SpriteComponent extends PositionComponent
     with HasPaint
     implements SizeProvider {
+  /// When set to true, the component is auto-resized to match the
+  /// size of underlying sprite.
+  late bool _autoResize;
+
+  /// Returns current value of auto resize flag.
+  bool get autoResize => _autoResize;
+
+  /// Sets the given value of autoResize flag.
+  /// Will update the size if new value is true.
+  set autoResize(bool value) {
+    _autoResize = value;
+    if (value) {
+      size.setFrom(sprite?.srcSize ?? Vector2.zero());
+    }
+  }
+
   /// The [sprite] to be rendered by this component.
-  Sprite? sprite;
+  Sprite? _sprite;
+
+  /// Returns the current sprite rendered by this component.
+  Sprite? get sprite => _sprite;
+
+  /// Sets the given sprite as the new [sprite] of this component.
+  /// Will update the size is [autoResize] is set to true.
+  set sprite(Sprite? value) {
+    _sprite = value;
+
+    if (_autoResize) {
+      if (value != null) {
+        size.setFrom(value.srcSize);
+      } else {
+        size.setZero();
+      }
+    }
+  }
 
   /// Creates a component with an empty sprite which can be set later
   SpriteComponent({
-    this.sprite,
+    Sprite? sprite,
+    bool? autoResize,
     Paint? paint,
     super.position,
     Vector2? size,
@@ -30,9 +64,15 @@ class SpriteComponent extends PositionComponent
     super.anchor,
     super.children,
     super.priority,
-  }) : super(
-          size: size ?? sprite?.srcSize,
-        ) {
+  })  : assert(
+          ((size == null) && (autoResize ?? true)) ||
+              ((size != null) && !(autoResize ?? false)),
+          '''If size is set, autoResize should be false and vice versa or
+          size should be null when autoResize is true''',
+        ),
+        _autoResize = autoResize ?? size == null,
+        _sprite = sprite,
+        super(size: size ?? sprite?.srcSize) {
     if (paint != null) {
       this.paint = paint;
     }
@@ -42,6 +82,7 @@ class SpriteComponent extends PositionComponent
     Image image, {
     Vector2? srcPosition,
     Vector2? srcSize,
+    bool? autoResize,
     Paint? paint,
     Vector2? position,
     Vector2? size,
@@ -56,6 +97,7 @@ class SpriteComponent extends PositionComponent
             srcPosition: srcPosition,
             srcSize: srcSize,
           ),
+          autoResize: autoResize,
           paint: paint,
           position: position,
           size: size ?? srcSize ?? image.size,

--- a/packages/flame/test/components/sprite_component_test.dart
+++ b/packages/flame/test/components/sprite_component_test.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 Future<void> main() async {
   final image = await generateImage();
@@ -35,6 +35,36 @@ Future<void> main() async {
 
       final component6 = SpriteComponent(sprite: sprite);
       expect(component6.size, Vector2(2, 2));
+    });
+  });
+
+  group('SpriteComponent.autoResize', () {
+    test('mutual exclusive with size while construction', () {
+      expect(
+        () => SpriteComponent(autoResize: true, size: Vector2.all(2)),
+        throwsAssertionError,
+      );
+
+      expect(() => SpriteComponent(autoResize: false), throwsAssertionError);
+    });
+
+    test('default value set correctly when not provided explicitly', () {
+      final component1 = SpriteComponent();
+      final component2 = SpriteComponent(size: Vector2.all(2));
+
+      expect(component1.autoResize, true);
+      expect(component2.autoResize, false);
+    });
+
+    test('resizes on sprite change', () {
+      final sprite1 = Sprite(image);
+      final sprite2 = Sprite(image, srcSize: Vector2.all(13));
+
+      final component = SpriteComponent()..sprite = sprite1;
+      expect(component.size, sprite1.srcSize);
+
+      component.sprite = sprite2;
+      expect(component.size, sprite2.srcSize);
     });
   });
 }

--- a/packages/flame/test/components/sprite_component_test.dart
+++ b/packages/flame/test/components/sprite_component_test.dart
@@ -66,5 +66,17 @@ Future<void> main() async {
       component.sprite = sprite2;
       expect(component.size, sprite2.srcSize);
     });
+
+    test('resizes only when true', () {
+      final sprite1 = Sprite(image);
+      final sprite2 = Sprite(image, srcSize: Vector2.all(13));
+      final component = SpriteComponent(sprite: sprite1)..autoResize = false;
+
+      component.sprite = sprite2;
+      expect(component.size, sprite1.srcSize);
+
+      component.autoResize = true;
+      expect(component.size, sprite2.srcSize);
+    });
   });
 }


### PR DESCRIPTION
# Description

This PR adds an `autoResize` parameter to `SpriteComponent` using which users will be able to control if the component should auto-resize on sprite change to match the sprite's `srcSize`. Some important design decisions about `autoResize`:

- It is mutually exclusive with `size` while construction: This means, if `size` is non-null while construction of `SpriteComponent`, `autoResize` cannot be true. This allows use-cases where one might want to render a sprite at a different size than its original size. If an user is setting the size explicitly, we can leave it up to them to handle resizing in such cases. 

- It is optional: If an user does not set this parameter while construction, it will be auto-populated depending upon if a `size` is provided or not.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2419 
