### PR TITLE
fix: Set size of viewports in `onLoad`

### DIFF
--- a/packages/flame/lib/src/camera/viewports/fixed_aspect_ratio_viewport.dart
+++ b/packages/flame/lib/src/camera/viewports/fixed_aspect_ratio_viewport.dart
@@ -22,9 +22,18 @@ class FixedAspectRatioViewport extends Viewport {
   Rect _clipRect = Rect.zero;
 
   @override
+  void onLoad() {
+    final canvasSize = findGame()!.canvasSize;
+    _handleResize(canvasSize);
+  }
+
+  @override
   void onGameResize(Vector2 canvasSize) {
     super.onGameResize(canvasSize);
+    _handleResize(canvasSize);
+  }
 
+  void _handleResize(Vector2 canvasSize) {
     final availableWidth = canvasSize.x;
     final availableHeight = canvasSize.y;
     size = (availableHeight * aspectRatio > availableWidth)

--- a/packages/flame/lib/src/camera/viewports/fixed_aspect_ratio_viewport.dart
+++ b/packages/flame/lib/src/camera/viewports/fixed_aspect_ratio_viewport.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flame/src/camera/viewport.dart';
+import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 /// [FixedAspectRatioViewport] is a rectangular viewport which auto-expands to
@@ -22,6 +23,7 @@ class FixedAspectRatioViewport extends Viewport {
   Rect _clipRect = Rect.zero;
 
   @override
+  @mustCallSuper
   void onLoad() {
     final canvasSize = findGame()!.canvasSize;
     _handleResize(canvasSize);

--- a/packages/flame/lib/src/camera/viewports/max_viewport.dart
+++ b/packages/flame/lib/src/camera/viewports/max_viewport.dart
@@ -10,6 +10,11 @@ class MaxViewport extends Viewport {
   MaxViewport({super.children});
 
   @override
+  void onLoad() {
+    size = findGame()!.canvasSize;
+  }
+
+  @override
   void onGameResize(Vector2 gameSize) {
     super.onGameResize(gameSize);
     size = gameSize;

--- a/packages/flame/lib/src/camera/viewports/max_viewport.dart
+++ b/packages/flame/lib/src/camera/viewports/max_viewport.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flame/src/camera/viewport.dart';
+import 'package:meta/meta.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 /// The default viewport, which is as big as the game canvas allows.
@@ -10,6 +11,7 @@ class MaxViewport extends Viewport {
   MaxViewport({super.children});
 
   @override
+  @mustCallSuper
   void onLoad() {
     size = findGame()!.canvasSize;
   }

--- a/packages/flame/test/camera/viewfinder_test.dart
+++ b/packages/flame/test/camera/viewfinder_test.dart
@@ -196,6 +196,29 @@ void main() {
         }
       },
     );
+
+    testWithFlameGame('can change visibleGameSize directly', (game) async {
+      final world = World()..addToParent(game);
+      final cameraComponent = CameraComponent(world: world)..addToParent(game);
+      expect(
+        () => cameraComponent.viewfinder.visibleGameSize = Vector2(100, 100),
+        returnsNormally,
+      );
+    });
+
+    testWithFlameGame(
+        'can change visibleGameSize directly with FixedAspectRatioViewport',
+        (game) async {
+      final world = World()..addToParent(game);
+      final cameraComponent = CameraComponent(
+        world: world,
+        viewport: FixedAspectRatioViewport(aspectRatio: 0.2),
+      )..addToParent(game);
+      expect(
+        () => cameraComponent.viewfinder.visibleGameSize = Vector2(100, 100),
+        returnsNormally,
+      );
+    });
   });
 }
 

--- a/packages/flame/test/camera/viewports/max_viewport_test.dart
+++ b/packages/flame/test/camera/viewports/max_viewport_test.dart
@@ -41,7 +41,7 @@ void main() {
 
       final viewport = camera.viewport;
       expect(viewport, isA<_MyMaxViewport>());
-      expect((viewport as _MyMaxViewport).onViewportResizeCalled, 2);
+      expect((viewport as _MyMaxViewport).onViewportResizeCalled, 3);
       game.onGameResize(Vector2(200, 200));
       expect(viewport.onViewportResizeCalled, 3);
     });

--- a/packages/flame/test/camera/viewports/max_viewport_test.dart
+++ b/packages/flame/test/camera/viewports/max_viewport_test.dart
@@ -43,7 +43,7 @@ void main() {
       expect(viewport, isA<_MyMaxViewport>());
       expect((viewport as _MyMaxViewport).onViewportResizeCalled, 3);
       game.onGameResize(Vector2(200, 200));
-      expect(viewport.onViewportResizeCalled, 3);
+      expect(viewport.onViewportResizeCalled, 4);
     });
   });
 }


### PR DESCRIPTION
# Description

#2317 removed the call to `onGameResize` before `onLoad` and since the viewports relied on that for setting their sizes you couldn't change for example the `viewfinder.visibleGameSize` before the `CameraComponent` had been mounted (since `onGameResize` is called right before `onMount`).

I'm not super happy with the solution, so I'm open to any suggestions.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.

## Related Issues

Closes #2426 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
