### PR TITLE
fix: Move `errorBuilder` and `loadingBuilder` to constructors

### DIFF
--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -12,19 +12,19 @@ export '../sprite_animation.dart';
 
 /// A [StatelessWidget] that renders a [SpriteAnimation]
 class SpriteAnimationWidget extends StatelessWidget {
-  /// The positioning [Anchor]
+  /// The positioning [Anchor].
   final Anchor anchor;
 
-  /// Should the animation be playing or not
+  /// Whether the animation should be playing or not.
   final bool playing;
 
   final FutureOr<SpriteAnimation> _animationFuture;
   final SpriteAnimationTicker? _animationTicker;
 
-  /// A builder function that is called if the loading fails
+  /// A builder function that is called if the loading fails.
   final WidgetBuilder? errorBuilder;
 
-  /// A builder function that is called while the loading is on the way
+  /// A builder function that is called while the loading is on the way.
   final WidgetBuilder? loadingBuilder;
 
   /// A callback that is called when the animation completes.
@@ -35,12 +35,12 @@ class SpriteAnimationWidget extends StatelessWidget {
     required SpriteAnimationTicker animationTicker,
     this.playing = true,
     this.anchor = Anchor.topLeft,
+    this.errorBuilder,
+    this.loadingBuilder,
+    this.onComplete,
     super.key,
   })  : _animationFuture = animation,
-        _animationTicker = animationTicker,
-        errorBuilder = null,
-        loadingBuilder = null,
-        onComplete = null;
+        _animationTicker = animationTicker;
 
   /// Loads image from the asset [path] and renders it as a widget.
   ///

--- a/packages/flame/lib/src/widgets/sprite_button.dart
+++ b/packages/flame/lib/src/widgets/sprite_button.dart
@@ -51,13 +51,13 @@ class SpriteButton extends StatelessWidget {
     this.srcSize,
     this.pressedSrcPosition,
     this.pressedSrcSize,
+    this.errorBuilder,
+    this.loadingBuilder,
     super.key,
-  })  : _buttonsFuture = [
+  }) : _buttonsFuture = [
           sprite,
           pressedSprite,
-        ],
-        errorBuilder = null,
-        loadingBuilder = null;
+        ];
 
   SpriteButton.future({
     required Future<Sprite> sprite,

--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -39,10 +39,10 @@ class SpriteWidget extends StatelessWidget {
     this.angle = 0,
     this.srcPosition,
     this.srcSize,
+    this.errorBuilder,
+    this.loadingBuilder,
     super.key,
-  })  : _spriteFuture = sprite,
-        errorBuilder = null,
-        loadingBuilder = null;
+  }) : _spriteFuture = sprite;
 
   /// Load the image from the asset [path] and renders it as a widget.
   ///


### PR DESCRIPTION
# Description

To make it consistent with the other constructors, all builders should be settable from the default constructor.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
