### PR TITLE
fix: Stop auto-resizing on external size change in sprite based components

### DIFF
--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -10,7 +10,7 @@ class SpriteAnimationComponent extends PositionComponent
     with HasPaint
     implements SizeProvider {
   /// The animation used by the component.
-  SpriteAnimation? animation;
+  SpriteAnimation? _animation;
 
   /// If the component should be removed once the animation has finished.
   /// Needs the animation to have `loop = false` to ever remove the component,
@@ -26,7 +26,7 @@ class SpriteAnimationComponent extends PositionComponent
 
   /// Creates a component with an empty animation which can be set later
   SpriteAnimationComponent({
-    this.animation,
+    SpriteAnimation? animation,
     bool? autoResize,
     this.removeOnFinish = false,
     this.playing = true,
@@ -43,11 +43,16 @@ class SpriteAnimationComponent extends PositionComponent
           (size == null) == (autoResize ?? size == null),
           '''If size is set, autoResize should be false or size should be null when autoResize is true.''',
         ),
+        _animation = animation,
         _autoResize = autoResize ?? size == null,
         super(size: size ?? animation?.getSprite().srcSize) {
     if (paint != null) {
       this.paint = paint;
     }
+
+    /// Register a listener to differentiate between size modification done by
+    /// external calls v/s the ones done by [_resizeToSprite].
+    this.size.addListener(_handleAutoResizeState);
   }
 
   /// Creates a SpriteAnimationComponent from a [size], an [image] and [data].
@@ -92,10 +97,25 @@ class SpriteAnimationComponent extends PositionComponent
     _resizeToSprite();
   }
 
+  /// This flag helps in detecting if the size modification is done by
+  /// some external call vs [_autoResize]ing code from [_resizeToSprite].
+  bool _isAutoResizing = false;
+
+  /// Returns the [SpriteAnimation] used by this component.
+  SpriteAnimation? get animation => _animation;
+
+  /// Sets the given [value] as [SpriteAnimation] to be used.
+  set animation(SpriteAnimation? value) {
+    if (_animation != value) {
+      _animation = value;
+      _resizeToSprite();
+    }
+  }
+
   @mustCallSuper
   @override
   void render(Canvas canvas) {
-    animation?.getSprite().render(
+    _animation?.getSprite().render(
           canvas,
           size: size,
           overridePaint: paint,
@@ -106,23 +126,32 @@ class SpriteAnimationComponent extends PositionComponent
   @override
   void update(double dt) {
     if (playing) {
-      animation?.update(dt);
+      _animation?.update(dt);
       _resizeToSprite();
     }
-    if (removeOnFinish && (animation?.done() ?? false)) {
+    if (removeOnFinish && (_animation?.done() ?? false)) {
       removeFromParent();
     }
   }
 
-  /// Updates the size to current animation sprite's srcSize if
+  /// Updates the size to current [animation] sprite's srcSize if
   /// [autoResize] is true.
   void _resizeToSprite() {
     if (_autoResize) {
-      if (animation != null) {
-        size.setFrom(animation!.getSprite().srcSize);
+      _isAutoResizing = true;
+      if (_animation != null) {
+        size.setFrom(_animation!.getSprite().srcSize);
       } else {
         size.setZero();
       }
+      _isAutoResizing = false;
+    }
+  }
+
+  /// Turns off [_autoResize]ing if a size modification is  done by user.
+  void _handleAutoResizeState() {
+    if (autoResize && (!_isAutoResizing)) {
+      _autoResize = false;
     }
   }
 }

--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -148,7 +148,7 @@ class SpriteAnimationComponent extends PositionComponent
     }
   }
 
-  /// Turns off [_autoResize]ing if a size modification is  done by user.
+  /// Turns off [_autoResize]ing if a size modification is done by user.
   void _handleAutoResizeState() {
     if (_autoResize && (!_isAutoResizing)) {
       _autoResize = false;

--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -150,7 +150,7 @@ class SpriteAnimationComponent extends PositionComponent
 
   /// Turns off [_autoResize]ing if a size modification is  done by user.
   void _handleAutoResizeState() {
-    if (autoResize && (!_isAutoResizing)) {
+    if (_autoResize && (!_isAutoResizing)) {
       _autoResize = false;
     }
   }

--- a/packages/flame/lib/src/components/sprite_animation_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_group_component.dart
@@ -177,7 +177,7 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
     }
   }
 
-  /// Turns off [_autoResize]ing if a size modification is  done by user.
+  /// Turns off [_autoResize]ing if a size modification is done by user.
   void _handleAutoResizeState() {
     if (_autoResize && (!_isAutoResizing)) {
       _autoResize = false;

--- a/packages/flame/lib/src/components/sprite_animation_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_group_component.dart
@@ -16,7 +16,7 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
   final Map<T, bool> removeOnFinish;
 
   /// Map with the available states for this animation group
-  Map<T, SpriteAnimation>? animations;
+  Map<T, SpriteAnimation>? _animations;
 
   /// Whether the animation is paused or playing.
   bool playing;
@@ -27,7 +27,7 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
 
   /// Creates a component with an empty animation which can be set later
   SpriteAnimationGroupComponent({
-    this.animations,
+    Map<T, SpriteAnimation>? animations,
     T? current,
     bool? autoResize,
     this.playing = true,
@@ -46,11 +46,16 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
           '''If size is set, autoResize should be false or size should be null when autoResize is true.''',
         ),
         _current = current,
+        _animations = animations,
         _autoResize = autoResize ?? size == null,
         super(size: size ?? animations?[current]?.getSprite().srcSize) {
     if (paint != null) {
       this.paint = paint;
     }
+
+    /// Register a listener to differentiate between size modification done by
+    /// external calls v/s the ones done by [_resizeToSprite].
+    this.size.addListener(_handleAutoResizeState);
   }
 
   /// Creates a SpriteAnimationGroupComponent from a [size], an [image] and
@@ -96,7 +101,7 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
           priority: priority,
         );
 
-  SpriteAnimation? get animation => animations?[current];
+  SpriteAnimation? get animation => _animations?[current];
 
   /// Returns the current group state.
   T? get current => _current;
@@ -107,6 +112,17 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
   set current(T? value) {
     _current = value;
     _resizeToSprite();
+  }
+
+  /// Returns the animations state map.
+  Map<T, SpriteAnimation>? get animations => _animations;
+
+  /// Sets the given [value] as animation state map.
+  set animations(Map<T, SpriteAnimation>? value) {
+    if (_animations != value) {
+      _animations = value;
+      _resizeToSprite();
+    }
   }
 
   /// Returns current value of auto resize flag.
@@ -120,6 +136,10 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
     _autoResize = value;
     _resizeToSprite();
   }
+
+  /// This flag helps in detecting if the size modification is done by
+  /// some external call vs [_autoResize]ing code from [_resizeToSprite].
+  bool _isAutoResizing = false;
 
   @mustCallSuper
   @override
@@ -147,11 +167,20 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
   /// [autoResize] is true.
   void _resizeToSprite() {
     if (_autoResize) {
+      _isAutoResizing = true;
       if (animation != null) {
         size.setFrom(animation!.getSprite().srcSize);
       } else {
         size.setZero();
       }
+      _isAutoResizing = true;
+    }
+  }
+
+  /// Turns off [_autoResize]ing if a size modification is  done by user.
+  void _handleAutoResizeState() {
+    if (_autoResize && (!_isAutoResizing)) {
+      _autoResize = false;
     }
   }
 }

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -45,6 +45,10 @@ class SpriteComponent extends PositionComponent
     if (paint != null) {
       this.paint = paint;
     }
+
+    /// Register a listener to differentiate between size modification done by
+    /// external calls v/s the ones done by [_resizeToSprite].
+    this.size.addListener(_handleAutoResizeState);
   }
 
   SpriteComponent.fromImage(
@@ -87,6 +91,10 @@ class SpriteComponent extends PositionComponent
     _resizeToSprite();
   }
 
+  /// This flag helps in detecting if the size modification is done by
+  /// some external call vs [_autoResize]ing code from [_resizeToSprite].
+  bool _isAutoResizing = false;
+
   /// Returns the current sprite rendered by this component.
   Sprite? get sprite => _sprite;
 
@@ -119,11 +127,20 @@ class SpriteComponent extends PositionComponent
   /// Updates the size [sprite]'s srcSize if [autoResize] is true.
   void _resizeToSprite() {
     if (_autoResize) {
+      _isAutoResizing = true;
       if (_sprite != null) {
         size.setFrom(_sprite!.srcSize);
       } else {
         size.setZero();
       }
+      _isAutoResizing = false;
+    }
+  }
+
+  /// Turns off [_autoResize]ing if a size modification is  done by user.
+  void _handleAutoResizeState() {
+    if (autoResize && (!_isAutoResizing)) {
+      _autoResize = false;
     }
   }
 }

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -139,7 +139,7 @@ class SpriteComponent extends PositionComponent
 
   /// Turns off [_autoResize]ing if a size modification is  done by user.
   void _handleAutoResizeState() {
-    if (autoResize && (!_isAutoResizing)) {
+    if (_autoResize && (!_isAutoResizing)) {
       _autoResize = false;
     }
   }

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -137,7 +137,7 @@ class SpriteComponent extends PositionComponent
     }
   }
 
-  /// Turns off [_autoResize]ing if a size modification is  done by user.
+  /// Turns off [_autoResize]ing if a size modification is done by user.
   void _handleAutoResizeState() {
     if (_autoResize && (!_isAutoResizing)) {
       _autoResize = false;

--- a/packages/flame/lib/src/components/sprite_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_group_component.dart
@@ -128,7 +128,7 @@ class SpriteGroupComponent<T> extends PositionComponent
     }
   }
 
-  /// Turns off [_autoResize]ing if a size modification is  done by user.
+  /// Turns off [_autoResize]ing if a size modification is done by user.
   void _handleAutoResizeState() {
     if (_autoResize && (!_isAutoResizing)) {
       _autoResize = false;

--- a/packages/flame/lib/src/components/sprite_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_group_component.dart
@@ -15,7 +15,7 @@ class SpriteGroupComponent<T> extends PositionComponent
   T? _current;
 
   /// Map with the available states for this sprite group
-  Map<T, Sprite>? sprites;
+  Map<T, Sprite>? _sprites;
 
   /// When set to true, the component is auto-resized to match the
   /// size of current sprite.
@@ -23,7 +23,7 @@ class SpriteGroupComponent<T> extends PositionComponent
 
   /// Creates a component with an empty animation which can be set later
   SpriteGroupComponent({
-    this.sprites,
+    Map<T, Sprite>? sprites,
     T? current,
     bool? autoResize,
     Paint? paint,
@@ -40,14 +40,19 @@ class SpriteGroupComponent<T> extends PositionComponent
           '''If size is set, autoResize should be false or size should be null when autoResize is true.''',
         ),
         _current = current,
+        _sprites = sprites,
         _autoResize = autoResize ?? size == null,
         super(size: size ?? sprites?[current]?.srcSize) {
     if (paint != null) {
       this.paint = paint;
     }
+
+    /// Register a listener to differentiate between size modification done by
+    /// external calls v/s the ones done by [_resizeToSprite].
+    this.size.addListener(_handleAutoResizeState);
   }
 
-  Sprite? get sprite => sprites?[current];
+  Sprite? get sprite => _sprites?[current];
 
   /// Returns the current group state.
   T? get current => _current;
@@ -63,6 +68,17 @@ class SpriteGroupComponent<T> extends PositionComponent
   /// Returns current value of auto resize flag.
   bool get autoResize => _autoResize;
 
+  /// Returns the sprites map.
+  Map<T, Sprite>? get sprites => _sprites;
+
+  /// Sets the given [value] as sprites map.
+  set sprites(Map<T, Sprite>? value) {
+    if (_sprites != value) {
+      _sprites = value;
+      _resizeToSprite();
+    }
+  }
+
   /// Sets the given value of autoResize flag.
   ///
   /// Will update the [size] to fit srcSize of
@@ -72,15 +88,19 @@ class SpriteGroupComponent<T> extends PositionComponent
     _resizeToSprite();
   }
 
+  /// This flag helps in detecting if the size modification is done by
+  /// some external call vs [_autoResize]ing code from [_resizeToSprite].
+  bool _isAutoResizing = false;
+
   @override
   @mustCallSuper
   void onMount() {
     assert(
-      sprites != null,
+      _sprites != null,
       'You have to set the sprites in either the constructor or in onLoad',
     );
     assert(
-      current != null,
+      _current != null,
       'You have to set current in either the constructor or in onLoad',
     );
   }
@@ -98,11 +118,20 @@ class SpriteGroupComponent<T> extends PositionComponent
   /// Updates the size to current [sprite]'s srcSize if [autoResize] is true.
   void _resizeToSprite() {
     if (_autoResize) {
+      _isAutoResizing = true;
       if (sprite != null) {
         size.setFrom(sprite!.srcSize);
       } else {
         size.setZero();
       }
+      _isAutoResizing = false;
+    }
+  }
+
+  /// Turns off [_autoResize]ing if a size modification is  done by user.
+  void _handleAutoResizeState() {
+    if (_autoResize && (!_isAutoResizing)) {
+      _autoResize = false;
     }
   }
 }

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -336,5 +336,29 @@ Future<void> main() async {
       component.autoResize = true;
       expect(component.size, spriteList[1].srcSize);
     });
+
+    test('stop autoResizing on external size modifications', () {
+      final spriteList = [
+        Sprite(image, srcSize: Vector2.all(1)),
+        Sprite(image, srcSize: Vector2.all(2)),
+      ];
+      final animation = SpriteAnimation.spriteList(
+        spriteList,
+        stepTime: 1,
+        loop: false,
+      );
+      final testSize = Vector2(83, 100);
+      final component = SpriteAnimationComponent();
+
+      // NOTE: Sequence of modifications is important here. Changing the size
+      // first disables the auto-resizing. So even if sprite is changed later,
+      // the component should still maintain testSize.
+      component
+        ..size = testSize
+        ..animation = animation;
+
+      expectDouble(component.size.x, testSize.x);
+      expectDouble(component.size.y, testSize.y);
+    });
   });
 }

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -351,8 +351,8 @@ Future<void> main() async {
       final component = SpriteAnimationComponent();
 
       // NOTE: Sequence of modifications is important here. Changing the size
-      // first disables the auto-resizing. So even if sprite is changed later,
-      // the component should still maintain testSize.
+      // first disables the auto-resizing. So even if animation is changed 
+      // later, the component should still maintain testSize.
       component
         ..size = testSize
         ..animation = animation;

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -351,7 +351,7 @@ Future<void> main() async {
       final component = SpriteAnimationComponent();
 
       // NOTE: Sequence of modifications is important here. Changing the size
-      // first disables the auto-resizing. So even if animation is changed 
+      // first disables the auto-resizing. So even if animation is changed
       // later, the component should still maintain testSize.
       component
         ..size = testSize

--- a/packages/flame/test/components/sprite_animation_group_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_group_component_test.dart
@@ -275,5 +275,37 @@ Future<void> main() async {
       component.autoResize = true;
       expect(component.size, sprite2.srcSize);
     });
+
+    test('stop autoResizing on external size modifications', () {
+      final testSize = Vector2(83, 100);
+      final sprite1 = Sprite(image, srcSize: Vector2.all(76));
+      final sprite2 = Sprite(image, srcSize: Vector2.all(15));
+      final animation1 = SpriteAnimation.spriteList(
+        List.filled(5, sprite1),
+        stepTime: 0.1,
+        loop: false,
+      );
+      final animation2 = SpriteAnimation.spriteList(
+        List.filled(5, sprite2),
+        stepTime: 0.1,
+        loop: false,
+      );
+      final animationsMap = {
+        _AnimationState.idle: animation1,
+        _AnimationState.running: animation2,
+      };
+      final component = SpriteAnimationGroupComponent<_AnimationState>();
+
+      // NOTE: Sequence of modifications is important here. Changing the size
+      // first disables the auto-resizing. So even if animations map is changed
+      // later, the component should still maintain testSize.
+      component
+        ..size = testSize
+        ..animations = animationsMap
+        ..current = _AnimationState.running;
+
+      expectDouble(component.size.x, testSize.x);
+      expectDouble(component.size.y, testSize.y);
+    });
   });
 }

--- a/packages/flame/test/components/sprite_component_test.dart
+++ b/packages/flame/test/components/sprite_component_test.dart
@@ -78,5 +78,21 @@ Future<void> main() async {
       component.autoResize = true;
       expect(component.size, sprite2.srcSize);
     });
+
+    test('stop autoResizing on external size modifications', () {
+      final testSize = Vector2(83, 100);
+      final sprite = Sprite(image, srcSize: Vector2.all(13));
+      final component = SpriteComponent();
+
+      // NOTE: Sequence of modifications is important here. Changing the size
+      // first disables the auto-resizing. So even if sprite is changed later,
+      // the component should still maintain testSize.
+      component
+        ..size = testSize
+        ..sprite = sprite;
+
+      expectDouble(component.size.x, testSize.x);
+      expectDouble(component.size.y, testSize.y);
+    });
   });
 }

--- a/packages/flame/test/components/sprite_group_component_test.dart
+++ b/packages/flame/test/components/sprite_group_component_test.dart
@@ -89,5 +89,25 @@ Future<void> main() async {
       component.autoResize = true;
       expect(component.size, sprite2.srcSize);
     });
+
+    test('stop autoResizing on external size modifications', () {
+      final testSize = Vector2(83, 100);
+      final spritesMap = {
+        _SpriteState.idle: Sprite(image),
+        _SpriteState.running: Sprite(image, srcSize: Vector2.all(15)),
+      };
+      final component = SpriteGroupComponent<_SpriteState>();
+
+      // NOTE: Sequence of modifications is important here. Changing the size
+      // first disables the auto-resizing. So even if sprites map is changed
+      // later, the component should still maintain testSize.
+      component
+        ..size = testSize
+        ..sprites = spritesMap
+        ..current = _SpriteState.running;
+
+      expectDouble(component.size.x, testSize.x);
+      expectDouble(component.size.y, testSize.y);
+    });
   });
 }


### PR DESCRIPTION
# Description

This PR fixes a regression introduced in Flame 1.7.0 and discussed in [this thread on discord](https://discord.com/channels/509714518008528896/1092822070280327330).

The whole idea is to detect if size is being modified by some external call apart from the `autoResize`ing code and stop auto-resize from that point onwards.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

NA
