### PR TITLE
fix: Animation ticker readability improvements

### DIFF
--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -545,9 +545,9 @@ final animation = SpriteAnimation.spriteList(sprites, stepTime: 0.01);
 
 final animationTicker = SpriteAnimationTicker(animation);
 
-// or alternatively
+// or alternatively, you can ask the animation object to create one for you.
 
-final animationTicker = animation.ticker(); // creates a new ticker
+final animationTicker = animation.createTicker(); // creates a new ticker
 
 animationTicker.update(dt);
 ```
@@ -590,7 +590,7 @@ final animationTicker = SpriteAnimationTicker(animation)
 ```
 
 
-## SpriteAnimationGroup
+## SpriteAnimationGroupComponent
 
 `SpriteAnimationGroupComponent` is a simple wrapper around `SpriteAnimationComponent` which enables
 your component to hold several animations and change the current playing animation at runtime. Since
@@ -624,6 +624,43 @@ final robot = SpriteAnimationGroupComponent<RobotState>(
 robot.current = RobotState.running;
 ```
 
+As this component works with multiple `SpriteAnimation`s, naturally it needs equal number of animation
+tickers to make all those animation tick. Use `animationsTickers` getter to access a map containing tickers
+for each animation state. This can be useful if you want to register callbacks for `onStart`, `onComplete`
+and `onFrame`.
+
+Example:
+
+```dart
+enum RobotState { idle, running, jump }
+
+final running = await loadSpriteAnimation(/* omitted */);
+final idle = await loadSpriteAnimation(/* omitted */);
+
+final robot = SpriteAnimationGroupComponent<RobotState>(
+  animations: {
+    RobotState.running: running,
+    RobotState.idle: idle,
+  },
+  current: RobotState.idle,
+);
+
+robot.animationTickers?[RobotState.running]?.onStart = () {
+  // Do something on start of running animation.
+};
+
+robot.animationTickers?[RobotState.jump]?.onStart = () {
+  // Do something on start of jump animation.
+};
+
+robot.animationTickers?[RobotState.jump]?.onComplete = () {
+  // Do something on complete of jump animation.
+};
+
+robot.animationTickers?[RobotState.idle]?.onFrame = (currentIndex) {
+  // Do something based on current frame index of idle animation.
+};
+```
 
 ## SpriteGroup
 

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -662,6 +662,7 @@ robot.animationTickers?[RobotState.idle]?.onFrame = (currentIndex) {
 };
 ```
 
+
 ## SpriteGroup
 
 `SpriteGroupComponent` is pretty similar to its animation counterpart, but especially for sprites.

--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -48,7 +48,7 @@ class SpriteAnimationComponent extends PositionComponent
           '''If size is set, autoResize should be false or size should be null when autoResize is true.''',
         ),
         _autoResize = autoResize ?? size == null,
-        _animationTicker = animation?.ticker() {
+        _animationTicker = animation?.createTicker() {
     if (paint != null) {
       this.paint = paint;
     }
@@ -112,7 +112,7 @@ class SpriteAnimationComponent extends PositionComponent
   set animation(SpriteAnimation? value) {
     if (animation != value) {
       if (value != null) {
-        _animationTicker = value.ticker();
+        _animationTicker = value.createTicker();
       } else {
         _animationTicker = null;
       }

--- a/packages/flame/lib/src/components/sprite_animation_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_group_component.dart
@@ -55,7 +55,7 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
         _animationTickers = animations != null
             ? Map.fromEntries(
                 animations.entries
-                    .map((e) => MapEntry(e.key, e.value.ticker()))
+                    .map((e) => MapEntry(e.key, e.value.createTicker()))
                     .toList(),
               )
             : null {
@@ -137,7 +137,7 @@ class SpriteAnimationGroupComponent<T> extends PositionComponent
       _animationTickers = _animations != null
           ? Map.fromEntries(
               _animations!.entries
-                  .map((e) => MapEntry(e.key, e.value.ticker()))
+                  .map((e) => MapEntry(e.key, e.value.createTicker()))
                   .toList(),
             )
           : null;

--- a/packages/flame/lib/src/parallax.dart
+++ b/packages/flame/lib/src/parallax.dart
@@ -171,7 +171,7 @@ class ParallaxAnimation extends ParallaxRenderer {
     super.repeat,
     super.alignment,
     super.fill,
-  }) : _animationTicker = animation.ticker();
+  }) : _animationTicker = animation.createTicker();
 
   /// Takes a path of an image, a SpriteAnimationData, and optionally arguments
   /// for how the image should repeat ([repeat]), which edge it should align

--- a/packages/flame/lib/src/particles/sprite_animation_particle.dart
+++ b/packages/flame/lib/src/particles/sprite_animation_particle.dart
@@ -26,7 +26,7 @@ class SpriteAnimationParticle extends Particle {
     this.overridePaint,
     super.lifespan,
     this.alignAnimationTime = true,
-  }) : animationTicker = animation.ticker();
+  }) : animationTicker = animation.createTicker();
 
   @override
   void setLifespan(double lifespan) {

--- a/packages/flame/lib/src/sprite_animation.dart
+++ b/packages/flame/lib/src/sprite_animation.dart
@@ -283,7 +283,11 @@ class SpriteAnimation {
   }
 
   /// Returns a new instance of [SpriteAnimationTicker].
+  @Deprecated('Will be removed in Flame v1.9, use createTicker() instead.')
   SpriteAnimationTicker ticker() {
     return SpriteAnimationTicker(this);
   }
+
+  /// Creates and returns a new [SpriteAnimationTicker].
+  SpriteAnimationTicker createTicker() => SpriteAnimationTicker(this);
 }

--- a/packages/flame/lib/src/widgets/animation_widget.dart
+++ b/packages/flame/lib/src/widgets/animation_widget.dart
@@ -66,7 +66,7 @@ class SpriteAnimationWidget extends StatelessWidget {
     return BaseFutureBuilder<SpriteAnimation>(
       future: _animationFuture,
       builder: (_, spriteAnimation) {
-        final ticker = _animationTicker ?? spriteAnimation.ticker();
+        final ticker = _animationTicker ?? spriteAnimation.createTicker();
         ticker.completed.then((_) => onComplete?.call());
 
         return InternalSpriteAnimationWidget(

--- a/packages/flame/test/components/sprite_animation_component_test.dart
+++ b/packages/flame/test/components/sprite_animation_component_test.dart
@@ -16,8 +16,8 @@ Future<void> main() async {
           loop: false,
         );
         final copy = animation.clone();
-        final ticker1 = animation.ticker();
-        final ticker2 = copy.ticker();
+        final ticker1 = animation.createTicker();
+        final ticker2 = copy.createTicker();
 
         expect(copy.loop, animation.loop);
 
@@ -39,8 +39,8 @@ Future<void> main() async {
           loop: false,
         );
         final copy = animation.reversed();
-        final ticker1 = animation.ticker();
-        final ticker2 = copy.ticker();
+        final ticker1 = animation.createTicker();
+        final ticker2 = copy.createTicker();
 
         expect(copy.loop, animation.loop);
 
@@ -216,7 +216,7 @@ Future<void> main() async {
         List.filled(5, Sprite(image)),
         stepTime: 0.1,
         loop: false,
-      ).ticker();
+      ).createTicker();
       var callbackInvoked = 0;
       animation.onComplete = () {
         callbackInvoked++;

--- a/packages/flame/test/sprite_animation_ticker_test.dart
+++ b/packages/flame/test/sprite_animation_ticker_test.dart
@@ -10,7 +10,7 @@ void main() {
       final sprite = MockSprite();
       final animationTicker =
           SpriteAnimation.spriteList([sprite], stepTime: 1, loop: false)
-              .ticker()
+              .createTicker()
             ..onStart = () => counter++;
 
       expect(counter, 0);
@@ -25,7 +25,7 @@ void main() {
       final sprite = MockSprite();
       final animationTicker =
           SpriteAnimation.spriteList([sprite], stepTime: 1, loop: false)
-              .ticker()
+              .createTicker()
             ..onComplete = () => counter++;
       expect(counter, 0);
       animationTicker.update(0.5);
@@ -46,7 +46,7 @@ void main() {
       final spriteList = [sprite, sprite, sprite];
       final animationTicker =
           SpriteAnimation.spriteList(spriteList, stepTime: 1, loop: false)
-              .ticker();
+              .createTicker();
       animationTicker.onFrame = (index) {
         expect(timePassed, closeTo(index * 1.0, dt));
         timesCalled++;
@@ -65,7 +65,7 @@ void main() {
       final sprite = MockSprite();
       final animationTicker =
           SpriteAnimation.spriteList([sprite], stepTime: 1, loop: false)
-              .ticker();
+              .createTicker();
       animationTicker.onStart = () {
         expect(animationStarted, false);
         expect(animationRunning, false);
@@ -94,7 +94,7 @@ void main() {
         [sprite],
         stepTime: 1,
         loop: false,
-      ).ticker();
+      ).createTicker();
 
       expectLater(animationTicker.completed, completes);
 
@@ -108,7 +108,7 @@ void main() {
         [sprite],
         stepTime: 1,
         loop: false,
-      ).ticker();
+      ).createTicker();
 
       animationTicker.update(1);
       expectLater(animationTicker.completed, completes);
@@ -121,7 +121,7 @@ void main() {
         [sprite],
         stepTime: 1,
         loop: false,
-      ).ticker();
+      ).createTicker();
 
       expectLater(animationTicker.completed, doesNotComplete);
     });
@@ -129,7 +129,7 @@ void main() {
     test("completed doesn't complete when animation is looping", () async {
       final sprite = MockSprite();
       final animationTicker =
-          SpriteAnimation.spriteList([sprite], stepTime: 1).ticker();
+          SpriteAnimation.spriteList([sprite], stepTime: 1).createTicker();
 
       expectLater(animationTicker.completed, doesNotComplete);
     });
@@ -139,7 +139,7 @@ void main() {
       () async {
         final sprite = MockSprite();
         final animationTicker =
-            SpriteAnimation.spriteList([sprite], stepTime: 1).ticker();
+            SpriteAnimation.spriteList([sprite], stepTime: 1).createTicker();
 
         animationTicker.update(1);
         expectLater(animationTicker.completed, doesNotComplete);

--- a/packages/flame/test/spritesheet_test.dart
+++ b/packages/flame/test/spritesheet_test.dart
@@ -32,7 +32,7 @@ void main() {
       final animationTicker = spriteSheet.createAnimationWithVariableStepTimes(
         row: 1,
         stepTimes: [2.0, 3.0],
-      ).ticker();
+      ).createTicker();
 
       expect(animationTicker.totalDuration(), 5.0);
     });

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -24,7 +24,7 @@ Future<void> main() async {
       await tester.pumpWidget(
         SpriteAnimationWidget(
           animation: spriteAnimation,
-          animationTicker: spriteAnimation.ticker(),
+          animationTicker: spriteAnimation.createTicker(),
         ),
       );
 


### PR DESCRIPTION
# Description

This PR marks `SpriteAnimation.ticker()` as deprecated with `SpriteAnimation.createTicker()` as a replacement. This is done to make it more clear that calling that method creates a new ticker. Also, the docs for `SpriteAnimationGroupComponent` are updated with code snippet showing how to access and use the callbacks from tickers of each animation state.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

N/A

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
