### PR TITLE
fix: Update step3.md to use correct constructor name

### DIFF
--- a/doc/tutorials/klondike/step3.md
+++ b/doc/tutorials/klondike/step3.md
@@ -98,7 +98,7 @@ import 'package:flutter/foundation.dart';
 
 @immutable
 class Rank {
-  factory Rank.of(int value) {
+  factory Rank.fromInt(int value) {
     assert(value >= 1 && value <= 13);
     return _singletons[value - 1];
   }


### PR DESCRIPTION

# Description
In the tutorial, the code that relies on `Rank` uses the `.fromInt` constructor, not `.of`



## Checklist

- [x ] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [+] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

### Migration instructions

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.

