### PR TITLE
docs: Hidden toctree details for flame_audio & flame_forge2d

### DIFF
--- a/doc/bridge_packages/flame_audio/flame_audio.md
+++ b/doc/bridge_packages/flame_audio/flame_audio.md
@@ -1,7 +1,6 @@
 # flame_audio
 
 ```{toctree}
-
 General audio    <audio.md>
 Background music <bgm.md>
 AudioPool        <audio_pool.md>

--- a/doc/bridge_packages/flame_audio/flame_audio.md
+++ b/doc/bridge_packages/flame_audio/flame_audio.md
@@ -1,7 +1,6 @@
 # flame_audio
 
 ```{toctree}
-:hidden:
 
 General audio    <audio.md>
 Background music <bgm.md>

--- a/doc/bridge_packages/flame_forge2d/flame_forge2d.md
+++ b/doc/bridge_packages/flame_forge2d/flame_forge2d.md
@@ -1,7 +1,6 @@
 # flame_forge2d
 
 ```{toctree}
-:hidden:
 
 Overview    <forge2d.md>
 Joints    <joints.md>

--- a/doc/bridge_packages/flame_forge2d/flame_forge2d.md
+++ b/doc/bridge_packages/flame_forge2d/flame_forge2d.md
@@ -1,7 +1,6 @@
 # flame_forge2d
 
 ```{toctree}
-
 Overview    <forge2d.md>
 Joints    <joints.md>
 ```


### PR DESCRIPTION
# Description
Remove `:hidden:` from `flame_audio.md` & `flame_forge2d.md` files.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Related Issues

Closes #2445 
