### PR TITLE
docs: Conflicting name 'Route' in flame and flutter libraries in Rout…

### DIFF
--- a/doc/flame/router.md
+++ b/doc/flame/router.md
@@ -56,6 +56,13 @@ class MyGame extends FlameGame {
 class PauseRoute extends Route { ... }
 ```
 
+```{note}
+Use `hide Route` if any of the imported packages have `Route()` in the same file.
+
+eg: `import 'package:flutter/material.dart' hide Route;`
+```
+
+
 [Flutter Navigator]: https://api.flutter.dev/flutter/widgets/Navigator-class.html
 
 


### PR DESCRIPTION
docs: Conflicting name 'Route' in flame and flutter libraries in Router component example code snippet

# Description
Added a note in router.md file

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Related Issues

Closes #2435
