### PR TITLE
feat: Add useful methods to Rectangle class

### DIFF
--- a/packages/flame/lib/src/experimental/geometry/shapes/rectangle.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/rectangle.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'dart:ui';
 
+import 'package:flame/geometry.dart';
 import 'package:flame/src/experimental/geometry/shapes/shape.dart';
 import 'package:flame/src/game/transform2d.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -39,8 +40,21 @@ class Rectangle extends Shape {
   factory Rectangle.fromPoints(Vector2 a, Vector2 b) =>
       Rectangle.fromLTRB(a.x, a.y, b.x, b.y);
 
+  /// Constructs a [Rectangle] from a [Rect].
   factory Rectangle.fromRect(Rect rect) =>
       Rectangle.fromLTRB(rect.left, rect.top, rect.right, rect.bottom);
+
+  /// Constructs a [Rectangle] from a center point and a size.
+  factory Rectangle.fromCenter({
+    required Vector2 center,
+    required Vector2 size,
+  }) {
+    final halfSize = size / 2;
+    return Rectangle.fromPoints(
+      center - halfSize,
+      center + halfSize,
+    );
+  }
 
   double _left;
   double _top;
@@ -69,6 +83,8 @@ class Rectangle extends Shape {
 
   @override
   double get perimeter => 2 * (width + height);
+
+  double get area => width * height;
 
   @override
   Path asPath() {
@@ -133,6 +149,30 @@ class Rectangle extends Shape {
         (point.y).clamp(_top, _bottom),
       );
   }
+
+  Rect toRect() => Rect.fromLTWH(left, top, width, height);
+
+  /// Returns all intersections between this rectangle's edges and the given
+  /// line segment.
+  Set<Vector2> intersections(LineSegment line) {
+    return edges.expand((e) => e.intersections(line)).toSet();
+  }
+
+  /// The 4 edges of this rectangle, returned in a clockwise fashion.
+  List<LineSegment> get edges => [topEdge, rightEdge, bottomEdge, leftEdge];
+
+  LineSegment get topEdge => LineSegment(topLeft, topRight);
+  LineSegment get rightEdge => LineSegment(topRight, bottomRight);
+  LineSegment get bottomEdge => LineSegment(bottomRight, bottomLeft);
+  LineSegment get leftEdge => LineSegment(bottomLeft, topLeft);
+
+  /// The 4 corners of this rectangle, returned in a clockwise fashion.
+  List<Vector2> get vertices => [topLeft, topRight, bottomRight, bottomLeft];
+
+  Vector2 get topLeft => Vector2(left, top);
+  Vector2 get topRight => Vector2(right, top);
+  Vector2 get bottomRight => Vector2(right, bottom);
+  Vector2 get bottomLeft => Vector2(left, bottom);
 
   @override
   String toString() => 'Rectangle([$_left, $_top], [$_right, $_bottom])';

--- a/packages/flame/test/experimental/geometry/shapes/rectangle_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/rectangle_test.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
+import 'package:flame/geometry.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -18,6 +19,7 @@ void main() {
       expect(rectangle.isConvex, true);
       expect(rectangle.isClosed, true);
       expect(rectangle.perimeter, 34);
+      expect(rectangle.area, 60);
       expect(rectangle.center, closeToVector(Vector2(6.5, 6)));
       expect('$rectangle', 'Rectangle([4.0, 0.0], [9.0, 12.0])');
     });
@@ -51,6 +53,17 @@ void main() {
         expect(rectangle.top, 8);
         expect(rectangle.bottom, 9);
       }
+    });
+
+    test('.fromCenter', () {
+      final rectangle = Rectangle.fromCenter(
+        center: Vector2.zero(),
+        size: Vector2(10.0, 2.0),
+      );
+      expect(rectangle.left, -5);
+      expect(rectangle.top, -1);
+      expect(rectangle.right, 5);
+      expect(rectangle.bottom, 1);
     });
 
     test('.fromRect', () {
@@ -223,5 +236,57 @@ void main() {
       expect(rectangle.nearestPoint(Vector2(17, 1)), Vector2(5, 1));
       expect(rectangle.nearestPoint(Vector2(8, -2)), Vector2(5, 0));
     });
+  });
+
+  test('edges and vertices', () {
+    final rectangle = Rectangle.fromCenter(
+      center: Vector2.zero(),
+      size: Vector2(10.0, 2.0),
+    );
+    expect(rectangle.topLeft, Vector2(-5, -1));
+    expect(rectangle.topRight, Vector2(5, -1));
+    expect(rectangle.bottomLeft, Vector2(-5, 1));
+    expect(rectangle.bottomRight, Vector2(5, 1));
+
+    expect(rectangle.topEdge.from, Vector2(-5, -1));
+    expect(rectangle.topEdge.to, Vector2(5, -1));
+    expect(rectangle.rightEdge.from, Vector2(5, -1));
+    expect(rectangle.rightEdge.to, Vector2(5, 1));
+    expect(rectangle.bottomEdge.from, Vector2(5, 1));
+    expect(rectangle.bottomEdge.to, Vector2(-5, 1));
+    expect(rectangle.leftEdge.from, Vector2(-5, 1));
+    expect(rectangle.leftEdge.to, Vector2(-5, -1));
+  });
+
+  test('intersections', () {
+    final rectangle = Rectangle.fromCenter(
+      center: Vector2.zero(),
+      size: Vector2(2.0, 2.0),
+    );
+    expect(
+      rectangle.intersections(LineSegment(Vector2.zero(), Vector2(0, -2))),
+      [Vector2(0, -1)],
+    );
+    expect(
+      rectangle.intersections(LineSegment(Vector2.zero(), Vector2(0, 2))),
+      [Vector2(0, 1)],
+    );
+    expect(
+      rectangle.intersections(LineSegment(Vector2(-2, 0), Vector2.zero())),
+      [Vector2(-1, 0)],
+    );
+    expect(
+      rectangle.intersections(LineSegment(Vector2(2, 0), Vector2.zero())),
+      [Vector2(1, 0)],
+    );
+
+    expect(
+      rectangle.intersections(LineSegment(Vector2(2, 2), Vector2(-2, -2))),
+      unorderedMatches([Vector2(1, 1), Vector2(-1, -1)]),
+    );
+    expect(
+      rectangle.intersections(LineSegment(Vector2(-2, 2), Vector2(2, -2))),
+      unorderedMatches([Vector2(-1, 1), Vector2(1, -1)]),
+    );
   });
 }


### PR DESCRIPTION
# Description

Add useful methods to Rectangle class:

* a fromCenter constructor
* an `area` getter
* edges and vertices
* intersections with Line Segment
* toRect()

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
