### PR TITLE
docs: Standardize sizes of the different contributing badges on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,21 +113,28 @@ in the section below, or contact us on [Discord](https://discord.gg/pxrBmy4).
 
 ## Support
 
-The simplest way to show us your support is by giving the project a star.
+The simplest way to show us your support is by giving the project a star! :star:
 
 You can also support us monetarily by donating through OpenCollective:
 
 <a href="https://opencollective.com/blue-fire/donate" target="_blank">
-  <img src="https://opencollective.com/blue-fire/donate/button@2x.png?color=blue" width=300 />
+  <img src="https://opencollective.com/blue-fire/donate/button@2x.png?color=blue" width=200 />
 </a>
 
-Or through GitHub sponsors:
+Through GitHub Sponsors:
 
-[![GitHub Badge](https://img.shields.io/badge/Github%20Sponsor-blue?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sponsors/bluefireteam)
+<a href="https://github.com/sponsors/bluefireteam" target="_blank">
+  <img
+    src="https://img.shields.io/badge/Github%20Sponsor-blue?style=for-the-badge&logo=github&logoColor=white"
+    width=200
+  />
+</a>
 
 Or by becoming a patron on Patreon:
 
-[![Patreon](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/bluefireoss)
+<a href="https://www.patreon.com/bluefireoss" target="_blank">
+  <img src="https://c5.patreon.com/external/logo/become_a_patron_button.png" width=200 />
+</a>
 
 You can also show on your repository that your game is made with Flame by using one of the following
 badges:


### PR DESCRIPTION
# Description

Standardize sizes of the different contributing badges on README.md to 200 pixels width.
Sadly the height and style are still different, but that is beyond my capabilities.

Also adds a star emoji to the star pledge, and slightly improve wording.

Before:
![image](https://user-images.githubusercontent.com/882703/229365719-25f11ce8-e424-4bab-aa11-3e170a726f33.png)
Now:
![image](https://user-images.githubusercontent.com/882703/229365769-d3a7114f-18ba-472c-a17d-779fbedee34e.png)

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
