### PR TITLE
fix: Modify size only if changed while auto-resizing

### DIFF
--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -139,11 +139,15 @@ class SpriteAnimationComponent extends PositionComponent
   void _resizeToSprite() {
     if (_autoResize) {
       _isAutoResizing = true;
-      if (_animation != null) {
-        size.setFrom(_animation!.getSprite().srcSize);
-      } else {
-        size.setZero();
+
+      final newX = _animation?.getSprite().srcSize.x ?? 0;
+      final newY = _animation?.getSprite().srcSize.y ?? 0;
+
+      // Modify only if changed.
+      if (size.x != newX || size.y != newY) {
+        size.setValues(newX, newY);
       }
+
       _isAutoResizing = false;
     }
   }

--- a/packages/flame/lib/src/components/sprite_animation_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_group_component.dart
@@ -168,11 +168,15 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
   void _resizeToSprite() {
     if (_autoResize) {
       _isAutoResizing = true;
-      if (animation != null) {
-        size.setFrom(animation!.getSprite().srcSize);
-      } else {
-        size.setZero();
+
+      final newX = animation?.getSprite().srcSize.x ?? 0;
+      final newY = animation?.getSprite().srcSize.y ?? 0;
+
+      // Modify only if changed.
+      if (size.x != newX || size.y != newY) {
+        size.setValues(newX, newY);
       }
+
       _isAutoResizing = false;
     }
   }

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -128,11 +128,15 @@ class SpriteComponent extends PositionComponent
   void _resizeToSprite() {
     if (_autoResize) {
       _isAutoResizing = true;
-      if (_sprite != null) {
-        size.setFrom(_sprite!.srcSize);
-      } else {
-        size.setZero();
+
+      final newX = _sprite?.srcSize.x ?? 0;
+      final newY = _sprite?.srcSize.y ?? 0;
+
+      // Modify only if changed.
+      if (size.x != newX || size.y != newY) {
+        size.setValues(newX, newY);
       }
+
       _isAutoResizing = false;
     }
   }

--- a/packages/flame/lib/src/components/sprite_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_group_component.dart
@@ -119,11 +119,15 @@ class SpriteGroupComponent<T> extends PositionComponent
   void _resizeToSprite() {
     if (_autoResize) {
       _isAutoResizing = true;
-      if (sprite != null) {
-        size.setFrom(sprite!.srcSize);
-      } else {
-        size.setZero();
+
+      final newX = sprite?.srcSize.x ?? 0;
+      final newY = sprite?.srcSize.y ?? 0;
+
+      // Modify only if changed.
+      if (size.x != newX || size.y != newY) {
+        size.setValues(newX, newY);
       }
+
       _isAutoResizing = false;
     }
   }

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -360,5 +360,35 @@ Future<void> main() async {
       expectDouble(component.size.x, testSize.x);
       expectDouble(component.size.y, testSize.y);
     });
+
+    test('modify size only if changed while auto-resizing', () {
+      final spriteList = [
+        Sprite(image, srcSize: Vector2.all(1)),
+        Sprite(image, srcSize: Vector2.all(1)),
+        Sprite(image, srcSize: Vector2(2, 1)),
+      ];
+      final animation = SpriteAnimation.spriteList(spriteList, stepTime: 1);
+      final component = SpriteAnimationComponent(animation: animation);
+
+      var sizeChangeCounter = 0;
+      component.size.addListener(() => ++sizeChangeCounter);
+
+      component.update(1);
+      expect(sizeChangeCounter, equals(0));
+
+      component.update(0.5);
+      expect(sizeChangeCounter, equals(0));
+
+      component.update(0.5);
+      expect(sizeChangeCounter, equals(1));
+
+      component.update(1);
+      expect(sizeChangeCounter, equals(2));
+
+      for (var i = 0; i < 15; ++i) {
+        component.update(1);
+      }
+      expect(sizeChangeCounter, equals(12));
+    });
   });
 }

--- a/packages/flame/test/components/sprite_animation_group_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_group_component_test.dart
@@ -308,5 +308,44 @@ Future<void> main() async {
       expectDouble(component.size.x, testSize.x);
       expectDouble(component.size.y, testSize.y);
     });
+
+    test('modify size only if changed while auto-resizing', () {
+      final sprite1 = Sprite(image, srcSize: Vector2.all(76));
+      final sprite2 = Sprite(image, srcSize: Vector2.all(15));
+      final animation1 = SpriteAnimation.spriteList(
+        List.filled(5, sprite1),
+        stepTime: 1,
+        loop: false,
+      );
+      final animation2 = SpriteAnimation.spriteList(
+        [sprite2, sprite1],
+        stepTime: 1,
+      );
+      final animationsMap = {
+        _AnimationState.idle: animation1,
+        _AnimationState.running: animation2,
+      };
+      final component = SpriteAnimationGroupComponent<_AnimationState>(
+        animations: animationsMap,
+      );
+
+      var sizeChangeCounter = 0;
+      component.size.addListener(() => ++sizeChangeCounter);
+
+      component.current = _AnimationState.running;
+      expect(sizeChangeCounter, equals(1));
+
+      component.current = _AnimationState.idle;
+      expect(sizeChangeCounter, equals(2));
+
+      component.update(1);
+      expect(sizeChangeCounter, equals(2));
+
+      component.current = _AnimationState.running;
+      expect(sizeChangeCounter, equals(3));
+
+      component.update(1);
+      expect(sizeChangeCounter, equals(4));
+    });
   });
 }

--- a/packages/flame/test/components/sprite_component_test.dart
+++ b/packages/flame/test/components/sprite_component_test.dart
@@ -94,5 +94,24 @@ Future<void> main() async {
       expectDouble(component.size.x, testSize.x);
       expectDouble(component.size.y, testSize.y);
     });
+
+    test('modify size only if changed while auto-resizing', () {
+      final sprite1 = Sprite(image, srcSize: Vector2.all(13));
+      final sprite2 = Sprite(image, srcSize: Vector2.all(13));
+      final sprite3 = Sprite(image, srcSize: Vector2(13, 14));
+      final component = SpriteComponent();
+
+      var sizeChangeCounter = 0;
+      component.size.addListener(() => ++sizeChangeCounter);
+
+      component.sprite = sprite1;
+      expect(sizeChangeCounter, equals(1));
+
+      component.sprite = sprite2;
+      expect(sizeChangeCounter, equals(1));
+
+      component.sprite = sprite3;
+      expect(sizeChangeCounter, equals(2));
+    });
   });
 }

--- a/packages/flame/test/components/sprite_group_component_test.dart
+++ b/packages/flame/test/components/sprite_group_component_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 enum _SpriteState {
   idle,
   running,
+  flying,
 }
 
 Future<void> main() async {
@@ -108,6 +109,27 @@ Future<void> main() async {
 
       expectDouble(component.size.x, testSize.x);
       expectDouble(component.size.y, testSize.y);
+    });
+
+    test('modify size only if changed while auto-resizing', () {
+      final spritesMap = {
+        _SpriteState.idle: Sprite(image, srcSize: Vector2.all(15)),
+        _SpriteState.running: Sprite(image, srcSize: Vector2.all(15)),
+        _SpriteState.flying: Sprite(image, srcSize: Vector2(15, 12)),
+      };
+      final component = SpriteGroupComponent<_SpriteState>(sprites: spritesMap);
+
+      var sizeChangeCounter = 0;
+      component.size.addListener(() => ++sizeChangeCounter);
+
+      component.current = _SpriteState.running;
+      expect(sizeChangeCounter, equals(1));
+
+      component.current = _SpriteState.idle;
+      expect(sizeChangeCounter, equals(1));
+
+      component.current = _SpriteState.flying;
+      expect(sizeChangeCounter, equals(2));
     });
   });
 }


### PR DESCRIPTION
# Description

Checks the size before modifying and skips if it hasn't changed.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2488 