### PR TITLE
docs: Some @overrides for the onLoad() function are missing

### DIFF
--- a/doc/bridge_packages/flame_svg/svg.md
+++ b/doc/bridge_packages/flame_svg/svg.md
@@ -30,6 +30,7 @@ or use the `SvgComponent` and add it to the component tree:
 
 ```dart
 class MyGame extends FlameGame {
+  @override
   Future<void> onLoad() async {
     final svgInstance = await Svg.load('android.svg');
     final size = Vector2.all(100);

--- a/doc/flame/camera_and_viewport.md
+++ b/doc/flame/camera_and_viewport.md
@@ -103,7 +103,7 @@ Example:
 class MyGame extends FlameGame {
   final someVector = Vector2(100, 100);
   @override
-  Future<void> onLoad() async {
+  void onLoad() {
      camera.followVector2(someVector);
   }
 }

--- a/doc/flame/camera_and_viewport.md
+++ b/doc/flame/camera_and_viewport.md
@@ -102,7 +102,7 @@ Example:
 ```dart
 class MyGame extends FlameGame {
   final someVector = Vector2(100, 100);
-
+  @override
   Future<void> onLoad() async {
      camera.followVector2(someVector);
   }

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -125,6 +125,7 @@ hitboxes to just like any other component:
 
 ```dart
 class MyComponent extends PositionComponent {
+  @override
   Future<void> onLoad() async {
     add(RectangleHitbox());
   }
@@ -267,6 +268,7 @@ To do this, add the `HasQuadTreeCollisionDetection` mixin to your game instead o
 
 ```dart
 class MyGame extends FlameGame with HasQuadTreeCollisionDetection {
+  @override
   Future<void> onLoad() async {
     initializeCollisionDetection(
       mapDimensions: const Rect.fromLTWH(0, 0, mapWidth, mapHeight),

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -126,7 +126,7 @@ hitboxes to just like any other component:
 ```dart
 class MyComponent extends PositionComponent {
   @override
-  Future<void> onLoad() async {
+  void onLoad() {
     add(RectangleHitbox());
   }
 }
@@ -269,7 +269,7 @@ To do this, add the `HasQuadTreeCollisionDetection` mixin to your game instead o
 ```dart
 class MyGame extends FlameGame with HasQuadTreeCollisionDetection {
   @override
-  Future<void> onLoad() async {
+  void onLoad() {
     initializeCollisionDetection(
       mapDimensions: const Rect.fromLTWH(0, 0, mapWidth, mapHeight),
       minimumDistance: 10,

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -390,7 +390,7 @@ So if you, for example, wanted to position a child in the center of the parent y
 
 ```dart
 @override
-Future<void> onLoad() async {
+void onLoad() {
   final parent = PositionComponent(
     position: Vector2(100, 100),
     size: Vector2(100, 100),
@@ -753,7 +753,7 @@ game speeds up.
 
 ```dart
 @override
-Future<void> onLoad() async {
+void onLoad() {
   final parallax = parallaxComponent.parallax;
   parallax.baseSpeed = Vector2(100, 0);
   parallax.velocityMultiplierDelta = Vector2(2.0, 1.0);

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -389,6 +389,7 @@ that the `position`, `angle` and `scale` will be relative to the parents state.
 So if you, for example, wanted to position a child in the center of the parent you would do this:
 
 ```dart
+@override
 Future<void> onLoad() async {
   final parent = PositionComponent(
     position: Vector2(100, 100),
@@ -463,6 +464,7 @@ This class is used to represent a Component that has sprites that run in a singl
 This will create a simple three frame animation using 3 different images:
 
 ```dart
+@override
 Future<void> onLoad() async {
   final sprites = [0, 1, 2]
       .map((i) => Sprite.load('player_$i.png'));
@@ -481,6 +483,7 @@ If you have a sprite sheet, you can use the `sequenced` constructor from the `Sp
 class (check more details on [Images &gt; Animation](rendering/images.md#animation)):
 
 ```dart
+@override
 Future<void> onLoad() async {
   final size = Vector2.all(64.0);
   final data = SpriteAnimationData.sequenced(
@@ -610,6 +613,7 @@ This component uses an instance of `Svg` class to represent a Component that has
 rendered in the game:
 
 ```dart
+@override
 Future<void> onLoad() async {
   final svg = await Svg.load('android.svg');
   final android = SvgComponent.fromSvg(
@@ -734,6 +738,7 @@ They simplest way is to set the named optional parameters `baseVelocity` and
 background images along the X-axis with a faster speed the "closer" the image is:
 
 ```dart
+@override
 Future<void> onLoad() async {
   final parallaxComponent = await loadParallaxComponent(
     _dataList,
@@ -747,6 +752,7 @@ You can set the baseSpeed and layerDelta at any time, for example if your charac
 game speeds up.
 
 ```dart
+@override
 Future<void> onLoad() async {
   final parallax = parallaxComponent.parallax;
   parallax.baseSpeed = Vector2(100, 0);

--- a/doc/other_modules/jenny/runtime/command_storage.md
+++ b/doc/other_modules/jenny/runtime/command_storage.md
@@ -76,7 +76,7 @@ class MyGame {
     assert(quests[questId]!.name == questName);
     // ...
   }
-
+  @override
   Future<void> onLoad() async {
     yarnProject = YarnProject()
       ..commands.addCommand2('StartQuest', startQuest);
@@ -106,6 +106,7 @@ class MyGame {
     yarnProject.variables.setVariable(r'$prompt', name);
   }
 
+  @override
   Future<void> onLoad() async {
     yarnProject
       ..variables.setVariable(r'$prompt', '')

--- a/doc/other_modules/jenny/runtime/command_storage.md
+++ b/doc/other_modules/jenny/runtime/command_storage.md
@@ -77,7 +77,7 @@ class MyGame {
     // ...
   }
   @override
-  Future<void> onLoad() async {
+  void onLoad() {
     yarnProject = YarnProject()
       ..commands.addCommand2('StartQuest', startQuest);
   }
@@ -107,7 +107,7 @@ class MyGame {
   }
 
   @override
-  Future<void> onLoad() async {
+  void onLoad() {
     yarnProject
       ..variables.setVariable(r'$prompt', '')
       ..commands.addCommand1('prompt', prompt);

--- a/doc/tutorials/klondike/step4.md
+++ b/doc/tutorials/klondike/step4.md
@@ -419,6 +419,7 @@ into the `TableauPile`s at the beginning of the game. Modify the code at the end
 method so that it looks like this:
 
 ```dart
+  @override
   Future<void> onLoad() async {
     ...
 


### PR DESCRIPTION
docs: Some `@overrides` for the `onLoad()` function are missing in the code snippets

# Description
missing `@overrides` are added in the corresponding code snippets.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Related Issues

Closes #2446 

