### PR TITLE
fix: Only use pre-set ReadonlySizeProvider for sizing in HudMarginComponent

### DIFF
--- a/packages/flame/lib/src/components/input/hud_margin_component.dart
+++ b/packages/flame/lib/src/components/input/hud_margin_component.dart
@@ -81,9 +81,7 @@ class HudMarginComponent extends PositionComponent {
   @override
   void onGameResize(Vector2 size) {
     super.onGameResize(size);
-    if (isMounted &&
-        (parent is FlameGame ||
-            (parent! as ReadonlySizeProvider).size is NotifyingVector2)) {
+    if (isMounted && _sizeProvider != null) {
       _updateMargins();
     }
   }


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

In a project where we wrapped the `JoystickComponent` into it's own `Component` to separate concerns resizing the window (or hot reloading) would throw an exception leading to a red screen.

The `HudMarginComponent` currently expects the parent to be either a `FlameGame` or `ReadOnlySizeProvider`, which throws an exception when our wrapped `Joystick` class is neither.

With the help of @spydon, we came to the conclusion that this fix should work and not break other cases.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [X] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

No related issue, I can open one if needed.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
