### PR TITLE
feat: TiledAtlas.clearCache function

### DIFF
--- a/doc/bridge_packages/flame_tiled/flame_tiled.md
+++ b/doc/bridge_packages/flame_tiled/flame_tiled.md
@@ -42,8 +42,8 @@ final component = await TiledComponent.load(
 
 ### Clearing images cache
 
-If you have called `Flame.images.clearCache()` you also need to call `TiledAtlas.clearCache()` to 
-remove disposed images from tiled cache. It might be useful if you next game map have completely 
+If you have called `Flame.images.clearCache()` you also need to call `TiledAtlas.clearCache()` to
+remove disposed images from tiled cache. It might be useful if you next game map have completely
 different tiles than previous.
 
 [Tiled]: https://www.mapeditor.org/

--- a/doc/bridge_packages/flame_tiled/flame_tiled.md
+++ b/doc/bridge_packages/flame_tiled/flame_tiled.md
@@ -44,7 +44,7 @@ final component = await TiledComponent.load(
 ### Clearing images cache
 
 If you have called `Flame.images.clearCache()` you also need to call `TiledAtlas.clearCache()` to
-remove disposed images from tiled cache. It might be useful if you next game map have completely
+remove disposed images from the tiled cache. It might be useful if your next game map have completely
 different tiles than previous.
 
 [Tiled]: https://www.mapeditor.org/

--- a/doc/bridge_packages/flame_tiled/flame_tiled.md
+++ b/doc/bridge_packages/flame_tiled/flame_tiled.md
@@ -40,6 +40,12 @@ final component = await TiledComponent.load(
 );
 ```
 
+### Clearing images cache
+
+If you have called `Flame.images.clearCache()` you also need to call `TiledAtlas.clearCache()` to 
+remove disposed images from tiled cache. It might be useful if you next game map have completely 
+different tiles than previous.
+
 [Tiled]: https://www.mapeditor.org/
 
 ```{toctree}

--- a/doc/bridge_packages/flame_tiled/flame_tiled.md
+++ b/doc/bridge_packages/flame_tiled/flame_tiled.md
@@ -40,6 +40,7 @@ final component = await TiledComponent.load(
 );
 ```
 
+
 ### Clearing images cache
 
 If you have called `Flame.images.clearCache()` you also need to call `TiledAtlas.clearCache()` to

--- a/doc/bridge_packages/flame_tiled/flame_tiled.md
+++ b/doc/bridge_packages/flame_tiled/flame_tiled.md
@@ -45,7 +45,7 @@ final component = await TiledComponent.load(
 
 If you have called `Flame.images.clearCache()` you also need to call `TiledAtlas.clearCache()` to
 remove disposed images from the tiled cache. It might be useful if your next game map have completely
-different tiles than previous.
+different tiles than the previous.
 
 [Tiled]: https://www.mapeditor.org/
 

--- a/packages/flame_tiled/lib/src/tile_atlas.dart
+++ b/packages/flame_tiled/lib/src/tile_atlas.dart
@@ -156,4 +156,10 @@ class TiledAtlas {
       key: key,
     );
   }
+
+  /// If you called `Flame.images.clearCache()` you also need to call this
+  /// function to clear disposed images from tiled cache.
+  static void clearCache() {
+    atlasMap.clear();
+  }
 }

--- a/packages/flame_tiled/lib/src/tile_atlas.dart
+++ b/packages/flame_tiled/lib/src/tile_atlas.dart
@@ -157,6 +157,8 @@ class TiledAtlas {
     );
   }
 
+  /// Clears images cached in `TiledAtlas`
+  ///
   /// If you called `Flame.images.clearCache()` you also need to call this
   /// function to clear disposed images from tiled cache.
   static void clearCache() {

--- a/packages/flame_tiled/test/tile_atlas_test.dart
+++ b/packages/flame_tiled/test/tile_atlas_test.dart
@@ -121,6 +121,18 @@ void main() {
           matchesGoldenFile('goldens/larger_atlas_component.png'),
         );
       });
+
+      test('clearing cache', () async {
+        await TiledAtlas.fromTiledMap(
+          simpleMap,
+        );
+
+        expect(TiledAtlas.atlasMap.isNotEmpty, true);
+
+        TiledAtlas.clearCache();
+
+        expect(TiledAtlas.atlasMap.isEmpty, true);
+      });
     });
 
     group('Single tileset map', () {


### PR DESCRIPTION
# Description

Possibility to clear TiledAtlas cache. This is required after `Flame.images.clearCache()` call. 

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2585

