### PR TITLE
feat!: Make world nullable in `CameraComponent`

### DIFF
--- a/packages/flame/lib/src/camera/camera_component.dart
+++ b/packages/flame/lib/src/camera/camera_component.dart
@@ -41,7 +41,7 @@ import 'package:vector_math/vector_math_64.dart';
 /// That is, they will be affected both by the viewport and the viewfinder.
 class CameraComponent extends Component {
   CameraComponent({
-    required this.world,
+    this.world,
     Viewport? viewport,
     Viewfinder? viewfinder,
     List<Component>? hudComponents,
@@ -58,9 +58,9 @@ class CameraComponent extends Component {
   /// initially set up to show world coordinates (0, 0) at the center of the
   /// viewport.
   factory CameraComponent.withFixedResolution({
-    required World world,
     required double width,
     required double height,
+    World? world,
     List<Component>? hudComponents,
   }) {
     return CameraComponent(
@@ -97,7 +97,7 @@ class CameraComponent extends Component {
   ///
   /// The [world] component is generally mounted externally to the camera, and
   /// this variable is a mere reference to it.
-  World world;
+  World? world;
 
   /// The axis-aligned bounding rectangle of a [world] region which is currently
   /// visible through the viewport.
@@ -140,13 +140,14 @@ class CameraComponent extends Component {
       viewport.position.y - viewport.anchor.y * viewport.size.y,
     );
     // Render the world through the viewport
-    if (world.isMounted && currentCameras.length < maxCamerasDepth) {
+    if ((world?.isMounted ?? false) &&
+        currentCameras.length < maxCamerasDepth) {
       canvas.save();
       viewport.clip(canvas);
       try {
         currentCameras.add(this);
         canvas.transform(viewfinder.transform.transformMatrix.storage);
-        world.renderFromCamera(canvas);
+        world!.renderFromCamera(canvas);
         viewfinder.renderTree(canvas);
       } finally {
         currentCameras.removeLast();
@@ -167,11 +168,12 @@ class CameraComponent extends Component {
       point.x - viewport.position.x + viewport.anchor.x * viewport.size.x,
       point.y - viewport.position.y + viewport.anchor.y * viewport.size.y,
     );
-    if (world.isMounted && currentCameras.length < maxCamerasDepth) {
+    if ((world?.isMounted ?? false) &&
+        currentCameras.length < maxCamerasDepth) {
       if (viewport.containsLocalPoint(viewportPoint)) {
         currentCameras.add(this);
         final worldPoint = viewfinder.transform.globalToLocal(viewportPoint);
-        yield* world.componentsAtPoint(worldPoint, nestedPoints);
+        yield* world!.componentsAtPoint(worldPoint, nestedPoints);
         yield* viewfinder.componentsAtPoint(worldPoint, nestedPoints);
         currentCameras.removeLast();
       }

--- a/packages/flame/test/camera/viewports/fixed_size_viewport_test.dart
+++ b/packages/flame/test/camera/viewports/fixed_size_viewport_test.dart
@@ -12,7 +12,7 @@ void main() {
         world: World(),
         viewport: FixedSizeViewport(300, 100),
       );
-      game.addAll([camera.world, camera]);
+      game.addAll([camera.world!, camera]);
       await game.ready();
 
       expect(camera.viewport, isA<FixedSizeViewport>());
@@ -29,7 +29,7 @@ void main() {
         world: World(),
         viewport: FixedSizeViewport(400, 100),
       );
-      game.addAll([camera.world, camera]);
+      game.addAll([camera.world!, camera]);
       await game.ready();
 
       final viewport = camera.viewport;


### PR DESCRIPTION
# Description

`CameraComponent` can now stare at nothingness because its world reference can be null now.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

`CameraComponent.world` is now nullable. While accessing it, make sure to perform null checks if it can be null in your case. Otherwise, if you are sure that the world is non-null perform unconditional using `CameraComponent.world!`.

## Related Issues

Closes #2614 
