### PR TITLE
docs: Consider "latest" as the latest version

### DIFF
--- a/doc/_sphinx/scripts/versions.js
+++ b/doc/_sphinx/scripts/versions.js
@@ -53,7 +53,7 @@ function convertVersionsToHtmlLinks(versionsList, currentVersion) {
 
 function maybeAddWarning(versions, currentVersion) {
   const latestVersion = getLatestVersion(versions);
-  const nonWarningVersions = [...specialVersions, latestVersion];
+  const nonWarningVersions = [...specialVersions, 'latest', latestVersion];
   const showWarning = !nonWarningVersions.includes(currentVersion);
   if (showWarning) {
     $('#version-warning')


### PR DESCRIPTION
# Description

After the #2345 change we also have to consider "latest" as the latest version, so that we don't show a warning box for that.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
