### PR TITLE
fix: Use `ComponentKey`s to keep track of dispatchers

### DIFF
--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -63,16 +63,6 @@ class ComponentTreeRoot extends Component {
     _componentsToRebalance.add(parent);
   }
 
-  @internal
-  Iterable<T> queuedAdds<T extends Component>() sync* {
-    for (final event in _queue) {
-      final child = event.child;
-      if (event.kind == _LifecycleEventKind.add && child is T) {
-        yield child;
-      }
-    }
-  }
-
   bool get hasLifecycleEvents => _queue.isNotEmpty;
 
   void processLifecycleEvents() {

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -63,6 +63,16 @@ class ComponentTreeRoot extends Component {
     _componentsToRebalance.add(parent);
   }
 
+  @internal
+  Iterable<T> queuedAdds<T extends Component>() sync* {
+    for (final event in _queue) {
+      final child = event.child;
+      if (event.kind == _LifecycleEventKind.add && child is T) {
+        yield child;
+      }
+    }
+  }
+
   bool get hasLifecycleEvents => _queue.isNotEmpty;
 
   void processLifecycleEvents() {

--- a/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
@@ -30,8 +30,10 @@ mixin DoubleTapCallbacks on Component {
   void onMount() {
     super.onMount();
     final game = findGame()! as FlameGame;
-    if (game.firstChild<DoubleTapDispatcher>() == null) {
-      game.add(DoubleTapDispatcher());
+    if (game.findByKey(const DoubleTapDispatcherKey()) == null) {
+      final dispatcher = DoubleTapDispatcher();
+      game.registerKey(const DoubleTapDispatcherKey(), dispatcher);
+      game.add(dispatcher);
     }
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
@@ -67,8 +67,10 @@ mixin DragCallbacks on Component {
   void onMount() {
     super.onMount();
     final game = findGame()! as FlameGame;
-    if (game.firstChild<MultiDragDispatcher>() == null) {
-      game.add(MultiDragDispatcher());
+    if (game.findByKey(const MultiDragDispatcherKey()) == null) {
+      final dispatcher = MultiDragDispatcher();
+      game.registerKey(const MultiDragDispatcherKey(), dispatcher);
+      game.add(dispatcher);
     }
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
@@ -24,7 +24,7 @@ mixin TapCallbacks on Component {
   void onMount() {
     super.onMount();
     final game = findGame()! as FlameGame;
-    if (game.firstChild<MultiTapDispatcher>() == null) {
+    if (game.firstChildOrQueued<MultiTapDispatcher>() == null) {
       game.add(MultiTapDispatcher());
     }
   }

--- a/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
@@ -24,8 +24,10 @@ mixin TapCallbacks on Component {
   void onMount() {
     super.onMount();
     final game = findGame()! as FlameGame;
-    if (game.firstChildOrQueued<MultiTapDispatcher>() == null) {
-      game.add(MultiTapDispatcher());
+    if (game.findByKey(const MultiTapDispatcherKey()) == null) {
+      final dispatcher = MultiTapDispatcher();
+      game.registerKey(const MultiTapDispatcherKey(), dispatcher);
+      game.add(dispatcher);
     }
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
@@ -7,7 +7,6 @@ import 'package:flame/src/events/messages/double_tap_event.dart';
 import 'package:flutter/gestures.dart';
 import 'package:meta/meta.dart';
 
-@internal
 class DoubleTapDispatcherKey implements ComponentKey {
   const DoubleTapDispatcherKey();
 

--- a/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
@@ -7,6 +7,18 @@ import 'package:flame/src/events/messages/double_tap_event.dart';
 import 'package:flutter/gestures.dart';
 import 'package:meta/meta.dart';
 
+@internal
+class DoubleTapDispatcherKey implements ComponentKey {
+  const DoubleTapDispatcherKey();
+
+  @override
+  int get hashCode => 20260645; // 'DoubleTapDispatcherKey' as hashCode
+
+  @override
+  bool operator ==(dynamic other) =>
+      other is DoubleTapDispatcherKey && other.hashCode == hashCode;
+}
+
 /// [DoubleTapDispatcher] propagates double-tap events to every components in
 /// the component tree that is mixed with [DoubleTapCallbacks]. This will be
 /// attached to the [FlameGame] instance automatically whenever any
@@ -14,7 +26,6 @@ import 'package:meta/meta.dart';
 @internal
 class DoubleTapDispatcher extends Component with HasGameRef<FlameGame> {
   final _components = <DoubleTapCallbacks>{};
-  bool _eventHandlerRegistered = false;
 
   void _onDoubleTapDown(DoubleTapDownEvent event) {
     event.deliverAtPoint(
@@ -37,30 +48,21 @@ class DoubleTapDispatcher extends Component with HasGameRef<FlameGame> {
 
   @override
   void onMount() {
-    if (game.firstChild<DoubleTapDispatcher>() == null) {
-      game.gestureDetectors.add(
-        DoubleTapGestureRecognizer.new,
-        (DoubleTapGestureRecognizer instance) {
-          instance.onDoubleTapDown =
-              (details) => _onDoubleTapDown(DoubleTapDownEvent(game, details));
-          instance.onDoubleTapCancel =
-              () => _onDoubleTapCancel(DoubleTapCancelEvent());
-          instance.onDoubleTap = () => _onDoubleTapUp(DoubleTapEvent());
-        },
-      );
-      _eventHandlerRegistered = true;
-    } else {
-      removeFromParent();
-    }
+    game.gestureDetectors.add(
+      DoubleTapGestureRecognizer.new,
+      (DoubleTapGestureRecognizer instance) {
+        instance.onDoubleTapDown =
+            (details) => _onDoubleTapDown(DoubleTapDownEvent(game, details));
+        instance.onDoubleTapCancel =
+            () => _onDoubleTapCancel(DoubleTapCancelEvent());
+        instance.onDoubleTap = () => _onDoubleTapUp(DoubleTapEvent());
+      },
+    );
   }
 
   @override
   void onRemove() {
-    if (!_eventHandlerRegistered) {
-      return;
-    }
-
     game.gestureDetectors.remove<DoubleTapGestureRecognizer>();
-    _eventHandlerRegistered = false;
+    game.unregisterKey(const DoubleTapDispatcherKey());
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/has_draggable_components.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/has_draggable_components.dart
@@ -15,7 +15,6 @@ import 'package:flame/src/game/game_render_box.dart';
 import 'package:flutter/gestures.dart';
 import 'package:meta/meta.dart';
 
-@internal
 class MultiDragDispatcherKey implements ComponentKey {
   const MultiDragDispatcherKey();
 

--- a/packages/flame/lib/src/events/flame_game_mixins/has_draggable_components.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/has_draggable_components.dart
@@ -1,4 +1,5 @@
 import 'package:flame/src/components/core/component.dart';
+import 'package:flame/src/components/core/component_key.dart';
 import 'package:flame/src/components/mixins/draggable.dart';
 import 'package:flame/src/events/component_mixins/drag_callbacks.dart';
 import 'package:flame/src/events/flame_drag_adapter.dart';
@@ -14,6 +15,18 @@ import 'package:flame/src/game/game_render_box.dart';
 import 'package:flutter/gestures.dart';
 import 'package:meta/meta.dart';
 
+@internal
+class MultiDragDispatcherKey implements ComponentKey {
+  const MultiDragDispatcherKey();
+
+  @override
+  int get hashCode => 91604879; // 'MultiDragDispatcherKey' as hashCode
+
+  @override
+  bool operator ==(dynamic other) =>
+      other is MultiDragDispatcherKey && other.hashCode == hashCode;
+}
+
 /// **MultiDragDispatcher** facilitates dispatching of drag events to the
 /// [DragCallbacks] components in the component tree. It will be attached to
 /// the [FlameGame] instance automatically whenever any [DragCallbacks]
@@ -22,7 +35,6 @@ import 'package:meta/meta.dart';
 class MultiDragDispatcher extends Component implements MultiDragListener {
   /// The record of all components currently being touched.
   final Set<TaggedComponent<DragCallbacks>> _records = {};
-  bool _eventHandlerRegistered = false;
 
   FlameGame get game => parent! as FlameGame;
 
@@ -165,26 +177,18 @@ class MultiDragDispatcher extends Component implements MultiDragListener {
 
   @override
   void onMount() {
-    if (game.firstChild<MultiDragDispatcher>() == null) {
-      game.gestureDetectors.add<ImmediateMultiDragGestureRecognizer>(
-        ImmediateMultiDragGestureRecognizer.new,
-        (ImmediateMultiDragGestureRecognizer instance) {
-          instance.onStart = (Offset point) => FlameDragAdapter(this, point);
-        },
-      );
-      _eventHandlerRegistered = true;
-    } else {
-      // Ensures that only one MultiDragDispatcher is attached to the Game.
-      removeFromParent();
-    }
+    game.gestureDetectors.add<ImmediateMultiDragGestureRecognizer>(
+      ImmediateMultiDragGestureRecognizer.new,
+      (ImmediateMultiDragGestureRecognizer instance) {
+        instance.onStart = (Offset point) => FlameDragAdapter(this, point);
+      },
+    );
   }
 
   @override
   void onRemove() {
-    if (_eventHandlerRegistered) {
-      game.gestureDetectors.remove<ImmediateMultiDragGestureRecognizer>();
-      _eventHandlerRegistered = false;
-    }
+    game.gestureDetectors.remove<ImmediateMultiDragGestureRecognizer>();
+    game.unregisterKey(const MultiDragDispatcherKey());
   }
 
   @override

--- a/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
@@ -27,7 +27,6 @@ class MultiTapDispatcherKey implements ComponentKey {
 class MultiTapDispatcher extends Component implements MultiTapListener {
   /// The record of all components currently being touched.
   final Set<TaggedComponent<TapCallbacks>> _record = {};
-  bool _eventHandlerRegistered = false;
 
   FlameGame get game => parent! as FlameGame;
 
@@ -204,16 +203,12 @@ class MultiTapDispatcher extends Component implements MultiTapListener {
         instance.onLongTapDown = handleLongTapDown;
       },
     );
-    _eventHandlerRegistered = true;
   }
 
   @override
   void onRemove() {
-    if (_eventHandlerRegistered) {
-      game.gestureDetectors.remove<MultiTapGestureRecognizer>();
-      game.unregisterKey(MultiTapDispatcherKey());
-      _eventHandlerRegistered = false;
-    }
+    game.gestureDetectors.remove<MultiTapGestureRecognizer>();
+    game.unregisterKey(const MultiTapDispatcherKey());
   }
 
   @override

--- a/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
@@ -12,6 +12,18 @@ import 'package:flutter/gestures.dart';
 import 'package:meta/meta.dart';
 
 @internal
+class MultiTapDispatcherKey implements ComponentKey {
+  const MultiTapDispatcherKey();
+
+  @override
+  int get hashCode => 401913931; // 'MultiTapDispatcherKey' as hashCode
+
+  @override
+  bool operator ==(dynamic other) =>
+      other is MultiTapDispatcherKey && other.hashCode == hashCode;
+}
+
+@internal
 class MultiTapDispatcher extends Component implements MultiTapListener {
   /// The record of all components currently being touched.
   final Set<TaggedComponent<TapCallbacks>> _record = {};
@@ -199,6 +211,7 @@ class MultiTapDispatcher extends Component implements MultiTapListener {
   void onRemove() {
     if (_eventHandlerRegistered) {
       game.gestureDetectors.remove<MultiTapGestureRecognizer>();
+      game.unregisterKey(MultiTapDispatcherKey());
       _eventHandlerRegistered = false;
     }
   }

--- a/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
@@ -11,7 +11,6 @@ import 'package:flame/src/game/game_render_box.dart';
 import 'package:flutter/gestures.dart';
 import 'package:meta/meta.dart';
 
-@internal
 class MultiTapDispatcherKey implements ComponentKey {
   const MultiTapDispatcherKey();
 

--- a/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/has_tappable_components.dart
@@ -179,25 +179,20 @@ class MultiTapDispatcher extends Component implements MultiTapListener {
 
   @override
   void onMount() {
-    if (game.firstChild<MultiTapDispatcher>() == null) {
-      game.gestureDetectors.add<MultiTapGestureRecognizer>(
-        MultiTapGestureRecognizer.new,
-        (MultiTapGestureRecognizer instance) {
-          instance.longTapDelay = Duration(
-            milliseconds: (longTapDelay * 1000).toInt(),
-          );
-          instance.onTap = handleTap;
-          instance.onTapDown = handleTapDown;
-          instance.onTapUp = handleTapUp;
-          instance.onTapCancel = handleTapCancel;
-          instance.onLongTapDown = handleLongTapDown;
-        },
-      );
-      _eventHandlerRegistered = true;
-    } else {
-      // Ensures that only one MultiTapDispatcher is attached to the Game.
-      removeFromParent();
-    }
+    game.gestureDetectors.add<MultiTapGestureRecognizer>(
+      MultiTapGestureRecognizer.new,
+      (MultiTapGestureRecognizer instance) {
+        instance.longTapDelay = Duration(
+          milliseconds: (longTapDelay * 1000).toInt(),
+        );
+        instance.onTap = handleTap;
+        instance.onTapDown = handleTapDown;
+        instance.onTapUp = handleTapUp;
+        instance.onTapCancel = handleTapCancel;
+        instance.onLongTapDown = handleLongTapDown;
+      },
+    );
+    _eventHandlerRegistered = true;
   }
 
   @override


### PR DESCRIPTION
# Description
This uses the `ComponentKey` API to register and unregister dispatchers, so that we don't have to create unnecessary dispatcher components that are removed directly in `onMount` if there already is a dispatcher or the same type added.

This also opens up for registering components to the dispatchers so that we don't have to go through the whole tree to deliver events which it does currently.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
