### PR TITLE
perf: Improve performance of raycasts

### DIFF
--- a/packages/flame/lib/src/collisions/standard_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/standard_collision_detection.dart
@@ -89,8 +89,8 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
       final possiblyFirstResult = !(finalResult?.isActive ?? false);
       if (currentResult != null &&
           (possiblyFirstResult ||
-              currentResult.distance! < finalResult!.distance!)) {
-        assert(currentResult.distance! <= (maxDistance ?? double.infinity));
+              currentResult.distance! < finalResult!.distance!) &&
+          currentResult.distance! <= (maxDistance ?? double.infinity)) {
         if (finalResult == null) {
           finalResult = currentResult.clone();
         } else {


### PR DESCRIPTION
# Description
Creates an axis-aligned bounding box (AABB) around the ray to short-circuit checking.

In the general case, we skip ~75% of the checks because the ray originates at some point in the 2D cartesian space and goes towards infinity. The AABB in that case is a quadrant of space, and so only entities intersecting with this quadrant of space need to be checked.

In the case where the raycast is called with a `maxDistance`, the savings are much higher. A relatively short ray will generate a small AABB around its origin and end point. In a typical game world, there will be many entities that do not intersect with this AABB, and can be skipped.

## Results

Toy example when run without the optimization:
<img width="912" alt="Screenshot 2023-07-21 at 12 27 33" src="https://github.com/flame-engine/flame/assets/919717/3a94c88d-8473-494a-9c9e-2d1697e3ccee">

Toy example when run with optimization but unbounded `maxDistance`:
<img width="912" alt="Screenshot 2023-07-21 at 13 28 19" src="https://github.com/flame-engine/flame/assets/919717/1e47d646-70f1-4522-967d-094803549de7">

Toy example when run with optimization and a reasonable `maxDistance`:
<img width="912" alt="Screenshot 2023-07-21 at 13 54 59" src="https://github.com/flame-engine/flame/assets/919717/76b4111b-4b28-4ace-81fe-6398f3678661">

That's 200 entities all sending 3 raycasts each.

I didn't add any tests since raycasts are tested, including maxDistance.


## Checklist


- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

The original maxDistance issue: #2011

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
