### PR TITLE
docs: Minor updates to steps 3 & 4 in Klondike tutorial

### DIFF
--- a/doc/tutorials/klondike/step3.md
+++ b/doc/tutorials/klondike/step3.md
@@ -55,10 +55,10 @@ symbol on the canvas. The sprite object is initialized using the
 ```
 
 Then comes the static list of all `Suit` objects in the game. Note that we
-define it as static variable so it is evaluated lazily (as if it was marked 
-with the `late` keyword) meaning that it will be only initialized the first 
-time it is needed. This is important: as we can see above, the constructor 
-tries to retrieve an image from the global cache, so it can only be invoked 
+define it as static variable so it is evaluated lazily (as if it was marked
+with the `late` keyword) meaning that it will be only initialized the first
+time it is needed. This is important: as we can see above, the constructor
+tries to retrieve an image from the global cache, so it can only be invoked
 after the image is loaded into the cache.
 
 ```dart

--- a/doc/tutorials/klondike/step3.md
+++ b/doc/tutorials/klondike/step3.md
@@ -55,13 +55,14 @@ symbol on the canvas. The sprite object is initialized using the
 ```
 
 Then comes the static list of all `Suit` objects in the game. Note that we
-define it as `late`, meaning that it will be only initialized the first time
-it is needed. This is important: as we seen above, the constructor tries to
-retrieve an image from the global cache, so it can only be invoked after the
-image is loaded into the cache.
+define it as static variable so it is evaluated lazily (as if it was marked 
+with the `late` keyword) meaning that it will be only initialized the first 
+time it is needed. This is important: as we can see above, the constructor 
+tries to retrieve an image from the global cache, so it can only be invoked 
+after the image is loaded into the cache.
 
 ```dart
-  static late final List<Suit> _singletons = [
+  static final List<Suit> _singletons = [
     Suit._(0, '♥', 1176, 17, 172, 183),
     Suit._(1, '♦', 973, 14, 177, 182),
     Suit._(2, '♣', 974, 226, 184, 172),
@@ -120,7 +121,7 @@ class Rank {
   final Sprite redSprite;
   final Sprite blackSprite;
 
-  static late final List<Rank> _singletons = [
+  static final List<Rank> _singletons = [
     Rank._(1, 'A', 335, 164, 789, 161, 120, 129),
     Rank._(2, '2', 20, 19, 15, 322, 83, 125),
     Rank._(3, '3', 122, 19, 117, 322, 80, 127),
@@ -272,7 +273,7 @@ Various properties used in the `_renderBack()` method are defined as follows:
     const Radius.circular(KlondikeGame.cardRadius),
   );
   static final RRect backRRectInner = cardRRect.deflate(40);
-  static late final Sprite flameSprite = klondikeSprite(1367, 6, 357, 501);
+  static final Sprite flameSprite = klondikeSprite(1367, 6, 357, 501);
 ```
 
 I declared these properties as static because they will all be the same across
@@ -307,9 +308,9 @@ depending on whether the card is of a "red" suit or "black":
 Next, we also need the images for the court cards:
 
 ```dart
-  static late final Sprite redJack = klondikeSprite(81, 565, 562, 488);
-  static late final Sprite redQueen = klondikeSprite(717, 541, 486, 515);
-  static late final Sprite redKing = klondikeSprite(1305, 532, 407, 549);
+  static final Sprite redJack = klondikeSprite(81, 565, 562, 488);
+  static final Sprite redQueen = klondikeSprite(717, 541, 486, 515);
+  static final Sprite redKing = klondikeSprite(1305, 532, 407, 549);
 ```
 
 Note that I'm calling these sprites `redJack`, `redQueen`, and `redKing`. This
@@ -325,11 +326,11 @@ blending mode:
       Color(0x880d8bff),
       BlendMode.srcATop,
     );
-  static late final Sprite blackJack = klondikeSprite(81, 565, 562, 488)
+  static final Sprite blackJack = klondikeSprite(81, 565, 562, 488)
     ..paint = blueFilter;
-  static late final Sprite blackQueen = klondikeSprite(717, 541, 486, 515)
+  static final Sprite blackQueen = klondikeSprite(717, 541, 486, 515)
     ..paint = blueFilter;
-  static late final Sprite blackKing = klondikeSprite(1305, 532, 407, 549)
+  static final Sprite blackKing = klondikeSprite(1305, 532, 407, 549)
     ..paint = blueFilter;
 ```
 

--- a/doc/tutorials/klondike/step4.md
+++ b/doc/tutorials/klondike/step4.md
@@ -576,19 +576,20 @@ it so that it would check whether the card is allowed to be moved before startin
 ```dart
   void onDragStart(DragStartEvent event) {
     if (pile?.canMoveCard(this) ?? false) {
-      _isDragging = true;
+      super.onDragStart(event);
       priority = 100;
     }
   }
 ```
 
-We have also added the boolean `_isDragging` variable here: make sure to define it, and then to
-check this flag in the `onDragUpdate()` method, and to set it back to false in the `onDragEnd()`:
+We have also added a call to `super.onDragStart()` which sets an `_isDragged` variable to `true` 
+in the `DragCallbacks` mixin, we need to check this flag via the public `isDragged` getter in 
+the `onDragUpdate()` method. Let's also use `super.onDragEnd()` to set the flag back to `false`:
 
 ```dart
   @override
   void onDragUpdate(DragUpdateEvent event) {
-    if (!_isDragging) {
+    if (!isDragged) {
       return;
     }
     final cameraZoom = (findGame()! as FlameGame)
@@ -600,11 +601,11 @@ check this flag in the `onDragUpdate()` method, and to set it back to false in t
 
   @override
   void onDragEnd(DragEndEvent event) {
-    _isDragging = false;
+    super.onDragEnd(event);
   }
 ```
 
-Now the only the proper cards can be dragged, but they still drop at random positions on the table,
+Now only the proper cards can be dragged, but they still drop at random positions on the table,
 so let's work on that.
 
 
@@ -620,10 +621,10 @@ Thus, my first attempt at revising the `onDragEnd` callback looks like this:
 ```dart
   @override
   void onDragEnd(DragEndEvent event) {
-    if (!_isDragging) {
+    if (!isDragged) {
       return;
     }
-    _isDragging = false;
+    super.onDragEnd(event);
     final dropPiles = parent!
         .componentsAtPoint(position + size / 2)
         .whereType<Pile>()
@@ -790,10 +791,10 @@ Now, putting this all together, the `Card`'s `onDragEnd` method will look like t
 ```dart
   @override
   void onDragEnd(DragEndEvent event) {
-    if (!_isDragging) {
+    if (!isDragged) {
       return;
     }
-    _isDragging = false;
+    super.onDragEnd(event);
     final dropPiles = parent!
         .componentsAtPoint(position + size / 2)
         .whereType<Pile>()
@@ -898,7 +899,7 @@ Heading back into the `Card` class, we can use this method in order to populate 
   @override
   void onDragStart(DragStartEvent event) {
     if (pile?.canMoveCard(this) ?? false) {
-      _isDragging = true;
+      super.onDragStart();
       priority = 100;
       if (pile is TableauPile) {
         attachedCards.clear();
@@ -918,7 +919,7 @@ the `onDragUpdate` method:
 ```dart
   @override
   void onDragUpdate(DragUpdateEvent event) {
-    if (!_isDragging) {
+    if (!isDragged) {
       return;
     }
     final cameraZoom = (findGame()! as FlameGame)
@@ -952,10 +953,10 @@ attached cards into the pile, and the same when it comes to returning the cards 
 ```dart
   @override
   void onDragEnd(DragEndEvent event) {
-    if (!_isDragging) {
+    if (!isDragged) {
       return;
     }
-    _isDragging = false;
+    super.onDragEnd(event);
     final dropPiles = parent!
         .componentsAtPoint(position + size / 2)
         .whereType<Pile>()

--- a/doc/tutorials/klondike/step4.md
+++ b/doc/tutorials/klondike/step4.md
@@ -584,7 +584,8 @@ it so that it would check whether the card is allowed to be moved before startin
 
 We have also added a call to `super.onDragStart()` which sets an `_isDragged` variable to `true` 
 in the `DragCallbacks` mixin, we need to check this flag via the public `isDragged` getter in 
-the `onDragUpdate()` method. Let's also use `super.onDragEnd()` to set the flag back to `false`:
+the `onDragUpdate()` method and use `super.onDragEnd()` in `onDragEnd()` so the flag is set back
+to `false`:
 
 ```dart
   @override

--- a/doc/tutorials/klondike/step4.md
+++ b/doc/tutorials/klondike/step4.md
@@ -582,8 +582,8 @@ it so that it would check whether the card is allowed to be moved before startin
   }
 ```
 
-We have also added a call to `super.onDragStart()` which sets an `_isDragged` variable to `true` 
-in the `DragCallbacks` mixin, we need to check this flag via the public `isDragged` getter in 
+We have also added a call to `super.onDragStart()` which sets an `_isDragged` variable to `true`
+in the `DragCallbacks` mixin, we need to check this flag via the public `isDragged` getter in
 the `onDragUpdate()` method and use `super.onDragEnd()` in `onDragEnd()` so the flag is set back
 to `false`:
 


### PR DESCRIPTION
# Description

I have just finished steps 1-4 of the Klondike tutorial and noticed a couple of minor things that look to be outdated with the current dart / flame versions.

### Step 3 - `late` keyword isn't required
When following this step the analyser hightlight this rule [unnecessary_late](https://dart.dev/tools/linter-rules/unnecessary_late) (introduced in Dart 2.16.0) which states:

> Top-level and static variables with initializers are already evaluated lazily as if they are marked late.

I updated the notes around why the laziness is important so the reader can still understand the reasoning.

### Step 4 - local `_isDragging` vs `DragCallbacks.isDragged`
Looking through the `DragCallbacks` mixin I found that `onDragStart()` and `onDragEnd()` both set a private `_isDragged` flag that acts the same as the `_isDragging` local flag created in the tutorial. This was added in https://github.com/flame-engine/flame/pull/2472 along with `@mustCallSuper` annotations on both methods.

So this change brings the docs up to date by having the new `onDragStart`/`onDragEnd` methods reference their `super`'s `super.onDragStart` and `super.onDragEnd` instead of the local flag, and now `onDragUpdate`, `onDragEnd` use `if (!isDragged) { .. }` instead of `if (!_isDragging) { .. }`.


Thanks for awesome tutorial! It's really well written and explains everything just as you need it without being overwhelming.

## Checklist

- [X] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
