### PR TITLE
feat: Possiblity to pass in FilterQuality to tiled layers

### DIFF
--- a/packages/flame_tiled/lib/src/renderable_layers/group_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/group_layer.dart
@@ -17,6 +17,7 @@ class GroupLayer extends RenderableLayer<Group> {
     required super.parent,
     required super.map,
     required super.destTileSize,
+    super.filterQuality,
   });
 
   @override

--- a/packages/flame_tiled/lib/src/renderable_layers/image_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/image_layer.dart
@@ -20,6 +20,7 @@ class FlameImageLayer extends RenderableLayer<ImageLayer> {
     required super.map,
     required super.destTileSize,
     required Image image,
+    super.filterQuality,
   }) : _image = image {
     _initImageRepeat();
   }
@@ -46,6 +47,7 @@ class FlameImageLayer extends RenderableLayer<ImageLayer> {
       opacity: opacity,
       alignment: Alignment.topLeft,
       repeat: _repeat,
+      filterQuality: filterQuality,
     );
 
     canvas.restore();
@@ -69,6 +71,7 @@ class FlameImageLayer extends RenderableLayer<ImageLayer> {
     required CameraComponent? camera,
     required TiledMap map,
     required Vector2 destTileSize,
+    FilterQuality? filterQuality,
     Images? images,
   }) async {
     return FlameImageLayer(
@@ -76,6 +79,7 @@ class FlameImageLayer extends RenderableLayer<ImageLayer> {
       parent: parent,
       map: map,
       destTileSize: destTileSize,
+      filterQuality: filterQuality,
       image: await (images ?? Flame.images).load(layer.image.source!),
     );
   }

--- a/packages/flame_tiled/lib/src/renderable_layers/object_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/object_layer.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_tiled/src/renderable_layers/renderable_layer.dart';
@@ -11,6 +13,7 @@ class ObjectLayer extends RenderableLayer<ObjectGroup> {
     required super.parent,
     required super.map,
     required super.destTileSize,
+    super.filterQuality,
   });
 
   @override
@@ -26,12 +29,14 @@ class ObjectLayer extends RenderableLayer<ObjectGroup> {
     ObjectGroup layer,
     TiledMap map,
     Vector2 destTileSize,
+    FilterQuality? filterQuality,
   ) async {
     return ObjectLayer(
       layer: layer,
       parent: null,
       map: map,
       destTileSize: destTileSize,
+      filterQuality: filterQuality,
     );
   }
 

--- a/packages/flame_tiled/lib/src/renderable_layers/renderable_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/renderable_layer.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flame/cache.dart';
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
@@ -19,12 +21,16 @@ abstract class RenderableLayer<T extends Layer> {
   /// The parent [Group] layer (if it exists)
   final GroupLayer? parent;
 
+  /// The [FilterQuality] that should be used by all the layers.
+  final FilterQuality filterQuality;
+
   RenderableLayer({
     required this.layer,
     required this.parent,
     required this.map,
     required this.destTileSize,
-  });
+    FilterQuality? filterQuality,
+  }) : filterQuality = filterQuality ?? FilterQuality.low;
 
   /// [load] is a factory method to create [RenderableLayer] by type of [layer].
   static Future<RenderableLayer> load({
@@ -35,6 +41,7 @@ abstract class RenderableLayer<T extends Layer> {
     required CameraComponent? camera,
     required Map<Tile, TileFrames> animationFrames,
     required TiledAtlas atlas,
+    FilterQuality? filterQuality,
     bool? ignoreFlip,
     Images? images,
   }) async {
@@ -47,6 +54,7 @@ abstract class RenderableLayer<T extends Layer> {
         animationFrames: animationFrames,
         atlas: atlas.clone(),
         ignoreFlip: ignoreFlip,
+        filterQuality: filterQuality,
       );
     } else if (layer is ImageLayer) {
       return FlameImageLayer.load(
@@ -55,6 +63,7 @@ abstract class RenderableLayer<T extends Layer> {
         camera: camera,
         map: map,
         destTileSize: destTileSize,
+        filterQuality: filterQuality,
         images: images,
       );
     } else if (layer is ObjectGroup) {
@@ -62,6 +71,7 @@ abstract class RenderableLayer<T extends Layer> {
         layer,
         map,
         destTileSize,
+        filterQuality,
       );
     } else if (layer is Group) {
       final groupLayer = layer;
@@ -70,6 +80,7 @@ abstract class RenderableLayer<T extends Layer> {
         parent: parent,
         map: map,
         destTileSize: destTileSize,
+        filterQuality: filterQuality,
       );
     }
 

--- a/packages/flame_tiled/lib/src/renderable_layers/renderable_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/renderable_layer.dart
@@ -30,7 +30,7 @@ abstract class RenderableLayer<T extends Layer> {
     required this.map,
     required this.destTileSize,
     FilterQuality? filterQuality,
-  }) : filterQuality = filterQuality ?? FilterQuality.low;
+  }) : filterQuality = filterQuality ?? FilterQuality.none;
 
   /// [load] is a factory method to create [RenderableLayer] by type of [layer].
   static Future<RenderableLayer> load({

--- a/packages/flame_tiled/lib/src/renderable_layers/tile_layers/hexagonal_tile_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/tile_layers/hexagonal_tile_layer.dart
@@ -18,6 +18,7 @@ class HexagonalTileLayer extends FlameTileLayer {
     required super.tiledAtlas,
     required super.animationFrames,
     required super.ignoreFlip,
+    super.filterQuality,
   });
 
   @override

--- a/packages/flame_tiled/lib/src/renderable_layers/tile_layers/isometric_tile_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/tile_layers/isometric_tile_layer.dart
@@ -17,6 +17,7 @@ class IsometricTileLayer extends FlameTileLayer {
     required super.tiledAtlas,
     required super.animationFrames,
     required super.ignoreFlip,
+    super.filterQuality,
   });
 
   @override

--- a/packages/flame_tiled/lib/src/renderable_layers/tile_layers/orthogonal_tile_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/tile_layers/orthogonal_tile_layer.dart
@@ -17,6 +17,7 @@ class OrthogonalTileLayer extends FlameTileLayer {
     required super.tiledAtlas,
     required super.animationFrames,
     required super.ignoreFlip,
+    super.filterQuality,
   });
 
   @override

--- a/packages/flame_tiled/lib/src/renderable_layers/tile_layers/staggered_tile_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/tile_layers/staggered_tile_layer.dart
@@ -17,6 +17,7 @@ class StaggeredTileLayer extends FlameTileLayer {
     required super.tiledAtlas,
     required super.animationFrames,
     required super.ignoreFlip,
+    super.filterQuality,
   });
 
   @override

--- a/packages/flame_tiled/lib/src/renderable_layers/tile_layers/tile_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/tile_layers/tile_layer.dart
@@ -34,7 +34,8 @@ import 'package:meta/meta.dart';
 /// {@endtemplate}
 @internal
 abstract class FlameTileLayer extends RenderableLayer<TileLayer> {
-  late final _layerPaint = Paint();
+  late final _layerPaint = Paint()
+    ..color = Color.fromRGBO(255, 255, 255, opacity);
   final TiledAtlas tiledAtlas;
   late List<List<MutableRSTransform?>> transforms;
   final animations = <TileAnimation>[];
@@ -50,11 +51,7 @@ abstract class FlameTileLayer extends RenderableLayer<TileLayer> {
     required this.animationFrames,
     required this.ignoreFlip,
     super.filterQuality,
-  }) {
-    _layerPaint
-      ..color = Color.fromRGBO(255, 255, 255, opacity)
-      ..filterQuality = filterQuality;
-  }
+  });
 
   /// {@macro flame_tile_layer}
   static FlameTileLayer load({

--- a/packages/flame_tiled/lib/src/renderable_layers/tile_layers/tile_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/tile_layers/tile_layer.dart
@@ -49,8 +49,11 @@ abstract class FlameTileLayer extends RenderableLayer<TileLayer> {
     required this.tiledAtlas,
     required this.animationFrames,
     required this.ignoreFlip,
+    super.filterQuality,
   }) {
-    _layerPaint.color = Color.fromRGBO(255, 255, 255, opacity);
+    _layerPaint
+      ..color = Color.fromRGBO(255, 255, 255, opacity)
+      ..filterQuality = filterQuality;
   }
 
   /// {@macro flame_tile_layer}
@@ -61,10 +64,10 @@ abstract class FlameTileLayer extends RenderableLayer<TileLayer> {
     required Vector2 destTileSize,
     required Map<Tile, TileFrames> animationFrames,
     required TiledAtlas atlas,
+    FilterQuality? filterQuality,
     bool? ignoreFlip,
   }) {
     ignoreFlip ??= false;
-
     final mapOrientation = map.orientation;
     if (mapOrientation == null) {
       throw StateError('Map orientation should be present');
@@ -80,6 +83,7 @@ abstract class FlameTileLayer extends RenderableLayer<TileLayer> {
           tiledAtlas: atlas,
           animationFrames: animationFrames,
           ignoreFlip: ignoreFlip,
+          filterQuality: filterQuality,
         );
       case MapOrientation.staggered:
         return StaggeredTileLayer(
@@ -90,6 +94,7 @@ abstract class FlameTileLayer extends RenderableLayer<TileLayer> {
           tiledAtlas: atlas,
           animationFrames: animationFrames,
           ignoreFlip: ignoreFlip,
+          filterQuality: filterQuality,
         );
       case MapOrientation.hexagonal:
         return HexagonalTileLayer(
@@ -100,6 +105,7 @@ abstract class FlameTileLayer extends RenderableLayer<TileLayer> {
           tiledAtlas: atlas,
           animationFrames: animationFrames,
           ignoreFlip: ignoreFlip,
+          filterQuality: filterQuality,
         );
       case MapOrientation.orthogonal:
         return OrthogonalTileLayer(
@@ -110,6 +116,7 @@ abstract class FlameTileLayer extends RenderableLayer<TileLayer> {
           tiledAtlas: atlas,
           animationFrames: animationFrames,
           ignoreFlip: ignoreFlip,
+          filterQuality: filterQuality,
         );
     }
   }


### PR DESCRIPTION
# Description
This makes it possible to pass in `FilterQuality` to the `TiledComponent` and to the layers, since `PaintImage` defaults to `FilterQuality.low`.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
