### PR TITLE
docs: Add sphinx copy button configurations in conf.py

### DIFF
--- a/doc/_sphinx/conf.py
+++ b/doc/_sphinx/conf.py
@@ -40,6 +40,10 @@ extensions = [
     'sphinx_copybutton'
 ]
 
+# Configuration options for sphinx_copybutton.
+html_static_path = ["theme"]
+html_css_files = ["copy-button.css"]
+
 # Configuration options for MyST:
 # https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
 myst_enable_extensions = [

--- a/doc/_sphinx/conf.py
+++ b/doc/_sphinx/conf.py
@@ -40,10 +40,6 @@ extensions = [
     'sphinx_copybutton'
 ]
 
-# Configuration options for sphinx_copybutton.
-html_static_path = ["theme"]
-html_css_files = ["copy-button.css"]
-
 # Configuration options for MyST:
 # https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
 myst_enable_extensions = [
@@ -97,6 +93,7 @@ pygments_style = 'monokai'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['images', 'scripts', 'theme']
 html_js_files = ['versions.js', 'menu-expand.js']
+html_css_files = ["copy-button.css"]
 
 
 # -- Custom setup ------------------------------------------------------------


### PR DESCRIPTION

# Description
Add sphinx copy button configurations in `conf.py`

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Related Issues

Closes #2463 