### PR TITLE
fix: Materialize list in `Component.removeWhere`

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -614,11 +614,7 @@ class Component {
 
   /// Removes all the children for which the [test] function returns true.
   void removeWhere(bool Function(Component component) test) {
-    for (final component in children) {
-      if (test(component)) {
-        remove(component);
-      }
-    }
+    removeAll([...children.where(test)]);
   }
 
   void _removeChild(Component child) {

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -691,6 +691,19 @@ void main() {
           );
         },
       );
+
+      testWithFlameGame(
+        'removeWhere works before all components are mounted',
+        (game) async {
+          game.add(_RemoveWhereComponent());
+          expect(
+            () async {
+              await game.ready();
+            },
+            returnsNormally,
+          );
+        },
+      );
     });
 
     group('Moving components', () {
@@ -1300,5 +1313,13 @@ class _OnChildrenChangedComponent extends PositionComponent {
   void onChildrenChanged(Component child, ChildrenChangeType type) {
     onChangedChildrenRuns++;
     lastChangeType = type;
+  }
+}
+
+class _RemoveWhereComponent extends Component {
+  @override
+  Future<void> onLoad() async {
+    add(Component());
+    removeWhere((_) => true);
   }
 }


### PR DESCRIPTION
# Description

This is needed since it'll get a `ConcurrentModificationException` in some cases otherwise, like in the test added for example.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #2424 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
