### PR TITLE
fix: Fill in mount implementation in `HasTappables`

### DIFF
--- a/packages/flame/lib/src/game/mixins/has_tappables.dart
+++ b/packages/flame/lib/src/game/mixins/has_tappables.dart
@@ -79,7 +79,16 @@ mixin HasTappables on FlameGame implements MultiTapListener {
   void mount() {
     gestureDetectors.add<MultiTapGestureRecognizer>(
       MultiTapGestureRecognizer.new,
-      (MultiTapGestureRecognizer instance) {},
+      (MultiTapGestureRecognizer instance) {
+        instance.longTapDelay = Duration(
+          milliseconds: (longTapDelay * 1000).toInt(),
+        );
+        instance.onTap = handleTap;
+        instance.onTapDown = handleTapDown;
+        instance.onTapUp = handleTapUp;
+        instance.onTapCancel = handleTapCancel;
+        instance.onLongTapDown = handleLongTapDown;
+      },
     );
     super.mount();
   }


### PR DESCRIPTION
# Description

`HasTappables` also needs the same full implementation in `mount` as `HasTappableComponents` has for `Tappable` to work properly.

It seems to work the same without this too, so there is something that I'm missing.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
