### PR TITLE
feat: Add a midpoint getter to LineSegment

### DIFF
--- a/packages/flame/lib/src/geometry/line.dart
+++ b/packages/flame/lib/src/geometry/line.dart
@@ -2,7 +2,9 @@ import 'dart:math';
 
 import 'package:flame/extensions.dart';
 
-/// This represents a line on the ax + by = c form
+/// An infinite line on the 2D Cartesian space, represented in the form
+/// of ax + by = c.
+///
 /// If you just want to represent a part of a line, look into LineSegment.
 class Line {
   final double a;

--- a/packages/flame/lib/src/geometry/line_segment.dart
+++ b/packages/flame/lib/src/geometry/line_segment.dart
@@ -11,6 +11,8 @@ class LineSegment {
 
   factory LineSegment.zero() => LineSegment(Vector2.zero(), Vector2.zero());
 
+  Vector2 get midpoint => (from + to) / 2;
+
   /// Returns an empty list if there are no intersections between the segments
   /// If the segments are concurrent, the intersecting point is returned as a
   /// list with a single point

--- a/packages/flame/lib/src/geometry/line_segment.dart
+++ b/packages/flame/lib/src/geometry/line_segment.dart
@@ -11,7 +11,7 @@ class LineSegment {
 
   factory LineSegment.zero() => LineSegment(Vector2.zero(), Vector2.zero());
 
-  Vector2 get midpoint => (from + to) / 2;
+  Vector2 get midpoint => (from + to)..scale(0.5);
 
   /// Returns an empty list if there are no intersections between the segments
   /// If the segments are concurrent, the intersecting point is returned as a

--- a/packages/flame/test/geometry/line_segment_test.dart
+++ b/packages/flame/test/geometry/line_segment_test.dart
@@ -1,0 +1,15 @@
+import 'package:flame/components.dart';
+import 'package:flame/geometry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LineSegment', () {
+    test('midpoint', () {
+      final lineSegment1 = LineSegment(Vector2.zero(), Vector2.all(2));
+      expect(lineSegment1.midpoint, Vector2.all(1));
+
+      final lineSegment2 = LineSegment(Vector2.all(0), Vector2(0, 2));
+      expect(lineSegment2.midpoint, Vector2(0, 1));
+    });
+  });
+}


### PR DESCRIPTION
# Description

Add a `LineSegment.midpoint` utility getter.

Extracted from our [lightrunners code](https://github.com/flame-engine/lightrunners/blob/eb2e91a29c7271e7f6bf7c8d25922d994adfc00b/lib/utils/triangle2.dart#L107).

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
