### PR TITLE
fix: Remove `mustCallSuper` from `onComponentTypeCheck`

### DIFF
--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -302,8 +302,9 @@ class Bullet extends PositionComponent with CollisionCallbacks {
       // do NOT collide with Player or Water
       return false;
     }
-    // Just return true if you not interested in component parent's type check result.
-    // Or call super it component's parent should be able to override the result.
+    // Just return true if you're not interested in the parent's type check result.
+    // Or call super and you will be able to override the result with the parent's
+    // result.
     return super.onComponentTypeCheck(other);
   }
 

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -302,6 +302,8 @@ class Bullet extends PositionComponent with CollisionCallbacks {
       // do NOT collide with Player or Water
       return false;
     }
+    // Just return true if you not interested in component parent's type check result.
+    // Or call super it component's parent should be able to override the result.
     return super.onComponentTypeCheck(other);
   }
 

--- a/packages/flame/lib/src/collisions/collision_callbacks.dart
+++ b/packages/flame/lib/src/collisions/collision_callbacks.dart
@@ -79,7 +79,6 @@ mixin GenericCollisionCallbacks<T> {
   /// reimplement [onComponentTypeCheck]. The result of calculation is cached
   /// so you should not check any dynamical parameters here, the function
   /// intended to be used as pure type checker.
-  @mustCallSuper
   bool onComponentTypeCheck(PositionComponent other);
 
   /// Assign your own [CollisionCallback] if you want a callback when this
@@ -136,7 +135,6 @@ mixin CollisionCallbacks on Component
   }
 
   @override
-  @mustCallSuper
   bool onComponentTypeCheck(PositionComponent other) {
     final myParent = parent;
     final otherParent = other.parent;

--- a/packages/flame/lib/src/collisions/collision_callbacks.dart
+++ b/packages/flame/lib/src/collisions/collision_callbacks.dart
@@ -79,8 +79,8 @@ mixin GenericCollisionCallbacks<T> {
   /// reimplement [onComponentTypeCheck]. The result of calculation is cached
   /// so you should not check any dynamical parameters here, the function
   /// intended to be used as pure type checker.
-  /// Call super.onComponentTypeCheck to get component parent's result of
-  /// type check if needed. In other causes this call is redundant in game code
+  /// Call super.onComponentTypeCheck to get the parent's result of the
+  /// type check if needed. In other causes this call is redundant in game code.
   bool onComponentTypeCheck(PositionComponent other);
 
   /// Assign your own [CollisionCallback] if you want a callback when this

--- a/packages/flame/lib/src/collisions/collision_callbacks.dart
+++ b/packages/flame/lib/src/collisions/collision_callbacks.dart
@@ -79,6 +79,8 @@ mixin GenericCollisionCallbacks<T> {
   /// reimplement [onComponentTypeCheck]. The result of calculation is cached
   /// so you should not check any dynamical parameters here, the function
   /// intended to be used as pure type checker.
+  /// Call super.onComponentTypeCheck to get component parent's result of
+  /// type check if needed. In other causes this call is redundant in game code
   bool onComponentTypeCheck(PositionComponent other);
 
   /// Assign your own [CollisionCallback] if you want a callback when this


### PR DESCRIPTION
# Description

@mustCallSuper is very strict requirement. This is true only for hitboxes and internal engine's logic, but unnecessary for other, "client-side" game components.
When overriding `onComponentTypeCheck` for component you can simple return true or false and this would not break anything.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.
