### PR TITLE
fix: Release instead of dispose audioplayer in play

### DIFF
--- a/packages/flame_audio/lib/bgm.dart
+++ b/packages/flame_audio/lib/bgm.dart
@@ -53,7 +53,7 @@ class Bgm extends WidgetsBindingObserver {
   /// It is safe to call this function even when a current BGM track is
   /// playing.
   Future<void> play(String fileName, {double volume = 1}) async {
-    await audioPlayer.dispose();
+    await audioPlayer.release();
     await audioPlayer.setReleaseMode(ReleaseMode.loop);
     await audioPlayer.setVolume(volume);
     await audioPlayer.setSource(AssetSource(fileName));


### PR DESCRIPTION
# Description

The `AudioPlayer` should not be disposed when it should be continued to be used, it should be `release`d.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues

https://github.com/bluefireteam/audioplayers/issues/1475

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
