### PR TITLE
fix: RecycleQueue cannot extends and implements Iterable at the same time

### DIFF
--- a/packages/flame/lib/src/components/core/recycled_queue.dart
+++ b/packages/flame/lib/src/components/core/recycled_queue.dart
@@ -21,7 +21,7 @@ import 'dart:math';
 ///
 /// Internally, the queue is backed by a circular list.
 class RecycledQueue<T extends Disposable> extends IterableMixin<T>
-    implements Iterable<T>, Iterator<T> {
+    implements Iterator<T> {
   RecycledQueue(this.factory, {int initialCapacity = 8})
       : _elements = List.generate(initialCapacity, (i) => factory()),
         _startIndex = -1,


### PR DESCRIPTION
# Description

Implementing and extending the iterable interface/mixin at the same time breaks Flame in the current beta channel (3.10...).

This PR removes the implementation of the interface to get flame ready for the next flutter release.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
