### PR TITLE
chore(release): Publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,112 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-04-16
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`flame` - `v1.7.3`](#flame---v173)
+ - [`flame_audio` - `v2.0.1`](#flame_audio---v201)
+ - [`flame_bloc` - `v1.8.4`](#flame_bloc---v184)
+ - [`flame_fire_atlas` - `v1.3.5`](#flame_fire_atlas---v135)
+ - [`flame_flare` - `v1.5.4`](#flame_flare---v154)
+ - [`flame_forge2d` - `v0.13.0+1`](#flame_forge2d---v01301)
+ - [`flame_isolate` - `v0.3.0+1`](#flame_isolate---v0301)
+ - [`flame_lint` - `v0.2.0+2`](#flame_lint---v0202)
+ - [`flame_oxygen` - `v0.1.8+2`](#flame_oxygen---v0182)
+ - [`flame_rive` - `v1.7.1`](#flame_rive---v171)
+ - [`flame_svg` - `v1.7.3`](#flame_svg---v173)
+ - [`flame_test` - `v1.10.1`](#flame_test---v1101)
+ - [`flame_tiled` - `v1.10.1`](#flame_tiled---v1101)
+ - [`jenny` - `v1.0.2`](#jenny---v102)
+ - [`flame_noise` - `v0.1.1+1`](#flame_noise---v0111)
+ - [`flame_network_assets` - `v0.2.0+1`](#flame_network_assets---v0201)
+ - [`flame_lottie` - `v0.2.0+2`](#flame_lottie---v0202)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `flame_noise` - `v0.1.1+1`
+ - `flame_network_assets` - `v0.2.0+1`
+ - `flame_lottie` - `v0.2.0+2`
+
+---
+
+#### `flame` - `v1.7.3`
+
+ - **REFACTOR**: Make atlas status to be more readable ([#2502](https://github.com/flame-engine/flame/issues/2502)). ([643793d0](https://github.com/flame-engine/flame/commit/643793d06e1c9264ce8fd557552ad8405bc65ec1))
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+ - **FIX**: Reverse invalid polygon definitions ([#2503](https://github.com/flame-engine/flame/issues/2503)). ([c4c516eb](https://github.com/flame-engine/flame/commit/c4c516ebf8fe6b8eaf82a3e49454b64faf6a7cd2))
+ - **FIX**: Fill in mount implementation in `HasTappables` ([#2496](https://github.com/flame-engine/flame/issues/2496)). ([d51a612f](https://github.com/flame-engine/flame/commit/d51a612f8bed2a7a294444e5f11402394dfbc3cd))
+ - **FIX**: Modify size only if changed while auto-resizing ([#2498](https://github.com/flame-engine/flame/issues/2498)). ([aa8d49da](https://github.com/flame-engine/flame/commit/aa8d49da9eb77c47d252ac3cc46d268eb10a2f20))
+ - **FIX**: RecycleQueue cannot extends and implements Iterable at the same time ([#2497](https://github.com/flame-engine/flame/issues/2497)). ([3e5be3d6](https://github.com/flame-engine/flame/commit/3e5be3d6c23bfc61237befa5d17311474c6d4234))
+ - **FIX**: Remove memory leak when creating the image from PictureRecorder ([#2493](https://github.com/flame-engine/flame/issues/2493)). ([a66f2bc0](https://github.com/flame-engine/flame/commit/a66f2bc0a97415f4f57b6c55174a2930cdf9e61b))
+ - **FEAT**: Bump ordered_set version ([#2500](https://github.com/flame-engine/flame/issues/2500)). ([81303ea9](https://github.com/flame-engine/flame/commit/81303ea9d805c04c5d85c8e7c2f40ab8e43ae811))
+ - **FEAT**: Deprecate `Component.changeParent` ([#2478](https://github.com/flame-engine/flame/issues/2478)). ([bd3e7886](https://github.com/flame-engine/flame/commit/bd3e7886125e60ad1386ec864a5ef33382f7f7f5))
+
+#### `flame_audio` - `v2.0.1`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_bloc` - `v1.8.4`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_fire_atlas` - `v1.3.5`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_flare` - `v1.5.4`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_forge2d` - `v0.13.0+1`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_isolate` - `v0.3.0+1`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_lint` - `v0.2.0+2`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_oxygen` - `v0.1.8+2`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_rive` - `v1.7.1`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_svg` - `v1.7.3`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+ - **FIX**: Remove memory leak when creating the image from PictureRecorder ([#2493](https://github.com/flame-engine/flame/issues/2493)). ([a66f2bc0](https://github.com/flame-engine/flame/commit/a66f2bc0a97415f4f57b6c55174a2930cdf9e61b))
+
+#### `flame_test` - `v1.10.1`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `flame_tiled` - `v1.10.1`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+#### `jenny` - `v1.0.2`
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
+
 ## 2023-04-11
 
 ### Changes

--- a/doc/flame/examples/pubspec.yaml
+++ b/doc/flame/examples/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
-  flame_rive: ^1.7.0
+  flame: ^1.7.3
+  flame_rive: ^1.7.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 
 flutter:
   assets:

--- a/doc/tutorials/klondike/app/pubspec.yaml
+++ b/doc/tutorials/klondike/app/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 flutter:
   assets:
     - assets/images/

--- a/doc/tutorials/platformer/app/pubspec.yaml
+++ b/doc/tutorials/platformer/app/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
 

--- a/doc/tutorials/space_shooter/app/pubspec.yaml
+++ b/doc/tutorials/space_shooter/app/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
 

--- a/examples/games/padracing/pubspec.yaml
+++ b/examples/games/padracing/pubspec.yaml
@@ -8,15 +8,15 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  flame: ^1.7.0
-  flame_forge2d: ^0.13.0
+  flame: ^1.7.3
+  flame_forge2d: ^0.13.0+1
   flutter:
     sdk: flutter
   google_fonts: ^2.3.2
   url_launcher: ^6.1.2
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
 

--- a/examples/games/rogue_shooter/pubspec.yaml
+++ b/examples/games/rogue_shooter/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 
 flutter:
   assets:

--- a/examples/games/trex/pubspec.yaml
+++ b/examples/games/trex/pubspec.yaml
@@ -11,12 +11,12 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 flutter:
   uses-material-design: true
   assets:

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -11,14 +11,14 @@ environment:
 
 dependencies:
   dashbook: 0.1.8
-  flame: ^1.7.0
-  flame_audio: ^2.0.0
-  flame_forge2d: ^0.13.0
-  flame_isolate: ^0.3.0
-  flame_lottie: ^0.2.0+1
-  flame_noise: ^0.1.1
-  flame_svg: ^1.7.2
-  flame_tiled: ^1.10.0
+  flame: ^1.7.3
+  flame_audio: ^2.0.1
+  flame_forge2d: ^0.13.0+1
+  flame_isolate: ^0.3.0+1
+  flame_lottie: ^0.2.0+2
+  flame_noise: ^0.1.1+1
+  flame_svg: ^1.7.3
+  flame_tiled: ^1.10.1
   flutter:
     sdk: flutter
   google_fonts: ^2.3.2
@@ -29,7 +29,7 @@ dependencies:
   trex_game: ^0.1.0
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   test: any
 
 flutter:

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.7.3
+
+ - **REFACTOR**: Make atlas status to be more readable ([#2502](https://github.com/flame-engine/flame/issues/2502)). ([643793d0](https://github.com/flame-engine/flame/commit/643793d06e1c9264ce8fd557552ad8405bc65ec1))
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+ - **FIX**: Reverse invalid polygon definitions ([#2503](https://github.com/flame-engine/flame/issues/2503)). ([c4c516eb](https://github.com/flame-engine/flame/commit/c4c516ebf8fe6b8eaf82a3e49454b64faf6a7cd2))
+ - **FIX**: Fill in mount implementation in `HasTappables` ([#2496](https://github.com/flame-engine/flame/issues/2496)). ([d51a612f](https://github.com/flame-engine/flame/commit/d51a612f8bed2a7a294444e5f11402394dfbc3cd))
+ - **FIX**: Modify size only if changed while auto-resizing ([#2498](https://github.com/flame-engine/flame/issues/2498)). ([aa8d49da](https://github.com/flame-engine/flame/commit/aa8d49da9eb77c47d252ac3cc46d268eb10a2f20))
+ - **FIX**: RecycleQueue cannot extends and implements Iterable at the same time ([#2497](https://github.com/flame-engine/flame/issues/2497)). ([3e5be3d6](https://github.com/flame-engine/flame/commit/3e5be3d6c23bfc61237befa5d17311474c6d4234))
+ - **FIX**: Remove memory leak when creating the image from PictureRecorder ([#2493](https://github.com/flame-engine/flame/issues/2493)). ([a66f2bc0](https://github.com/flame-engine/flame/commit/a66f2bc0a97415f4f57b6c55174a2930cdf9e61b))
+ - **FEAT**: Bump ordered_set version ([#2500](https://github.com/flame-engine/flame/issues/2500)). ([81303ea9](https://github.com/flame-engine/flame/commit/81303ea9d805c04c5d85c8e7c2f40ab8e43ae811))
+ - **FEAT**: Deprecate `Component.changeParent` ([#2478](https://github.com/flame-engine/flame/issues/2478)). ([bd3e7886](https://github.com/flame-engine/flame/commit/bd3e7886125e60ad1386ec864a5ef33382f7f7f5))
+
 ## 1.7.2
 
  - **FIX**: A mistake in auto-resizing disabling logic ([#2471](https://github.com/flame-engine/flame/issues/2471)). ([e7ebf8e5](https://github.com/flame-engine/flame/commit/e7ebf8e55a0ad7b0f3aaae769c0b8855fb1efd96))

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 1.7.2
+version: 1.7.3
 homepage: https://github.com/flame-engine/flame
 funding:
   - https://opencollective.com/blue-fire
@@ -22,8 +22,8 @@ dependencies:
 dev_dependencies:
   canvas_test: ^0.2.0
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
-  flame_test: ^1.10.0
+  flame_lint: ^0.2.0+2
+  flame_test: ^1.10.1
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_audio/CHANGELOG.md
+++ b/packages/flame_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 2.0.0
 
 > Note: This release has breaking changes.

--- a/packages/flame_audio/example/pubspec.yaml
+++ b/packages/flame_audio/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
-  flame_audio: ^2.0.0
+  flame: ^1.7.3
+  flame_audio: ^2.0.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 flutter:
   assets:
     - assets/audio/music/bg_music.ogg

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_audio
 description: |
   Audio support for the Flame game engine, basically a thin wrapper around the audioplayers package.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_audio
 funding:
   - https://opencollective.com/blue-fire
@@ -14,11 +14,11 @@ environment:
 
 dependencies:
   audioplayers: ^4.0.0
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   synchronized: ^3.0.1
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2

--- a/packages/flame_bloc/CHANGELOG.md
+++ b/packages/flame_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.4
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 1.8.3
 
  - **REFACTOR**: Remove unused event "ScoreEventCleared" from flame_block example ([#2380](https://github.com/flame-engine/flame/issues/2380)). ([a9db3f4c](https://github.com/flame-engine/flame/commit/a9db3f4ce5c7c11ddca511826bdf9ab72eb19dfe))

--- a/packages/flame_bloc/example/pubspec.yaml
+++ b/packages/flame_bloc/example/pubspec.yaml
@@ -10,14 +10,14 @@ environment:
 
 dependencies:
   equatable: ^2.0.3
-  flame: ^1.7.0
-  flame_bloc: ^1.8.3
+  flame: ^1.7.3
+  flame_bloc: ^1.8.4
   flutter:
     sdk: flutter
   flutter_bloc: ^8.0.1
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_bloc
 description: Integration for the Bloc state management library to Flame games.
-version: 1.8.3
+version: 1.8.4
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_bloc
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   bloc: ^8.0.2
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   flutter_bloc: ^8.0.1
@@ -21,8 +21,8 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
-  flame_test: ^1.10.0
+  flame_lint: ^0.2.0+2
+  flame_test: ^1.10.1
   flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter

--- a/packages/flame_fire_atlas/CHANGELOG.md
+++ b/packages/flame_fire_atlas/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.5
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 1.3.4
 
  - **DOCS**: Update funding links ([#2420](https://github.com/flame-engine/flame/issues/2420)). ([8294a2a1](https://github.com/flame-engine/flame/commit/8294a2a15638c504aa2b77f967f5963af1f23c2c))

--- a/packages/flame_fire_atlas/example/pubspec.yaml
+++ b/packages/flame_fire_atlas/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
-  flame_fire_atlas: ^1.3.4
+  flame: ^1.7.3
+  flame_fire_atlas: ^1.3.5
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_fire_atlas
 description: Easy to use texture atlases for the flame engine created with the fire atlas editor
-version: 1.3.4
+version: 1.3.5
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_fire_atlas
 funding:
   - https://opencollective.com/blue-fire
@@ -13,13 +13,13 @@ environment:
 
 dependencies:
   archive: ^3.1.5
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_flare/CHANGELOG.md
+++ b/packages/flame_flare/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.4
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 1.5.3
 
  - **DOCS**: Update funding links ([#2420](https://github.com/flame-engine/flame/issues/2420)). ([8294a2a1](https://github.com/flame-engine/flame/commit/8294a2a15638c504aa2b77f967f5963af1f23c2c))

--- a/packages/flame_flare/example/pubspec.yaml
+++ b/packages/flame_flare/example/pubspec.yaml
@@ -8,14 +8,14 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
-  flame_flare: ^1.5.3
+  flame: ^1.7.3
+  flame_flare: ^1.5.4
   flare_flutter: ^3.0.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 flutter:
   assets:
     - assets/Bob_Minion.flr

--- a/packages/flame_flare/pubspec.yaml
+++ b/packages/flame_flare/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_flare
 description: This packages allows you to use flare animations into a Flame game.
-version: 1.5.3
+version: 1.5.4
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_flare
 funding:
   - https://opencollective.com/blue-fire
@@ -12,11 +12,11 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flare_flutter: ^3.0.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.0+1
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 0.13.0
 
 > Note: This release has breaking changes.

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -11,13 +11,13 @@ environment:
 
 dependencies:
   dashbook: ^0.1.6
-  flame: ^1.7.0
-  flame_forge2d: ^0.13.0
+  flame: ^1.7.3
+  flame_forge2d: ^0.13.0+1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_forge2d
 description: Forge2D (Box2D) support for the Flame game engine. This uses the forge2d package and provides wrappers and components to be used inside Flame.
-version: 0.13.0
+version: 0.13.0+1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_forge2d
 funding:
   - https://opencollective.com/blue-fire
@@ -12,15 +12,15 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   forge2d: ">=0.11.0 <0.12.0"
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
-  flame_test: ^1.10.0
+  flame_lint: ^0.2.0+2
+  flame_test: ^1.10.1
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_isolate/CHANGELOG.md
+++ b/packages/flame_isolate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+1
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 0.3.0
 
 > Note: This release has breaking changes.

--- a/packages/flame_isolate/example/pubspec.yaml
+++ b/packages/flame_isolate/example/pubspec.yaml
@@ -10,15 +10,15 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  flame: ^1.7.0
-  flame_isolate: ^0.3.0
+  flame: ^1.7.3
+  flame_isolate: ^0.3.0+1
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0
   quiver: ^3.1.0
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 flutter:
   assets:
     - assets/images/

--- a/packages/flame_isolate/pubspec.yaml
+++ b/packages/flame_isolate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_isolate
 description: Flame wrapper for integral_isolates making multi-threading easy in Flame
-version: 0.3.0
+version: 0.3.0+1
 homepage: https://github.com/lohnn/integral_isolates
 
 environment:
@@ -8,14 +8,14 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
-  flame_test: ^1.10.0
+  flame_lint: ^0.2.0+2
+  flame_test: ^1.10.1
   flutter_test:
     sdk: flutter
   lint: ^1.10.0

--- a/packages/flame_jenny/jenny/CHANGELOG.md
+++ b/packages/flame_jenny/jenny/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 1.0.1
 
  - **DOCS**: Update funding links ([#2420](https://github.com/flame-engine/flame/issues/2420)). ([8294a2a1](https://github.com/flame-engine/flame/commit/8294a2a15638c504aa2b77f967f5963af1f23c2c))

--- a/packages/flame_jenny/jenny/pubspec.yaml
+++ b/packages/flame_jenny/jenny/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jenny
 description: YarnSpinner equivalent for Dart.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_jenny/jenny
 funding:
   - https://opencollective.com/blue-fire
@@ -15,5 +15,5 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   test: any

--- a/packages/flame_jenny/pubspec.yaml
+++ b/packages/flame_jenny/pubspec.yaml
@@ -14,13 +14,13 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
-  jenny: ^1.0.1
+  jenny: ^1.0.2
   meta: ^1.7.0
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   test: any

--- a/packages/flame_lint/CHANGELOG.md
+++ b/packages/flame_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+2
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 0.2.0+1
 
  - **DOCS**: Update funding links ([#2420](https://github.com/flame-engine/flame/issues/2420)). ([8294a2a1](https://github.com/flame-engine/flame/commit/8294a2a15638c504aa2b77f967f5963af1f23c2c))

--- a/packages/flame_lint/pubspec.yaml
+++ b/packages/flame_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_lint
 description: Flame lint package
-version: 0.2.0+1
+version: 0.2.0+2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_lint
 funding:
   - https://opencollective.com/blue-fire

--- a/packages/flame_lottie/CHANGELOG.md
+++ b/packages/flame_lottie/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+2
+
+ - Update a dependency to the latest release.
+
 ## 0.2.0+1
 
  - **DOCS**: Update funding links ([#2420](https://github.com/flame-engine/flame/issues/2420)). ([8294a2a1](https://github.com/flame-engine/flame/commit/8294a2a15638c504aa2b77f967f5963af1f23c2c))

--- a/packages/flame_lottie/example/pubspec.yaml
+++ b/packages/flame_lottie/example/pubspec.yaml
@@ -8,14 +8,14 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
-  flame_lottie: ^0.2.0+1
+  flame: ^1.7.3
+  flame_lottie: ^0.2.0+2
   flutter:
     sdk: flutter
   lottie:
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 flutter:
   uses-material-design: true
   assets:

--- a/packages/flame_lottie/pubspec.yaml
+++ b/packages/flame_lottie/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_lottie
 description: Flame wrapper for Lottie by AirBnB. This package implements a bridge between Lottie and Flame, allowing to load and display Lottie animations.
-version: 0.2.0+1
+version: 0.2.0+2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_lottie
 funding:
   - https://opencollective.com/blue-fire
@@ -12,14 +12,14 @@ environment:
   flutter: '>=3.3.0'
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   lottie: ^1.4.3
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
-  flame_test: ^1.10.0
+  flame_lint: ^0.2.0+2
+  flame_test: ^1.10.1
   flutter_test:
     sdk: flutter
   lint: ^1.10.0

--- a/packages/flame_network_assets/CHANGELOG.md
+++ b/packages/flame_network_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+1
+
+ - Update a dependency to the latest release.
+
 ## 0.2.0
 
 > Note: This release has breaking changes.

--- a/packages/flame_network_assets/example/pubspec.yaml
+++ b/packages/flame_network_assets/example/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
-  flame: ^1.7.0
-  flame_network_assets: ^0.2.0
+  flame: ^1.7.3
+  flame_network_assets: ^0.2.0+1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2

--- a/packages/flame_network_assets/pubspec.yaml
+++ b/packages/flame_network_assets/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_network_assets
 description: Network assets support for Flame.
-version: 0.2.0
+version: 0.2.0+1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_network_assets
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   dev: ^1.0.0
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   http: ^0.13.5
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_noise/CHANGELOG.md
+++ b/packages/flame_noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+1
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1
 
  - **FEAT**: Introduce flame_noise, deprecate NoiseEffectController ([#2393](https://github.com/flame-engine/flame/issues/2393)). ([b2fdf06a](https://github.com/flame-engine/flame/commit/b2fdf06a79520c2b556c1c83de0b0f24df80cfd2))

--- a/packages/flame_noise/pubspec.yaml
+++ b/packages/flame_noise/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_noise
 description: Integrate the fast_noise package into Flame
-version: 0.1.1
+version: 0.1.1+1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_noise
 funding:
   - https://opencollective.com/blue-fire
@@ -13,12 +13,12 @@ environment:
 
 dependencies:
   fast_noise: ^1.0.1
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
-  flame_test: ^1.10.0
+  flame_lint: ^0.2.0+2
+  flame_test: ^1.10.1
   test: any

--- a/packages/flame_oxygen/CHANGELOG.md
+++ b/packages/flame_oxygen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8+2
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 0.1.8+1
 
  - **DOCS**: Update funding links ([#2420](https://github.com/flame-engine/flame/issues/2420)). ([8294a2a1](https://github.com/flame-engine/flame/commit/8294a2a15638c504aa2b77f967f5963af1f23c2c))

--- a/packages/flame_oxygen/example/pubspec.yaml
+++ b/packages/flame_oxygen/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
-  flame_oxygen: ^0.1.8+1
+  flame: ^1.7.3
+  flame_oxygen: ^0.1.8+2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 flutter:
   uses-material-design: true
   assets:

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_oxygen
 description: Integrate the Oxygen ECS with the Flame Engine.
-version: 0.1.8+1
+version: 0.1.8+2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_oxygen
 funding:
   - https://opencollective.com/blue-fire
@@ -12,11 +12,11 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   oxygen: ^0.2.0
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2

--- a/packages/flame_rive/CHANGELOG.md
+++ b/packages/flame_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.1
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 1.7.0
 
 > Note: This release has breaking changes.

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
-  flame_rive: ^1.7.0
+  flame: ^1.7.3
+  flame_rive: ^1.7.1
   flutter:
     sdk: flutter
   rive: 0.10.2
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_rive
 description: Rive support for the Flame game engine. This uses the rive package and provides wrappers and components to be used inside Flame.
 homepage: https://github.com/flame-engine/flame
-version: 1.7.0
+version: 1.7.1
 funding:
   - https://opencollective.com/blue-fire
   - https://github.com/sponsors/bluefireteam
@@ -12,14 +12,14 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   rive: ^0.10.2
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
-  flame_test: ^1.10.0
+  flame_lint: ^0.2.0+2
+  flame_test: ^1.10.1
   flutter_test:
     sdk: flutter

--- a/packages/flame_studio/pubspec.yaml
+++ b/packages/flame_studio/pubspec.yaml
@@ -14,14 +14,14 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.1.3
   meta: ^1.7.0
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_svg/CHANGELOG.md
+++ b/packages/flame_svg/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.3
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+ - **FIX**: Remove memory leak when creating the image from PictureRecorder ([#2493](https://github.com/flame-engine/flame/issues/2493)). ([a66f2bc0](https://github.com/flame-engine/flame/commit/a66f2bc0a97415f4f57b6c55174a2930cdf9e61b))
+
 ## 1.7.2
 
  - **DOCS**: Update funding links ([#2420](https://github.com/flame-engine/flame/issues/2420)). ([8294a2a1](https://github.com/flame-engine/flame/commit/8294a2a15638c504aa2b77f967f5963af1f23c2c))

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
-  flame_svg: ^1.7.2
+  flame: ^1.7.3
+  flame_svg: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_svg
 description: Package to add SVG rendering support for the Flame game engine
-version: 1.7.2
+version: 1.7.3
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_svg
 funding:
   - https://opencollective.com/blue-fire
@@ -12,14 +12,14 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.3
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_test/CHANGELOG.md
+++ b/packages/flame_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.1
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 1.10.0
 
 > Note: This release has breaking changes.

--- a/packages/flame_test/example/pubspec.yaml
+++ b/packages/flame_test/example/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
-  flame_test: ^1.10.0
+  flame_lint: ^0.2.0+2
+  flame_test: ^1.10.1
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_test
 description: A package with classes to help testing applications using Flame
-version: 1.10.0
+version: 1.10.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_test
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   flutter_test:
@@ -23,4 +23,4 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2

--- a/packages/flame_tiled/CHANGELOG.md
+++ b/packages/flame_tiled/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.1
+
+ - **REFACTOR**: Add new lint rules ([#2477](https://github.com/flame-engine/flame/issues/2477)). ([dbda37b8](https://github.com/flame-engine/flame/commit/dbda37b81a9a7411559a6ba919ffbda6018b85c2))
+
 ## 1.10.0
 
  - **REFACTOR**: Divide TileLayer by its Layer type ([#2326](https://github.com/flame-engine/flame/issues/2326)). ([0c14d4cb](https://github.com/flame-engine/flame/commit/0c14d4cb87ba81957221695547bc06111a28617a))

--- a/packages/flame_tiled/example/pubspec.yaml
+++ b/packages/flame_tiled/example/pubspec.yaml
@@ -7,13 +7,13 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flame: ^1.7.0
-  flame_tiled: ^1.10.0
+  flame: ^1.7.3
+  flame_tiled: ^1.10.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
 flutter:
   uses-material-design: true
   assets:

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_tiled
 description: Tiled support for the Flame game engine. This uses the tiled package and provides wrappers and components to be used inside Flame.
-version: 1.10.0
+version: 1.10.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_tiled
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  flame: ^1.7.0
+  flame: ^1.7.3
   flutter:
     sdk: flutter
   meta: ^1.7.0
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0+1
+  flame_lint: ^0.2.0+2
   flutter_test:
     sdk: flutter
   test: any


### PR DESCRIPTION
 - flame@1.7.3
 - flame_audio@2.0.1
 - flame_bloc@1.8.4
 - flame_fire_atlas@1.3.5
 - flame_flare@1.5.4
 - flame_forge2d@0.13.0+1
 - flame_isolate@0.3.0+1
 - flame_lint@0.2.0+2
 - flame_oxygen@0.1.8+2
 - flame_rive@1.7.1
 - flame_svg@1.7.3
 - flame_test@1.10.1
 - flame_tiled@1.10.1
 - jenny@1.0.2
 - flame_noise@0.1.1+1
 - flame_network_assets@0.2.0+1
 - flame_lottie@0.2.0+2