### PR TITLE
feat: Add Rectangle.fromLTWH and Rect.toFlameRectangle utility methods

### DIFF
--- a/doc/flame/other/util.md
+++ b/doc/flame/other/util.md
@@ -251,6 +251,7 @@ Methods:
 - `intersectsSegment`; Whether the segment formed by two `Vector2`s intersects this `Rect`.
 - `intersectsLineSegment`: Whether the `LineSegment` intersects the `Rect`.
 - `toVertices`: Turns the four corners of the `Rect` into a list of `Vector2`.
+- `toFlameRectangle`: Converts this `Rect` into a Flame `Rectangle`.
 - `toMathRectangle`: Converts this `Rect` into a `math.Rectangle`.
 - `toGeometryRectangle`: Converts this `Rect` into a `Rectangle` from flame-geom.
 - `transform`: Transforms the `Rect` using a `Matrix4`.

--- a/packages/flame/lib/src/experimental/geometry/shapes/rectangle.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/rectangle.dart
@@ -35,6 +35,9 @@ class Rectangle extends Shape {
     }
   }
 
+  Rectangle.fromLTWH(double left, double top, double width, double height)
+      : this.fromLTRB(left, top, left + width, top + height);
+
   /// Constructs a [Rectangle] from two opposite corners. The points can be in
   /// any disposition to each other.
   factory Rectangle.fromPoints(Vector2 a, Vector2 b) =>

--- a/packages/flame/lib/src/extensions/rect.dart
+++ b/packages/flame/lib/src/extensions/rect.dart
@@ -2,6 +2,7 @@ import 'dart:math' show min, max;
 import 'dart:math' as math;
 import 'dart:ui';
 
+import 'package:flame/experimental.dart' as flame show Rectangle;
 import 'package:flame/geometry.dart';
 import 'package:flame/src/extensions/matrix4.dart';
 import 'package:flame/src/extensions/offset.dart';
@@ -18,6 +19,10 @@ extension RectExtension on Rect {
 
   /// Converts this [Rect] into a [math.Rectangle].
   math.Rectangle toMathRectangle() => math.Rectangle(left, top, width, height);
+
+  /// Converts this [Rect] into a [flame.Rectangle].
+  flame.Rectangle toFlameRectangle() =>
+      flame.Rectangle.fromLTWH(left, top, width, height);
 
   /// Converts this [Rect] into a [RectangleComponent].
   RectangleComponent toRectangleComponent() {

--- a/packages/flame/test/experimental/geometry/shapes/rectangle_test.dart
+++ b/packages/flame/test/experimental/geometry/shapes/rectangle_test.dart
@@ -24,6 +24,16 @@ void main() {
       expect('$rectangle', 'Rectangle([4.0, 0.0], [9.0, 12.0])');
     });
 
+    test('simple rectangle from LTWH', () {
+      final rectangle = Rectangle.fromLTWH(2, 2, 5, 7);
+      expect(rectangle.left, 2);
+      expect(rectangle.top, 2);
+      expect(rectangle.right, 7);
+      expect(rectangle.bottom, 9);
+      expect(rectangle.width, 5);
+      expect(rectangle.height, 7);
+    });
+
     test('rectangle with inverted left-right edges', () {
       final rectangle = Rectangle.fromLTRB(3, 4, 0, 10);
       expect(rectangle.left, 0);

--- a/packages/flame/test/extensions/rect_test.dart
+++ b/packages/flame/test/extensions/rect_test.dart
@@ -22,9 +22,21 @@ void main() {
       expect(vector.x, rect.width);
       expect(vector.y, rect.height);
     });
+
     test('test from ui Rect to math Rectangle', () {
       const r1 = Rect.fromLTWH(0, 10, 20, 30);
       final r2 = r1.toMathRectangle();
+      expect(r2.top, r1.top);
+      expect(r2.bottom, r1.bottom);
+      expect(r2.left, r1.left);
+      expect(r2.right, r1.right);
+      expect(r2.width, r1.width);
+      expect(r2.height, r1.height);
+    });
+
+    test('test from ui Rect to Flame Rectangle', () {
+      const r1 = Rect.fromLTWH(0, 10, 20, 30);
+      final r2 = r1.toFlameRectangle();
       expect(r2.top, r1.top);
       expect(r2.bottom, r1.bottom);
       expect(r2.left, r1.left);


### PR DESCRIPTION
# Description

Add a `Rectangle.fromLTWH` and `Rect.toFlameRectangle` utility methods to more easily create and convert between different rectangle represenations.

Extracted from our [lightrunners code](https://github.com/flame-engine/lightrunners/blob/eb2e91a29c7271e7f6bf7c8d25922d994adfc00b/lib/utils/triangle2.dart#L107).

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
