### PR TITLE
feat: Option to prevent propagating collision events from ShapeHitbox to _hitboxParent

### DIFF
--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -138,6 +138,7 @@ initiate hitboxes and it is with the normal constructor where you define the hit
 a size and a position etc. The other way is to use the `relative` constructor which defines the
 hitbox in relation to the size of its intended parent.
 
+
 In some specific cases you might want to handle collisions only between hitboxes, without
 propagating `onCollision*` events to the hitbox's parent component. For example, a vehicle could have a
 body hitbox to control collisions and side hitboxes to check the possibility to turn left or right.

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -139,9 +139,9 @@ a size and a position etc. The other way is to use the `relative` constructor wh
 hitbox in relation to the size of its intended parent.
 
 In some specific cases you might want to handle collisions only between hitboxes, without
-propagating 'onCollision*' events to hitbox's parent component. For example, a vehicle could have
-body hitbox to control collisions and side hitboxes to check availability to turn left or right.
-So, colliding with body hitbox means a collision with component itself, whereas colliding with side
+propagating `onCollision*` events to the hitbox's parent component. For example, a vehicle could have a
+body hitbox to control collisions and side hitboxes to check the possibility to turn left or right.
+So, colliding with a body hitbox means colliding with the component itself, whereas colliding with a side
 hitbox does not mean a real collision and should not be propagated to hitbox's parent.
 For this case you can set `triggersParentCollision` variable to `false`:
 

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -140,10 +140,11 @@ hitbox in relation to the size of its intended parent.
 
 
 In some specific cases you might want to handle collisions only between hitboxes, without
-propagating `onCollision*` events to the hitbox's parent component. For example, a vehicle could have a
-body hitbox to control collisions and side hitboxes to check the possibility to turn left or right.
-So, colliding with a body hitbox means colliding with the component itself, whereas colliding with a side
-hitbox does not mean a real collision and should not be propagated to hitbox's parent.
+propagating `onCollision*` events to the hitbox's parent component. For example, a vehicle could
+have a body hitbox to control collisions and side hitboxes to check the possibility to turn left
+or right.
+So, colliding with a body hitbox means colliding with the component itself, whereas colliding with
+a side hitbox does not mean a real collision and should not be propagated to hitbox's parent.
 For this case you can set `triggersParentCollision` variable to `false`:
 
 ```dart

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -138,6 +138,42 @@ initiate hitboxes and it is with the normal constructor where you define the hit
 a size and a position etc. The other way is to use the `relative` constructor which defines the
 hitbox in relation to the size of its intended parent.
 
+In some specific cases you might want to handle collisions only between hitboxes, without
+propagating 'onCollision*' events to hitbox's parent component. For example, a vehicle could have
+body hitbox to control collisions and side hitboxes to check availability to turn left or right.
+So, colliding with body hitbox means a collision with component itself, whereas colliding with side
+hitbox does not mean a real collision and should not be propagated to hitbox's parent.
+For this case you can set `triggersParentCollision` variable to `false`:
+
+```dart
+class MyComponent extends PositionComponent {
+
+  late final MySpecialHitbox utilityHitbox;
+
+  @override
+  void onLoad() {
+    utilityHitbox = MySpecialHitbox();
+    add(utilityHitbox);
+  }
+
+  void update(double dt) {
+    if (utilityHitbox.isColliding) {
+      // do some specific things if hitbox is colliding
+    }
+  }
+// component's onCollision* functions, ignoring MySpecialHitbox collisions.
+}
+
+class MySpecialHitbox extends RectangleHitbox {
+  MySpecialHitbox() {
+    triggersParentCollision = false;
+  }
+
+// hitbox specific onCollision* functions
+
+}
+```
+
 You can read more about how the different shapes are defined in the
 [ShapeComponents](components.md#shapecomponents) section.
 

--- a/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
@@ -27,6 +27,10 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   /// added to the same parent.
   bool allowSiblingCollision = false;
 
+  /// Whether the hitbox collision with other hitbox should trigger
+  /// "onCollision" functions for hitbox's parent component.
+  bool triggersParentCollision = true;
+
   @override
   Aabb2 get aabb => _validAabb ? _aabb : _recalculateAabb();
   final Aabb2 _aabb = Aabb2();
@@ -182,7 +186,7 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   @mustCallSuper
   void onCollision(Set<Vector2> intersectionPoints, ShapeHitbox other) {
     onCollisionCallback?.call(intersectionPoints, other);
-    if (hitboxParent is CollisionCallbacks) {
+    if (hitboxParent is CollisionCallbacks && triggersParentCollision) {
       (hitboxParent as CollisionCallbacks).onCollision(
         intersectionPoints,
         other.hitboxParent,
@@ -195,7 +199,7 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   void onCollisionStart(Set<Vector2> intersectionPoints, ShapeHitbox other) {
     activeCollisions.add(other);
     onCollisionStartCallback?.call(intersectionPoints, other);
-    if (hitboxParent is CollisionCallbacks) {
+    if (hitboxParent is CollisionCallbacks && triggersParentCollision) {
       (hitboxParent as CollisionCallbacks).onCollisionStart(
         intersectionPoints,
         other.hitboxParent,
@@ -208,7 +212,7 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   void onCollisionEnd(ShapeHitbox other) {
     activeCollisions.remove(other);
     onCollisionEndCallback?.call(other);
-    if (hitboxParent is CollisionCallbacks) {
+    if (hitboxParent is CollisionCallbacks && triggersParentCollision) {
       (hitboxParent as CollisionCallbacks).onCollisionEnd(other.hitboxParent);
     }
   }

--- a/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
@@ -27,8 +27,8 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   /// added to the same parent.
   bool allowSiblingCollision = false;
 
-  /// Whether the hitbox collision with other hitbox should trigger
-  /// "onCollision" functions for hitbox's parent component.
+  /// Whether hitbox collisions with other hitboxes should trigger the
+  /// "onCollision" functions for the hitbox's parent component.
   bool triggersParentCollision = true;
 
   @override

--- a/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
@@ -65,6 +65,7 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   bool renderShape = false;
 
   late PositionComponent _hitboxParent;
+
   PositionComponent get hitboxParent => _hitboxParent;
   void Function()? _parentSizeListener;
   @protected
@@ -186,7 +187,9 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   @mustCallSuper
   void onCollision(Set<Vector2> intersectionPoints, ShapeHitbox other) {
     onCollisionCallback?.call(intersectionPoints, other);
-    if (hitboxParent is CollisionCallbacks && triggersParentCollision) {
+    if (hitboxParent is CollisionCallbacks &&
+        triggersParentCollision &&
+        other.triggersParentCollision) {
       (hitboxParent as CollisionCallbacks).onCollision(
         intersectionPoints,
         other.hitboxParent,
@@ -199,7 +202,9 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   void onCollisionStart(Set<Vector2> intersectionPoints, ShapeHitbox other) {
     activeCollisions.add(other);
     onCollisionStartCallback?.call(intersectionPoints, other);
-    if (hitboxParent is CollisionCallbacks && triggersParentCollision) {
+    if (hitboxParent is CollisionCallbacks &&
+        triggersParentCollision &&
+        other.triggersParentCollision) {
       (hitboxParent as CollisionCallbacks).onCollisionStart(
         intersectionPoints,
         other.hitboxParent,
@@ -212,7 +217,9 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   void onCollisionEnd(ShapeHitbox other) {
     activeCollisions.remove(other);
     onCollisionEndCallback?.call(other);
-    if (hitboxParent is CollisionCallbacks && triggersParentCollision) {
+    if (hitboxParent is CollisionCallbacks &&
+        triggersParentCollision &&
+        other.triggersParentCollision) {
       (hitboxParent as CollisionCallbacks).onCollisionEnd(other.hitboxParent);
     }
   }
@@ -249,5 +256,5 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
   @override
   CollisionEndCallback<ShapeHitbox>? onCollisionEndCallback;
 
-  //#endregion
+//#endregion
 }

--- a/packages/flame/test/collisions/collision_callback_test.dart
+++ b/packages/flame/test/collisions/collision_callback_test.dart
@@ -403,6 +403,52 @@ void main() {
       expect(blockA.endCounter, 1);
       expect(blockB.endCounter, 1);
     },
+    'component collision callbacks are not called with hitbox '
+        'triggersParentCollision option': (game) async {
+      final utilityHitboxA = TestHitbox()..triggersParentCollision = false;
+      final blockA = TestBlock(
+        Vector2.all(10),
+        Vector2.all(10),
+      );
+      blockA.add(utilityHitboxA);
+
+      final utilityHitboxB = TestHitbox()..triggersParentCollision = false;
+      final blockB = TestBlock(
+        Vector2.all(15),
+        Vector2.all(10),
+      );
+      blockB.add(utilityHitboxB);
+      await game.ensureAddAll([blockA, blockB]);
+
+      game.update(0);
+      expect(blockA.startCounter, 1);
+      expect(blockB.startCounter, 1);
+      expect(blockA.onCollisionCounter, 1);
+      expect(blockB.onCollisionCounter, 1);
+      expect(blockA.endCounter, 0);
+      expect(blockB.endCounter, 0);
+      expect(utilityHitboxA.startCounter, 2);
+      expect(utilityHitboxB.startCounter, 2);
+      expect(utilityHitboxA.onCollisionCounter, 2);
+      expect(utilityHitboxB.onCollisionCounter, 2);
+      expect(utilityHitboxA.endCounter, 0);
+      expect(utilityHitboxB.endCounter, 0);
+
+      blockB.position = Vector2(30, 30);
+      game.update(0);
+      expect(blockA.startCounter, 1);
+      expect(blockB.startCounter, 1);
+      expect(blockA.onCollisionCounter, 1);
+      expect(blockB.onCollisionCounter, 1);
+      expect(blockA.endCounter, 1);
+      expect(blockB.endCounter, 1);
+      expect(utilityHitboxA.startCounter, 2);
+      expect(utilityHitboxB.startCounter, 2);
+      expect(utilityHitboxA.onCollisionCounter, 2);
+      expect(utilityHitboxB.onCollisionCounter, 2);
+      expect(utilityHitboxA.endCounter, 2);
+      expect(utilityHitboxB.endCounter, 2);
+    },
 
     // Reproduced #1478
     'collision callbacks with many hitboxes added': (game) async {


### PR DESCRIPTION
# Description

See #2590 

Added `triggersParentCollision` variable to `ShapeHitbox` class to prevent propogating `onCollision*` events to parent component

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2590 
