### PR TITLE
feat: Add `autoResize` for `SpriteGroupComponent`

### DIFF
--- a/packages/flame/lib/src/components/sprite_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_group_component.dart
@@ -11,32 +11,63 @@ export '../sprite_animation.dart';
 class SpriteGroupComponent<T> extends PositionComponent
     with HasPaint
     implements SizeProvider {
-  /// Key with the current playing animation
-  T? current;
+  T? _current;
 
   /// Map with the available states for this sprite group
   Map<T, Sprite>? sprites;
 
+  bool _autoResize;
+
   /// Creates a component with an empty animation which can be set later
   SpriteGroupComponent({
     this.sprites,
-    this.current,
+    T? current,
+    bool? autoResize,
     Paint? paint,
     super.position,
-    super.size,
+    Vector2? size,
     super.scale,
     super.angle,
     super.nativeAngle,
     super.anchor,
     super.children,
     super.priority,
-  }) {
+  })  : assert(
+          (size == null) == (autoResize ?? size == null),
+          '''If size is set, autoResize should be false or size should be null when autoResize is true.''',
+        ),
+        _current = current,
+        _autoResize = autoResize ?? size == null,
+        super(size: size ?? sprites?[current]?.srcSize) {
     if (paint != null) {
       this.paint = paint;
     }
   }
 
   Sprite? get sprite => sprites?[current];
+
+  /// Returns the current group state.
+  T? get current => _current;
+
+  /// The the group state to given state.
+  ///
+  /// Will update [size] if [autoResize] is true.
+  set current(T? value) {
+    _current = value;
+    _resizeToSprite();
+  }
+
+  /// Returns current value of auto resize flag.
+  bool get autoResize => _autoResize;
+
+  /// Sets the given value of autoResize flag.
+  ///
+  /// Will update the [size] to fit srcSize of
+  /// current [sprite] if set to  true.
+  set autoResize(bool value) {
+    _autoResize = value;
+    _resizeToSprite();
+  }
 
   @override
   @mustCallSuper
@@ -59,5 +90,16 @@ class SpriteGroupComponent<T> extends PositionComponent
       size: size,
       overridePaint: paint,
     );
+  }
+
+  /// Updates the size to current [sprite]'s srcSize if [autoResize] is true.
+  void _resizeToSprite() {
+    if (_autoResize) {
+      if (sprite != null) {
+        size.setFrom(sprite!.srcSize);
+      } else {
+        size.setZero();
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description

This PR adds an `autoResize` parameter to `SpriteGroupComponent` which will allow Flame users to control if the size of the component should be re-calculated to fit the size of current active sprite in the group.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2441 
