### PR TITLE
refactor: Add new lint rules

### DIFF
--- a/doc/flame/examples/lib/drag_events.dart
+++ b/doc/flame/examples/lib/drag_events.dart
@@ -58,13 +58,13 @@ class DragTarget extends PositionComponent with DragCallbacks {
   final Map<int, Trail> _trails = {};
 
   @override
-  void onGameResize(Vector2 canvasSize) {
-    super.onGameResize(canvasSize);
-    size = canvasSize - Vector2(100, 75);
-    if (size.x < 100 || size.y < 100) {
-      size = canvasSize * 0.9;
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    this.size = size - Vector2(100, 75);
+    if (this.size.x < 100 || this.size.y < 100) {
+      this.size = size * 0.9;
     }
-    position = canvasSize / 2;
+    position = size / 2;
   }
 
   @override

--- a/doc/flame/examples/lib/ember.dart
+++ b/doc/flame/examples/lib/ember.dart
@@ -5,9 +5,9 @@ import 'package:flame/flame.dart';
 
 class EmberPlayer extends SpriteAnimationComponent with TapCallbacks {
   EmberPlayer({
-    void Function(EmberPlayer)? onTap,
     required super.position,
     required super.size,
+    void Function(EmberPlayer)? onTap,
   })  : _onTap = onTap,
         super();
 

--- a/doc/flame/examples/lib/router.dart
+++ b/doc/flame/examples/lib/router.dart
@@ -373,8 +373,8 @@ class PauseRoute extends Route {
   }
 
   @override
-  void onPop(Route previousRoute) {
-    previousRoute
+  void onPop(Route nextRoute) {
+    nextRoute
       ..resumeTime()
       ..removeRenderEffect();
   }

--- a/doc/flame/examples/lib/tap_events.dart
+++ b/doc/flame/examples/lib/tap_events.dart
@@ -24,13 +24,13 @@ class TapTarget extends PositionComponent with TapCallbacks {
   final Map<int, ExpandingCircle> _circles = {};
 
   @override
-  void onGameResize(Vector2 canvasSize) {
-    super.onGameResize(canvasSize);
-    size = canvasSize - Vector2(100, 75);
-    if (size.x < 100 || size.y < 100) {
-      size = canvasSize * 0.9;
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    this.size = size - Vector2(100, 75);
+    if (this.size.x < 100 || this.size.y < 100) {
+      this.size = size * 0.9;
     }
-    position = canvasSize / 2;
+    position = size / 2;
   }
 
   @override

--- a/doc/tutorials/klondike/app/lib/step3/components/card.dart
+++ b/doc/tutorials/klondike/app/lib/step3/components/card.dart
@@ -47,7 +47,7 @@ class Card extends PositionComponent {
     const Radius.circular(KlondikeGame.cardRadius),
   );
   static final RRect backRRectInner = cardRRect.deflate(40);
-  static late final Sprite flameSprite = klondikeSprite(1367, 6, 357, 501);
+  static final Sprite flameSprite = klondikeSprite(1367, 6, 357, 501);
 
   void _renderBack(Canvas canvas) {
     canvas.drawRRect(cardRRect, backBackgroundPaint);
@@ -71,14 +71,14 @@ class Card extends PositionComponent {
       Color(0x880d8bff),
       BlendMode.srcATop,
     );
-  static late final Sprite redJack = klondikeSprite(81, 565, 562, 488);
-  static late final Sprite redQueen = klondikeSprite(717, 541, 486, 515);
-  static late final Sprite redKing = klondikeSprite(1305, 532, 407, 549);
-  static late final Sprite blackJack = klondikeSprite(81, 565, 562, 488)
+  static final Sprite redJack = klondikeSprite(81, 565, 562, 488);
+  static final Sprite redQueen = klondikeSprite(717, 541, 486, 515);
+  static final Sprite redKing = klondikeSprite(1305, 532, 407, 549);
+  static final Sprite blackJack = klondikeSprite(81, 565, 562, 488)
     ..paint = blueFilter;
-  static late final Sprite blackQueen = klondikeSprite(717, 541, 486, 515)
+  static final Sprite blackQueen = klondikeSprite(717, 541, 486, 515)
     ..paint = blueFilter;
-  static late final Sprite blackKing = klondikeSprite(1305, 532, 407, 549)
+  static final Sprite blackKing = klondikeSprite(1305, 532, 407, 549)
     ..paint = blueFilter;
 
   void _renderFront(Canvas canvas) {

--- a/doc/tutorials/klondike/app/lib/step3/rank.dart
+++ b/doc/tutorials/klondike/app/lib/step3/rank.dart
@@ -29,7 +29,7 @@ class Rank {
   final Sprite redSprite;
   final Sprite blackSprite;
 
-  static late final List<Rank> _singletons = [
+  static final List<Rank> _singletons = [
     Rank._(1, 'A', 335, 164, 789, 161, 120, 129),
     Rank._(2, '2', 20, 19, 15, 322, 83, 125),
     Rank._(3, '3', 122, 19, 117, 322, 80, 127),

--- a/doc/tutorials/klondike/app/lib/step3/suit.dart
+++ b/doc/tutorials/klondike/app/lib/step3/suit.dart
@@ -19,7 +19,7 @@ class Suit {
   final String label;
   final Sprite sprite;
 
-  static late final List<Suit> _singletons = [
+  static final List<Suit> _singletons = [
     Suit._(0, '♥', 1176, 17, 172, 183),
     Suit._(1, '♦', 973, 14, 177, 182),
     Suit._(2, '♣', 974, 226, 184, 172),

--- a/doc/tutorials/klondike/app/lib/step4/components/card.dart
+++ b/doc/tutorials/klondike/app/lib/step4/components/card.dart
@@ -56,7 +56,7 @@ class Card extends PositionComponent with DragCallbacks {
     const Radius.circular(KlondikeGame.cardRadius),
   );
   static final RRect backRRectInner = cardRRect.deflate(40);
-  static late final Sprite flameSprite = klondikeSprite(1367, 6, 357, 501);
+  static final Sprite flameSprite = klondikeSprite(1367, 6, 357, 501);
 
   void _renderBack(Canvas canvas) {
     canvas.drawRRect(cardRRect, backBackgroundPaint);
@@ -80,14 +80,14 @@ class Card extends PositionComponent with DragCallbacks {
       Color(0x880d8bff),
       BlendMode.srcATop,
     );
-  static late final Sprite redJack = klondikeSprite(81, 565, 562, 488);
-  static late final Sprite redQueen = klondikeSprite(717, 541, 486, 515);
-  static late final Sprite redKing = klondikeSprite(1305, 532, 407, 549);
-  static late final Sprite blackJack = klondikeSprite(81, 565, 562, 488)
+  static final Sprite redJack = klondikeSprite(81, 565, 562, 488);
+  static final Sprite redQueen = klondikeSprite(717, 541, 486, 515);
+  static final Sprite redKing = klondikeSprite(1305, 532, 407, 549);
+  static final Sprite blackJack = klondikeSprite(81, 565, 562, 488)
     ..paint = blueFilter;
-  static late final Sprite blackQueen = klondikeSprite(717, 541, 486, 515)
+  static final Sprite blackQueen = klondikeSprite(717, 541, 486, 515)
     ..paint = blueFilter;
-  static late final Sprite blackKing = klondikeSprite(1305, 532, 407, 549)
+  static final Sprite blackKing = klondikeSprite(1305, 532, 407, 549)
     ..paint = blueFilter;
 
   void _renderFront(Canvas canvas) {

--- a/doc/tutorials/klondike/app/lib/step4/rank.dart
+++ b/doc/tutorials/klondike/app/lib/step4/rank.dart
@@ -29,7 +29,7 @@ class Rank {
   final Sprite redSprite;
   final Sprite blackSprite;
 
-  static late final List<Rank> _singletons = [
+  static final List<Rank> _singletons = [
     Rank._(1, 'A', 335, 164, 789, 161, 120, 129),
     Rank._(2, '2', 20, 19, 15, 322, 83, 125),
     Rank._(3, '3', 122, 19, 117, 322, 80, 127),

--- a/doc/tutorials/klondike/app/lib/step4/suit.dart
+++ b/doc/tutorials/klondike/app/lib/step4/suit.dart
@@ -19,7 +19,7 @@ class Suit {
   final String label;
   final Sprite sprite;
 
-  static late final List<Suit> _singletons = [
+  static final List<Suit> _singletons = [
     Suit._(0, '♥', 1176, 17, 172, 183),
     Suit._(1, '♦', 973, 14, 177, 182),
     Suit._(2, '♣', 974, 226, 184, 172),

--- a/doc/tutorials/platformer/app/lib/ember_quest.dart
+++ b/doc/tutorials/platformer/app/lib/ember_quest.dart
@@ -35,7 +35,7 @@ class EmberQuestGame extends FlameGame
       'star.png',
       'water_enemy.png',
     ]);
-    initializeGame(true);
+    initializeGame(loadHud: true);
   }
 
   @override
@@ -90,7 +90,7 @@ class EmberQuestGame extends FlameGame
     }
   }
 
-  void initializeGame(bool loadHud) {
+  void initializeGame({required bool loadHud}) {
     // Assume that size.x < 3200
     final segmentsToLoad = (size.x / 640).ceil();
     segmentsToLoad.clamp(0, segments.length);
@@ -111,6 +111,6 @@ class EmberQuestGame extends FlameGame
   void reset() {
     starsCollected = 0;
     health = 3;
-    initializeGame(false);
+    initializeGame(loadHud: false);
   }
 }

--- a/doc/tutorials/platformer/app/lib/overlays/game_over.dart
+++ b/doc/tutorials/platformer/app/lib/overlays/game_over.dart
@@ -5,7 +5,7 @@ import '../ember_quest.dart';
 class GameOver extends StatelessWidget {
   // Reference to parent game.
   final EmberQuestGame game;
-  const GameOver({super.key, required this.game});
+  const GameOver({required this.game, super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/doc/tutorials/platformer/app/lib/overlays/main_menu.dart
+++ b/doc/tutorials/platformer/app/lib/overlays/main_menu.dart
@@ -6,7 +6,7 @@ class MainMenu extends StatelessWidget {
   // Reference to parent game.
   final EmberQuestGame game;
 
-  const MainMenu({super.key, required this.game});
+  const MainMenu({required this.game, super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/examples/games/padracing/lib/lap_line.dart
+++ b/examples/games/padracing/lib/lap_line.dart
@@ -10,7 +10,7 @@ import 'package:padracing/car.dart';
 import 'package:padracing/game_colors.dart';
 
 class LapLine extends BodyComponent with ContactCallbacks {
-  LapLine(this.id, this.position, this.size, this.isFinish)
+  LapLine(this.id, this.position, this.size, {required this.isFinish})
       : super(priority: 1);
 
   final int id;

--- a/examples/games/padracing/lib/menu.dart
+++ b/examples/games/padracing/lib/menu.dart
@@ -71,9 +71,9 @@ class Menu extends StatelessWidget {
                             ),
                             recognizer: TapGestureRecognizer()
                               ..onTap = () {
-                                final _url =
-                                    Uri.parse('https://github.com/spydon');
-                                launchUrl(_url);
+                                launchUrl(
+                                  Uri.parse('https://github.com/spydon'),
+                                );
                               },
                           ),
                         ],

--- a/examples/games/padracing/lib/menu_card.dart
+++ b/examples/games/padracing/lib/menu_card.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart' hide Image, Gradient;
 import 'package:padracing/game_colors.dart';
 
 class MenuCard extends StatelessWidget {
-  const MenuCard({super.key, required this.children});
+  const MenuCard({required this.children, super.key});
 
   final List<Widget> children;
 

--- a/examples/games/padracing/lib/padracing_game.dart
+++ b/examples/games/padracing/lib/padracing_game.dart
@@ -65,9 +65,9 @@ class PadRacingGame extends Forge2DGame with KeyboardEvents {
     final walls = createWalls(trackSize);
     final bigBall = Ball(position: Vector2(200, 245), isMovable: false);
     cameraWorld.addAll([
-      LapLine(1, Vector2(25, 50), Vector2(50, 5), false),
-      LapLine(2, Vector2(25, 70), Vector2(50, 5), false),
-      LapLine(3, Vector2(52.5, 25), Vector2(5, 50), true),
+      LapLine(1, Vector2(25, 50), Vector2(50, 5), isFinish: false),
+      LapLine(2, Vector2(25, 70), Vector2(50, 5), isFinish: false),
+      LapLine(3, Vector2(52.5, 25), Vector2(5, 50), isFinish: true),
       bigBall,
       ...walls,
       ...createBalls(trackSize, walls, bigBall),

--- a/examples/games/rogue_shooter/lib/components/bullet_component.dart
+++ b/examples/games/rogue_shooter/lib/components/bullet_component.dart
@@ -28,8 +28,11 @@ class BulletComponent extends SpriteAnimationComponent
   }
 
   @override
-  void onCollisionStart(Set<Vector2> points, PositionComponent other) {
-    super.onCollisionStart(points, other);
+  void onCollisionStart(
+    Set<Vector2> intersectionPoints,
+    PositionComponent other,
+  ) {
+    super.onCollisionStart(intersectionPoints, other);
     if (other is EnemyComponent) {
       other.takeHit();
       removeFromParent();

--- a/examples/games/rogue_shooter/lib/components/player_component.dart
+++ b/examples/games/rogue_shooter/lib/components/player_component.dart
@@ -61,8 +61,11 @@ class PlayerComponent extends SpriteAnimationComponent
   }
 
   @override
-  void onCollisionStart(Set<Vector2> points, PositionComponent other) {
-    super.onCollisionStart(points, other);
+  void onCollisionStart(
+    Set<Vector2> intersectionPoints,
+    PositionComponent other,
+  ) {
+    super.onCollisionStart(intersectionPoints, other);
     if (other is EnemyComponent) {
       other.takeHit();
     }

--- a/examples/games/rogue_shooter/lib/rogue_shooter_game.dart
+++ b/examples/games/rogue_shooter/lib/rogue_shooter_game.dart
@@ -65,8 +65,8 @@ class RogueShooterGame extends FlameGame
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo details) {
-    player.position += details.delta.game;
+  void onPanUpdate(DragUpdateInfo info) {
+    player.position += info.delta.game;
   }
 
   void increaseScore() {

--- a/examples/games/trex/lib/background/cloud.dart
+++ b/examples/games/trex/lib/background/cloud.dart
@@ -52,8 +52,8 @@ class Cloud extends SpriteComponent
   }
 
   @override
-  void onGameResize(Vector2 gameSize) {
-    super.onGameResize(gameSize);
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
     y = ((absolutePosition.y / 2 - (maxSkyLevel - minSkyLevel)) +
             random.fromRange(minSkyLevel, maxSkyLevel)) -
         absolutePositionOf(absoluteTopLeftPosition).y;

--- a/examples/games/trex/lib/background/horizon.dart
+++ b/examples/games/trex/lib/background/horizon.dart
@@ -50,12 +50,12 @@ class Horizon extends PositionComponent with HasGameRef<TRexGame> {
   }
 
   @override
-  void onGameResize(Vector2 gameSize) {
-    super.onGameResize(gameSize);
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
     final newLines = _generateLines();
     groundLayers.addAll(newLines);
     addAll(newLines);
-    y = (gameSize.y / 2) + 21.0;
+    y = (size.y / 2) + 21.0;
   }
 
   void reset() {

--- a/examples/games/trex/lib/game_over.dart
+++ b/examples/games/trex/lib/game_over.dart
@@ -33,10 +33,10 @@ class GameOverText extends SpriteComponent with HasGameRef<TRexGame> {
   }
 
   @override
-  void onGameResize(Vector2 gameSize) {
-    super.onGameResize(gameSize);
-    x = gameSize.x / 2;
-    y = gameSize.y * .25;
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    x = size.x / 2;
+    y = size.y * .25;
   }
 }
 
@@ -53,9 +53,9 @@ class GameOverRestart extends SpriteComponent with HasGameRef<TRexGame> {
   }
 
   @override
-  void onGameResize(Vector2 gameSize) {
-    super.onGameResize(gameSize);
-    x = gameSize.x / 2;
-    y = gameSize.y * .75;
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    x = size.x / 2;
+    y = size.y * .75;
   }
 }

--- a/examples/games/trex/lib/obstacle/obstacle_type.dart
+++ b/examples/games/trex/lib/obstacle/obstacle_type.dart
@@ -19,10 +19,10 @@ class ObstacleTypeSettings {
     required this.multipleAt,
     required this.minGap,
     required this.minSpeed,
+    required this.generateHitboxes,
     this.numFrames,
     this.frameRate,
     this.speedOffset,
-    required this.generateHitboxes,
   });
 
   final ObstacleType type;

--- a/examples/lib/commons/commons.dart
+++ b/examples/lib/commons/commons.dart
@@ -1,6 +1,6 @@
 String baseLink(String path) {
-  const _basePath =
+  const basePath =
       'https://github.com/flame-engine/flame/blob/main/examples/lib/stories/';
 
-  return '$_basePath$path';
+  return '$basePath$path';
 }

--- a/examples/lib/stories/bridge_libraries/audio/basic_audio_example.dart
+++ b/examples/lib/stories/bridge_libraries/audio/basic_audio_example.dart
@@ -74,8 +74,8 @@ class BasicAudioExample extends FlameGame with TapDetector {
   }
 
   @override
-  void onTapDown(TapDownInfo details) {
-    if (button.containsPoint(details.eventPosition.game)) {
+  void onTapDown(TapDownInfo info) {
+    if (button.containsPoint(info.eventPosition.game)) {
       fireTwo();
     } else {
       fireOne();

--- a/examples/lib/stories/bridge_libraries/flame_isolate/simple_isolate_example.dart
+++ b/examples/lib/stories/bridge_libraries/flame_isolate/simple_isolate_example.dart
@@ -93,8 +93,8 @@ class CalculatePrimeNumber extends PositionComponent
   }
 
   @override
-  void update(double t) {
-    _interval.update(t);
+  void update(double dt) {
+    _interval.update(dt);
   }
 
   @override

--- a/examples/lib/stories/bridge_libraries/forge2d/animated_body_example.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/animated_body_example.dart
@@ -36,9 +36,9 @@ class AnimatedBodyExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  void onTapDown(TapDownInfo details) {
-    super.onTapDown(details);
-    final position = details.eventPosition.game;
+  void onTapDown(TapDownInfo info) {
+    super.onTapDown(info);
+    final position = info.eventPosition.game;
     final spriteSize = Vector2.all(10);
     final animationComponent = SpriteAnimationComponent(
       animation: animation,

--- a/examples/lib/stories/bridge_libraries/forge2d/blob_example.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/blob_example.dart
@@ -31,9 +31,9 @@ class BlobExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  void onTapDown(TapDownInfo details) {
-    super.onTapDown(details);
-    add(FallingBox(details.eventPosition.game));
+  void onTapDown(TapDownInfo info) {
+    super.onTapDown(info);
+    add(FallingBox(info.eventPosition.game));
   }
 }
 

--- a/examples/lib/stories/bridge_libraries/forge2d/camera_example.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/camera_example.dart
@@ -11,8 +11,8 @@ class CameraExample extends DominoExample {
   ''';
 
   @override
-  void onTapDown(TapDownInfo details) {
-    final position = details.eventPosition.game;
+  void onTapDown(TapDownInfo info) {
+    final position = info.eventPosition.game;
     final pizza = Pizza(position);
     add(pizza);
     pizza.mounted.whenComplete(() => camera.followBodyComponent(pizza));

--- a/examples/lib/stories/bridge_libraries/forge2d/contact_callbacks_example.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/contact_callbacks_example.dart
@@ -22,9 +22,9 @@ class ContactCallbacksExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  void onTapDown(TapDownInfo details) {
-    super.onTapDown(details);
-    final position = details.eventPosition.game;
+  void onTapDown(TapDownInfo info) {
+    super.onTapDown(info);
+    final position = info.eventPosition.game;
     if (math.Random().nextInt(10) < 2) {
       add(WhiteBall(position));
     } else {

--- a/examples/lib/stories/bridge_libraries/forge2d/domino_example.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/domino_example.dart
@@ -39,9 +39,9 @@ class DominoExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  void onTapDown(TapDownInfo details) {
-    super.onTapDown(details);
-    final position = details.eventPosition.game;
+  void onTapDown(TapDownInfo info) {
+    super.onTapDown(info);
+    final position = info.eventPosition.game;
     add(Pizza(position)..renderBody = true);
   }
 }

--- a/examples/lib/stories/bridge_libraries/forge2d/joints/constant_volume_joint.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/joints/constant_volume_joint.dart
@@ -18,9 +18,9 @@ class ConstantVolumeJointExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  Future<void> onTapDown(TapDownInfo details) async {
-    super.onTapDown(details);
-    final center = details.eventPosition.game;
+  Future<void> onTapDown(TapDownInfo info) async {
+    super.onTapDown(info);
+    final center = info.eventPosition.game;
 
     const numPieces = 20;
     const radius = 5.0;

--- a/examples/lib/stories/bridge_libraries/forge2d/joints/distance_joint.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/joints/distance_joint.dart
@@ -16,9 +16,9 @@ class DistanceJointExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  Future<void> onTapDown(TapDownInfo details) async {
-    super.onTapDown(details);
-    final tap = details.eventPosition.game;
+  Future<void> onTapDown(TapDownInfo info) async {
+    super.onTapDown(info);
+    final tap = info.eventPosition.game;
 
     final first = Ball(tap);
     final second = Ball(Vector2(tap.x + 3, tap.y + 3));

--- a/examples/lib/stories/bridge_libraries/forge2d/joints/friction_joint.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/joints/friction_joint.dart
@@ -29,8 +29,8 @@ class FrictionJointExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  Future<void> onTapDown(TapDownInfo details) async {
-    super.onTapDown(details);
+  Future<void> onTapDown(TapDownInfo info) async {
+    super.onTapDown(info);
     ball.body.applyLinearImpulse(Vector2.random() * 5000);
   }
 

--- a/examples/lib/stories/bridge_libraries/forge2d/joints/motor_joint.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/joints/motor_joint.dart
@@ -41,8 +41,8 @@ class MotorJointExample extends Forge2DGame with TapDetector, HasDraggables {
   }
 
   @override
-  Future<void> onTapDown(TapDownInfo details) async {
-    super.onTapDown(details);
+  Future<void> onTapDown(TapDownInfo info) async {
+    super.onTapDown(info);
     clockWise = !clockWise;
   }
 

--- a/examples/lib/stories/bridge_libraries/forge2d/joints/mouse_joint.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/joints/mouse_joint.dart
@@ -30,7 +30,7 @@ class MouseJointExample extends Forge2DGame with MultiTouchDragDetector {
   }
 
   @override
-  bool onDragUpdate(int pointerId, DragUpdateInfo details) {
+  bool onDragUpdate(int pointerId, DragUpdateInfo info) {
     final mouseJointDef = MouseJointDef()
       ..maxForce = 3000 * ball.body.mass * 10
       ..dampingRatio = 0.1
@@ -45,12 +45,12 @@ class MouseJointExample extends Forge2DGame with MultiTouchDragDetector {
       world.createJoint(mouseJoint!);
     }
 
-    mouseJoint?.setTarget(details.eventPosition.game);
+    mouseJoint?.setTarget(info.eventPosition.game);
     return false;
   }
 
   @override
-  bool onDragEnd(int pointerId, DragEndInfo details) {
+  bool onDragEnd(int pointerId, DragEndInfo info) {
     if (mouseJoint == null) {
       return true;
     }

--- a/examples/lib/stories/bridge_libraries/forge2d/joints/revolute_joint.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/joints/revolute_joint.dart
@@ -21,9 +21,9 @@ class RevoluteJointExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  void onTapDown(TapDownInfo details) {
-    super.onTapDown(details);
-    final ball = Ball(details.eventPosition.game);
+  void onTapDown(TapDownInfo info) {
+    super.onTapDown(info);
+    final ball = Ball(info.eventPosition.game);
     add(ball);
     add(CircleShuffler(ball));
   }

--- a/examples/lib/stories/bridge_libraries/forge2d/revolute_joint_with_motor_example.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/revolute_joint_with_motor_example.dart
@@ -26,9 +26,9 @@ class RevoluteJointWithMotorExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  void onTapDown(TapDownInfo details) {
-    super.onTapDown(details);
-    final tapPosition = details.eventPosition.game;
+  void onTapDown(TapDownInfo info) {
+    super.onTapDown(info);
+    final tapPosition = info.eventPosition.game;
     final random = Random();
     List.generate(15, (i) {
       final randomVector = (Vector2.random() - Vector2.all(-0.5)).normalized();

--- a/examples/lib/stories/bridge_libraries/forge2d/sprite_body_example.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/sprite_body_example.dart
@@ -19,9 +19,9 @@ class SpriteBodyExample extends Forge2DGame with TapDetector {
   }
 
   @override
-  void onTapDown(TapDownInfo details) {
-    super.onTapDown(details);
-    final position = details.eventPosition.game;
+  void onTapDown(TapDownInfo info) {
+    super.onTapDown(info);
+    final position = info.eventPosition.game;
     add(Pizza(position, size: Vector2(10, 15)));
   }
 }

--- a/examples/lib/stories/bridge_libraries/forge2d/utils/balls.dart
+++ b/examples/lib/stories/bridge_libraries/forge2d/utils/balls.dart
@@ -44,10 +44,10 @@ class Ball extends BodyComponent with ContactCallbacks {
   }
 
   @override
-  void renderCircle(Canvas c, Offset center, double radius) {
-    super.renderCircle(c, center, radius);
+  void renderCircle(Canvas canvas, Offset center, double radius) {
+    super.renderCircle(canvas, center, radius);
     final lineRotation = Offset(0, radius);
-    c.drawLine(center, center + lineRotation, _blue);
+    canvas.drawLine(center, center + lineRotation, _blue);
   }
 
   @override

--- a/examples/lib/stories/camera_and_viewport/camera_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_component_example.dart
@@ -353,12 +353,12 @@ class Ant extends PositionComponent {
       ..cubicTo(0, -1.8, 0, -1.1, 0.5, -1.1)
       ..close();
     legs = [
-      InsectLeg(-0.3, 0.4, -2.6, 0.6, 1.1, 1.1, 0.5, true),
-      InsectLeg(-0.2, 0.7, -2.3, 2.6, 1.5, 1.5, 0.6, true),
-      InsectLeg(0.3, 0, 1.7, -2.3, 1.5, 1.3, 0.6, true),
-      InsectLeg(0.3, 0.4, 2.6, 0.6, 1.1, 1.1, 0.5, false),
-      InsectLeg(0.2, 0.7, 2.3, 2.6, 1.5, 1.5, 0.6, false),
-      InsectLeg(-0.3, 0, -1.7, -2.3, 1.5, 1.3, 0.6, false),
+      InsectLeg(-0.3, 0.4, -2.6, 0.6, 1.1, 1.1, 0.5, mirrorBendDirection: true),
+      InsectLeg(-0.2, 0.7, -2.3, 2.6, 1.5, 1.5, 0.6, mirrorBendDirection: true),
+      InsectLeg(0.3, 0, 1.7, -2.3, 1.5, 1.3, 0.6, mirrorBendDirection: true),
+      InsectLeg(0.3, 0.4, 2.6, 0.6, 1.1, 1.1, 0.5, mirrorBendDirection: false),
+      InsectLeg(0.2, 0.7, 2.3, 2.6, 1.5, 1.5, 0.6, mirrorBendDirection: false),
+      InsectLeg(-0.3, 0, -1.7, -2.3, 1.5, 1.3, 0.6, mirrorBendDirection: false),
     ];
   }
 
@@ -478,9 +478,9 @@ class InsectLeg {
     this.y1,
     this.l1,
     this.l2,
-    this.l3,
-    bool bendDirection,
-  )   : dir = bendDirection ? -1 : 1,
+    this.l3, {
+    required bool mirrorBendDirection,
+  })  : dir = mirrorBendDirection ? -1 : 1,
         path = Path(),
         foot = Vector2.zero() {
     final ok = placeFoot(Vector2(x1, y1));
@@ -488,14 +488,18 @@ class InsectLeg {
   }
 
   /// Place where the leg is attached to the body
-  final double x0, y0;
+  final double x0;
+  final double y0;
 
   /// Place on the ground where the ant needs to place its foot
-  final double x1, y1;
+  final double x1;
+  final double y1;
 
   /// Lengths of the 3 segments of the leg: [l1] is nearest to the body, [l2]
   /// is the middle part, and [l3] is the "foot".
-  final double l1, l2, l3;
+  final double l1;
+  final double l2;
+  final double l3;
 
   /// +1 if the leg bends "forward", or -1 if backwards
   final double dir;

--- a/examples/lib/stories/camera_and_viewport/coordinate_systems_example.dart
+++ b/examples/lib/stories/camera_and_viewport/coordinate_systems_example.dart
@@ -40,21 +40,21 @@ class CoordinateSystemsExample extends FlameGame
   }
 
   @override
-  void render(Canvas c) {
-    c.drawRect(canvasSize.toRect(), _borderPaint);
+  void render(Canvas canvas) {
+    canvas.drawRect(canvasSize.toRect(), _borderPaint);
     _text.render(
-      c,
+      canvas,
       'Camera: WASD to move, QE to zoom',
       Vector2.all(5.0),
     );
     _text.render(
-      c,
+      canvas,
       'Camera: ${camera.position}, zoom: ${camera.zoom}',
       Vector2(canvasSize.x - 5, 5.0),
       anchor: Anchor.topRight,
     );
     _text.render(
-      c,
+      canvas,
       'This is your Flame game!',
       canvasSize - Vector2.all(5.0),
       anchor: Anchor.bottomRight,
@@ -62,22 +62,22 @@ class CoordinateSystemsExample extends FlameGame
     final lastEventDescription = this.lastEventDescription;
     if (lastEventDescription != null) {
       _text.render(
-        c,
+        canvas,
         lastEventDescription,
         canvasSize / 2,
         anchor: Anchor.center,
       );
     }
-    super.render(c);
+    super.render(canvas);
   }
 
   @override
-  void onTapUp(int pointer, TapUpInfo info) {
+  void onTapUp(int pointerId, TapUpInfo info) {
     lastEventDescription = _describe('TapUp', info);
   }
 
   @override
-  void onTapDown(int pointer, TapDownInfo info) {
+  void onTapDown(int pointerId, TapDownInfo info) {
     lastEventDescription = _describe('TapDown', info);
   }
 

--- a/examples/lib/stories/camera_and_viewport/fixed_resolution_example.dart
+++ b/examples/lib/stories/camera_and_viewport/fixed_resolution_example.dart
@@ -55,7 +55,7 @@ class Background extends PositionComponent with HasGameRef {
   }
 
   @override
-  void render(Canvas c) {
-    c.drawRect(hugeRect, white);
+  void render(Canvas canvas) {
+    canvas.drawRect(hugeRect, white);
   }
 }

--- a/examples/lib/stories/camera_and_viewport/follow_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/follow_component_example.dart
@@ -78,8 +78,8 @@ class MovableEmber extends Ember<FollowComponentExample>
   }
 
   @override
-  void onCollision(Set<Vector2> points, PositionComponent other) {
-    super.onCollision(points, other);
+  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+    super.onCollision(intersectionPoints, other);
     if (other is Rock) {
       gameRef.camera.setRelativeOffset(Anchor.topCenter);
     }

--- a/examples/lib/stories/collision_detection/multiple_shapes_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes_example.dart
@@ -74,7 +74,7 @@ class MultipleShapesExample extends FlameGame with HasCollisionDetection {
       collidableSize,
       velocity,
       screenHitbox,
-      rng: _rng,
+      random: _rng,
     );
   }
 }
@@ -273,11 +273,11 @@ MyCollidable randomCollidable(
   Vector2 size,
   Vector2 velocity,
   ScreenHitbox screenHitbox, {
-  Random? rng,
+  Random? random,
 }) {
-  final _rng = rng ?? Random();
-  final rotationSpeed = 0.5 - _rng.nextDouble();
-  final shapeType = Shapes.values[_rng.nextInt(Shapes.values.length)];
+  final rng = random ?? Random();
+  final rotationSpeed = 0.5 - rng.nextDouble();
+  final shapeType = Shapes.values[rng.nextInt(Shapes.values.length)];
   switch (shapeType) {
     case Shapes.circle:
       return CollidableCircle(position, size, velocity, screenHitbox)

--- a/examples/lib/stories/components/components_notifier_example.dart
+++ b/examples/lib/stories/components/components_notifier_example.dart
@@ -60,9 +60,9 @@ class _ComponentsNotifierExampleWidgetState
 
 class GameHud extends StatelessWidget {
   const GameHud({
-    super.key,
     required this.remainingEnemies,
     required this.onReplay,
+    super.key,
   });
 
   final int remainingEnemies;

--- a/examples/lib/stories/components/look_at_example.dart
+++ b/examples/lib/stories/components/look_at_example.dart
@@ -83,7 +83,7 @@ class LookAtExample extends FlameGame with TapDetector {
 
   // Just displays some information. No functional contribution to the example.
   void _spawnInfoText() {
-    final _shaded = TextPaint(
+    final shaded = TextPaint(
       style: TextStyle(
         color: BasicPalette.white.color,
         fontSize: 20.0,
@@ -96,7 +96,7 @@ class LookAtExample extends FlameGame with TapDetector {
     add(
       TextComponent(
         text: 'nativeAngle = pi',
-        textRenderer: _shaded,
+        textRenderer: shaded,
         anchor: Anchor.center,
         position: _chopper1.absolutePosition + Vector2(0, -50),
       ),
@@ -105,7 +105,7 @@ class LookAtExample extends FlameGame with TapDetector {
     add(
       TextComponent(
         text: 'nativeAngle = 0',
-        textRenderer: _shaded,
+        textRenderer: shaded,
         anchor: Anchor.center,
         position: _chopper2.absolutePosition + Vector2(0, -50),
       ),

--- a/examples/lib/stories/components/look_at_smooth_example.dart
+++ b/examples/lib/stories/components/look_at_smooth_example.dart
@@ -103,7 +103,7 @@ class LookAtSmoothExample extends FlameGame with TapDetector {
 
   // Just displays some information. No functional contribution to the example.
   void _spawnInfoText() {
-    final _shaded = TextPaint(
+    final shaded = TextPaint(
       style: TextStyle(
         color: BasicPalette.white.color,
         fontSize: 20.0,
@@ -116,7 +116,7 @@ class LookAtSmoothExample extends FlameGame with TapDetector {
     add(
       TextComponent(
         text: 'nativeAngle = pi',
-        textRenderer: _shaded,
+        textRenderer: shaded,
         anchor: Anchor.center,
         position: _chopper1.absolutePosition + Vector2(0, -50),
       ),
@@ -125,7 +125,7 @@ class LookAtSmoothExample extends FlameGame with TapDetector {
     add(
       TextComponent(
         text: 'nativeAngle = 0',
-        textRenderer: _shaded,
+        textRenderer: shaded,
         anchor: Anchor.center,
         position: _chopper2.absolutePosition + Vector2(0, -50),
       ),

--- a/examples/lib/stories/components/priority_example.dart
+++ b/examples/lib/stories/components/priority_example.dart
@@ -30,7 +30,7 @@ class Square extends RectangleComponent
         );
 
   @override
-  void onTapDown(TapDownEvent info) {
+  void onTapDown(TapDownEvent event) {
     final topComponent = gameRef.children.last;
     if (topComponent != this) {
       priority = topComponent.priority + 1;

--- a/examples/lib/stories/input/double_tap_callbacks_example.dart
+++ b/examples/lib/stories/input/double_tap_callbacks_example.dart
@@ -17,13 +17,13 @@ class DoubleTapCallbacksExample extends FlameGame with DoubleTapCallbacks {
   }
 
   @override
-  void onGameResize(Vector2 canvasSize) {
+  void onGameResize(Vector2 size) {
     children
         .query<DoubleTappableEmber>()
         .forEach((element) => element.removeFromParent());
-    add(DoubleTappableEmber(position: canvasSize / 2));
+    add(DoubleTappableEmber(position: size / 2));
 
-    super.onGameResize(canvasSize);
+    super.onGameResize(size);
   }
 
   @override

--- a/examples/lib/stories/input/gesture_hitboxes_example.dart
+++ b/examples/lib/stories/input/gesture_hitboxes_example.dart
@@ -50,9 +50,9 @@ class GestureHitboxesExample extends FlameGame
   }
 
   @override
-  void onTapDown(TapDownEvent info) {
-    super.onTapDown(info);
-    final tapPosition = info.localPosition;
+  void onTapDown(TapDownEvent event) {
+    super.onTapDown(event);
+    final tapPosition = event.localPosition;
     final component = randomShape(tapPosition);
     add(component);
   }

--- a/examples/lib/stories/input/joystick_advanced_example.dart
+++ b/examples/lib/stories/input/joystick_advanced_example.dart
@@ -152,16 +152,16 @@ class JoystickAdvancedExample extends FlameGame with HasCollisionDetection {
       ),
     );
 
-    final _regular = TextPaint(
+    final regular = TextPaint(
       style: TextStyle(color: BasicPalette.white.color),
     );
     speedText = TextComponent(
       text: 'Speed: 0',
-      textRenderer: _regular,
+      textRenderer: regular,
     )..positionType = PositionType.viewport;
     directionText = TextComponent(
       text: 'Direction: idle',
-      textRenderer: _regular,
+      textRenderer: regular,
     )..positionType = PositionType.viewport;
 
     final speedWithMargin = HudMarginComponent(

--- a/examples/lib/stories/input/joystick_player.dart
+++ b/examples/lib/stories/input/joystick_player.dart
@@ -32,14 +32,12 @@ class JoystickPlayer extends SpriteComponent
   }
 
   @override
-  void onCollisionStart(Set<Vector2> _, PositionComponent __) {
-    super.onCollisionStart(_, __);
+  void onCollisionStart(
+    Set<Vector2> intersectionPoints,
+    PositionComponent other,
+  ) {
+    super.onCollisionStart(intersectionPoints, other);
     transform.setFrom(_lastTransform);
     size.setFrom(_lastSize);
-  }
-
-  @override
-  void onCollisionEnd(PositionComponent __) {
-    super.onCollisionEnd(__);
   }
 }

--- a/examples/lib/stories/input/multitap_advanced_example.dart
+++ b/examples/lib/stories/input/multitap_advanced_example.dart
@@ -56,7 +56,8 @@ class MultitapAdvancedExample extends FlameGame
 
   @override
   void onDragEnd(int pointerId, _) {
-    final start = this.start, end = this.end;
+    final start = this.start;
+    final end = this.end;
     if (start != null && end != null) {
       panRect = start.toPositionedRect(end - start);
     }

--- a/examples/lib/stories/rendering/particles_example.dart
+++ b/examples/lib/stories/rendering/particles_example.dart
@@ -536,6 +536,7 @@ class TrafficLightComponent extends Component {
     Colors.orange,
     Colors.red,
   ];
+  final Paint _paint = Paint();
 
   @override
   void onMount() {
@@ -543,8 +544,8 @@ class TrafficLightComponent extends Component {
   }
 
   @override
-  void render(Canvas c) {
-    c.drawRect(rect, Paint()..color = currentColor);
+  void render(Canvas canvas) {
+    canvas.drawRect(rect, _paint..color = currentColor);
   }
 
   @override

--- a/packages/flame/lib/src/camera/viewports/fixed_aspect_ratio_viewport.dart
+++ b/packages/flame/lib/src/camera/viewports/fixed_aspect_ratio_viewport.dart
@@ -30,9 +30,9 @@ class FixedAspectRatioViewport extends Viewport {
   }
 
   @override
-  void onGameResize(Vector2 canvasSize) {
-    super.onGameResize(canvasSize);
-    _handleResize(canvasSize);
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    _handleResize(size);
   }
 
   void _handleResize(Vector2 canvasSize) {

--- a/packages/flame/lib/src/camera/viewports/fixed_size_viewport.dart
+++ b/packages/flame/lib/src/camera/viewports/fixed_size_viewport.dart
@@ -23,7 +23,8 @@ class FixedSizeViewport extends Viewport {
 
   @override
   bool containsLocalPoint(Vector2 point) {
-    final x = point.x, y = point.y;
+    final x = point.x;
+    final y = point.y;
     return x >= 0 && x <= size.x && y >= 0 && y <= size.y;
   }
 

--- a/packages/flame/lib/src/camera/viewports/max_viewport.dart
+++ b/packages/flame/lib/src/camera/viewports/max_viewport.dart
@@ -17,9 +17,9 @@ class MaxViewport extends Viewport {
   }
 
   @override
-  void onGameResize(Vector2 gameSize) {
-    super.onGameResize(gameSize);
-    size = gameSize;
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    this.size = size;
   }
 
   @override

--- a/packages/flame/lib/src/collisions/broadphase/broadphase.dart
+++ b/packages/flame/lib/src/collisions/broadphase/broadphase.dart
@@ -50,9 +50,9 @@ class CollisionProspect<T> {
   const CollisionProspect(this.a, this.b);
 
   @override
-  bool operator ==(Object o) =>
-      o is CollisionProspect &&
-      ((o.a == a && o.b == b) || (o.a == b && o.b == a));
+  bool operator ==(Object other) =>
+      other is CollisionProspect &&
+      ((other.a == a && other.b == b) || (other.a == b && other.b == a));
 
   @override
   int get hashCode => Object.hashAllUnordered([a, b]);

--- a/packages/flame/lib/src/collisions/broadphase/quadtree/quad_tree_broadphase.dart
+++ b/packages/flame/lib/src/collisions/broadphase/quadtree/quad_tree_broadphase.dart
@@ -113,12 +113,12 @@ class QuadTreeBroadphase<T extends Hitbox<T>> extends Broadphase<T> {
   }
 
   @override
-  void add(T hitbox) {
-    tree.add(hitbox);
-    if (hitbox.collisionType == CollisionType.active) {
-      activeCollisions.add(hitbox);
+  void add(T item) {
+    tree.add(item);
+    if (item.collisionType == CollisionType.active) {
+      activeCollisions.add(item);
     }
-    _cacheCenterOfHitbox(hitbox as ShapeHitbox);
+    _cacheCenterOfHitbox(item as ShapeHitbox);
   }
 
   @override

--- a/packages/flame/lib/src/collisions/broadphase/quadtree/quadtree.dart
+++ b/packages/flame/lib/src/collisions/broadphase/quadtree/quadtree.dart
@@ -193,8 +193,9 @@ class QuadTree<T extends Hitbox<T>> {
     final node = _hitboxAtNode.remove(hitbox);
     if (node != null) {
       node.hitboxes.remove(hitbox);
+      // TODO(Spydon): Shouldn't this if be negated?
       if (keepOldPosition) {
-        _oldPositionByItem.remove(node);
+        _oldPositionByItem.remove(hitbox);
       }
     }
   }

--- a/packages/flame/lib/src/collisions/broadphase/quadtree/quadtree.dart
+++ b/packages/flame/lib/src/collisions/broadphase/quadtree/quadtree.dart
@@ -26,10 +26,10 @@ class QuadTree<T extends Hitbox<T>> {
 
   Rect mainBoxSize;
 
-  var _rootNode = _Node<T>();
+  var _rootNode = QuadTreeNode<T>();
   int _nodeLastId = 0;
   final _oldPositionByItem = <ShapeHitbox, Aabb2>{};
-  final _hitboxAtNode = <ShapeHitbox, _Node>{};
+  final _hitboxAtNode = <ShapeHitbox, QuadTreeNode>{};
 
   List<T> get hitboxes => _rootNode.valuesRecursive;
 
@@ -41,10 +41,10 @@ class QuadTree<T extends Hitbox<T>> {
     return Rect.fromPoints(minOffset, value.aabb.max.toOffset());
   }
 
-  bool _noChildren(_Node node) => node.children[0] == null;
+  bool _noChildren(QuadTreeNode node) => node.children[0] == null;
 
   void clear() {
-    _rootNode = _Node<T>();
+    _rootNode = QuadTreeNode<T>();
     _nodeLastId = 0;
     _hitboxAtNode.clear();
     _oldPositionByItem.clear();
@@ -113,8 +113,14 @@ class QuadTree<T extends Hitbox<T>> {
     _hitboxAtNode[hitbox as ShapeHitbox] = node;
   }
 
-  _Node<T> _add(_Node<T> node, int depth, Rect box, T value, _Node? parent) {
-    _Node<T> finalNode;
+  QuadTreeNode<T> _add(
+    QuadTreeNode<T> node,
+    int depth,
+    Rect box,
+    T value,
+    QuadTreeNode? parent,
+  ) {
+    QuadTreeNode<T> finalNode;
     if (_noChildren(node)) {
       // Insert the value in this node if possible.
       if (depth >= maxDepth || node.hitboxes.length < maxObjects) {
@@ -135,7 +141,7 @@ class QuadTree<T extends Hitbox<T>> {
           throw 'Invalid index $quadrant';
         }
         finalNode = _add(
-          children as _Node<T>,
+          children as QuadTreeNode<T>,
           depth + 1,
           _computeBox(box, quadrant),
           value,
@@ -154,12 +160,12 @@ class QuadTree<T extends Hitbox<T>> {
     return finalNode;
   }
 
-  void _split(_Node node, Rect box) {
+  void _split(QuadTreeNode node, Rect box) {
     assert(_noChildren(node), 'Only leaves can be split');
     // Create children
     for (var i = 0; i < node.children.length; i++) {
       final newId = ++_nodeLastId;
-      node.children[i] = _Node<T>()
+      node.children[i] = QuadTreeNode<T>()
         ..parent = node
         ..id = newId;
     }
@@ -197,7 +203,7 @@ class QuadTree<T extends Hitbox<T>> {
     _tryMergeRecursive(_rootNode);
   }
 
-  void _tryMergeRecursive(_Node node) {
+  void _tryMergeRecursive(QuadTreeNode node) {
     if (_noChildren(node)) {
       return;
     }
@@ -243,7 +249,7 @@ class QuadTree<T extends Hitbox<T>> {
     return {id: values};
   }
 
-  List<T> _getChildrenItems(_Node parent) {
+  List<T> _getChildrenItems(QuadTreeNode parent) {
     final list = <T>[];
     for (final child in parent.children) {
       if (child != null) {
@@ -256,7 +262,7 @@ class QuadTree<T extends Hitbox<T>> {
     return list;
   }
 
-  List<T> _getParentItems(_Node node) {
+  List<T> _getParentItems(QuadTreeNode node) {
     final list = <T>[];
     final parent = node.parent;
     if (parent != null) {
@@ -287,7 +293,7 @@ class QuadTree<T extends Hitbox<T>> {
 /// The class might be useful to render debugging info.
 /// See examples for details.
 class QuadTreeNodeDebugInfo {
-  QuadTreeNodeDebugInfo(this.rect, this._node, this.cd);
+  QuadTreeNodeDebugInfo(this.rect, this.node, this.cd);
 
   factory QuadTreeNodeDebugInfo.init(QuadTreeCollisionDetection cd) {
     final node = cd.broadphase.tree._rootNode;
@@ -296,22 +302,23 @@ class QuadTreeNodeDebugInfo {
   }
 
   final Rect rect;
-  final _Node _node;
+  final QuadTreeNode node;
   final QuadTreeCollisionDetection cd;
 
-  List<ShapeHitbox> get ownElements => _node.hitboxes as List<ShapeHitbox>;
+  List<ShapeHitbox> get ownElements => node.hitboxes as List<ShapeHitbox>;
 
   List<ShapeHitbox> get allElements =>
-      _node.valuesRecursive as List<ShapeHitbox>;
+      node.valuesRecursive as List<ShapeHitbox>;
 
-  bool get noChildren => _node.children[0] == null;
+  bool get noChildren => node.children[0] == null;
 
-  int get id => _node.id;
+  int get id => node.id;
 
   List<QuadTreeNodeDebugInfo> get nodes {
     final list = <QuadTreeNodeDebugInfo>[this];
-    for (var i = 0; i < _node.children.length; i++) {
-      final node = _node.children[i];
+    var i = 0;
+    for (final node in this.node.children) {
+      i++;
       if (node == null) {
         continue;
       }
@@ -325,13 +332,13 @@ class QuadTreeNodeDebugInfo {
   }
 }
 
-class _Node<T extends Hitbox<T>> {
-  final List<_Node?> children =
+class QuadTreeNode<T extends Hitbox<T>> {
+  final List<QuadTreeNode?> children =
       List.generate(4, (index) => null, growable: false);
 
   List<T> hitboxes = <T>[];
 
-  _Node? parent;
+  QuadTreeNode? parent;
   int id = 0;
 
   List<T> get valuesRecursive {

--- a/packages/flame/lib/src/collisions/hitboxes/circle_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/circle_hitbox.dart
@@ -24,8 +24,8 @@ class CircleHitbox extends CircleComponent with ShapeHitbox {
   /// that fills half of the [parentSize].
   CircleHitbox.relative(
     super.relation, {
-    super.position,
     required super.parentSize,
+    super.position,
     super.angle,
     super.anchor,
     bool isSolid = false,

--- a/packages/flame/lib/src/collisions/hitboxes/polygon_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/polygon_hitbox.dart
@@ -25,8 +25,8 @@ class PolygonHitbox extends PolygonComponent
   /// screen coordinate system)
   PolygonHitbox.relative(
     super.relation, {
-    super.position,
     required super.parentSize,
+    super.position,
     double super.angle = 0,
     super.anchor,
     bool isSolid = false,

--- a/packages/flame/lib/src/collisions/hitboxes/rectangle_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/rectangle_hitbox.dart
@@ -27,8 +27,8 @@ class RectangleHitbox extends RectangleComponent
   /// [parentSize].
   RectangleHitbox.relative(
     super.relation, {
-    super.position,
     required super.parentSize,
+    super.position,
     super.angle,
     super.anchor,
     bool isSolid = false,

--- a/packages/flame/lib/src/collisions/hitboxes/screen_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/screen_hitbox.dart
@@ -22,8 +22,8 @@ class ScreenHitbox<T extends FlameGame> extends PositionComponent
   }
 
   @override
-  void onGameResize(Vector2 gameSize) {
-    super.onGameResize(gameSize);
-    size = gameSize;
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    this.size = size;
   }
 }

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -646,6 +646,7 @@ class Component {
 
   /// Changes the current parent for another parent and prepares the tree under
   /// the new root.
+  // ignore: use_setters_to_change_properties
   void changeParent(Component newParent) {
     parent = newParent;
   }
@@ -748,6 +749,7 @@ class Component {
   /// component list isn't re-ordered when it is called.
   /// See FlameGame.changePriority instead.
   @Deprecated('Will be removed in 1.8.0. Use priority setter instead.')
+  // ignore: use_setters_to_change_properties
   void changePriorityWithoutResorting(int priority) => _priority = priority;
 
   /// Call this if any of this component's children priorities have changed

--- a/packages/flame/lib/src/components/input/button_component.dart
+++ b/packages/flame/lib/src/components/input/button_component.dart
@@ -52,7 +52,7 @@ class ButtonComponent extends PositionComponent with TapCallbacks {
 
   @override
   @mustCallSuper
-  void onTapDown(TapDownEvent info) {
+  void onTapDown(TapDownEvent event) {
     if (buttonDown != null) {
       button!.removeFromParent();
       buttonDown!.parent = this;
@@ -62,7 +62,7 @@ class ButtonComponent extends PositionComponent with TapCallbacks {
 
   @override
   @mustCallSuper
-  void onTapUp(TapUpEvent info) {
+  void onTapUp(TapUpEvent event) {
     if (buttonDown != null) {
       buttonDown!.removeFromParent();
       button!.parent = this;
@@ -72,7 +72,7 @@ class ButtonComponent extends PositionComponent with TapCallbacks {
 
   @override
   @mustCallSuper
-  void onTapCancel(TapCancelEvent info) {
+  void onTapCancel(TapCancelEvent event) {
     if (buttonDown != null) {
       buttonDown!.removeFromParent();
       button!.parent = this;

--- a/packages/flame/lib/src/components/input/hud_margin_component.dart
+++ b/packages/flame/lib/src/components/input/hud_margin_component.dart
@@ -67,8 +67,8 @@ class HudMarginComponent<T extends FlameGame> extends PositionComponent
   }
 
   @override
-  void onGameResize(Vector2 gameSize) {
-    super.onGameResize(gameSize);
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
     _updateMargins();
   }
 

--- a/packages/flame/lib/src/components/input/joystick_component.dart
+++ b/packages/flame/lib/src/components/input/joystick_component.dart
@@ -105,14 +105,14 @@ class JoystickComponent extends HudMarginComponent with DragCallbacks {
   }
 
   @override
-  bool onDragStart(DragStartEvent info) {
-    super.onDragStart(info);
+  bool onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
     return false;
   }
 
   @override
-  bool onDragUpdate(DragUpdateEvent info) {
-    _unscaledDelta.add(info.delta);
+  bool onDragUpdate(DragUpdateEvent event) {
+    _unscaledDelta.add(event.delta);
     return false;
   }
 

--- a/packages/flame/lib/src/components/isometric_tile_map_component.dart
+++ b/packages/flame/lib/src/components/isometric_tile_map_component.dart
@@ -9,8 +9,11 @@ import 'package:meta/meta.dart';
 /// Represents a position in a matrix, or in this case, on the tilemap.
 @immutable
 class Block {
-  /// x and y coordinates on the matrix
-  final int x, y;
+  /// x coordinate in the matrix.
+  final int x;
+
+  /// y coordinate in the matrix.
+  final int y;
 
   const Block(this.x, this.y);
 
@@ -77,7 +80,7 @@ class IsometricTileMapComponent extends PositionComponent {
 
   Sprite _renderSprite;
   @override
-  void render(Canvas c) {
+  void render(Canvas canvas) {
     _renderSprite.image = tileset.image;
     final size = effectiveTileSize;
     for (var i = 0; i < matrix.length; i++) {
@@ -87,7 +90,7 @@ class IsometricTileMapComponent extends PositionComponent {
           _renderSprite = tileset.getSpriteById(element);
           final p = getBlockRenderPositionInts(j, i);
           _renderSprite.render(
-            c,
+            canvas,
             position: p,
             size: size,
           );

--- a/packages/flame/lib/src/components/mixins/has_paint.dart
+++ b/packages/flame/lib/src/components/mixins/has_paint.dart
@@ -30,16 +30,16 @@ mixin HasPaint<T extends Object> on Component
   /// Returns the main paint if no [paintId] is provided.
   Paint getPaint([T? paintId]) {
     if (paintId == null) {
-      return paint;
+      return this.paint;
     }
 
-    final _paint = _paints[paintId];
+    final paint = _paints[paintId];
 
-    if (_paint == null) {
+    if (paint == null) {
       throw ArgumentError('No Paint found for $paintId');
     }
 
-    return _paint;
+    return paint;
   }
 
   /// Sets a paint on the collection.
@@ -153,8 +153,8 @@ mixin HasPaint<T extends Object> on Component
   }) {
     return _MultiPaintOpacityProvider(
       paintIds ?? (List<T?>.from(_paints.keys)..add(null)),
-      includeLayers,
       this,
+      includeLayers: includeLayers,
     );
   }
 }
@@ -173,7 +173,11 @@ class _ProxyOpacityProvider<T extends Object> implements OpacityProvider {
 }
 
 class _MultiPaintOpacityProvider<T extends Object> implements OpacityProvider {
-  _MultiPaintOpacityProvider(this.paintIds, this.includeLayers, this.target) {
+  _MultiPaintOpacityProvider(
+    this.paintIds,
+    this.target, {
+    required this.includeLayers,
+  }) {
     final maxOpacity = opacity;
 
     _opacityRatios = [

--- a/packages/flame/lib/src/components/mixins/single_child_particle.dart
+++ b/packages/flame/lib/src/components/mixins/single_child_particle.dart
@@ -32,8 +32,8 @@ mixin SingleChildParticle on Particle {
   }
 
   @override
-  void render(Canvas c) {
-    child.render(c);
+  void render(Canvas canvas) {
+    child.render(canvas);
   }
 
   @override

--- a/packages/flame/lib/src/components/nine_tile_box_component.dart
+++ b/packages/flame/lib/src/components/nine_tile_box_component.dart
@@ -37,7 +37,7 @@ class NineTileBoxComponent extends PositionComponent implements SizeProvider {
 
   @mustCallSuper
   @override
-  void render(Canvas c) {
-    nineTileBox?.drawRect(c, size.toRect());
+  void render(Canvas canvas) {
+    nineTileBox?.drawRect(canvas, size.toRect());
   }
 }

--- a/packages/flame/lib/src/components/router_component.dart
+++ b/packages/flame/lib/src/components/router_component.dart
@@ -31,7 +31,7 @@ class RouterComponent extends Component {
   RouterComponent({
     required this.initialRoute,
     required Map<String, Route> routes,
-    Map<String, _RouteFactory>? routeFactories,
+    Map<String, RouteFactory>? routeFactories,
     this.onUnknownRoute,
   })  : _routes = routes,
         _routeFactories = routeFactories ?? {} {
@@ -64,12 +64,12 @@ class RouterComponent extends Component {
   /// "prefix/arg". For such a name, we will call the factory "prefix" with the
   /// argument "arg". The produced route will be cached in the main [_routes]
   /// map, and then built and mounted normally.
-  final Map<String, _RouteFactory> _routeFactories;
+  final Map<String, RouteFactory> _routeFactories;
 
   /// Function that will be called to resolve any route names that couldn't be
   /// resolved via [_routes] or [_routeFactories]. Unlike with routeFactories,
   /// the route returned by this function will not be cached.
-  final _RouteFactory? onUnknownRoute;
+  final RouteFactory? onUnknownRoute;
 
   /// Returns the route that is currently at the top of the stack.
   Route get currentRoute => _routeStack.last;
@@ -295,4 +295,4 @@ class RouterComponent extends Component {
   }
 }
 
-typedef _RouteFactory = Route Function(String parameter);
+typedef RouteFactory = Route Function(String parameter);

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -183,10 +183,10 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
 
   int get currentLine {
     var totalCharCount = 0;
-    final _currentChar = currentChar;
+    final cachedCurrentChar = currentChar;
     for (var i = 0; i < lines.length; i++) {
       totalCharCount += lines[i].length;
-      if (totalCharCount > _currentChar) {
+      if (totalCharCount > cachedCurrentChar) {
         return i;
       }
     }
@@ -205,11 +205,12 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
     } else if (_boxConfig.growingBox) {
       var i = 0;
       var totalCharCount = 0;
-      final _currentChar = currentChar;
-      final _currentLine = currentLine;
-      final textWidth = lines.sublist(0, _currentLine + 1).map((line) {
-        final charCount =
-            (i < _currentLine) ? line.length : (_currentChar - totalCharCount);
+      final cachedCurrentChar = currentChar;
+      final cachedCurrentLine = currentLine;
+      final textWidth = lines.sublist(0, cachedCurrentLine + 1).map((line) {
+        final charCount = (i < cachedCurrentLine)
+            ? line.length
+            : (cachedCurrentChar - totalCharCount);
         totalCharCount += line.length;
         i++;
         return getLineWidth(line, charCount);
@@ -227,14 +228,14 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
   }
 
   @override
-  void render(Canvas c) {
+  void render(Canvas canvas) {
     if (cache == null) {
       return;
     }
-    c.save();
-    c.scale(1 / pixelRatio);
-    c.drawImage(cache!, Offset.zero, _imagePaint);
-    c.restore();
+    canvas.save();
+    canvas.scale(1 / pixelRatio);
+    canvas.drawImage(cache!, Offset.zero, _imagePaint);
+    canvas.restore();
   }
 
   Future<Image> _fullRenderAsImage(Vector2 size) {

--- a/packages/flame/lib/src/components/value_route.dart
+++ b/packages/flame/lib/src/components/value_route.dart
@@ -37,7 +37,7 @@ abstract class ValueRoute<T> extends Route {
 
   @mustCallSuper
   @override
-  void didPop(Route previousRoute) {
+  void didPop(Route nextRoute) {
     if (!_completer.isCompleted) {
       _completer.complete(_defaultValue);
     }

--- a/packages/flame/lib/src/effects/glow_effect.dart
+++ b/packages/flame/lib/src/effects/glow_effect.dart
@@ -18,9 +18,7 @@ class GlowEffect extends Effect with EffectTarget<PaintProvider> {
 
   @override
   void apply(double progress) {
-    final _value = strength * progress;
-
-    target.paint.maskFilter = MaskFilter.blur(style, _value);
+    target.paint.maskFilter = MaskFilter.blur(style, strength * progress);
   }
 
   @override

--- a/packages/flame/lib/src/effects/sequence_effect.dart
+++ b/packages/flame/lib/src/effects/sequence_effect.dart
@@ -39,7 +39,10 @@ class SequenceEffect extends Effect {
       !(infinite && repeatCount != 1),
       'Parameters infinite and repeatCount cannot be specified simultaneously',
     );
-    EffectController ec = _SequenceEffectEffectController(effects, alternate);
+    EffectController ec = _SequenceEffectEffectController(
+      effects,
+      alternate: alternate,
+    );
     if (infinite) {
       ec = InfiniteEffectController(ec);
     } else if (repeatCount > 1) {
@@ -75,9 +78,9 @@ class SequenceEffect extends Effect {
 /// `SequenceEffect.apply()` is empty.
 class _SequenceEffectEffectController extends EffectController {
   _SequenceEffectEffectController(
-    this.effects,
-    this.alternate,
-  ) : super.empty();
+    this.effects, {
+    required this.alternate,
+  }) : super.empty();
 
   /// The list of children effects.
   final List<Effect> effects;

--- a/packages/flame/lib/src/experimental/geometry/shapes/polygon.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/polygon.dart
@@ -218,18 +218,18 @@ class Polygon extends Shape {
   static final Vector2 _tmpResult = Vector2.zero();
 
   @override
-  Vector2 nearestPoint(Vector2 externalPoint) {
+  Vector2 nearestPoint(Vector2 point) {
     var shortestDistance2 = double.infinity;
     for (var i = 0; i < _vertices.length; i++) {
       final vertex = _vertices[i];
       final edge = _edges[i];
-      final dotProduct = (externalPoint.x - vertex.x) * edge.x +
-          (externalPoint.y - vertex.y) * edge.y;
+      final dotProduct =
+          (point.x - vertex.x) * edge.x + (point.y - vertex.y) * edge.y;
       final t = (dotProduct / edge.length2).clamp(-1.0, 0.0);
       final edgePointX = vertex.x + edge.x * t;
       final edgePointY = vertex.y + edge.y * t;
-      final dx = edgePointX - externalPoint.x;
-      final dy = edgePointY - externalPoint.y;
+      final dx = edgePointX - point.x;
+      final dy = edgePointY - point.y;
       final distance2 = dx * dx + dy * dy;
       if (distance2 < shortestDistance2) {
         shortestDistance2 = distance2;

--- a/packages/flame/lib/src/experimental/geometry/shapes/shape.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/shape.dart
@@ -84,13 +84,13 @@ abstract class Shape {
   Vector2 support(Vector2 direction);
 
   /// Returns a point on the shape's boundary which is closest to the given
-  /// [externalPoint].
+  /// [point].
   ///
-  /// The [externalPoint] must lie outside of the shape. If there are multiple
-  /// nearest points, any one can be returned.
+  /// The [point] must lie outside of the shape. If there are multiple nearest
+  /// points, any one can be returned.
   ///
-  /// This method will not modify [externalPoint]. At the same time, the caller
-  /// does not get ownership of the returned object: they must treat it as an
+  /// This method will not modify [point]. At the same time, the caller does
+  /// not get ownership of the returned object: they must treat it as an
   /// immutable short-lived object.
-  Vector2 nearestPoint(Vector2 externalPoint);
+  Vector2 nearestPoint(Vector2 point);
 }

--- a/packages/flame/lib/src/game/camera/camera_wrapper.dart
+++ b/packages/flame/lib/src/game/camera/camera_wrapper.dart
@@ -21,12 +21,12 @@ class CameraWrapper {
   }
 
   void render(Canvas canvas) {
-    PositionType? _previousType;
+    PositionType? previousType;
     canvas.save();
     world.forEach((component) {
-      final sameType = component.positionType == _previousType;
+      final sameType = component.positionType == previousType;
       if (!sameType) {
-        if (_previousType != null && _previousType != PositionType.widget) {
+        if (previousType != null && previousType != PositionType.widget) {
           canvas.restore();
           canvas.save();
         }
@@ -42,10 +42,10 @@ class CameraWrapper {
         }
       }
       component.renderTree(canvas);
-      _previousType = component.positionType;
+      previousType = component.positionType;
     });
 
-    if (_previousType != PositionType.widget) {
+    if (previousType != PositionType.widget) {
       canvas.restore();
     }
   }

--- a/packages/flame/lib/src/game/camera/viewport.dart
+++ b/packages/flame/lib/src/game/camera/viewport.dart
@@ -92,16 +92,16 @@ class DefaultViewport extends Viewport {
   Vector2 get effectiveSize => canvasSize!;
 
   @override
-  Vector2 projectVector(Vector2 vector) => vector;
+  Vector2 projectVector(Vector2 worldCoordinates) => worldCoordinates;
 
   @override
-  Vector2 unprojectVector(Vector2 vector) => vector;
+  Vector2 unprojectVector(Vector2 screenCoordinates) => screenCoordinates;
 
   @override
-  Vector2 scaleVector(Vector2 vector) => vector;
+  Vector2 scaleVector(Vector2 worldCoordinates) => worldCoordinates;
 
   @override
-  Vector2 unscaleVector(Vector2 vector) => vector;
+  Vector2 unscaleVector(Vector2 screenCoordinates) => screenCoordinates;
 }
 
 /// This is the most common viewport if you want to have full control of what
@@ -183,6 +183,7 @@ class FixedResolutionViewport extends Viewport {
   }
 
   @override
+  // ignore: avoid_renaming_method_parameters
   Vector2 projectVector(Vector2 viewportCoordinates) {
     return (viewportCoordinates * _scale)..add(_resizeOffset);
   }
@@ -193,6 +194,7 @@ class FixedResolutionViewport extends Viewport {
   }
 
   @override
+  // ignore: avoid_renaming_method_parameters
   Vector2 scaleVector(Vector2 viewportCoordinates) {
     return viewportCoordinates * scale;
   }

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -107,14 +107,14 @@ class FlameGame extends ComponentTreeRoot
   /// the coordinate system appropriately.
   @override
   @mustCallSuper
-  void onGameResize(Vector2 canvasSize) {
-    camera.handleResize(canvasSize);
-    super.onGameResize(canvasSize);
+  void onGameResize(Vector2 size) {
+    camera.handleResize(size);
+    super.onGameResize(size);
     // [onGameResize] is declared both in [Component] and in [Game]. Since
     // there is no way to explicitly call the [Component]'s implementation,
     // we propagate the event to [FlameGame]'s children manually.
-    handleResize(canvasSize);
-    children.forEach((child) => child.onParentResize(canvasSize));
+    handleResize(size);
+    children.forEach((child) => child.onParentResize(size));
   }
 
   /// Ensure that all pending tree operations finish.

--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -35,9 +35,8 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   GameRenderBox(
     this._game,
     this.buildContext, {
-        required bool isRepaintBoundary,
-      }
-  ) : _isRepaintBoundary = isRepaintBoundary;
+    required bool isRepaintBoundary,
+  }) : _isRepaintBoundary = isRepaintBoundary;
 
   GameLoop? gameLoop;
 

--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -8,18 +8,18 @@ import 'package:flutter/widgets.dart' hide WidgetBuilder;
 /// This is the widget that is used by the [GameWidget] to ACTUALLY
 /// render the game.
 class RenderGameWidget extends LeafRenderObjectWidget {
+  const RenderGameWidget({
+    required this.game,
+    required this.addRepaintBoundary,
+    super.key,
+  });
+
   final Game game;
   final bool addRepaintBoundary;
 
-  const RenderGameWidget({
-    super.key,
-    required this.game,
-    required this.addRepaintBoundary,
-  });
-
   @override
   RenderBox createRenderObject(BuildContext context) {
-    return GameRenderBox(game, context, addRepaintBoundary);
+    return GameRenderBox(game, context, isRepaintBoundary: addRepaintBoundary);
   }
 
   @override
@@ -34,9 +34,10 @@ class RenderGameWidget extends LeafRenderObjectWidget {
 class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   GameRenderBox(
     this._game,
-    this.buildContext,
-    this._isRepaintBoundary,
-  );
+    this.buildContext, {
+        required bool isRepaintBoundary,
+      }
+  ) : _isRepaintBoundary = isRepaintBoundary;
 
   GameLoop? gameLoop;
 
@@ -63,7 +64,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
     }
   }
 
-  bool _isRepaintBoundary = false;
+  bool _isRepaintBoundary;
 
   set isRepaintBoundary(bool value) {
     if (_isRepaintBoundary == value) {

--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -165,7 +165,7 @@ class GameWidget<T extends Game> extends StatefulWidget {
   ///
   /// To use overlays, the game subclass has to be mixed with HasWidgetsOverlay.
   @override
-  _GameWidgetState<T> createState() => _GameWidgetState<T>();
+  GameWidgetState<T> createState() => GameWidgetState<T>();
 
   void _initializeGame(T game) {
     if (mouseCursor != null) {
@@ -185,7 +185,7 @@ class GameWidget<T extends Game> extends StatefulWidget {
   }
 }
 
-class _GameWidgetState<T extends Game> extends State<GameWidget<T>> {
+class GameWidgetState<T extends Game> extends State<GameWidget<T>> {
   late T currentGame;
 
   Future<void> get loaderFuture => _loaderFuture ??= (() async {

--- a/packages/flame/lib/src/game/notifying_vector2.dart
+++ b/packages/flame/lib/src/game/notifying_vector2.dart
@@ -23,14 +23,14 @@ class NotifyingVector2 extends Vector2 with ChangeNotifier {
       NotifyingVector2.zero()..setFrom(v);
 
   @override
-  void setValues(double x, double y) {
-    super.setValues(x, y);
+  void setValues(double x_, double y_) {
+    super.setValues(x_, y_);
     notifyListeners();
   }
 
   @override
-  void setFrom(Vector2 v) {
-    super.setFrom(v);
+  void setFrom(Vector2 other) {
+    super.setFrom(other);
     notifyListeners();
   }
 

--- a/packages/flame/lib/src/game/overlay_manager.dart
+++ b/packages/flame/lib/src/game/overlay_manager.dart
@@ -12,7 +12,7 @@ class OverlayManager {
 
   final Game _game;
   final List<String> _activeOverlays = [];
-  final Map<String, _OverlayBuilderFunction> _builders = {};
+  final Map<String, OverlayBuilderFunction> _builders = {};
 
   /// The names of all currently active overlays.
   UnmodifiableListView<String> get activeOverlays {
@@ -59,7 +59,7 @@ class OverlayManager {
   }
 
   /// Adds a named overlay builder
-  void addEntry(String name, _OverlayBuilderFunction builder) {
+  void addEntry(String name, OverlayBuilderFunction builder) {
     _builders[name] = builder;
   }
 
@@ -97,7 +97,7 @@ class OverlayManager {
   }
 }
 
-typedef _OverlayBuilderFunction = Widget Function(
+typedef OverlayBuilderFunction = Widget Function(
   BuildContext context,
   Game game,
 );

--- a/packages/flame/lib/src/image_composition.dart
+++ b/packages/flame/lib/src/image_composition.dart
@@ -133,11 +133,9 @@ class _Fragment {
     this.source,
     this.angle,
     this.anchor,
-    this.blendMode,
-      {
-        required this.antiAlias,
-      }
-  );
+    this.blendMode, {
+    required this.antiAlias,
+  });
 
   /// The image that will be composed.
   final Image image;

--- a/packages/flame/lib/src/image_composition.dart
+++ b/packages/flame/lib/src/image_composition.dart
@@ -73,8 +73,8 @@ class ImageComposition {
         source,
         angle,
         anchor,
-        isAntiAlias,
         blendMode,
+        antiAlias: isAntiAlias,
       ),
     );
   }
@@ -94,7 +94,7 @@ class ImageComposition {
       final source = compose.source;
       final rotation = compose.angle;
       final anchor = compose.anchor;
-      final isAntiAlias = compose.isAntiAlias;
+      final isAntiAlias = compose.antiAlias;
       final blendMode = compose.blendMode;
       final destination = Rect.fromLTWH(0, 0, source.width, source.height);
       final realDest = destination.translate(position.x, position.y);
@@ -133,8 +133,10 @@ class _Fragment {
     this.source,
     this.angle,
     this.anchor,
-    this.isAntiAlias,
     this.blendMode,
+      {
+        required this.antiAlias,
+      }
   );
 
   /// The image that will be composed.
@@ -153,7 +155,7 @@ class _Fragment {
   /// (defaults to the centre of the [source]).
   final Vector2 anchor;
 
-  final bool isAntiAlias;
+  final bool antiAlias;
 
   /// The [BlendMode] that will be used when composing the [image].
   final BlendMode blendMode;

--- a/packages/flame/lib/src/parallax.dart
+++ b/packages/flame/lib/src/parallax.dart
@@ -150,7 +150,7 @@ class ParallaxImage extends ParallaxRenderer {
   Image get image => _image;
 
   @override
-  void update(_) {
+  void update(double dt) {
     // noop
   }
 }

--- a/packages/flame/lib/src/particles/circle_particle.dart
+++ b/packages/flame/lib/src/particles/circle_particle.dart
@@ -16,7 +16,7 @@ class CircleParticle extends Particle {
   });
 
   @override
-  void render(Canvas c) {
-    c.drawCircle(Offset.zero, radius, paint);
+  void render(Canvas canvas) {
+    canvas.drawCircle(Offset.zero, radius, paint);
   }
 }

--- a/packages/flame/lib/src/particles/composed_particle.dart
+++ b/packages/flame/lib/src/particles/composed_particle.dart
@@ -29,9 +29,9 @@ class ComposedParticle extends Particle {
   }
 
   @override
-  void render(Canvas c) {
+  void render(Canvas canvas) {
     for (final child in children) {
-      child.render(c);
+      child.render(canvas);
     }
   }
 

--- a/packages/flame/lib/src/particles/moving_particle.dart
+++ b/packages/flame/lib/src/particles/moving_particle.dart
@@ -25,13 +25,13 @@ class MovingParticle extends CurvedParticle with SingleChildParticle {
   static final _tmpVector = Vector2.zero();
 
   @override
-  void render(Canvas c) {
-    c.save();
+  void render(Canvas canvas) {
+    canvas.save();
     final current = _tmpVector
       ..setFrom(from)
       ..lerp(to, progress);
-    c.translateVector(current);
-    super.render(c);
-    c.restore();
+    canvas.translateVector(current);
+    super.render(canvas);
+    canvas.restore();
   }
 }

--- a/packages/flame/lib/src/particles/particle.dart
+++ b/packages/flame/lib/src/particles/particle.dart
@@ -25,8 +25,8 @@ abstract class Particle {
   ///
   /// Useful for procedural particle generation.
   static Particle generate({
-    int count = 10,
     required ParticleGenerator generator,
+    int count = 10,
     double? lifespan,
     bool applyLifespanToChildren = true,
   }) {
@@ -111,8 +111,8 @@ abstract class Particle {
   ///
   /// Allowing it to move from one [Vector2] to another one.
   Particle moving({
-    Vector2? from,
     required Vector2 to,
+    Vector2? from,
     Curve curve = Curves.linear,
   }) {
     return MovingParticle(

--- a/packages/flame/lib/src/particles/translated_particle.dart
+++ b/packages/flame/lib/src/particles/translated_particle.dart
@@ -18,10 +18,10 @@ class TranslatedParticle extends Particle with SingleChildParticle {
   });
 
   @override
-  void render(Canvas c) {
-    c.save();
-    c.translateVector(offset);
-    super.render(c);
-    c.restore();
+  void render(Canvas canvas) {
+    canvas.save();
+    canvas.translateVector(offset);
+    super.render(canvas);
+    canvas.restore();
   }
 }

--- a/packages/flame/lib/src/sprite.dart
+++ b/packages/flame/lib/src/sprite.dart
@@ -38,8 +38,8 @@ class Sprite {
     Vector2? srcSize,
     Images? images,
   }) async {
-    final _images = images ?? Flame.images;
-    final image = await _images.load(src);
+    final imagesCache = images ?? Flame.images;
+    final image = await imagesCache.load(src);
     return Sprite(image, srcPosition: srcPosition, srcSize: srcSize);
   }
 

--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -241,8 +241,8 @@ class SpriteAnimation {
     SpriteAnimationData data, {
     Images? images,
   }) async {
-    final _images = images ?? Flame.images;
-    final image = await _images.load(src);
+    final imagesCache = images ?? Flame.images;
+    final image = await imagesCache.load(src);
     return SpriteAnimation.fromFrameData(image, data);
   }
 

--- a/packages/flame/lib/src/sprite_batch.dart
+++ b/packages/flame/lib/src/sprite_batch.dart
@@ -37,8 +37,8 @@ class BatchItem {
   BatchItem({
     required this.source,
     required this.transform,
-    this.flip = false,
     required this.color,
+    this.flip = false,
   })  : paint = Paint()..color = color,
         destination = Offset.zero & source.size;
 
@@ -116,14 +116,14 @@ class SpriteBatch {
     Images? images,
     bool useAtlas = true,
   }) async {
-    final _images = images ?? Flame.images;
+    final imagesCache = images ?? Flame.images;
     return SpriteBatch(
-      await _images.load(path),
+      await imagesCache.load(path),
       defaultColor: defaultColor,
       defaultTransform: defaultTransform ?? RSTransform(1, 0, 0, 0),
       defaultBlendMode: defaultBlendMode,
       useAtlas: useAtlas,
-      imageCache: _images,
+      imageCache: imagesCache,
       imageKey: path,
     );
   }
@@ -226,7 +226,6 @@ class SpriteBatch {
   Future<Image> _generateFlippedAtlas(Image image) {
     final recorder = PictureRecorder();
     final canvas = Canvas(recorder);
-    final _emptyPaint = Paint();
     canvas.drawImage(image, Offset.zero, _emptyPaint);
     canvas.scale(-1, 1);
     canvas.drawImage(image, Offset(-image.width * 2, 0), _emptyPaint);
@@ -346,7 +345,8 @@ class SpriteBatch {
     _batchItems.clear();
   }
 
-  // Used to not create new paint objects in [render] on every tick.
+  // Used to not create new Paint objects in [render] and
+  // [generateFlippedAtlas].
   final Paint _emptyPaint = Paint();
 
   void render(

--- a/packages/flame/lib/src/text/nodes/column_node.dart
+++ b/packages/flame/lib/src/text/nodes/column_node.dart
@@ -56,9 +56,9 @@ abstract class ColumnNode extends BlockNode {
 
   @mustCallSuper
   @override
-  void fillStyles(DocumentStyle rootStyle, FlameTextStyle parentTextStyle) {
+  void fillStyles(DocumentStyle stylesheet, FlameTextStyle parentTextStyle) {
     for (final node in children) {
-      node.fillStyles(rootStyle, parentTextStyle);
+      node.fillStyles(stylesheet, parentTextStyle);
     }
   }
 }

--- a/packages/flame/lib/src/widgets/components_notifier_builder.dart
+++ b/packages/flame/lib/src/widgets/components_notifier_builder.dart
@@ -4,9 +4,9 @@ import 'package:flutter/material.dart';
 /// A widget that rebuilds every time the given [notifier] changes.
 class ComponentsNotifierBuilder<T extends Component> extends StatefulWidget {
   const ComponentsNotifierBuilder({
-    super.key,
     required this.notifier,
     required this.builder,
+    super.key,
   });
 
   final ComponentsNotifier<T> notifier;

--- a/packages/flame/lib/src/widgets/sprite_painter.dart
+++ b/packages/flame/lib/src/widgets/sprite_painter.dart
@@ -14,10 +14,10 @@ class SpritePainter extends CustomPainter {
       : _angle = angle;
 
   @override
-  bool shouldRepaint(SpritePainter old) {
-    return old._sprite != _sprite ||
-        old._anchor != _anchor ||
-        old._angle != _angle;
+  bool shouldRepaint(SpritePainter oldDelegate) {
+    return oldDelegate._sprite != _sprite ||
+        oldDelegate._anchor != _anchor ||
+        oldDelegate._angle != _angle;
   }
 
   @override

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -104,12 +104,10 @@ class InternalSpriteWidget extends StatelessWidget {
   });
 
   @override
-  Widget build(_) {
-    return Container(
-      child: CustomPaint(
-        painter: SpritePainter(sprite, anchor, angle: angle),
-        size: sprite.srcSize.toSize(),
-      ),
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: SpritePainter(sprite, anchor, angle: angle),
+      size: sprite.srcSize.toSize(),
     );
   }
 }

--- a/packages/flame/test/components/fps_component_test.dart
+++ b/packages/flame/test/components/fps_component_test.dart
@@ -3,7 +3,7 @@ import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const _diff = 0.0000000000001;
+  const diff = 0.0000000000001;
 
   group('FPSComponent', () {
     testWithFlameGame('reports correct FPS for 1 frames', (game) async {
@@ -12,7 +12,7 @@ void main() {
       expect(fpsComponent.fps, 0);
       game.update(1 / 60);
 
-      expect(fpsComponent.fps, closeTo(60, _diff));
+      expect(fpsComponent.fps, closeTo(60, diff));
     });
 
     testWithFlameGame('reports correct FPS with full window', (game) async {
@@ -23,7 +23,7 @@ void main() {
         game.update(1 / 60);
       }
 
-      expect(fpsComponent.fps, closeTo(60, _diff));
+      expect(fpsComponent.fps, closeTo(60, diff));
     });
 
     testWithFlameGame('reports correct FPS with slided window', (game) async {
@@ -34,7 +34,7 @@ void main() {
         game.update(1 / 60);
       }
 
-      expect(fpsComponent.fps, closeTo(60, _diff));
+      expect(fpsComponent.fps, closeTo(60, diff));
     });
 
     testWithFlameGame('reports correct FPS with varying dt', (game) async {
@@ -46,7 +46,7 @@ void main() {
         game.update(dt);
       }
 
-      expect(fpsComponent.fps, closeTo(100 / 1.5, _diff));
+      expect(fpsComponent.fps, closeTo(100 / 1.5, diff));
     });
   });
 }

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -320,8 +320,8 @@ void main() {
         final bottomLeftPoint = Vector2(topLeftPoint.x, bottomRightPoint.y);
         final epsilon = Vector2.all(0.0001);
         void checkOutsideCorners(
-          bool expectedResult, {
-          bool? topLeftResult,
+          {
+            required bool expectedResult, bool? topLeftResult,
           bool? bottomRightResult,
           bool? topRightResult,
           bool? bottomLeftResult,
@@ -352,20 +352,20 @@ void main() {
           );
         }
 
-        checkOutsideCorners(false);
+        checkOutsideCorners(expectedResult: false);
         component.scale = Vector2.all(1.0001);
-        checkOutsideCorners(true);
+        checkOutsideCorners(expectedResult: true);
         component.angle = 1;
-        checkOutsideCorners(false);
+        checkOutsideCorners(expectedResult: false);
         component.angle = 0;
         component.anchor = Anchor.topLeft;
-        checkOutsideCorners(false, bottomRightResult: true);
+        checkOutsideCorners(expectedResult: false, bottomRightResult: true);
         component.anchor = Anchor.bottomRight;
-        checkOutsideCorners(false, topLeftResult: true);
+        checkOutsideCorners(expectedResult: false, topLeftResult: true);
         component.anchor = Anchor.topRight;
-        checkOutsideCorners(false, bottomLeftResult: true);
+        checkOutsideCorners(expectedResult: false, bottomLeftResult: true);
         component.anchor = Anchor.bottomLeft;
-        checkOutsideCorners(false, topRightResult: true);
+        checkOutsideCorners(expectedResult: false, topRightResult: true);
       });
     });
 

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -319,9 +319,9 @@ void main() {
         final topRightPoint = Vector2(bottomRightPoint.x, topLeftPoint.y);
         final bottomLeftPoint = Vector2(topLeftPoint.x, bottomRightPoint.y);
         final epsilon = Vector2.all(0.0001);
-        void checkOutsideCorners(
-          {
-            required bool expectedResult, bool? topLeftResult,
+        void checkOutsideCorners({
+          required bool expectedResult,
+          bool? topLeftResult,
           bool? bottomRightResult,
           bool? topRightResult,
           bool? bottomLeftResult,

--- a/packages/flame/test/effects/opacity_effect_test.dart
+++ b/packages/flame/test/effects/opacity_effect_test.dart
@@ -21,7 +21,7 @@ class _CustomPaintComponent<T extends Object> extends Component
 enum _PaintTypes { paint1, paint2, paint3 }
 
 void main() {
-  const _epsilon = 0.004; // 1/255, since alpha only holds 8 bits
+  const epsilon = 0.004; // 1/255, since alpha only holds 8 bits
 
   group('OpacityEffect', () {
     testWithFlameGame('relative', (game) async {
@@ -37,13 +37,13 @@ void main() {
       expect(component.children.length, 1);
 
       game.update(0.5);
-      expectDouble(component.getOpacity(), 0.4, epsilon: _epsilon);
+      expectDouble(component.getOpacity(), 0.4, epsilon: epsilon);
 
       game.update(0.5);
-      expectDouble(component.getOpacity(), 0.6, epsilon: _epsilon);
+      expectDouble(component.getOpacity(), 0.6, epsilon: epsilon);
       game.update(0);
       expect(component.children.length, 0);
-      expectDouble(component.getOpacity(), 0.6, epsilon: _epsilon);
+      expectDouble(component.getOpacity(), 0.6, epsilon: epsilon);
     });
 
     testWithFlameGame('absolute', (game) async {
@@ -59,13 +59,13 @@ void main() {
       expect(component.children.length, 1);
 
       game.update(0.5);
-      expectDouble(component.getOpacity(), 0.3, epsilon: _epsilon);
+      expectDouble(component.getOpacity(), 0.3, epsilon: epsilon);
 
       game.update(0.5);
-      expectDouble(component.getOpacity(), 0.4, epsilon: _epsilon);
+      expectDouble(component.getOpacity(), 0.4, epsilon: epsilon);
       game.update(0);
       expect(component.children.length, 0);
-      expectDouble(component.getOpacity(), 0.4, epsilon: _epsilon);
+      expectDouble(component.getOpacity(), 0.4, epsilon: epsilon);
     });
 
     testWithFlameGame('reset relative', (game) async {
@@ -81,7 +81,7 @@ void main() {
       );
       component.add(effect..removeOnFinish = false);
       for (var i = 0; i < 5; i++) {
-        expectDouble(component.getOpacity(), 1.0 - step * i, epsilon: _epsilon);
+        expectDouble(component.getOpacity(), 1.0 - step * i, epsilon: epsilon);
         // After each reset the object will have its opacity modified by -10/255
         // relative to its opacity at the start of the effect.
         effect.reset();
@@ -89,7 +89,7 @@ void main() {
         expectDouble(
           component.getOpacity(),
           1.0 - step * (i + 1),
-          epsilon: _epsilon,
+          epsilon: epsilon,
         );
       }
     });
@@ -136,18 +136,18 @@ void main() {
       expectDouble(
         component.getOpacity(),
         0.55, // 0.5/10 + 0.5*1
-        epsilon: _epsilon,
+        epsilon: epsilon,
       );
       game.update(1);
       expectDouble(
         component.getOpacity(),
         0.1,
-        epsilon: _epsilon,
+        epsilon: epsilon,
       ); // 0.5*2/10 + 0.5*1 - 0.5*1
       for (var i = 0; i < 10; i++) {
         game.update(1);
       }
-      expectDouble(component.getOpacity(), 0.5, epsilon: _epsilon);
+      expectDouble(component.getOpacity(), 0.5, epsilon: epsilon);
       expect(component.children.length, 0);
     });
 
@@ -381,7 +381,7 @@ void main() {
         game.update(dt);
       }
       game.update(1000 - totalTime);
-      expectDouble(component.getOpacity(), 1.0, epsilon: _epsilon);
+      expectDouble(component.getOpacity(), 1.0, epsilon: epsilon);
     });
   });
 }

--- a/packages/flame/test/effects/sequence_effect_test.dart
+++ b/packages/flame/test/effects/sequence_effect_test.dart
@@ -234,17 +234,17 @@ void main() {
         EffectController duration(double t) => EffectController(duration: t);
         const dt = 0.01;
         const x0 = 0.0;
-const y0 = 0.0;
+        const y0 = 0.0;
         const x1 = 10.0;
-const y1 = 10.0;
+        const y1 = 10.0;
         const x2 = 20.0;
-const y2 = 0.0;
+        const y2 = 0.0;
         const x3 = 30.0;
-const y3 = 10.0;
+        const y3 = 10.0;
         const x4 = 10.0;
-const y4 = 30.0;
+        const y4 = 30.0;
         const dx5 = 1.6;
-const dy5 = 0.9;
+        const dy5 = 0.9;
 
         final effect = SequenceEffect(
           [

--- a/packages/flame/test/effects/sequence_effect_test.dart
+++ b/packages/flame/test/effects/sequence_effect_test.dart
@@ -233,12 +233,18 @@ void main() {
       testWithFlameGame('sequence in sequence', (game) async {
         EffectController duration(double t) => EffectController(duration: t);
         const dt = 0.01;
-        const x0 = 0.0, y0 = 0.0;
-        const x1 = 10.0, y1 = 10.0;
-        const x2 = 20.0, y2 = 0.0;
-        const x3 = 30.0, y3 = 10.0;
-        const x4 = 10.0, y4 = 30.0;
-        const dx5 = 1.6, dy5 = 0.9;
+        const x0 = 0.0;
+const y0 = 0.0;
+        const x1 = 10.0;
+const y1 = 10.0;
+        const x2 = 20.0;
+const y2 = 0.0;
+        const x3 = 30.0;
+const y3 = 10.0;
+        const x4 = 10.0;
+const y4 = 30.0;
+        const dx5 = 1.6;
+const dy5 = 0.9;
 
         final effect = SequenceEffect(
           [

--- a/packages/flame/test/events/flame_game_mixins/has_tappable_components_test.dart
+++ b/packages/flame/test/events/flame_game_mixins/has_tappable_components_test.dart
@@ -282,9 +282,9 @@ class _GameWithDualTappableComponents extends FlameGame
 
 class _TapCallbacksComponent extends PositionComponent with TapCallbacks {
   _TapCallbacksComponent({
-    super.children,
     required Vector2 super.position,
     required Vector2 super.size,
+    super.children,
     void Function(TapDownEvent)? onTapDown,
     void Function(TapDownEvent)? onLongTapDown,
     void Function(TapUpEvent)? onTapUp,

--- a/packages/flame/test/game/flame_game_test.dart
+++ b/packages/flame/test/game/flame_game_test.dart
@@ -111,7 +111,11 @@ void main() {
           await tester.pumpWidget(
             Builder(
               builder: (BuildContext context) {
-                renderBox = GameRenderBox(game, context, true);
+                renderBox = GameRenderBox(
+                  game,
+                  context,
+                  isRepaintBoundary: true,
+                );
                 return GameWidget(game: game);
               },
             ),

--- a/packages/flame/test/game/game_render_box_test.dart
+++ b/packages/flame/test/game/game_render_box_test.dart
@@ -25,7 +25,7 @@ void main() {
       when(() => game.paused).thenReturn(true);
 
       final BuildContext context = _MockBuildContext();
-      final renderBox = GameRenderBox(game, context, false);
+      final renderBox = GameRenderBox(game, context, isRepaintBoundary: false);
       renderBox.attach(owner);
 
       verify(() => game.attach(owner, renderBox)).called(1);
@@ -47,7 +47,7 @@ void main() {
       when(() => game.paused).thenReturn(true);
 
       final BuildContext context = _MockBuildContext();
-      final renderBox = GameRenderBox(game, context, false);
+      final renderBox = GameRenderBox(game, context, isRepaintBoundary: false);
       renderBox.attach(owner);
 
       expect(renderBox.buildContext, context);
@@ -59,7 +59,7 @@ void main() {
       when(() => game.paused).thenReturn(true);
 
       final BuildContext context = _MockBuildContext();
-      final renderBox = GameRenderBox(game, context, false);
+      final renderBox = GameRenderBox(game, context, isRepaintBoundary: false);
       renderBox.attach(owner);
 
       expect(renderBox.isRepaintBoundary, false);

--- a/packages/flame/test/game/game_widget/game_widget_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_test.dart
@@ -82,7 +82,7 @@ class _MyGame extends FlameGame {
   }
 }
 
-FlameTester<_MyGame> myGame({required bool open}) {
+FlameTester<_MyGame> _myGame({required bool open}) {
   return FlameTester(
     _MyGame.new,
     pumpWidget: (gameWidget, tester) async {
@@ -92,7 +92,7 @@ FlameTester<_MyGame> myGame({required bool open}) {
 }
 
 void main() {
-  myGame(open: false).testGameWidget(
+  _myGame(open: false).testGameWidget(
     'calls onAttach when it enters the tree and onDetach and it leaves',
     verify: (game, tester) async {
       expect(game.onAttachCalled, isFalse);
@@ -113,7 +113,7 @@ void main() {
     },
   );
 
-  myGame(open: true).testGameWidget(
+  _myGame(open: true).testGameWidget(
     'size is kept on game after a detach',
     verify: (game, tester) async {
       expect(game.hasLayout, isTrue);

--- a/packages/flame/test/rendering/paint_decorator_test.dart
+++ b/packages/flame/test/rendering/paint_decorator_test.dart
@@ -107,9 +107,9 @@ void main() {
 
 class _DecoratedSprite extends SpriteComponent {
   _DecoratedSprite({
+    required Decorator decorator,
     super.sprite,
     super.position,
-    required Decorator decorator,
   }) {
     this.decorator.addLast(decorator);
   }

--- a/packages/flame_audio/example/lib/main.dart
+++ b/packages/flame_audio/example/lib/main.dart
@@ -75,8 +75,8 @@ class AudioGame extends FlameGame with TapDetector {
   }
 
   @override
-  void onTapDown(TapDownInfo details) {
-    if (button.containsPoint(details.eventPosition.game)) {
+  void onTapDown(TapDownInfo info) {
+    if (button.containsPoint(info.eventPosition.game)) {
       fireTwo();
     } else {
       fireOne();

--- a/packages/flame_audio/lib/audio_pool.dart
+++ b/packages/flame_audio/lib/audio_pool.dart
@@ -23,8 +23,11 @@ class AudioPool {
   /// The path of the sound of this pool.
   final String sound;
 
-  /// Max and min numbers of players.
-  final int minPlayers, maxPlayers;
+  /// Min numbers of players.
+  final int minPlayers;
+
+  /// Max numbers of players.
+  final int maxPlayers;
 
   final Lock _lock = Lock();
 
@@ -38,9 +41,9 @@ class AudioPool {
   /// Creates an [AudioPool] instance with the given parameters.
   static Future<AudioPool> create(
     String sound, {
+    required int maxPlayers,
     AudioCache? audioCache,
     int minPlayers = 1,
-    required int maxPlayers,
   }) async {
     final instance = AudioPool._(
       sound,

--- a/packages/flame_audio/lib/flame_audio.dart
+++ b/packages/flame_audio/lib/flame_audio.dart
@@ -76,13 +76,13 @@ class FlameAudio {
   /// Access a shared instance of the [Bgm] class.
   ///
   /// This will use the same global audio cache from [FlameAudio].
-  static late final Bgm bgm = Bgm(audioCache: audioCache);
+  static final Bgm bgm = Bgm(audioCache: audioCache);
 
   /// Creates a new Audio Pool using Flame's global Audio Cache.
   static Future<AudioPool> createPool(
     String sound, {
-    int minPlayers = 1,
     required int maxPlayers,
+    int minPlayers = 1,
   }) {
     return AudioPool.create(
       sound,

--- a/packages/flame_bloc/example/lib/src/game/components/bullet.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/bullet.dart
@@ -70,8 +70,8 @@ class BulletComponent extends SpriteAnimationComponent
   }
 
   @override
-  void onCollision(Set<Vector2> points, PositionComponent other) {
-    super.onCollision(points, other);
+  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+    super.onCollision(intersectionPoints, other);
     if (other is EnemyComponent) {
       destroyed = true;
       other.takeHit();

--- a/packages/flame_bloc/example/lib/src/game/components/player.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/player.dart
@@ -118,8 +118,8 @@ class PlayerComponent extends SpriteAnimationComponent
   }
 
   @override
-  void onCollision(Set<Vector2> points, PositionComponent other) {
-    super.onCollision(points, other);
+  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+    super.onCollision(intersectionPoints, other);
     if (other is EnemyComponent) {
       takeHit();
       other.takeHit();

--- a/packages/flame_bloc/lib/src/flame_bloc_listenable.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listenable.dart
@@ -52,10 +52,10 @@ mixin FlameBlocListenable<B extends BlocBase<S>, S> on Component {
     _state = bloc.state;
     _subscription = bloc.stream.listen((newState) {
       if (_state != newState) {
-        final _callNewState = listenWhen(_state, newState);
+        final callNewState = listenWhen(_state, newState);
         _state = newState;
 
-        if (_callNewState) {
+        if (callNewState) {
           onNewState(newState);
         }
       }

--- a/packages/flame_bloc/lib/src/flame_bloc_listener.dart
+++ b/packages/flame_bloc/lib/src/flame_bloc_listener.dart
@@ -10,8 +10,8 @@ class FlameBlocListener<B extends BlocBase<S>, S> extends Component
     with FlameBlocListenable<B, S> {
   /// {@macro flame_bloc_listener}
   FlameBlocListener({
-    B? bloc,
     required void Function(S state) onNewState,
+    B? bloc,
     bool Function(S previousState, S newState)? listenWhen,
   })  : _onNewState = onNewState,
         _listenWhen = listenWhen {

--- a/packages/flame_bloc/lib/src/flame_multi_bloc_provider.dart
+++ b/packages/flame_bloc/lib/src/flame_multi_bloc_provider.dart
@@ -22,11 +22,11 @@ class FlameMultiBlocProvider extends Component {
   FlameBlocProvider? _lastProvider;
 
   Future<void> _addProviders() async {
-    final _list = [..._providers];
+    final list = [..._providers];
 
-    var current = _list.removeAt(0);
-    while (_list.isNotEmpty) {
-      final provider = _list.removeAt(0);
+    var current = list.removeAt(0);
+    while (list.isNotEmpty) {
+      final provider = list.removeAt(0);
       await current.add(provider);
       current = provider;
     }

--- a/packages/flame_bloc/test/src/flame_multi_bloc_provider_test.dart
+++ b/packages/flame_bloc/test/src/flame_multi_bloc_provider_test.dart
@@ -95,7 +95,8 @@ void main() {
       final inventoryCubit = InventoryCubit();
       final playerCubit = PlayerCubit();
 
-      late FlameBlocProvider inventoryCubitProvider, playerCubitProvider;
+      late FlameBlocProvider inventoryCubitProvider;
+      late FlameBlocProvider playerCubitProvider;
 
       final provider = FlameMultiBlocProvider(
         providers: [

--- a/packages/flame_fire_atlas/example/lib/main.dart
+++ b/packages/flame_fire_atlas/example/lib/main.dart
@@ -52,7 +52,7 @@ class ExampleGame extends FlameGame with TapDetector {
   }
 
   @override
-  void onTapUp(TapUpInfo details) {
+  void onTapUp(TapUpInfo info) {
     add(
       SpriteAnimationComponent(
         size: Vector2(100, 100),
@@ -60,7 +60,7 @@ class ExampleGame extends FlameGame with TapDetector {
         removeOnFinish: true,
       )
         ..anchor = Anchor.center
-        ..position = details.eventPosition.game,
+        ..position = info.eventPosition.game,
     );
   }
 }

--- a/packages/flame_fire_atlas/lib/flame_fire_atlas.dart
+++ b/packages/flame_fire_atlas/lib/flame_fire_atlas.dart
@@ -218,8 +218,8 @@ class FireAtlas {
     if (imageData == null) {
       throw 'Attempting on calling load on an already loaded Image';
     }
-    final _images = images ?? Flame.images;
-    _image = await _images.fromBase64(id, imageData!);
+    final imagesCache = images ?? Flame.images;
+    _image = await imagesCache.fromBase64(id, imageData!);
 
     // Clear memory
     if (clearImageData) {
@@ -275,9 +275,9 @@ class FireAtlas {
     AssetsCache? assets,
     Images? images,
   }) async {
-    final _assets = assets ?? Flame.assets;
+    final assetsCache = assets ?? Flame.assets;
 
-    final bytes = await _assets.readBinaryFile(fileName);
+    final bytes = await assetsCache.readBinaryFile(fileName);
     final atlas = FireAtlas.deserialize(bytes);
     await atlas.loadImage(images: images);
     return atlas;

--- a/packages/flame_flare/example/lib/main.dart
+++ b/packages/flame_flare/example/lib/main.dart
@@ -75,17 +75,17 @@ class MinionComponent extends FlareActorComponent {
         );
 
   @override
-  void render(Canvas c) {
+  void render(Canvas canvas) {
     final rect = Rect.fromLTWH(x, y, width, height);
     final paint = Paint()..color = const Color(0xFFfafbfc);
-    c.drawRect(rect, paint);
-    super.render(c);
+    canvas.drawRect(rect, paint);
+    super.render(canvas);
   }
 
   @override
-  void onGameResize(Vector2 gameSize) {
-    super.onGameResize(gameSize);
-    position = (gameSize - size) / 2;
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    position = (size - this.size) / 2;
   }
 }
 
@@ -93,7 +93,7 @@ class BGComponent extends Component with HasGameRef {
   static final paint = BasicPalette.white.paint();
 
   @override
-  void render(Canvas c) {
-    c.drawRect(gameRef.size.toRect(), paint);
+  void render(Canvas canvas) {
+    canvas.drawRect(gameRef.size.toRect(), paint);
   }
 }

--- a/packages/flame_flare/lib/src/flare_animation.dart
+++ b/packages/flame_flare/lib/src/flare_animation.dart
@@ -181,7 +181,8 @@ class FlareActorAnimation {
         contentHeight / 2.0 -
         (alignment.y * contentHeight / 2.0);
 
-    var scaleX = 1.0, scaleY = 1.0;
+    var scaleX = 1.0;
+    var scaleY = 1.0;
 
     c.save();
     // pre paint

--- a/packages/flame_flare/lib/src/flare_particle.dart
+++ b/packages/flame_flare/lib/src/flare_particle.dart
@@ -12,8 +12,8 @@ class FlareParticle extends Particle {
 
   FlareParticle({
     required this.flareAnimation,
-    super.lifespan,
     required this.size,
+    super.lifespan,
   }) {
     flareAnimation.init();
   }

--- a/packages/flame_forge2d/lib/world_contact_listener.dart
+++ b/packages/flame_forge2d/lib/world_contact_listener.dart
@@ -68,11 +68,11 @@ class WorldContactListener extends ContactListener {
   }
 
   @override
-  void postSolve(Contact contact, ContactImpulse contactImpulse) {
+  void postSolve(Contact contact, ContactImpulse impulse) {
     _callback(
       contact,
       (contactCallback, other) =>
-          contactCallback.postSolve(other, contact, contactImpulse),
+          contactCallback.postSolve(other, contact, impulse),
     );
   }
 }

--- a/packages/flame_isolate/example/lib/brains/worker_overmind.dart
+++ b/packages/flame_isolate/example/lib/brains/worker_overmind.dart
@@ -43,9 +43,9 @@ class WorkerOvermind extends Component
       _queuedTasks.add(Pair(objectToMove, destination));
 
   @override
-  void update(double t) {
-    _assignTaskInterval.update(t);
-    super.update(t);
+  void update(double dt) {
+    _assignTaskInterval.update(dt);
+    super.update(dt);
   }
 
   /// Set that keeps track of what workers are currently in queue to get a job.

--- a/packages/flame_isolate/example/lib/standard/int_vector2.dart
+++ b/packages/flame_isolate/example/lib/standard/int_vector2.dart
@@ -15,7 +15,8 @@ class IntVector2 {
   }
 
   @override
-  bool operator ==(Object o) => o is IntVector2 && x == o.x && y == o.y;
+  bool operator ==(Object other) =>
+      other is IntVector2 && x == other.x && y == other.y;
 
   @override
   int get hashCode => hash2(x, y);

--- a/packages/flame_isolate/example/lib/units/actions/movable.dart
+++ b/packages/flame_isolate/example/lib/units/actions/movable.dart
@@ -31,6 +31,7 @@ enum MoveDirection {
     if (index >= 6 && index <= 8) {
       return MoveDirection.values[index - 3];
     }
+    // ignore: avoid_returning_this
     return this;
   }
 }

--- a/packages/flame_jenny/jenny/lib/src/command_storage.dart
+++ b/packages/flame_jenny/jenny/lib/src/command_storage.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: library_private_types_in_public_api
+
 import 'dart:async';
 
 import 'package:jenny/jenny.dart';

--- a/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
+++ b/packages/flame_jenny/jenny/lib/src/parse/tokenize.dart
@@ -1033,7 +1033,8 @@ class _Lexer {
   String _errorMessageAtPosition(int position) {
     final lineEnd = _findLineEnd(position);
     final lineStart = _findLineStart(position);
-    String lineFragment, markerIndent;
+    String lineFragment;
+    String markerIndent;
     if (lineEnd - lineStart <= 74) {
       lineFragment = text.substring(lineStart, lineEnd);
       markerIndent = ' ' * (position - lineStart);

--- a/packages/flame_jenny/jenny/lib/src/structure/commands/command.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/commands/command.dart
@@ -11,7 +11,7 @@ abstract class Command extends DialogueEntry {
   String get name;
 
   @override
-  Future<void> processInDialogueRunner(DialogueRunner runner) {
-    return runner.deliverCommand(this);
+  Future<void> processInDialogueRunner(DialogueRunner dialogueRunner) {
+    return dialogueRunner.deliverCommand(this);
   }
 }

--- a/packages/flame_jenny/jenny/lib/src/structure/dialogue_choice.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/dialogue_choice.dart
@@ -8,11 +8,11 @@ class DialogueChoice extends DialogueEntry {
   final List<DialogueOption> options;
 
   @override
-  Future<void> processInDialogueRunner(DialogueRunner runner) {
+  Future<void> processInDialogueRunner(DialogueRunner dialogueRunner) {
     for (final option in options) {
       option.evaluate();
     }
-    return runner.deliverChoices(this);
+    return dialogueRunner.deliverChoices(this);
   }
 
   @override

--- a/packages/flame_jenny/jenny/lib/src/structure/dialogue_line.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/dialogue_line.dart
@@ -85,9 +85,9 @@ class DialogueLine extends DialogueEntry {
   bool get isConst => _content.isConst;
 
   @override
-  Future<void> processInDialogueRunner(DialogueRunner runner) {
+  Future<void> processInDialogueRunner(DialogueRunner dialogueRunner) {
     evaluate();
-    return runner.deliverLine(this);
+    return dialogueRunner.deliverLine(this);
   }
 
   /// Computes the [text] of the line, substituting the current values of all

--- a/packages/flame_jenny/jenny/lib/src/structure/expressions/literal.dart
+++ b/packages/flame_jenny/jenny/lib/src/structure/expressions/literal.dart
@@ -15,6 +15,7 @@ class StringLiteral extends StringExpression {
 }
 
 class BoolLiteral extends BoolExpression {
+  // ignore: avoid_positional_boolean_parameters
   const BoolLiteral(this.value);
 
   @override

--- a/packages/flame_jenny/jenny/test/command_storage_test.dart
+++ b/packages/flame_jenny/jenny/test/command_storage_test.dart
@@ -63,25 +63,25 @@ void main() {
       storage.addCommand1('check', (bool x) => value = x);
       expect(storage.hasCommand('check'), true);
 
-      void check(String arg, bool expectedValue) {
+      void check(String arg, {required bool expectedValue}) {
         storage.runCommand(UserDefinedCommand('check', LineContent(arg)));
         expect(value, expectedValue);
       }
 
-      check('true', true);
-      check('  false ', false);
-      check('+', true);
-      check('-', false);
-      check(' "on"', true);
-      check('off ', false);
-      check('yes', true);
-      check('no', false);
-      check('T', true);
-      check('F', false);
-      check('1', true);
-      check('0', false);
+      check('true', expectedValue: true);
+      check('  false ', expectedValue: false);
+      check('+', expectedValue: true);
+      check('-', expectedValue: false);
+      check(' "on"', expectedValue: true);
+      check('off ', expectedValue: false);
+      check('yes', expectedValue: true);
+      check('no', expectedValue: false);
+      check('T', expectedValue: true);
+      check('F', expectedValue: false);
+      check('1', expectedValue: true);
+      check('0', expectedValue: false);
       expect(
-        () => check('12', true),
+        () => check('12', expectedValue: true),
         hasTypeError(
           'TypeError: Argument 1 for command <<check>> has value "12", which '
           'is not a boolean',
@@ -161,6 +161,7 @@ void main() {
       });
       expect(storage.hasCommand('three'), true);
 
+      // ignore: avoid_positional_boolean_parameters
       void check(String args, bool v1, bool v2, bool v3) {
         storage.runCommand(UserDefinedCommand('three', LineContent(args)));
         expect(value1, v1);

--- a/packages/flame_jenny/jenny/test/structure/commands/wait_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/wait_command_test.dart
@@ -26,7 +26,8 @@ void main() {
 
     test('normal command <<wait>>', () async {
       int getTime() => DateTime.now().millisecondsSinceEpoch;
-      late int t0, t1;
+      late int t0;
+      late int t1;
       await testScenario(
         yarn: YarnProject()
           ..commands.addCommand0('startTimer', () => t0 = getTime())

--- a/packages/flame_jenny/jenny/test/test_scenario.dart
+++ b/packages/flame_jenny/jenny/test/test_scenario.dart
@@ -12,9 +12,9 @@ import 'package:test/test.dart';
 /// for convenience.
 @isTest
 Future<void> testScenario({
-  String? testName,
   required String input,
   required String testPlan,
+  String? testName,
   bool skip = false,
   List<String>? commands,
   YarnProject? yarn,
@@ -215,8 +215,8 @@ class _TestPlan extends DialogueView {
       } else if (match2 != null) {
         final name = match2.group(2);
         final text = match2.group(3)!;
-        final disabled = match2.group(4) != null;
-        _expected.add(_Option(name, text, !disabled));
+        final enabled = match2.group(4) == null;
+        _expected.add(_Option(name, text, enabled: enabled));
       } else if (match3 != null) {
         final index = int.parse(match3.group(1)!);
         final options = <_Option>[];
@@ -254,7 +254,7 @@ class _Choice {
 }
 
 class _Option {
-  const _Option(this.character, this.text, this.enabled);
+  const _Option(this.character, this.text, {required this.enabled});
   final String? character;
   final String text;
   final bool enabled;

--- a/packages/flame_lint/lib/analysis_options.yaml
+++ b/packages/flame_lint/lib/analysis_options.yaml
@@ -75,12 +75,15 @@ linter:
     - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
+    - library_private_types_in_public_api
     - lines_longer_than_80_chars
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
+    - no_leading_underscores_for_library_prefixes
+    - no_leading_underscores_for_local_identifiers
     - no_runtimeType_toString
     - non_constant_identifier_names
     - noop_primitive_operations
@@ -92,6 +95,7 @@ linter:
     - parameter_assignments
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
+    - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -117,6 +121,7 @@ linter:
     - prefer_is_not_empty
     - prefer_is_not_operator
     - prefer_iterable_whereType
+    - prefer_null_aware_method_calls
     - prefer_null_aware_operators
     - prefer_single_quotes
     - prefer_spread_collections
@@ -131,6 +136,7 @@ linter:
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally
+    - tighten_type_of_initializing_formals
     - type_annotate_public_apis
     - type_init_formals
     - unnecessary_await_in_return
@@ -139,6 +145,7 @@ linter:
     - unnecessary_constructor_name
     - unnecessary_getters_setters
     - unnecessary_lambdas
+    - unnecessary_late
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_checks
@@ -164,7 +171,9 @@ linter:
     - use_named_constants
     - use_raw_strings
     - use_rethrow_when_possible
+    - use_setters_to_change_properties
     - use_super_parameters
     - use_test_throws_matchers
+    - use_to_and_as_if_applicable
     - valid_regexps
     - void_checks

--- a/packages/flame_lint/lib/analysis_options.yaml
+++ b/packages/flame_lint/lib/analysis_options.yaml
@@ -34,7 +34,6 @@ linter:
     - avoid_private_typedef_functions
     - avoid_redundant_argument_values
     - avoid_relative_lib_imports
-    - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
     - avoid_returning_null_for_void
     - avoid_returning_this
@@ -52,7 +51,6 @@ linter:
     - cancel_subscriptions
     - cast_nullable_to_non_nullable
     - close_sinks
-    - collection_methods_unrelated_type
     - comment_references
     - constant_identifier_names
     - control_flow_in_finally
@@ -94,7 +92,6 @@ linter:
     - parameter_assignments
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -173,6 +170,5 @@ linter:
     - use_setters_to_change_properties
     - use_super_parameters
     - use_test_throws_matchers
-    - use_to_and_as_if_applicable
     - valid_regexps
     - void_checks

--- a/packages/flame_lint/lib/analysis_options.yaml
+++ b/packages/flame_lint/lib/analysis_options.yaml
@@ -12,6 +12,7 @@ linter:
   rules:
     - always_declare_return_types
     - always_put_control_body_on_new_line
+    - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
     - always_use_package_imports
     - annotate_overrides
@@ -26,17 +27,23 @@ linter:
     - avoid_final_parameters
     - avoid_init_to_null
     - avoid_js_rounded_ints
+    - avoid_multiple_declarations_per_line
     - avoid_null_checks_in_equality_operators
+    - avoid_positional_boolean_parameters
     - avoid_print
     - avoid_private_typedef_functions
     - avoid_redundant_argument_values
     - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
+    - avoid_returning_null_for_void
+    - avoid_returning_this
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
     - avoid_slow_async_io
     - avoid_type_to_string
     - avoid_types_as_parameter_names
+    - avoid_unnecessary_containers
     - avoid_unused_constructor_parameters
     - avoid_void_async
     - await_only_futures
@@ -45,6 +52,7 @@ linter:
     - cancel_subscriptions
     - cast_nullable_to_non_nullable
     - close_sinks
+    - collection_methods_unrelated_type
     - comment_references
     - constant_identifier_names
     - control_flow_in_finally
@@ -56,6 +64,7 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
+    - enable_null_safety
     - exhaustive_cases
     - file_names
     - flutter_style_todos
@@ -63,6 +72,7 @@ linter:
     - implementation_imports
     - iterable_contains_unrelated_type
     - join_return_with_assignment
+    - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
     - lines_longer_than_80_chars

--- a/packages/flame_lint/lib/analysis_options.yaml
+++ b/packages/flame_lint/lib/analysis_options.yaml
@@ -72,7 +72,6 @@ linter:
     - implementation_imports
     - iterable_contains_unrelated_type
     - join_return_with_assignment
-    - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
     - library_private_types_in_public_api

--- a/packages/flame_oxygen/lib/src/oxygen_game.dart
+++ b/packages/flame_oxygen/lib/src/oxygen_game.dart
@@ -19,9 +19,9 @@ abstract class OxygenGame extends Game {
 
   /// Create a new [Entity].
   Entity createEntity({
-    String? name,
     required Vector2 position,
     required Vector2 size,
+    String? name,
     double? angle,
     Anchor? anchor,
     bool flipX = false,
@@ -65,5 +65,5 @@ abstract class OxygenGame extends Game {
 
   @override
   @mustCallSuper
-  void update(double delta) => world.update(delta);
+  void update(double dt) => world.update(dt);
 }

--- a/packages/flame_rive/example/lib/main.dart
+++ b/packages/flame_rive/example/lib/main.dart
@@ -62,12 +62,12 @@ class SkillsAnimationComponent extends RiveComponent with TapCallbacks {
   }
 
   @override
-  void onTapDown(TapDownEvent info) {
+  void onTapDown(TapDownEvent event) {
     final levelInput = _levelInput;
     if (levelInput == null) {
       return;
     }
     levelInput.value = (levelInput.value + 1) % 3;
-    info.continuePropagation = true;
+    event.continuePropagation = true;
   }
 }

--- a/packages/flame_rive/lib/src/rive_component.dart
+++ b/packages/flame_rive/lib/src/rive_component.dart
@@ -100,7 +100,8 @@ class RiveArtboardRenderer {
         contentHeight / 2.0 -
         (alignment.y * contentHeight / 2.0);
 
-    var scaleX = 1.0, scaleY = 1.0;
+    var scaleX = 1.0;
+    var scaleY = 1.0;
 
     canvas.save();
     canvas.clipRect(position & size);

--- a/packages/flame_studio/lib/src/widgets/panels/hierarchy_view.dart
+++ b/packages/flame_studio/lib/src/widgets/panels/hierarchy_view.dart
@@ -31,7 +31,7 @@ class HierarchyViewState extends ConsumerState<ConsumerStatefulWidget> {
   }
 
   void _buildList(ComponentTreeNode node, int depth, List<Widget> out) {
-    out.add(_ListItem(this, node, depth, out.isEmpty));
+    out.add(_ListItem(this, node, depth, isFirst: out.isEmpty));
     final isExpanded = expandedComponents.contains(node.component);
     if (isExpanded && node.hasChildren) {
       for (final childNode in node.children!) {
@@ -68,7 +68,7 @@ class HierarchyViewState extends ConsumerState<ConsumerStatefulWidget> {
 }
 
 class _ListItem extends StatelessWidget {
-  _ListItem(this.state, this.node, this.indent, this.isFirst)
+  _ListItem(this.state, this.node, this.indent, {required this.isFirst})
       : super(key: ObjectKey(node.component));
 
   final HierarchyViewState state;

--- a/packages/flame_studio/lib/src/widgets/toolbar/toolbar_button.dart
+++ b/packages/flame_studio/lib/src/widgets/toolbar/toolbar_button.dart
@@ -15,10 +15,10 @@ class ToolbarButton extends ConsumerStatefulWidget {
   final bool disabled;
 
   @override
-  _ToolbarButtonState createState() => _ToolbarButtonState();
+  ToolbarButtonState createState() => ToolbarButtonState();
 }
 
-class _ToolbarButtonState extends ConsumerState<ToolbarButton> {
+class ToolbarButtonState extends ConsumerState<ToolbarButton> {
   bool _isHovered = false;
   bool _isActive = false;
 
@@ -26,11 +26,11 @@ class _ToolbarButtonState extends ConsumerState<ToolbarButton> {
   Widget build(BuildContext context) {
     final painter = CustomPaint(
       painter: _ToolbarButtonPainter(
-        widget.disabled,
-        _isHovered,
-        _isActive,
         widget.icon,
         ref.watch(themeProvider),
+        isDisabled: widget.disabled,
+        isHovered: _isHovered,
+        isActive: _isActive,
       ),
     );
 
@@ -70,12 +70,12 @@ class _ToolbarButtonState extends ConsumerState<ToolbarButton> {
 
 class _ToolbarButtonPainter extends CustomPainter {
   _ToolbarButtonPainter(
-    this.isDisabled,
-    this.isHovered,
-    this.isActive,
     this.icon,
-    this.theme,
-  );
+    this.theme, {
+    required this.isDisabled,
+    required this.isHovered,
+    required this.isActive,
+  });
 
   final bool isDisabled;
   final bool isHovered;

--- a/packages/flame_svg/lib/svg.dart
+++ b/packages/flame_svg/lib/svg.dart
@@ -48,8 +48,8 @@ class Svg {
     Vector2 size, {
     Paint? overridePaint,
   }) {
-    final _size = size.toSize();
-    final image = _getImage(_size);
+    final localSize = size.toSize();
+    final image = _getImage(localSize);
 
     if (image != null) {
       canvas.save();
@@ -58,7 +58,7 @@ class Svg {
       canvas.drawImage(image, Offset.zero, drawPaint);
       canvas.restore();
     } else {
-      _render(canvas, _size);
+      _render(canvas, localSize);
     }
   }
 
@@ -80,8 +80,8 @@ class Svg {
       final recorder = PictureRecorder();
       final canvas = Canvas(recorder);
       _render(canvas, size);
-      final _picture = recorder.endRecording();
-      _picture
+      final picture = recorder.endRecording();
+      picture
           .toImage(
         (size.width * pixelRatio).ceil(),
         (size.height * pixelRatio).ceil(),
@@ -89,7 +89,7 @@ class Svg {
           .then((image) {
         _imageCache.setValue(size, image);
         _lock.remove(size);
-        _picture.dispose();
+        picture.dispose();
       });
     }
 

--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -120,11 +120,11 @@ class GameTester<T extends Game> {
           final gameWidget =
               createGameWidget?.call(game) ?? GameWidget(game: game);
 
-          final _pump = pumpWidget ??
-              (GameWidget<T> _gameWidget, WidgetTester _tester) =>
-                  _tester.pumpWidget(_gameWidget);
+          final pump = pumpWidget ??
+              (GameWidget<T> pumpWidget, WidgetTester tester) =>
+                  tester.pumpWidget(pumpWidget);
 
-          await _pump(gameWidget, tester);
+          await pump(gameWidget, tester);
           await tester.pump();
 
           if (setUp != null) {

--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -71,9 +71,9 @@ class RenderableTiledMap {
   }
 
   /// Changes the visibility of the corresponding layer, if different
-  void setLayerVisibility(int layerId, bool visibility) {
-    if (map.layers[layerId].visible != visibility) {
-      map.layers[layerId].visible = visibility;
+  void setLayerVisibility(int layerId, {required bool visible}) {
+    if (map.layers[layerId].visible != visible) {
+      map.layers[layerId].visible = visible;
       _refreshCache();
     }
   }

--- a/packages/flame_tiled/lib/src/simple_flips.dart
+++ b/packages/flame_tiled/lib/src/simple_flips.dart
@@ -28,12 +28,14 @@ class SimpleFlips {
   final bool flip;
 
   /// {@macro _simple_flips}
-  SimpleFlips(this.angle, this.cos, this.sin, this.flip);
+  SimpleFlips(this.angle, this.cos, this.sin, {required this.flip});
 
   /// This is the conversion from the truth table that I drew.
   factory SimpleFlips.fromFlips(Flips flips) {
-    int angle, cos, sin;
-    bool flip;
+    final int angle;
+    final int cos;
+    final int sin;
+    final bool flip;
 
     if (!flips.diagonally && !flips.vertically && !flips.horizontally) {
       angle = 0;
@@ -80,6 +82,6 @@ class SimpleFlips {
       throw 'Invalid combination of booleans: $flips';
     }
 
-    return SimpleFlips(angle, cos, sin, flip);
+    return SimpleFlips(angle, cos, sin, flip: flip);
   }
 }

--- a/packages/flame_tiled/lib/src/tile_atlas.dart
+++ b/packages/flame_tiled/lib/src/tile_atlas.dart
@@ -117,7 +117,6 @@ class TiledAtlas {
     final bin = RectangleBinPacker();
     final recorder = PictureRecorder();
     final canvas = Canvas(recorder);
-    final _emptyPaint = Paint();
 
     final offsetMap = <String, Offset>{};
 
@@ -133,6 +132,7 @@ class TiledAtlas {
       ...imageList.map((tiledImage) => Flame.images.load(tiledImage.source!))
     ]);
 
+    final emptyPaint = Paint();
     for (final tiledImage in imageList) {
       final image = await Flame.images.load(tiledImage.source!);
       final rect = bin.pack(image.width.toDouble(), image.height.toDouble());
@@ -142,7 +142,7 @@ class TiledAtlas {
       final offset =
           offsetMap[tiledImage.source!] = Offset(rect.left, rect.top);
 
-      canvas.drawImage(image, offset, _emptyPaint);
+      canvas.drawImage(image, offset, emptyPaint);
     }
     final picture = recorder.endRecording();
     final image = await picture.toImageSafe(

--- a/packages/flame_tiled/lib/src/tiled_component.dart
+++ b/packages/flame_tiled/lib/src/tiled_component.dart
@@ -77,9 +77,9 @@ class TiledComponent<T extends FlameGame> extends PositionComponent
   }
 
   @override
-  void onGameResize(Vector2 canvasSize) {
-    super.onGameResize(canvasSize);
-    tileMap.handleResize(canvasSize);
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    tileMap.handleResize(size);
   }
 
   /// Loads a [TiledComponent] from a file.

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -188,7 +188,8 @@ void main() {
   });
 
   group('Flipped and rotated tiles render correctly with sprite batch:', () {
-    late Uint8List pixelsBeforeFlipApplied, pixelsAfterFlipApplied;
+    late Uint8List pixelsBeforeFlipApplied;
+    late Uint8List pixelsAfterFlipApplied;
     late RenderableTiledMap overlapMap;
 
     Future<Uint8List> renderMap() async {
@@ -340,47 +341,47 @@ void main() {
   });
 
   group('Test getLayer:', () {
-    late RenderableTiledMap _renderableTiledMap;
+    late RenderableTiledMap renderableTiledMap;
     setUp(() async {
       Flame.bundle = TestAssetBundle(
         imageNames: ['map-level1.png'],
         stringNames: ['layers_test.tmx'],
       );
-      _renderableTiledMap =
+      renderableTiledMap =
           await RenderableTiledMap.fromFile('layers_test.tmx', Vector2.all(32));
     });
 
     test('Get Tile Layer', () {
       expect(
-        _renderableTiledMap.getLayer<TileLayer>('MyTileLayer'),
+        renderableTiledMap.getLayer<TileLayer>('MyTileLayer'),
         isNotNull,
       );
     });
 
     test('Get Object Layer', () {
       expect(
-        _renderableTiledMap.getLayer<ObjectGroup>('MyObjectLayer'),
+        renderableTiledMap.getLayer<ObjectGroup>('MyObjectLayer'),
         isNotNull,
       );
     });
 
     test('Get Image Layer', () {
       expect(
-        _renderableTiledMap.getLayer<ImageLayer>('MyImageLayer'),
+        renderableTiledMap.getLayer<ImageLayer>('MyImageLayer'),
         isNotNull,
       );
     });
 
     test('Get Group Layer', () {
       expect(
-        _renderableTiledMap.getLayer<Group>('MyGroupLayer'),
+        renderableTiledMap.getLayer<Group>('MyGroupLayer'),
         isNotNull,
       );
     });
 
     test('Get no layer', () {
       expect(
-        _renderableTiledMap.getLayer<TileLayer>('Nonexistent layer'),
+        renderableTiledMap.getLayer<TileLayer>('Nonexistent layer'),
         isNull,
       );
     });


### PR DESCRIPTION
# Description
This PR adds the following lint rules to our list:

```
always_put_required_named_parameters_first
avoid_multiple_declarations_per_line
avoid_positional_boolean_parameters
avoid_returning_null_for_void
avoid_returning_this
avoid_unnecessary_containers
enable_null_safety
library_private_types_in_public_api
no_leading_underscores_for_library_prefixes
no_leading_underscores_for_local_identifiers
prefer_null_aware_method_calls
tighten_type_of_initializing_formals
unnecessary_late
use_setters_to_change_properties
```

And these rules were considered, and some changes were made according to them as a clean-up, but in many places they didn't make sense (`prefer_asserts_with_message` I would have included, but there were too many places that needed to be changes):

```
collection_methods_unrelated_type
prefer_asserts_with_message
avoid_renaming_method_parameters
```


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [x] No, this PR is not a breaking change.