### PR TITLE
docs: Update step4.md to use `!isFaceUp` instead of nonexistent `isFaceDown`

### DIFF
--- a/doc/tutorials/klondike/step4.md
+++ b/doc/tutorials/klondike/step4.md
@@ -726,7 +726,7 @@ class TableauPile ... implements Pile {
     assert(_cards.contains(card) && card.isFaceUp);
     final index = _cards.indexOf(card);
     _cards.removeRange(index, _cards.length);
-    if (_cards.isNotEmpty && _cards.last.isFaceDown) {
+    if (_cards.isNotEmpty && !_cards.last.isFaceUp) {
       flipTopCard();
     }
   }
@@ -840,7 +840,7 @@ would be to ensure that all cards currently in the pile have the right positions
     for (var i = 1; i < _cards.length; i++) {
       _cards[i].position
         ..setFrom(_cards[i - 1].position)
-        ..add(_cards[i - 1].isFaceDown ? _fanOffset1 : _fanOffset2);
+        ..add(!_cards[i - 1].isFaceUp ? _fanOffset1 : _fanOffset2);
     }
   }
 ```

--- a/doc/tutorials/klondike/step4.md
+++ b/doc/tutorials/klondike/step4.md
@@ -441,7 +441,7 @@ after that we put the remaining cards into the stock. Also, the `flipTopCard` me
 
 ```dart
   void flipTopCard() {
-    assert(_cards.last.!isFaceUp);
+    assert(!_cards.last.isFaceUp);
     _cards.last.flip();
   }
 ```

--- a/doc/tutorials/klondike/step4.md
+++ b/doc/tutorials/klondike/step4.md
@@ -441,7 +441,7 @@ after that we put the remaining cards into the stock. Also, the `flipTopCard` me
 
 ```dart
   void flipTopCard() {
-    assert(_cards.last.isFaceDown);
+    assert(_cards.last.!isFaceUp);
     _cards.last.flip();
   }
 ```


### PR DESCRIPTION


# Description
`isFaceDown` does not exist on `Card`. Instead, use `!isFaceUp`



## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

