### PR TITLE
fix: It should be possible to re-add `ColorEffect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,60 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-04-05
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`flame` - `v1.7.1`](#flame---v171)
+ - [`flame_isolate` - `v0.3.0+1`](#flame_isolate---v0301)
+ - [`flame_tiled` - `v1.10.1`](#flame_tiled---v1101)
+ - [`flame_audio` - `v1.4.2`](#flame_audio---v142)
+ - [`flame_svg` - `v1.7.3`](#flame_svg---v173)
+ - [`flame_test` - `v1.10.1`](#flame_test---v1101)
+ - [`flame_flare` - `v1.5.4`](#flame_flare---v154)
+ - [`flame_oxygen` - `v0.1.8+2`](#flame_oxygen---v0182)
+ - [`flame_bloc` - `v1.8.4`](#flame_bloc---v184)
+ - [`flame_fire_atlas` - `v1.3.5`](#flame_fire_atlas---v135)
+ - [`flame_forge2d` - `v0.13.0+1`](#flame_forge2d---v01301)
+ - [`flame_rive` - `v1.7.1`](#flame_rive---v171)
+ - [`flame_noise` - `v0.1.1+1`](#flame_noise---v0111)
+ - [`flame_network_assets` - `v0.2.0+1`](#flame_network_assets---v0201)
+ - [`flame_lottie` - `v0.2.0+2`](#flame_lottie---v0202)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `flame_isolate` - `v0.3.0+1`
+ - `flame_tiled` - `v1.10.1`
+ - `flame_audio` - `v1.4.2`
+ - `flame_svg` - `v1.7.3`
+ - `flame_test` - `v1.10.1`
+ - `flame_flare` - `v1.5.4`
+ - `flame_oxygen` - `v0.1.8+2`
+ - `flame_bloc` - `v1.8.4`
+ - `flame_fire_atlas` - `v1.3.5`
+ - `flame_forge2d` - `v0.13.0+1`
+ - `flame_rive` - `v1.7.1`
+ - `flame_noise` - `v0.1.1+1`
+ - `flame_network_assets` - `v0.2.0+1`
+ - `flame_lottie` - `v0.2.0+2`
+
+---
+
+#### `flame` - `v1.7.1`
+
+ - **FIX**: Stop auto-resizing on external size change in sprite based components ([#2467](https://github.com/flame-engine/flame/issues/2467)). ([df236af4](https://github.com/flame-engine/flame/commit/df236af4f0164cc20b664ab973d91b4554b13b62))
+
+
 ## 2023-04-02
 
 ### Changes

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.1
+
+ - **FIX**: Stop auto-resizing on external size change in sprite based components ([#2467](https://github.com/flame-engine/flame/issues/2467)). ([df236af4](https://github.com/flame-engine/flame/commit/df236af4f0164cc20b664ab973d91b4554b13b62))
+
 ## 1.7.0
 
 > Note: This release has breaking changes.

--- a/packages/flame/lib/src/effects/color_effect.dart
+++ b/packages/flame/lib/src/effects/color_effect.dart
@@ -13,7 +13,7 @@ import 'package:flutter/material.dart';
 class ColorEffect extends ComponentEffect<HasPaint> {
   final String? paintId;
   final Color color;
-  late final ColorFilter? _original;
+  ColorFilter? _original;
   late final Tween<double> _tween;
 
   ColorEffect(

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 1.7.0
+version: 1.7.1
 homepage: https://github.com/flame-engine/flame
 funding:
   - https://opencollective.com/blue-fire

--- a/packages/flame/test/effects/color_effect_test.dart
+++ b/packages/flame/test/effects/color_effect_test.dart
@@ -62,5 +62,28 @@ void main() {
         );
       },
     );
+
+    testWithFlameGame(
+      'can be re-added in the component tree',
+      (game) async {
+        final component = _PaintComponent();
+        await game.ensureAdd(component);
+
+        final effect = ColorEffect(
+          Colors.red,
+          const Offset(0, 1),
+          EffectController(duration: 1),
+        );
+        await component.ensureAdd(effect);
+        game.update(0.5);
+        effect.removeFromParent();
+        game.update(0.0);
+        component.add(effect);
+        expect(
+          () => game.update(0),
+          returnsNormally,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
# Description

Currently you'll get an error that the `late final _original` field is already initialized if you re-add effect to a component, since that field is set in `onMount`. This PR simply removes final from that field so that it can be updated in `onMount`.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
