### PR TITLE
fix: TextBoxConfig dismissDelay to not be ignored

### DIFF
--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -296,7 +296,9 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
       // See issue #1618 for details.
       Future.delayed(const Duration(milliseconds: 100), () {
         cachedToRemove.remove(cachedImage);
-        cachedImage.dispose();
+        if (isMounted) {
+          cachedImage.dispose();
+        }
       });
     }
     cache = await _fullRenderAsImage(newSize);

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -174,7 +174,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
   double get totalCharTime => text.length * _boxConfig.timePerChar;
 
   bool get finished =>
-      _lifeTime > totalCharTime + (_boxConfig.dismissDelay ?? 0);
+      _lifeTime >= totalCharTime + (_boxConfig.dismissDelay ?? 0);
 
   int get _actualTextLength {
     return lines.map((e) => e.length).sum;

--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -26,9 +26,9 @@ class TextBoxConfig {
   /// between each character.
   final double timePerChar;
 
-  /// Defaults to 0. If not zero, this component will disappear after this many
-  /// seconds after being fully typed out.
-  final double dismissDelay;
+  /// Defaults to null. If not null, this component will disappear after this
+  /// many seconds after being fully typed out.
+  final double? dismissDelay;
 
   /// Only relevant if [timePerChar] is set. If true, the box will start with
   /// the size to fit the first character and grow as more lines are typed.
@@ -40,7 +40,7 @@ class TextBoxConfig {
     this.maxWidth = 200.0,
     this.margins = const EdgeInsets.all(8.0),
     this.timePerChar = 0.0,
-    this.dismissDelay = 0.0,
+    this.dismissDelay,
     this.growingBox = false,
   });
 }
@@ -173,7 +173,8 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
 
   double get totalCharTime => text.length * _boxConfig.timePerChar;
 
-  bool get finished => _lifeTime > totalCharTime + _boxConfig.dismissDelay;
+  bool get finished =>
+      _lifeTime > totalCharTime + (_boxConfig.dismissDelay ?? 0);
 
   int get _actualTextLength {
     return lines.map((e) => e.length).sum;
@@ -309,6 +310,10 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
       redraw();
     }
     _previousChar = currentChar;
+
+    if (_boxConfig.dismissDelay != null && finished) {
+      removeFromParent();
+    }
   }
 
   @override

--- a/packages/flame/test/components/text_box_component_test.dart
+++ b/packages/flame/test/components/text_box_component_test.dart
@@ -48,6 +48,25 @@ void main() {
     });
 
     testWithFlameGame('onLoad waits for cache to be done', (game) async {
+      final component = TextBoxComponent(
+        text: 'foo bar',
+        boxConfig: TextBoxConfig(
+          dismissDelay: 10.0,
+          timePerChar: 1.0,
+        ),
+      );
+
+      await game.ensureAdd(component);
+      game.update(8);
+      expect(component.isMounted, isTrue);
+      game.update(9);
+      expect(component.finished, isTrue);
+      expect(component.isRemoving, isTrue);
+      game.update(0);
+      expect(component.isMounted, isFalse);
+    });
+
+    testWithFlameGame('onLoad waits for cache to be done', (game) async {
       final c = TextBoxComponent(text: 'foo bar');
 
       await game.ensureAdd(c);

--- a/packages/flame/test/components/text_box_component_test.dart
+++ b/packages/flame/test/components/text_box_component_test.dart
@@ -47,24 +47,27 @@ void main() {
       );
     });
 
-    testWithFlameGame('onLoad waits for cache to be done', (game) async {
-      final component = TextBoxComponent(
-        text: 'foo bar',
-        boxConfig: TextBoxConfig(
-          dismissDelay: 10.0,
-          timePerChar: 1.0,
-        ),
-      );
+    testWithFlameGame(
+      'setting dismissDelay removes component when finished',
+      (game) async {
+        final component = TextBoxComponent(
+          text: 'foo bar',
+          boxConfig: TextBoxConfig(
+            dismissDelay: 10.0,
+            timePerChar: 1.0,
+          ),
+        );
 
-      await game.ensureAdd(component);
-      game.update(8);
-      expect(component.isMounted, isTrue);
-      game.update(9);
-      expect(component.finished, isTrue);
-      expect(component.isRemoving, isTrue);
-      game.update(0);
-      expect(component.isMounted, isFalse);
-    });
+        await game.ensureAdd(component);
+        game.update(8);
+        expect(component.isMounted, isTrue);
+        game.update(9);
+        expect(component.finished, isTrue);
+        expect(component.isRemoving, isTrue);
+        game.update(0);
+        expect(component.isMounted, isFalse);
+      },
+    );
 
     testWithFlameGame('onLoad waits for cache to be done', (game) async {
       final c = TextBoxComponent(text: 'foo bar');


### PR DESCRIPTION
# Description

`TextBoxConfig.dismissDelay` was being ignored, now it removed the component once it is finished and the delay has passed, like intended.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
