### PR TITLE
feat: Deprecate Component.changeParent

### DIFF
--- a/examples/lib/stories/components/game_in_game_example.dart
+++ b/examples/lib/stories/components/game_in_game_example.dart
@@ -39,6 +39,6 @@ class GameChangeTimer extends TimerComponent
     final newParent = child.parent == gameRef.draggablesGame
         ? gameRef.composedGame.parentSquare as Component
         : gameRef.draggablesGame;
-    child.changeParent(newParent);
+    child.parent = newParent;
   }
 }

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -262,8 +262,7 @@ class Component {
   /// This can be null if the component hasn't been added to the component tree
   /// yet, or if it is the root of component tree.
   ///
-  /// Setting this property is equivalent to the [changeParent] method, or to
-  /// [removeFromParent] if setting to null.
+  /// Setting this property to null is equivalent to [removeFromParent].
   Component? get parent => _parent;
   Component? _parent;
   set parent(Component? newParent) {
@@ -555,7 +554,7 @@ class Component {
   /// A component can only be added to one parent at a time. It is an error to
   /// try to add it to multiple parents, or even to the same parent multiple
   /// times. If you need to change the parent of a component, use the
-  /// [changeParent] method.
+  /// [parent] setter.
   FutureOr<void> add(Component component) => _addChild(component);
 
   /// Adds this component as a child of [parent] (see [add] for details).
@@ -646,6 +645,7 @@ class Component {
 
   /// Changes the current parent for another parent and prepares the tree under
   /// the new root.
+  @Deprecated('Will be removed in 1.9.0. Use the parent setter instead.')
   void changeParent(Component newParent) {
     parent = newParent;
   }

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -67,7 +67,7 @@ void main() {
           await game.ready();
           final removed = child.removed;
 
-          child.changeParent(game);
+          child.parent = game;
           game.update(0);
           await expectLater(removed, completes);
 
@@ -104,7 +104,7 @@ void main() {
 
           await expectLater(mounted, completes);
 
-          child.changeParent(game);
+          child.parent = game;
           mounted = child.mounted;
           game.update(0);
           await game.ready();
@@ -123,7 +123,7 @@ void main() {
           final mounted = child.mounted;
           await game.ready();
 
-          child.changeParent(parent);
+          child.parent = parent;
           game.update(0);
           await game.ready();
 
@@ -179,7 +179,7 @@ void main() {
         parent.add(child);
         game.add(parent);
         await game.ready();
-        child.changeParent(game);
+        child.parent = game;
         game.update(0);
         await game.ready();
 
@@ -933,7 +933,7 @@ void main() {
           await game.ensureAdd(parent1);
           await game.ensureAdd(parent2);
           await parent1.ensureAdd(child);
-          child.changeParent(parent2);
+          child.parent = parent2;
           await game.ready();
           expect(parent1.onChangedChildrenRuns, 2);
           expect(parent1.lastChangeType, ChildrenChangeType.removed);


### PR DESCRIPTION
# Description

Since we now have a setter directly for `parent`, `changeParent` is no longer needed.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
