### PR TITLE
feat: Add optional world input to `CameraComponent.canSee`

### DIFF
--- a/packages/flame/lib/src/camera/camera_component.dart
+++ b/packages/flame/lib/src/camera/camera_component.dart
@@ -282,7 +282,6 @@ class CameraComponent extends Component {
   }
 
   /// Returns true if this camera is able to see the [component].
-  ///
   /// Will always return false if
   /// - [world] is null or
   /// - [world] is not mounted or

--- a/packages/flame/lib/src/camera/camera_component.dart
+++ b/packages/flame/lib/src/camera/camera_component.dart
@@ -296,8 +296,7 @@ class CameraComponent extends Component {
   /// currently looking at. This can be changed by passing the the component's
   /// world as [componentWorld].
   bool canSee(PositionComponent component, {World? componentWorld}) {
-    if (world == null ||
-        !world!.isMounted ||
+    if (!(world?.isMounted ?? false) ||
         !component.isMounted ||
         (componentWorld != null && componentWorld != world)) {
       return false;

--- a/packages/flame/lib/src/camera/camera_component.dart
+++ b/packages/flame/lib/src/camera/camera_component.dart
@@ -41,7 +41,7 @@ import 'package:vector_math/vector_math_64.dart';
 /// That is, they will be affected both by the viewport and the viewfinder.
 class CameraComponent extends Component {
   CameraComponent({
-    required this.world,
+    this.world,
     Viewport? viewport,
     Viewfinder? viewfinder,
     List<Component>? hudComponents,
@@ -58,9 +58,9 @@ class CameraComponent extends Component {
   /// initially set up to show world coordinates (0, 0) at the center of the
   /// viewport.
   factory CameraComponent.withFixedResolution({
-    required World world,
     required double width,
     required double height,
+    World? world,
     List<Component>? hudComponents,
   }) {
     return CameraComponent(
@@ -97,7 +97,7 @@ class CameraComponent extends Component {
   ///
   /// The [world] component is generally mounted externally to the camera, and
   /// this variable is a mere reference to it.
-  World world;
+  World? world;
 
   /// The axis-aligned bounding rectangle of a [world] region which is currently
   /// visible through the viewport.
@@ -140,13 +140,14 @@ class CameraComponent extends Component {
       viewport.position.y - viewport.anchor.y * viewport.size.y,
     );
     // Render the world through the viewport
-    if (world.isMounted && currentCameras.length < maxCamerasDepth) {
+    if ((world?.isMounted ?? false) &&
+        currentCameras.length < maxCamerasDepth) {
       canvas.save();
       viewport.clip(canvas);
       try {
         currentCameras.add(this);
         canvas.transform(viewfinder.transform.transformMatrix.storage);
-        world.renderFromCamera(canvas);
+        world!.renderFromCamera(canvas);
         viewfinder.renderTree(canvas);
       } finally {
         currentCameras.removeLast();
@@ -167,11 +168,12 @@ class CameraComponent extends Component {
       point.x - viewport.position.x + viewport.anchor.x * viewport.size.x,
       point.y - viewport.position.y + viewport.anchor.y * viewport.size.y,
     );
-    if (world.isMounted && currentCameras.length < maxCamerasDepth) {
+    if ((world?.isMounted ?? false) &&
+        currentCameras.length < maxCamerasDepth) {
       if (viewport.containsLocalPoint(viewportPoint)) {
         currentCameras.add(this);
         final worldPoint = viewfinder.transform.globalToLocal(viewportPoint);
-        yield* world.componentsAtPoint(worldPoint, nestedPoints);
+        yield* world!.componentsAtPoint(worldPoint, nestedPoints);
         yield* viewfinder.componentsAtPoint(worldPoint, nestedPoints);
         currentCameras.removeLast();
       }

--- a/packages/flame/lib/src/camera/camera_component.dart
+++ b/packages/flame/lib/src/camera/camera_component.dart
@@ -8,8 +8,6 @@ import 'package:flame/src/camera/viewports/fixed_aspect_ratio_viewport.dart';
 import 'package:flame/src/camera/viewports/max_viewport.dart';
 import 'package:flame/src/camera/world.dart';
 import 'package:flame/src/components/core/component.dart';
-import 'package:flame/src/components/mixins/has_ancestor.dart';
-import 'package:flame/src/components/mixins/parent_is_a.dart';
 import 'package:flame/src/components/position_component.dart';
 import 'package:flame/src/effects/controllers/effect_controller.dart';
 import 'package:flame/src/effects/move_by_effect.dart';
@@ -284,18 +282,18 @@ class CameraComponent extends Component {
   }
 
   /// Returns true if this camera is able to see the [component].
-  /// 
+  ///
   /// Will always return false if
-  /// - [world] is null or 
+  /// - [world] is null or
   /// - [world] is not mounted or
   /// - [component] is not mounted or
   /// - [componentWorld] is non-null and does not match with [world]
-  /// 
+  ///
   /// If [componentWorld] is null, this method does not take into consideration
   /// the world to which the given [component] belongs (if any). This means, in
   /// such cases, any component overlapping the [visibleWorldRect] will be
   /// reported as visible, even if it is not part of the [world] this camera is
-  /// currently looking at. This can be changed by passing the the component's 
+  /// currently looking at. This can be changed by passing the the component's
   /// world as [componentWorld].
   bool canSee(PositionComponent component, {World? componentWorld}) {
     if (world == null ||

--- a/packages/flame/lib/src/camera/camera_component.dart
+++ b/packages/flame/lib/src/camera/camera_component.dart
@@ -284,29 +284,24 @@ class CameraComponent extends Component {
   }
 
   /// Returns true if this camera is able to see the [component].
-  ///
-  /// Will return false if the component does not belong to the [world] this
-  /// camera is looking at.
-  ///
-  /// For components deeply nested in the world, consider use the [HasAncestor]
-  /// or [ParentIsA] mixin with [World] type to make the world lookup faster.
-  bool canSee(PositionComponent component) {
-    if (world == null || !component.isMounted) {
-      return false;
-    }
-
-    World? componentWorld;
-
-    // Try to find which world the given component belongs to.
-    if (component is ParentIsA<World>) {
-      componentWorld = (component as ParentIsA<World>).parent;
-    } else if (component is HasAncestor<World>) {
-      componentWorld = (component as HasAncestor<World>).ancestor;
-    } else {
-      componentWorld = component.findParent<World>();
-    }
-
-    if (world != componentWorld) {
+  /// 
+  /// Will always return false if
+  /// - [world] is null or 
+  /// - [world] is not mounted or
+  /// - [component] is not mounted or
+  /// - [componentWorld] is non-null and does not match with [world]
+  /// 
+  /// If [componentWorld] is null, this method does not take into consideration
+  /// the world to which the given [component] belongs (if any). This means, in
+  /// such cases, any component overlapping the [visibleWorldRect] will be
+  /// reported as visible, even if it is not part of the [world] this camera is
+  /// currently looking at. This can be changed by passing the the component's 
+  /// world as [componentWorld].
+  bool canSee(PositionComponent component, {World? componentWorld}) {
+    if (world == null ||
+        !world!.isMounted ||
+        !component.isMounted ||
+        (componentWorld != null && componentWorld != world)) {
       return false;
     }
 

--- a/packages/flame/test/camera/camera_component_test.dart
+++ b/packages/flame/test/camera/camera_component_test.dart
@@ -313,6 +313,62 @@ void main() {
       expect(camera.canSee(component), isFalse);
     });
   });
+
+  group('CameraComponent.canSee', () {
+    testWithFlameGame('null world', (game) async {
+      final player = PositionComponent();
+      final world = World(children: [player]);
+      final camera = CameraComponent();
+
+      await game.addAll([camera, world]);
+      await game.ready();
+      expect(camera.canSee(player), false);
+
+      camera.world = world;
+      expect(camera.canSee(player), true);
+    });
+
+    testWithFlameGame('unmounted component', (game) async {
+      final player = PositionComponent();
+      final world = World();
+      final camera = CameraComponent(world: world);
+
+      await game.addAll([camera, world]);
+      await game.ready();
+      expect(camera.canSee(player), false);
+
+      await world.add(player);
+      await game.ready();
+      expect(camera.canSee(player), true);
+    });
+
+    testWithFlameGame('component with parent world', (game) async {
+      final player = _ParentIsAWorld();
+      final world = World(children: [player]);
+      final camera = CameraComponent();
+
+      await game.addAll([camera, world]);
+      await game.ready();
+      expect(camera.canSee(player), false);
+
+      camera.world = world;
+      expect(camera.canSee(player), true);
+    });
+
+    testWithFlameGame('component with ancestor world', (game) async {
+      final player = _HasAncestorWorld();
+      final level = PositionComponent(children: [player]);
+      final world = World(children: [level]);
+      final camera = CameraComponent();
+
+      await game.addAll([camera, world]);
+      await game.ready();
+      expect(camera.canSee(player), false);
+
+      camera.world = world;
+      expect(camera.canSee(player), true);
+    });
+  });
 }
 
 class _SolidBackground extends Component with HasPaint {
@@ -321,3 +377,7 @@ class _SolidBackground extends Component with HasPaint {
   @override
   void render(Canvas canvas) => canvas.drawColor(color, BlendMode.src);
 }
+
+class _HasAncestorWorld extends PositionComponent with HasAncestor<World> {}
+
+class _ParentIsAWorld extends PositionComponent with ParentIsA<World> {}

--- a/packages/flame/test/camera/camera_component_test.dart
+++ b/packages/flame/test/camera/camera_component_test.dart
@@ -280,18 +280,17 @@ void main() {
     });
 
     testWithFlameGame('component is in view for the camera', (game) async {
-      final world = World();
+      final component = PositionComponent(
+        size: Vector2(10, 10),
+        position: Vector2(0, 0),
+      );
+      final world = World(children: [component]);
       final camera = CameraComponent(
         world: world,
         viewport: FixedSizeViewport(60, 40),
       );
       game.addAll([world, camera]);
       await game.ready();
-
-      final component = PositionComponent(
-        size: Vector2(10, 10),
-        position: Vector2(0, 0),
-      );
 
       expect(camera.canSee(component), isTrue);
     });

--- a/packages/flame/test/camera/camera_component_test.dart
+++ b/packages/flame/test/camera/camera_component_test.dart
@@ -326,6 +326,20 @@ void main() {
       expect(camera.canSee(player), true);
     });
 
+    testWithFlameGame('unmounted world', (game) async {
+      final player = PositionComponent();
+      final world = World(children: [player]);
+      final camera = CameraComponent(world: world);
+
+      await game.addAll([camera]);
+      await game.ready();
+      expect(camera.canSee(player), false);
+
+      await game.add(world);
+      await game.ready();
+      expect(camera.canSee(player), true);
+    });
+
     testWithFlameGame('unmounted component', (game) async {
       final player = PositionComponent();
       final world = World();
@@ -340,31 +354,20 @@ void main() {
       expect(camera.canSee(player), true);
     });
 
-    testWithFlameGame('component with parent world', (game) async {
-      final player = _ParentIsAWorld();
-      final world = World(children: [player]);
-      final camera = CameraComponent();
+    testWithFlameGame('component from another world', (game) async {
+      final player = PositionComponent();
+      final world1 = World(children: [player]);
+      final world2 = World();
+      final camera = CameraComponent(world: world2);
 
-      await game.addAll([camera, world]);
+      await game.addAll([camera, world1, world2]);
       await game.ready();
-      expect(camera.canSee(player), false);
 
-      camera.world = world;
+      // can see when player world is not known.
       expect(camera.canSee(player), true);
-    });
 
-    testWithFlameGame('component with ancestor world', (game) async {
-      final player = _HasAncestorWorld();
-      final level = PositionComponent(children: [player]);
-      final world = World(children: [level]);
-      final camera = CameraComponent();
-
-      await game.addAll([camera, world]);
-      await game.ready();
-      expect(camera.canSee(player), false);
-
-      camera.world = world;
-      expect(camera.canSee(player), true);
+      // can't see when the player world is known.
+      expect(camera.canSee(player, componentWorld: world1), false);
     });
   });
 }
@@ -375,7 +378,3 @@ class _SolidBackground extends Component with HasPaint {
   @override
   void render(Canvas canvas) => canvas.drawColor(color, BlendMode.src);
 }
-
-class _HasAncestorWorld extends PositionComponent with HasAncestor<World> {}
-
-class _ParentIsAWorld extends PositionComponent with ParentIsA<World> {}

--- a/packages/flame/test/camera/camera_component_test.dart
+++ b/packages/flame/test/camera/camera_component_test.dart
@@ -296,18 +296,17 @@ void main() {
     });
 
     testWithFlameGame('component is out of view for the camera', (game) async {
-      final world = World();
+      final component = PositionComponent(
+        size: Vector2(10, 10),
+        position: Vector2(100, 100),
+      );
+      final world = World(children: [component]);
       final camera = CameraComponent(
         world: world,
         viewport: FixedSizeViewport(60, 40),
       );
       game.addAll([world, camera]);
       await game.ready();
-
-      final component = PositionComponent(
-        size: Vector2(10, 10),
-        position: Vector2(100, 100),
-      );
 
       expect(camera.canSee(component), isFalse);
     });

--- a/packages/flame/test/camera/viewports/fixed_size_viewport_test.dart
+++ b/packages/flame/test/camera/viewports/fixed_size_viewport_test.dart
@@ -12,7 +12,7 @@ void main() {
         world: World(),
         viewport: FixedSizeViewport(300, 100),
       );
-      game.addAll([camera.world, camera]);
+      game.addAll([camera.world!, camera]);
       await game.ready();
 
       expect(camera.viewport, isA<FixedSizeViewport>());
@@ -29,7 +29,7 @@ void main() {
         world: World(),
         viewport: FixedSizeViewport(400, 100),
       );
-      game.addAll([camera.world, camera]);
+      game.addAll([camera.world!, camera]);
       await game.ready();
 
       final viewport = camera.viewport;


### PR DESCRIPTION
# Description

`CameraComponent.canSee` wasn't performing any kind of sanity checks on the given components world or mounted-ness. This PR adds these checks to correctly return false if the component is not mounted or if the optional world is not the same as camera's current target world.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

NA