### PR TITLE
docs: Remove deprecated mixin from klondike tutorial

### DIFF
--- a/doc/tutorials/klondike/step4.md
+++ b/doc/tutorials/klondike/step4.md
@@ -148,14 +148,7 @@ Now that the waste pile is ready, let's get back to the `StockPile`.
 The second item on our todo list is the first interactive functionality in the game: tap the stock
 pile to deal 3 cards onto the waste.
 
-Adding tap functionality to the components in Flame is quite simple: first, we add the mixin
-`HasTappableComponents` to our top-level game class:
-
-```dart
-class KlondikeGame extends FlameGame with HasTappableComponents { ... }
-```
-
-And second, we add the mixin `TapCallbacks` to the component that we want to be tappable:
+Adding tap functionality to the components in Flame is quite simple: we just add the mixin `TapCallbacks` to the component that we want to be tappable:
 
 ```dart
 class StockPile extends PositionComponent with TapCallbacks { ... }

--- a/doc/tutorials/klondike/step4.md
+++ b/doc/tutorials/klondike/step4.md
@@ -148,7 +148,8 @@ Now that the waste pile is ready, let's get back to the `StockPile`.
 The second item on our todo list is the first interactive functionality in the game: tap the stock
 pile to deal 3 cards onto the waste.
 
-Adding tap functionality to the components in Flame is quite simple: we just add the mixin `TapCallbacks` to the component that we want to be tappable:
+Adding tap functionality to the components in Flame is quite simple: we just add the mixin
+`TapCallbacks` to the component that we want to be tappable:
 
 ```dart
 class StockPile extends PositionComponent with TapCallbacks { ... }


### PR DESCRIPTION
# Description
It just removes a deprecated line that is in the tutorial for building a Klondike game. The final code does not have it and it is no longer necessary to have it in the `KlondikeGame` class.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

No, just docs.

### Migration instructions

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
