### PR TITLE
docs: Add interactive example for `Anchor`

### DIFF
--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -379,7 +379,8 @@ Right/East| pi/2         | 90
 :sources: ../flame/examples
 :page: anchor
 :show: widget code infobox
-This example shows effect of `anchor` on parent child relationship.
+This example shows effect of changing `anchor` point of parent (red) and child (blue)
+components. Tap on them to cycle through the anchor points.
 ```
 
 The `anchor` is where on the component that the position and rotation should be defined from (the

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -380,7 +380,8 @@ Right/East| pi/2         | 90
 :page: anchor
 :show: widget code infobox
 This example shows effect of changing `anchor` point of parent (red) and child (blue)
-components. Tap on them to cycle through the anchor points.
+components. Tap on them to cycle through the anchor points. Note that the local
+position of child component is (0, 0) at all times.
 ```
 
 The `anchor` is where on the component that the position and rotation should be defined from (the

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -381,6 +381,29 @@ position on the screen will be in the center of the component and if an `angle` 
 rotated around the anchor, so in this case around the center of the component. You can think of it
 as the point within the component by which Flame "grabs" it.
 
+When `position` or `absolutePosition` of a component is queried, the return coordinates are that of
+the `anchor` of the component. In case if you want to find the position of a specific anchor point
+of a component which is not actually the `anchor` of that component, you can use the `positionOfAnchor`
+and `absolutePositionOfAnchor` method.
+
+```dart
+final component = PositionComponent(
+  size: Vector2.all(20),
+  anchor: Anchor.center,
+);
+
+// Returns (0,0)
+final centerPosition = component.position;
+
+// Returns (10, 10)
+final bottomRightPosition = component.positionOfAnchor(Anchor.bottomRight);
+```
+
+A common fitfall when using `anchor` is confusing it for as being the attachment point for children
+components. For example, setting `anchor` to `Anchor.center` for a parent component does not mean
+that the children components will be placed w.r.t the center of parent. Local origin for a child is
+always the top-left corner of its parent.
+
 
 ### PositionComponent children
 

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -375,6 +375,13 @@ Right/East| pi/2         | 90
 
 ### Anchor
 
+```{flutter-app}
+:sources: ../flame/examples
+:page: anchor
+:show: widget code infobox
+This example shows effect of `anchor` on parent child relationship.
+```
+
 The `anchor` is where on the component that the position and rotation should be defined from (the
 default is `Anchor.topLeft`). So if you have the anchor set as `Anchor.center` the component's
 position on the screen will be in the center of the component and if an `angle` is applied, it is
@@ -387,22 +394,26 @@ of a component which is not actually the `anchor` of that component, you can use
 and `absolutePositionOfAnchor` method.
 
 ```dart
-final component = PositionComponent(
+final comp = PositionComponent(
   size: Vector2.all(20),
   anchor: Anchor.center,
 );
 
 // Returns (0,0)
-final centerPosition = component.position;
+final p1 = component.position;
 
 // Returns (10, 10)
-final bottomRightPosition = component.positionOfAnchor(Anchor.bottomRight);
+final p2 = component.positionOfAnchor(Anchor.bottomRight);
 ```
 
 A common fitfall when using `anchor` is confusing it for as being the attachment point for children
 components. For example, setting `anchor` to `Anchor.center` for a parent component does not mean
-that the children components will be placed w.r.t the center of parent. Local origin for a child is
-always the top-left corner of its parent.
+that the children components will be placed w.r.t the center of parent.
+
+```{note}
+Local origin for a child component is always the top-left corner of its parent component,
+irrespective of their `anchor` values.
+```
 
 
 ### PositionComponent children

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -390,7 +390,7 @@ position on the screen will be in the center of the component and if an `angle` 
 rotated around the anchor, so in this case around the center of the component. You can think of it
 as the point within the component by which Flame "grabs" it.
 
-When `position` or `absolutePosition` of a component is queried, the return coordinates are that of
+When `position` or `absolutePosition` of a component is queried, the returned coordinates are that of
 the `anchor` of the component. In case if you want to find the position of a specific anchor point
 of a component which is not actually the `anchor` of that component, you can use the `positionOfAnchor`
 and `absolutePositionOfAnchor` method.

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -407,7 +407,7 @@ final p1 = component.position;
 final p2 = component.positionOfAnchor(Anchor.bottomRight);
 ```
 
-A common fitfall when using `anchor` is confusing it for as being the attachment point for children
+A common pitfall when using `anchor` is confusing it for as being the attachment point for children
 components. For example, setting `anchor` to `Anchor.center` for a parent component does not mean
 that the children components will be placed w.r.t the center of parent.
 

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -381,7 +381,7 @@ Right/East| pi/2         | 90
 :show: widget code infobox
 This example shows effect of changing `anchor` point of parent (red) and child (blue)
 components. Tap on them to cycle through the anchor points. Note that the local
-position of child component is (0, 0) at all times.
+position of the child component is (0, 0) at all times.
 ```
 
 The `anchor` is where on the component that the position and rotation should be defined from (the

--- a/doc/flame/examples/lib/anchor.dart
+++ b/doc/flame/examples/lib/anchor.dart
@@ -1,18 +1,69 @@
 import 'dart:async';
-import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:flame/events.dart';
 import 'package:flame/game.dart';
 import 'package:flame/palette.dart';
 
 class AnchorGame extends FlameGame {
+  final _parentAnchorText = TextComponent(position: Vector2.all(5));
+  final _childAnchorText = TextComponent(position: Vector2(5, 30));
+
+  late _AnchorableRectangle _redComponent;
+  late _AnchorableRectangle _blueComponent;
+
   @override
   Future<void> onLoad() async {
-    final parent = RectangleComponent(
-      size: size / 2,
-      paint: BasicPalette.red.paint(),
+    _redComponent = _AnchorableRectangle(
+      size: size / 4,
       position: size / 2,
+      paint: BasicPalette.red.paint(),
     );
-    await add(parent);
+
+    _blueComponent = _AnchorableRectangle(
+      size: size / 8,
+      paint: BasicPalette.blue.paint(),
+    );
+
+    await _redComponent.addAll([
+      _blueComponent,
+      CircleComponent(radius: 2, anchor: Anchor.center),
+    ]);
+
+    await addAll([
+      _redComponent,
+      _parentAnchorText,
+      _childAnchorText,
+      CircleComponent(
+        radius: 4,
+        position: size / 2,
+        anchor: Anchor.center,
+      )
+    ]);
+  }
+
+  @override
+  void update(double dt) {
+    _parentAnchorText.text = 'Parent: ${_redComponent.anchor}';
+    _childAnchorText.text = 'Child: ${_blueComponent.anchor}';
+    super.update(dt);
+  }
+}
+
+class _AnchorableRectangle extends RectangleComponent with TapCallbacks {
+  _AnchorableRectangle({
+    super.position,
+    super.size,
+    super.paint,
+  });
+
+  @override
+  void onTapDown(TapDownEvent event) {
+    var index = Anchor.values.indexOf(anchor) + 1;
+    if (index == Anchor.values.length) {
+      index = 0;
+    }
+    anchor = Anchor.values.elementAt(index);
+    super.onTapDown(event);
   }
 }

--- a/doc/flame/examples/lib/anchor.dart
+++ b/doc/flame/examples/lib/anchor.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame/palette.dart';
+
+class AnchorGame extends FlameGame {
+  @override
+  Future<void> onLoad() async {
+    final parent = RectangleComponent(
+      size: size / 2,
+      paint: BasicPalette.red.paint(),
+      position: size / 2,
+    );
+    await add(parent);
+  }
+}

--- a/doc/flame/examples/lib/anchor.dart
+++ b/doc/flame/examples/lib/anchor.dart
@@ -9,18 +9,18 @@ class AnchorGame extends FlameGame {
   final _parentAnchorText = TextComponent(position: Vector2.all(5));
   final _childAnchorText = TextComponent(position: Vector2(5, 30));
 
-  late _AnchorableRectangle _redComponent;
-  late _AnchorableRectangle _blueComponent;
+  late _AnchoredRectangle _redComponent;
+  late _AnchoredRectangle _blueComponent;
 
   @override
   Future<void> onLoad() async {
-    _redComponent = _AnchorableRectangle(
+    _redComponent = _AnchoredRectangle(
       size: size / 4,
       position: size / 2,
       paint: BasicPalette.red.paint(),
     );
 
-    _blueComponent = _AnchorableRectangle(
+    _blueComponent = _AnchoredRectangle(
       size: size / 8,
       paint: BasicPalette.blue.paint(),
     );
@@ -50,8 +50,8 @@ class AnchorGame extends FlameGame {
   }
 }
 
-class _AnchorableRectangle extends RectangleComponent with TapCallbacks {
-  _AnchorableRectangle({
+class _AnchoredRectangle extends RectangleComponent with TapCallbacks {
+  _AnchoredRectangle({
     super.position,
     super.size,
     super.paint,

--- a/doc/flame/examples/lib/main.dart
+++ b/doc/flame/examples/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:html'; // ignore: avoid_web_libraries_in_flutter
 
+import 'package:doc_flame_examples/anchor.dart';
 import 'package:doc_flame_examples/anchor_by_effect.dart';
 import 'package:doc_flame_examples/anchor_to_effect.dart';
 import 'package:doc_flame_examples/collision_detection.dart';
@@ -73,6 +74,7 @@ void main() {
     'remove_effect': RemoveEffectGame.new,
     'color_effect': ColorEffectExample.new,
     'time_scale': TimeScaleGame.new,
+    'anchor': AnchorGame.new,
   };
   final game = routes[page]?.call();
   if (game != null) {


### PR DESCRIPTION
# Description

This PR add an interactive example to show the parent child relationship when their anchors are changed. It also elaborates the same in written docs as well.

https://user-images.githubusercontent.com/33748002/235361268-7636d25c-5c07-4124-9ce5-de9485b0fb1b.mp4

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2510 