### PR TITLE
fix: Reduce the Vector2 creations in Anchor

### DIFF
--- a/packages/flame/lib/src/anchor.dart
+++ b/packages/flame/lib/src/anchor.dart
@@ -54,9 +54,9 @@ class Anchor {
     if (this == otherAnchor) {
       return position;
     } else {
-      // TODO(Any): This should not be creating new Vector2 objects.
-      return position +
-          ((otherAnchor.toVector2() - toVector2())..multiply(size));
+      return Vector2(otherAnchor.x - x, otherAnchor.y - y)
+        ..multiply(size)
+        ..add(position);
     }
   }
 


### PR DESCRIPTION
method in Anchor class creates multiple objects of Vector2. This leads to increased memory usage. This commit reduces the creation of multiple Vector2 to having only one Vector2 created.

# Description
This PR changes/reduces the creation of `Vector2` objects to only one. There is only one method in the `Anchor` class that uses vector2.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [-] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #2543 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
