### PR TITLE
docs: Error in flame_svg code snippets in documentation

### DIFF
--- a/doc/bridge_packages/flame_svg/svg.md
+++ b/doc/bridge_packages/flame_svg/svg.md
@@ -18,7 +18,7 @@ To use it just import the `Svg` class from `'package:flame_svg/flame_svg.dart'`,
 following snippet to render it on the canvas:
 
 ```dart
-Svg svgInstance = Svg('android.svg');
+final svgInstance = await Svg.load('android.svg');
 
 final position = Vector2(100, 100);
 final size = Vector2(300, 300);
@@ -34,10 +34,10 @@ class MyGame extends FlameGame {
     final svgInstance = await Svg.load('android.svg');
     final size = Vector2.all(100);
     final position = Vector2.all(100);
-    final svgComponent = SvgComponent.fromSvg(
-      size,
-      position,
-      svgInstance,
+    final svgComponent = SvgComponent(
+      size: size,
+      position: position,
+      svg: svgInstance,
     );
 
     add(svgComponent);


### PR DESCRIPTION
Error in flame_svg code snippets in documentation causing issues in IDE

# Description
update code snippets for [flame_svg docs](https://docs.flame-engine.org/1.6.0/bridge_packages/flame_svg/svg.html#how-to-use-flame-svg)


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #2432