### PR TITLE
fix!: Convert PositionEvent.canvasPosition to local coordinates

### DIFF
--- a/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
@@ -42,7 +42,7 @@ class DoubleTapDispatcher extends Component with HasGameRef<FlameGame> {
         DoubleTapGestureRecognizer.new,
         (DoubleTapGestureRecognizer instance) {
           instance.onDoubleTapDown =
-              (details) => _onDoubleTapDown(DoubleTapDownEvent(details));
+              (details) => _onDoubleTapDown(DoubleTapDownEvent(game, details));
           instance.onDoubleTapCancel =
               () => _onDoubleTapCancel(DoubleTapCancelEvent());
           instance.onDoubleTap = () => _onDoubleTapUp(DoubleTapEvent());

--- a/packages/flame/lib/src/events/flame_game_mixins/has_draggable_components.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/has_draggable_components.dart
@@ -140,13 +140,13 @@ class MultiDragDispatcher extends Component implements MultiDragListener {
   @internal
   @override
   void handleDragStart(int pointerId, DragStartDetails details) {
-    onDragStart(DragStartEvent(pointerId, details));
+    onDragStart(DragStartEvent(pointerId, game, details));
   }
 
   @internal
   @override
   void handleDragUpdate(int pointerId, DragUpdateDetails details) {
-    onDragUpdate(DragUpdateEvent(pointerId, details));
+    onDragUpdate(DragUpdateEvent(pointerId, game, details));
   }
 
   @internal

--- a/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
@@ -160,19 +160,19 @@ class MultiTapDispatcher extends Component implements MultiTapListener {
   @internal
   @override
   void handleTapDown(int pointerId, TapDownDetails details) {
-    onTapDown(TapDownEvent(pointerId, details));
+    onTapDown(TapDownEvent(pointerId, game, details));
   }
 
   @internal
   @override
   void handleTapUp(int pointerId, TapUpDetails details) {
-    onTapUp(TapUpEvent(pointerId, details));
+    onTapUp(TapUpEvent(pointerId, game, details));
   }
 
   @internal
   @override
   void handleLongTapDown(int pointerId, TapDownDetails details) {
-    onLongTapDown(TapDownEvent(pointerId, details));
+    onLongTapDown(TapDownEvent(pointerId, game, details));
   }
 
   //#endregion

--- a/packages/flame/lib/src/events/messages/double_tap_down_event.dart
+++ b/packages/flame/lib/src/events/messages/double_tap_down_event.dart
@@ -5,10 +5,9 @@ import 'package:flutter/gestures.dart';
 class DoubleTapDownEvent extends PositionEvent {
   final PointerDeviceKind deviceKind;
 
-  DoubleTapDownEvent(TapDownDetails details)
+  DoubleTapDownEvent(super.game, TapDownDetails details)
       : deviceKind = details.kind ?? PointerDeviceKind.unknown,
         super(
-          canvasPosition: details.localPosition.toVector2(),
           devicePosition: details.globalPosition.toVector2(),
         );
 }

--- a/packages/flame/lib/src/events/messages/drag_start_event.dart
+++ b/packages/flame/lib/src/events/messages/drag_start_event.dart
@@ -11,10 +11,9 @@ import 'package:flutter/gestures.dart';
 ///
 /// This is a [PositionEvent], where the position is the point of touch.
 class DragStartEvent extends PositionEvent {
-  DragStartEvent(this.pointerId, DragStartDetails details)
+  DragStartEvent(this.pointerId, super.game, DragStartDetails details)
       : deviceKind = details.kind ?? PointerDeviceKind.unknown,
         super(
-          canvasPosition: details.localPosition.toVector2(),
           devicePosition: details.globalPosition.toVector2(),
         );
 

--- a/packages/flame/lib/src/events/messages/drag_update_event.dart
+++ b/packages/flame/lib/src/events/messages/drag_update_event.dart
@@ -5,11 +5,10 @@ import 'package:flame/src/game/flame_game.dart';
 import 'package:flutter/gestures.dart';
 
 class DragUpdateEvent extends PositionEvent {
-  DragUpdateEvent(this.pointerId, DragUpdateDetails details)
+  DragUpdateEvent(this.pointerId, super.game, DragUpdateDetails details)
       : timestamp = details.sourceTimeStamp ?? Duration.zero,
         delta = details.delta.toVector2(),
         super(
-          canvasPosition: details.localPosition.toVector2(),
           devicePosition: details.globalPosition.toVector2(),
         );
 

--- a/packages/flame/lib/src/events/messages/position_event.dart
+++ b/packages/flame/lib/src/events/messages/position_event.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/src/events/messages/event.dart';
+import 'package:flame/src/game/game.dart';
 import 'package:meta/meta.dart';
 
 /// Base class for events that originate at some point on the screen. These
@@ -8,13 +9,15 @@ import 'package:meta/meta.dart';
 /// This class includes properties that describe the position where the event
 /// has occurred.
 abstract class PositionEvent extends Event {
-  PositionEvent({required this.canvasPosition, required this.devicePosition});
+  PositionEvent(this._game, {required this.devicePosition});
+  final Game _game;
 
   /// Event position in the coordinate space of the game widget, i.e. relative
   /// to the game canvas.
   ///
   /// This could be considered the Flame-level global position.
-  final Vector2 canvasPosition;
+  late final Vector2 canvasPosition =
+      _game.convertGlobalToLocalCoordinate(devicePosition);
 
   /// Event position in the coordinate space of the device -- either the phone,
   /// or the browser window, or the app.

--- a/packages/flame/lib/src/events/messages/tap_down_event.dart
+++ b/packages/flame/lib/src/events/messages/tap_down_event.dart
@@ -15,10 +15,9 @@ import 'package:flutter/gestures.dart';
 /// In order for a component to be eligible to receive this event, it must add
 /// the [TapCallbacks] mixin.
 class TapDownEvent extends PositionEvent {
-  TapDownEvent(this.pointerId, TapDownDetails details)
+  TapDownEvent(this.pointerId, super.game, TapDownDetails details)
       : deviceKind = details.kind ?? PointerDeviceKind.unknown,
         super(
-          canvasPosition: details.localPosition.toVector2(),
           devicePosition: details.globalPosition.toVector2(),
         );
 

--- a/packages/flame/lib/src/events/messages/tap_up_event.dart
+++ b/packages/flame/lib/src/events/messages/tap_up_event.dart
@@ -13,10 +13,9 @@ import 'package:flutter/gestures.dart';
 ///
 /// The [TapUpEvent] will only occur if there was a previous [TapDownEvent].
 class TapUpEvent extends PositionEvent {
-  TapUpEvent(this.pointerId, TapUpDetails details)
+  TapUpEvent(this.pointerId, super.game, TapUpDetails details)
       : deviceKind = details.kind,
         super(
-          canvasPosition: details.localPosition.toVector2(),
           devicePosition: details.globalPosition.toVector2(),
         );
 

--- a/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
@@ -29,6 +29,7 @@ void main() {
       expect(game.children.whereType<MultiDragDispatcher>().length, 1);
       game.firstChild<MultiDragDispatcher>()!.onDragStart(
             createDragStartEvents(
+              game: game,
               localPosition: const Offset(12, 12),
               globalPosition: const Offset(12, 12),
             ),
@@ -47,6 +48,7 @@ void main() {
 
       dispatcher.onDragStart(
         createDragStartEvents(
+          game: game,
           localPosition: const Offset(12, 12),
           globalPosition: const Offset(12, 12),
         ),
@@ -57,6 +59,7 @@ void main() {
 
       dispatcher.onDragUpdate(
         createDragUpdateEvents(
+          game: game,
           localPosition: const Offset(15, 15),
           globalPosition: const Offset(15, 15),
         ),
@@ -84,6 +87,7 @@ void main() {
 
         dispatcher.onDragUpdate(
           createDragUpdateEvents(
+            game: game,
             localPosition: const Offset(15, 15),
             globalPosition: const Offset(15, 15),
           ),

--- a/packages/flame/test/events/component_mixins/tap_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/tap_callbacks_test.dart
@@ -27,6 +27,7 @@ void main() {
       expect(game.children.whereType<MultiTapDispatcher>().length, equals(1));
       game.firstChild<MultiTapDispatcher>()!.onTapDown(
             createTapDownEvents(
+              game: game,
               localPosition: const Offset(12, 12),
               globalPosition: const Offset(12, 12),
             ),
@@ -48,6 +49,7 @@ void main() {
 
         dispatcher.onTapDown(
           createTapDownEvents(
+            game: game,
             localPosition: const Offset(12, 12),
             globalPosition: const Offset(12, 12),
           ),
@@ -59,6 +61,7 @@ void main() {
         // [onTapUp] will call, if there was an [onTapDown] event before
         dispatcher.onTapUp(
           createTapUpEvents(
+            game: game,
             localPosition: const Offset(12, 12),
             globalPosition: const Offset(12, 12),
           ),
@@ -82,6 +85,7 @@ void main() {
 
         dispatcher.onTapDown(
           createTapDownEvents(
+            game: game,
             localPosition: const Offset(12, 12),
             globalPosition: const Offset(12, 12),
           ),
@@ -93,6 +97,7 @@ void main() {
         // [onTapUp] will call, if there was an [onTapDown] event before
         dispatcher.onLongTapDown(
           createTapDownEvents(
+            game: game,
             localPosition: const Offset(12, 12),
             globalPosition: const Offset(12, 12),
           ),

--- a/packages/flame_test/lib/src/mock_tap_drag_events.dart
+++ b/packages/flame_test/lib/src/mock_tap_drag_events.dart
@@ -1,7 +1,9 @@
 import 'package:flame/events.dart';
+import 'package:flame/game.dart';
 import 'package:flutter/gestures.dart';
 
 TapDownEvent createTapDownEvents({
+  required Game game,
   int? pointerId,
   PointerDeviceKind? kind,
   Offset? globalPosition,
@@ -9,6 +11,7 @@ TapDownEvent createTapDownEvents({
 }) {
   return TapDownEvent(
     pointerId ?? 1,
+    game,
     TapDownDetails(
       localPosition: localPosition ?? Offset.zero,
       globalPosition: globalPosition ?? Offset.zero,
@@ -18,6 +21,7 @@ TapDownEvent createTapDownEvents({
 }
 
 TapUpEvent createTapUpEvents({
+  required Game game,
   int? pointerId,
   PointerDeviceKind? kind,
   Offset? globalPosition,
@@ -25,6 +29,7 @@ TapUpEvent createTapUpEvents({
 }) {
   return TapUpEvent(
     pointerId ?? 1,
+    game,
     TapUpDetails(
       localPosition: localPosition ?? Offset.zero,
       globalPosition: globalPosition ?? Offset.zero,
@@ -34,6 +39,7 @@ TapUpEvent createTapUpEvents({
 }
 
 DragStartEvent createDragStartEvents({
+  required Game game,
   int? pointerId,
   PointerDeviceKind? kind,
   Offset? globalPosition,
@@ -41,6 +47,7 @@ DragStartEvent createDragStartEvents({
 }) {
   return DragStartEvent(
     pointerId ?? 1,
+    game,
     DragStartDetails(
       localPosition: localPosition ?? Offset.zero,
       globalPosition: globalPosition ?? Offset.zero,
@@ -49,6 +56,7 @@ DragStartEvent createDragStartEvents({
 }
 
 DragUpdateEvent createDragUpdateEvents({
+  required Game game,
   int? pointerId,
   PointerDeviceKind? kind,
   Offset? globalPosition,
@@ -56,6 +64,7 @@ DragUpdateEvent createDragUpdateEvents({
 }) {
   return DragUpdateEvent(
     pointerId ?? 1,
+    game,
     DragUpdateDetails(
       localPosition: localPosition ?? Offset.zero,
       globalPosition: globalPosition ?? Offset.zero,


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
This PR makes the `PositionEvent` class take a `Game` instance as a required parameter. The game is the used
to convert `canvasPosition` lazily as it is done in `EventPosition`.
As a result, i had to change several constructor calls to include the game, and make a breaking change in the `flame_test` package for all the `create[...]Events` functions. This may not be the best solution, but it is the easiest. Feel free to share your opinion and improvement ideas.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

## Migration instructions

The `create[...]Events` functions in the `flame_test` package changed their signature.
You now have to pass in the game as the required `game` named parameter.

Change:
```dart
createTapDownEvents(
    localPosition: const Offset(12, 12),
    globalPosition: const Offset(12, 12),
);
```

To:
```dart
createTapDownEvents(
    game: game,
    localPosition: const Offset(12, 12),
    globalPosition: const Offset(12, 12),
);
```



## Related Issues

Closes #2586


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
