### PR TITLE
feat: Add `autoResize` for `SpriteAnimationComponent` and `SpriteAnimationGroupComponent`

### DIFF
--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -28,8 +28,8 @@ class SpriteAnimationComponent extends PositionComponent
   SpriteAnimationComponent({
     this.animation,
     bool? autoResize,
-    bool? removeOnFinish,
-    bool? playing,
+    this.removeOnFinish = false,
+    this.playing = true,
     Paint? paint,
     super.position,
     Vector2? size,
@@ -44,8 +44,6 @@ class SpriteAnimationComponent extends PositionComponent
           '''If size is set, autoResize should be false or size should be null when autoResize is true.''',
         ),
         _autoResize = autoResize ?? size == null,
-        removeOnFinish = removeOnFinish ?? false,
-        playing = playing ?? true,
         super(size: size ?? animation?.getSprite().srcSize) {
     if (paint != null) {
       this.paint = paint;
@@ -61,8 +59,8 @@ class SpriteAnimationComponent extends PositionComponent
     Image image,
     SpriteAnimationData data, {
     bool? autoResize,
-    bool? removeOnFinish,
-    bool? playing,
+    bool removeOnFinish = false,
+    bool playing = true,
     Paint? paint,
     Vector2? position,
     Vector2? size,

--- a/packages/flame/lib/src/components/sprite_animation_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_group_component.dart
@@ -10,7 +10,7 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
     with HasPaint
     implements SizeProvider {
   /// Key with the current playing animation
-  T? current;
+  T? _current;
 
   /// Map with the mapping each state to the flag removeOnFinish
   final Map<T, bool> removeOnFinish;
@@ -18,21 +18,38 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
   /// Map with the available states for this animation group
   Map<T, SpriteAnimation>? animations;
 
+  /// Whether the animation is paused or playing.
+  bool playing;
+
+  /// When set to true, the component is auto-resized to match the
+  /// size of current animation sprite.
+  bool _autoResize;
+
   /// Creates a component with an empty animation which can be set later
   SpriteAnimationGroupComponent({
     this.animations,
-    this.current,
+    T? current,
+    bool? autoResize,
+    bool? playing,
     Map<T, bool>? removeOnFinish,
     Paint? paint,
     super.position,
-    super.size,
+    Vector2? size,
     super.scale,
     super.angle,
     super.nativeAngle,
     super.anchor,
     super.children,
     super.priority,
-  }) : removeOnFinish = removeOnFinish ?? const {} {
+  })  : assert(
+          (size == null) == (autoResize ?? size == null),
+          '''If size is set, autoResize should be false or size should be null when autoResize is true.''',
+        ),
+        _current = current,
+        _autoResize = autoResize ?? size == null,
+        playing = playing ?? true,
+        removeOnFinish = removeOnFinish ?? const {},
+        super(size: size ?? animations?[current]?.getSprite().srcSize) {
     if (paint != null) {
       this.paint = paint;
     }
@@ -48,6 +65,8 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
     Image image,
     Map<T, SpriteAnimationData> data, {
     T? current,
+    bool? autoResize,
+    bool? playing,
     Map<T, bool>? removeOnFinish,
     Paint? paint,
     Vector2? position,
@@ -67,7 +86,9 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
             );
           }),
           current: current,
+          autoResize: autoResize,
           removeOnFinish: removeOnFinish,
+          playing: playing,
           paint: paint,
           position: position,
           size: size,
@@ -78,6 +99,29 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
         );
 
   SpriteAnimation? get animation => animations?[current];
+
+  /// Returns the current group state.
+  T? get current => _current;
+
+  /// The the group state to given state.
+  ///
+  /// Will update [size] if [autoResize] is true.
+  set current(T? value) {
+    _current = value;
+    _resizeToSprite();
+  }
+
+  /// Returns current value of auto resize flag.
+  bool get autoResize => _autoResize;
+
+  /// Sets the given value of autoResize flag.
+  ///
+  /// Will update the [size] to fit srcSize of
+  /// current animation sprite if set to  true.
+  set autoResize(bool value) {
+    _autoResize = value;
+    _resizeToSprite();
+  }
 
   @mustCallSuper
   @override
@@ -92,9 +136,24 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
   @mustCallSuper
   @override
   void update(double dt) {
-    animation?.update(dt);
+    if (playing) {
+      animation?.update(dt);
+      _resizeToSprite();
+    }
     if ((removeOnFinish[current] ?? false) && (animation?.done() ?? false)) {
       removeFromParent();
+    }
+  }
+
+  /// Updates the size to current animation sprite's srcSize if
+  /// [autoResize] is true.
+  void _resizeToSprite() {
+    if (_autoResize) {
+      if (animation != null) {
+        size.setFrom(animation!.getSprite().srcSize);
+      } else {
+        size.setZero();
+      }
     }
   }
 }

--- a/packages/flame/lib/src/components/sprite_animation_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_group_component.dart
@@ -30,8 +30,8 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
     this.animations,
     T? current,
     bool? autoResize,
-    bool? playing,
-    Map<T, bool>? removeOnFinish,
+    this.playing = true,
+    this.removeOnFinish = const {},
     Paint? paint,
     super.position,
     Vector2? size,
@@ -47,8 +47,6 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
         ),
         _current = current,
         _autoResize = autoResize ?? size == null,
-        playing = playing ?? true,
-        removeOnFinish = removeOnFinish ?? const {},
         super(size: size ?? animations?[current]?.getSprite().srcSize) {
     if (paint != null) {
       this.paint = paint;
@@ -66,8 +64,8 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
     Map<T, SpriteAnimationData> data, {
     T? current,
     bool? autoResize,
-    bool? playing,
-    Map<T, bool>? removeOnFinish,
+    bool playing = true,
+    Map<T, bool> removeOnFinish = const {},
     Paint? paint,
     Vector2? position,
     Vector2? size,
@@ -116,8 +114,8 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
 
   /// Sets the given value of autoResize flag.
   ///
-  /// Will update the [size] to fit srcSize of
-  /// current animation sprite if set to  true.
+  /// Will update the [size] to fit srcSize of current animation sprite if set
+  /// to  true.
   set autoResize(bool value) {
     _autoResize = value;
     _resizeToSprite();

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -17,43 +17,10 @@ class SpriteComponent extends PositionComponent
     implements SizeProvider {
   /// When set to true, the component is auto-resized to match the
   /// size of underlying sprite.
-  late bool _autoResize;
-
-  /// Returns current value of auto resize flag.
-  bool get autoResize => _autoResize;
-
-  /// Sets the given value of autoResize flag. Will update the [size]
-  /// to fit srcSize of [sprite] if set to  true.
-  set autoResize(bool value) {
-    _autoResize = value;
-    if (value) {
-      if (_sprite != null) {
-        size.setFrom(_sprite!.srcSize);
-      } else {
-        size.setZero();
-      }
-    }
-  }
+  bool _autoResize;
 
   /// The [sprite] to be rendered by this component.
   Sprite? _sprite;
-
-  /// Returns the current sprite rendered by this component.
-  Sprite? get sprite => _sprite;
-
-  /// Sets the given sprite as the new [sprite] of this component.
-  /// Will update the size if [autoResize] is set to true.
-  set sprite(Sprite? value) {
-    _sprite = value;
-
-    if (_autoResize) {
-      if (value != null) {
-        size.setFrom(value.srcSize);
-      } else {
-        size.setZero();
-      }
-    }
-  }
 
   /// Creates a component with an empty sprite which can be set later
   SpriteComponent({
@@ -110,6 +77,26 @@ class SpriteComponent extends PositionComponent
           priority: priority,
         );
 
+  /// Returns current value of auto resize flag.
+  bool get autoResize => _autoResize;
+
+  /// Sets the given value of autoResize flag. Will update the [size]
+  /// to fit srcSize of [sprite] if set to  true.
+  set autoResize(bool value) {
+    _autoResize = value;
+    _resizeToSprite();
+  }
+
+  /// Returns the current sprite rendered by this component.
+  Sprite? get sprite => _sprite;
+
+  /// Sets the given sprite as the new [sprite] of this component.
+  /// Will update the size if [autoResize] is set to true.
+  set sprite(Sprite? value) {
+    _sprite = value;
+    _resizeToSprite();
+  }
+
   @override
   @mustCallSuper
   void onMount() {
@@ -127,5 +114,16 @@ class SpriteComponent extends PositionComponent
       size: size,
       overridePaint: paint,
     );
+  }
+
+  /// Updates the size [sprite]'s srcSize if [autoResize] is true.
+  void _resizeToSprite() {
+    if (_autoResize) {
+      if (_sprite != null) {
+        size.setFrom(_sprite!.srcSize);
+      } else {
+        size.setZero();
+      }
+    }
   }
 }

--- a/packages/flame/lib/src/components/sprite_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_group_component.dart
@@ -11,11 +11,14 @@ export '../sprite_animation.dart';
 class SpriteGroupComponent<T> extends PositionComponent
     with HasPaint
     implements SizeProvider {
+  /// Key with the current playing animation
   T? _current;
 
   /// Map with the available states for this sprite group
   Map<T, Sprite>? sprites;
 
+  /// When set to true, the component is auto-resized to match the
+  /// size of current sprite.
   bool _autoResize;
 
   /// Creates a component with an empty animation which can be set later

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -281,7 +281,10 @@ Future<void> main() async {
         throwsAssertionError,
       );
 
-      expect(() => SpriteComponent(autoResize: false), throwsAssertionError);
+      expect(
+        () => SpriteAnimationComponent(autoResize: false),
+        throwsAssertionError,
+      );
     });
 
     test('default value set correctly when not provided explicitly', () {

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 Future<void> main() async {
   // Generate an image
@@ -271,6 +271,67 @@ Future<void> main() async {
       expect(callbackInvoked, 1);
       expect(animation.currentIndex, 4);
       expect(animation.done(), true);
+    });
+  });
+
+  group('SpriteAnimationComponent.autoResize', () {
+    test('mutual exclusive with size while construction', () {
+      expect(
+        () => SpriteAnimationComponent(autoResize: true, size: Vector2.all(2)),
+        throwsAssertionError,
+      );
+
+      expect(() => SpriteComponent(autoResize: false), throwsAssertionError);
+    });
+
+    test('default value set correctly when not provided explicitly', () {
+      final component1 = SpriteAnimationComponent();
+      final component2 = SpriteAnimationComponent(size: Vector2.all(2));
+
+      expect(component1.autoResize, true);
+      expect(component2.autoResize, false);
+    });
+
+    test('resizes on animation update', () {
+      final spriteList = [
+        Sprite(image, srcSize: Vector2.all(1)),
+        Sprite(image, srcSize: Vector2.all(2)),
+        Sprite(image, srcSize: Vector2.all(3)),
+      ];
+      final animation = SpriteAnimation.spriteList(
+        spriteList,
+        stepTime: 1,
+        loop: false,
+      );
+
+      final component = SpriteAnimationComponent(animation: animation);
+      expect(component.size, spriteList[0].srcSize);
+
+      component.update(1);
+      expect(component.size, spriteList[1].srcSize);
+
+      component.update(1);
+      expect(component.size, spriteList[2].srcSize);
+    });
+
+    test('resizes only when true', () {
+      final spriteList = [
+        Sprite(image, srcSize: Vector2.all(1)),
+        Sprite(image, srcSize: Vector2.all(2)),
+      ];
+      final animation = SpriteAnimation.spriteList(
+        spriteList,
+        stepTime: 1,
+        loop: false,
+      );
+      final component = SpriteAnimationComponent(animation: animation)
+        ..autoResize = false;
+
+      component.update(1);
+      expect(component.size, spriteList[0].srcSize);
+
+      component.autoResize = true;
+      expect(component.size, spriteList[1].srcSize);
     });
   });
 }

--- a/packages/flame/test/components/sprite_animation_group_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_group_component_test.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 enum _AnimationState {
   idle,
@@ -191,6 +191,89 @@ Future<void> main() async {
       // runs a cycle to remove the component, but failed
       game.update(0.1);
       expect(game.children.length, 1);
+    });
+  });
+
+  group('SpriteAnimationGroupComponent.autoResize', () {
+    test('mutual exclusive with size while construction', () {
+      expect(
+        () => SpriteAnimationGroupComponent<_AnimationState>(
+          autoResize: true,
+          size: Vector2.all(2),
+        ),
+        throwsAssertionError,
+      );
+
+      expect(
+        () => SpriteAnimationGroupComponent<_AnimationState>(autoResize: false),
+        throwsAssertionError,
+      );
+    });
+
+    test('default value set correctly when not provided explicitly', () {
+      final component1 = SpriteAnimationGroupComponent<_AnimationState>();
+      final component2 = SpriteAnimationGroupComponent<_AnimationState>(
+        size: Vector2.all(2),
+      );
+
+      expect(component1.autoResize, true);
+      expect(component2.autoResize, false);
+    });
+
+    test('resizes on current state change', () {
+      final sprite1 = Sprite(image, srcSize: Vector2.all(76));
+      final sprite2 = Sprite(image, srcSize: Vector2.all(15));
+      final animation1 = SpriteAnimation.spriteList(
+        List.filled(5, sprite1),
+        stepTime: 0.1,
+        loop: false,
+      );
+      final animation2 = SpriteAnimation.spriteList(
+        List.filled(5, sprite2),
+        stepTime: 0.1,
+        loop: false,
+      );
+
+      final component = SpriteAnimationGroupComponent<_AnimationState>(
+        animations: {
+          _AnimationState.idle: animation1,
+          _AnimationState.running: animation2
+        },
+        current: _AnimationState.idle,
+      );
+      expect(component.size, sprite1.srcSize);
+
+      component.current = _AnimationState.running;
+      expect(component.size, sprite2.srcSize);
+    });
+
+    test('resizes only when true', () {
+      final sprite1 = Sprite(image, srcSize: Vector2.all(76));
+      final sprite2 = Sprite(image, srcSize: Vector2.all(15));
+      final animation1 = SpriteAnimation.spriteList(
+        List.filled(5, sprite1),
+        stepTime: 0.1,
+        loop: false,
+      );
+      final animation2 = SpriteAnimation.spriteList(
+        List.filled(5, sprite2),
+        stepTime: 0.1,
+        loop: false,
+      );
+
+      final component = SpriteAnimationGroupComponent<_AnimationState>(
+        animations: {
+          _AnimationState.idle: animation1,
+          _AnimationState.running: animation2
+        },
+        current: _AnimationState.idle,
+      )..autoResize = false;
+
+      component.current = _AnimationState.running;
+      expect(component.size, sprite1.srcSize);
+
+      component.autoResize = true;
+      expect(component.size, sprite2.srcSize);
     });
   });
 }


### PR DESCRIPTION
# Description

This PR extends `autoResize` to `SpriteAnimationComponent` and `SpriteAnimationGroupComponent`  similar to what was done in #2430 and #2442. 

Additionally, this PR also adds `playing` property to `SpriteAnimationGroupComponent`. If it is desired to make this appear as a separate entry in the changlog, I can move this change to a separate PR as it is completely unrelated to the auto-resize changes.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

NA