### PR TITLE
fix: Reset _completeCompleter in ticker

### DIFF
--- a/packages/flame/lib/src/sprite_animation_ticker.dart
+++ b/packages/flame/lib/src/sprite_animation_ticker.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flame/components.dart';
-import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
 
 /// A helper class to make the [spriteAnimation] tick.
 class SpriteAnimationTicker {

--- a/packages/flame/lib/src/sprite_animation_ticker.dart
+++ b/packages/flame/lib/src/sprite_animation_ticker.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flame/components.dart';
+import 'package:flutter/material.dart';
 
 /// A helper class to make the [spriteAnimation] tick.
 class SpriteAnimationTicker {
@@ -30,7 +31,8 @@ class SpriteAnimationTicker {
   /// Registered method to be triggered when the animation complete.
   void Function()? onComplete;
 
-  Completer<void>? _completeCompleter;
+  @visibleForTesting
+  Completer<void>? completeCompleter;
 
   /// The current frame that should be displayed.
   SpriteAnimationFrame get currentFrame => spriteAnimation.frames[currentIndex];
@@ -54,9 +56,9 @@ class SpriteAnimationTicker {
       return Future.value();
     }
 
-    _completeCompleter ??= Completer<void>();
+    completeCompleter ??= Completer<void>();
 
-    return _completeCompleter!.future;
+    return completeCompleter!.future;
   }
 
   /// Resets the animation, like it would just have been created.
@@ -66,7 +68,7 @@ class SpriteAnimationTicker {
     currentIndex = 0;
     _done = false;
     _started = false;
-    _completeCompleter = null;
+    completeCompleter = null;
   }
 
   /// Sets this animation to be on the last frame.
@@ -128,7 +130,7 @@ class SpriteAnimationTicker {
         } else {
           _done = true;
           onComplete?.call();
-          _completeCompleter?.complete();
+          completeCompleter?.complete();
           return;
         }
       } else {

--- a/packages/flame/lib/src/sprite_animation_ticker.dart
+++ b/packages/flame/lib/src/sprite_animation_ticker.dart
@@ -68,7 +68,11 @@ class SpriteAnimationTicker {
     currentIndex = 0;
     _done = false;
     _started = false;
-    completeCompleter = null;
+
+    // Reset completeCompleter if it's already completed
+    if (completeCompleter?.isCompleted ?? false) {
+      completeCompleter = null;
+    }
   }
 
   /// Sets this animation to be on the last frame.

--- a/packages/flame/lib/src/sprite_animation_ticker.dart
+++ b/packages/flame/lib/src/sprite_animation_ticker.dart
@@ -66,6 +66,7 @@ class SpriteAnimationTicker {
     currentIndex = 0;
     _done = false;
     _started = false;
+    _completeCompleter = null;
   }
 
   /// Sets this animation to be on the last frame.

--- a/packages/flame/test/sprite_animation_ticker_test.dart
+++ b/packages/flame/test/sprite_animation_ticker_test.dart
@@ -145,5 +145,22 @@ void main() {
         expectLater(animationTicker.completed, doesNotComplete);
       },
     );
+
+    test("completed doesn't complete after the animation is reset", () async {
+      final sprite = MockSprite();
+      final animationTicker = SpriteAnimation.spriteList(
+        [sprite],
+        stepTime: 1,
+        loop: false,
+      ).createTicker();
+
+      animationTicker.completed;
+      animationTicker.update(1);
+      expect(animationTicker.completeCompleter!.isCompleted, true);
+
+      animationTicker.reset();
+      animationTicker.completed;
+      expect(animationTicker.completeCompleter!.isCompleted, false);
+    });
   });
 }


### PR DESCRIPTION
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
I was running this code:
```dart
void attack() async {
  print('Attack started');
  current = PlayerState.attack;

  final attackTicker = animationTicker!;
  await attackTicker.completed;
  print('Attack ticker completed');

  attackTicker.reset();
  current = PlayerState.idle;
}
```
and `attackTicker.completed` would get stuck as permanently completed after the first completion.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [X] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [-] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

The closest issue I can find is https://github.com/flame-engine/flame/issues/2584 which uses the `ticker.onComplete` function and ran into a problem because of creating a new ticker. This PR concerns the `ticker.completed` future.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
