### PR TITLE
chore(release): Publish Flame 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,85 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-08-08
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`flame` - `v1.8.2`](#flame---v182)
+ - [`flame_lint` - `v1.1.0`](#flame_lint---v110)
+
+Packages with other changes:
+
+ - [`flame_rive` - `v1.9.1`](#flame_rive---v191)
+ - [`flame_tiled` - `v1.13.0`](#flame_tiled---v1130)
+ - [`flame_isolate` - `v0.4.0+2`](#flame_isolate---v0402)
+ - [`flame_audio` - `v2.0.5`](#flame_audio---v205)
+ - [`flame_spine` - `v0.1.1+1`](#flame_spine---v0111)
+ - [`flame_svg` - `v1.8.1`](#flame_svg---v181)
+ - [`flame_test` - `v1.12.1`](#flame_test---v1121)
+ - [`flame_oxygen` - `v0.1.8+5`](#flame_oxygen---v0185)
+ - [`flame_bloc` - `v1.10.1`](#flame_bloc---v1101)
+ - [`flame_fire_atlas` - `v1.3.8`](#flame_fire_atlas---v138)
+ - [`flame_forge2d` - `v0.14.1+1`](#flame_forge2d---v01411)
+ - [`flame_noise` - `v0.1.1+4`](#flame_noise---v0114)
+ - [`flame_network_assets` - `v0.2.0+4`](#flame_network_assets---v0204)
+ - [`flame_lottie` - `v0.2.1+1`](#flame_lottie---v0211)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `flame_isolate` - `v0.4.0+2`
+ - `flame_audio` - `v2.0.5`
+ - `flame_spine` - `v0.1.1+1`
+ - `flame_svg` - `v1.8.1`
+ - `flame_test` - `v1.12.1`
+ - `flame_oxygen` - `v0.1.8+5`
+ - `flame_bloc` - `v1.10.1`
+ - `flame_fire_atlas` - `v1.3.8`
+ - `flame_forge2d` - `v0.14.1+1`
+ - `flame_noise` - `v0.1.1+4`
+ - `flame_network_assets` - `v0.2.0+4`
+ - `flame_lottie` - `v0.2.1+1`
+
+---
+
+#### `flame` - `v1.8.2`
+
+ - **PERF**: Improve performance of raycasts ([#2617](https://github.com/flame-engine/flame/issues/2617)). ([8e0a7879](https://github.com/flame-engine/flame/commit/8e0a7879d7669e09efcbcee28d9f2038fe9014c0))
+ - **FIX**: Reset _completeCompleter in ticker ([#2636](https://github.com/flame-engine/flame/issues/2636)). ([a35d3a10](https://github.com/flame-engine/flame/commit/a35d3a10abfe9e5caab1a646e0980d03fbf585d1))
+ - **FIX**: Viewport should recieve events before the world  ([#2630](https://github.com/flame-engine/flame/issues/2630)). ([e852064e](https://github.com/flame-engine/flame/commit/e852064e494e58ea2be19a5b035e09ed2e465608))
+ - **FIX**: Use `ComponentKey`s to keep track of dispatchers ([#2629](https://github.com/flame-engine/flame/issues/2629)). ([ff59aa15](https://github.com/flame-engine/flame/commit/ff59aa152c5a2e0b360f980c78a8b3cc4fad7507))
+ - **FIX**: FlameGame onRemove fix to prevent memory leak ([#2602](https://github.com/flame-engine/flame/issues/2602)). ([dac2ebbf](https://github.com/flame-engine/flame/commit/dac2ebbf506ff48ca8f34d872bbc47cba3ad6c7b))
+ - **FIX**: Only use pre-set ReadonlySizeProvider for sizing in HudMarginComponent ([#2611](https://github.com/flame-engine/flame/issues/2611)). ([832c0510](https://github.com/flame-engine/flame/commit/832c051085e0fade8a7e4b262bf9941d279baef4))
+ - **FIX**: TextBoxConfig dismissDelay to not be ignored ([#2607](https://github.com/flame-engine/flame/issues/2607)). ([1567b389](https://github.com/flame-engine/flame/commit/1567b3891057e4ce168d76c920bd40403febd82a))
+ - **FEAT**: Adding key argument to shape components ([#2632](https://github.com/flame-engine/flame/issues/2632)). ([c542d3c3](https://github.com/flame-engine/flame/commit/c542d3c34bf911cec8332dcdeb65d0017e6cb576))
+ - **FEAT**: Add optional world input to `CameraComponent.canSee` ([#2616](https://github.com/flame-engine/flame/issues/2616)). ([1cad0b23](https://github.com/flame-engine/flame/commit/1cad0b23e18db8f352da5790c8ea5ec6053936da))
+ - **FEAT**: Add a Circle.fromPoints utility method ([#2603](https://github.com/flame-engine/flame/issues/2603)). ([a83f2815](https://github.com/flame-engine/flame/commit/a83f2815bbdaf9c176a34a325485a96b5a323575))
+ - **FEAT**: Add a midpoint getter to LineSegment ([#2605](https://github.com/flame-engine/flame/issues/2605)). ([1f9f3509](https://github.com/flame-engine/flame/commit/1f9f35093b3b90113e32a36e1103b87246212fa4))
+ - **FEAT**: Add Rectangle.fromLTWH and Rect.toFlameRectangle utility methods ([#2604](https://github.com/flame-engine/flame/issues/2604)). ([76271cee](https://github.com/flame-engine/flame/commit/76271ceef04264ec8fa5c39a23f43d638d731694))
+ - **DOCS**: Add more guidance to collision detection algorithm choices ([#2624](https://github.com/flame-engine/flame/issues/2624)). ([781e8983](https://github.com/flame-engine/flame/commit/781e898315a0162117a83bf62e2650ce7244503d))
+ - **BREAKING** **PERF**: Pool `CollisionProspect`s and remove some list creations from the collision detection ([#2625](https://github.com/flame-engine/flame/issues/2625)). ([e430b6cd](https://github.com/flame-engine/flame/commit/e430b6cdf2e6be52bf384efb3428bcb41ae13d30))
+ - **BREAKING** **FEAT**: Make world nullable in `CameraComponent` ([#2615](https://github.com/flame-engine/flame/issues/2615)). ([14f51635](https://github.com/flame-engine/flame/commit/14f51635421b8b30049ea287b7c472e54a269250))
+
+#### `flame_lint` - `v1.1.0`
+
+ - **BREAKING** **PERF**: Pool `CollisionProspect`s and remove some list creations from the collision detection ([#2625](https://github.com/flame-engine/flame/issues/2625)). ([e430b6cd](https://github.com/flame-engine/flame/commit/e430b6cdf2e6be52bf384efb3428bcb41ae13d30))
+
+#### `flame_rive` - `v1.9.1`
+
+ - **FIX**: Respect artboard clip value ([#2639](https://github.com/flame-engine/flame/issues/2639)). ([4e664245](https://github.com/flame-engine/flame/commit/4e6642458494b4d4544bcc03b568476faeb0a71f))
+
+#### `flame_tiled` - `v1.13.0`
+
+ - **FIX**: Compute scale in TileLayers based on native map tile size rather than image sizes to support oversized/undersized tiles. ([#2634](https://github.com/flame-engine/flame/issues/2634)). ([1c4d6cd0](https://github.com/flame-engine/flame/commit/1c4d6cd0654f133771a7af5795cc1de2343268c1))
+ - **FEAT**: Possiblity to pass in FilterQuality to tiled layers ([#2627](https://github.com/flame-engine/flame/issues/2627)). ([f3de6650](https://github.com/flame-engine/flame/commit/f3de66507e623e2fe0100cfd4d002dea14f72470))
+
+
 ## 2023-07-02
 
 ### Changes

--- a/doc/flame/examples/pubspec.yaml
+++ b/doc/flame/examples/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.8.1
-  flame_rive: ^1.9.0
+  flame: ^1.8.2
+  flame_rive: ^1.9.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
 
 flutter:
   assets:

--- a/doc/tutorials/klondike/app/pubspec.yaml
+++ b/doc/tutorials/klondike/app/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
 flutter:
   assets:
     - assets/images/

--- a/doc/tutorials/platformer/app/pubspec.yaml
+++ b/doc/tutorials/platformer/app/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
 

--- a/doc/tutorials/space_shooter/app/pubspec.yaml
+++ b/doc/tutorials/space_shooter/app/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
 

--- a/examples/games/padracing/pubspec.yaml
+++ b/examples/games/padracing/pubspec.yaml
@@ -8,15 +8,15 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.8.1
-  flame_forge2d: ^0.14.1
+  flame: ^1.8.2
+  flame_forge2d: ^0.14.1+1
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4
   url_launcher: ^6.1.11
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
 

--- a/examples/games/rogue_shooter/pubspec.yaml
+++ b/examples/games/rogue_shooter/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
 
 flutter:
   assets:

--- a/examples/games/trex/pubspec.yaml
+++ b/examples/games/trex/pubspec.yaml
@@ -11,12 +11,12 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
 flutter:
   uses-material-design: true
   assets:

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -11,15 +11,15 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.8.1
-  flame_audio: ^2.0.4
-  flame_forge2d: ^0.14.1
-  flame_isolate: ^0.4.0+1
-  flame_lottie: ^0.2.1
-  flame_noise: ^0.1.1+3
-  flame_spine: ^0.1.1
-  flame_svg: ^1.8.0
-  flame_tiled: ^1.12.0
+  flame: ^1.8.2
+  flame_audio: ^2.0.5
+  flame_forge2d: ^0.14.1+1
+  flame_isolate: ^0.4.0+2
+  flame_lottie: ^0.2.1+1
+  flame_noise: ^0.1.1+4
+  flame_spine: ^0.1.1+1
+  flame_svg: ^1.8.1
+  flame_tiled: ^1.13.0
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4
@@ -30,7 +30,7 @@ dependencies:
   trex_game: ^0.1.0
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   test: any
 
 flutter:

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 1.8.2
+
+> Note: This release has breaking changes.
+
+ - **PERF**: Improve performance of raycasts ([#2617](https://github.com/flame-engine/flame/issues/2617)). ([8e0a7879](https://github.com/flame-engine/flame/commit/8e0a7879d7669e09efcbcee28d9f2038fe9014c0))
+ - **FIX**: Reset _completeCompleter in ticker ([#2636](https://github.com/flame-engine/flame/issues/2636)). ([a35d3a10](https://github.com/flame-engine/flame/commit/a35d3a10abfe9e5caab1a646e0980d03fbf585d1))
+ - **FIX**: Viewport should recieve events before the world  ([#2630](https://github.com/flame-engine/flame/issues/2630)). ([e852064e](https://github.com/flame-engine/flame/commit/e852064e494e58ea2be19a5b035e09ed2e465608))
+ - **FIX**: Use `ComponentKey`s to keep track of dispatchers ([#2629](https://github.com/flame-engine/flame/issues/2629)). ([ff59aa15](https://github.com/flame-engine/flame/commit/ff59aa152c5a2e0b360f980c78a8b3cc4fad7507))
+ - **FIX**: FlameGame onRemove fix to prevent memory leak ([#2602](https://github.com/flame-engine/flame/issues/2602)). ([dac2ebbf](https://github.com/flame-engine/flame/commit/dac2ebbf506ff48ca8f34d872bbc47cba3ad6c7b))
+ - **FIX**: Only use pre-set ReadonlySizeProvider for sizing in HudMarginComponent ([#2611](https://github.com/flame-engine/flame/issues/2611)). ([832c0510](https://github.com/flame-engine/flame/commit/832c051085e0fade8a7e4b262bf9941d279baef4))
+ - **FIX**: TextBoxConfig dismissDelay to not be ignored ([#2607](https://github.com/flame-engine/flame/issues/2607)). ([1567b389](https://github.com/flame-engine/flame/commit/1567b3891057e4ce168d76c920bd40403febd82a))
+ - **FEAT**: Adding key argument to shape components ([#2632](https://github.com/flame-engine/flame/issues/2632)). ([c542d3c3](https://github.com/flame-engine/flame/commit/c542d3c34bf911cec8332dcdeb65d0017e6cb576))
+ - **FEAT**: Add optional world input to `CameraComponent.canSee` ([#2616](https://github.com/flame-engine/flame/issues/2616)). ([1cad0b23](https://github.com/flame-engine/flame/commit/1cad0b23e18db8f352da5790c8ea5ec6053936da))
+ - **FEAT**: Add a Circle.fromPoints utility method ([#2603](https://github.com/flame-engine/flame/issues/2603)). ([a83f2815](https://github.com/flame-engine/flame/commit/a83f2815bbdaf9c176a34a325485a96b5a323575))
+ - **FEAT**: Add a midpoint getter to LineSegment ([#2605](https://github.com/flame-engine/flame/issues/2605)). ([1f9f3509](https://github.com/flame-engine/flame/commit/1f9f35093b3b90113e32a36e1103b87246212fa4))
+ - **FEAT**: Add Rectangle.fromLTWH and Rect.toFlameRectangle utility methods ([#2604](https://github.com/flame-engine/flame/issues/2604)). ([76271cee](https://github.com/flame-engine/flame/commit/76271ceef04264ec8fa5c39a23f43d638d731694))
+ - **DOCS**: Add more guidance to collision detection algorithm choices ([#2624](https://github.com/flame-engine/flame/issues/2624)). ([781e8983](https://github.com/flame-engine/flame/commit/781e898315a0162117a83bf62e2650ce7244503d))
+ - **BREAKING** **PERF**: Pool `CollisionProspect`s and remove some list creations from the collision detection ([#2625](https://github.com/flame-engine/flame/issues/2625)). ([e430b6cd](https://github.com/flame-engine/flame/commit/e430b6cdf2e6be52bf384efb3428bcb41ae13d30))
+ - **BREAKING** **FEAT**: Make world nullable in `CameraComponent` ([#2615](https://github.com/flame-engine/flame/issues/2615)). ([14f51635](https://github.com/flame-engine/flame/commit/14f51635421b8b30049ea287b7c472e54a269250))
+
 ## 1.8.1
 
 > Note: This release has breaking changes.

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 1.8.1
+version: 1.8.2
 homepage: https://github.com/flame-engine/flame
 funding:
   - https://opencollective.com/blue-fire
@@ -22,8 +22,8 @@ dependencies:
 dev_dependencies:
   canvas_test: ^0.2.0
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
-  flame_test: ^1.12.0
+  flame_lint: ^1.1.0
+  flame_test: ^1.12.1
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_audio/CHANGELOG.md
+++ b/packages/flame_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5
+
+ - Update a dependency to the latest release.
+
 ## 2.0.4
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_audio/example/pubspec.yaml
+++ b/packages/flame_audio/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
-  flame_audio: ^2.0.4
+  flame: ^1.8.2
+  flame_audio: ^2.0.5
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
 
 flutter:
   assets:

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_audio
 description: |
   Audio support for the Flame game engine, basically a thin wrapper around the audioplayers package.
-version: 2.0.4
+version: 2.0.5
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_audio
 funding:
   - https://opencollective.com/blue-fire
@@ -14,11 +14,11 @@ environment:
 
 dependencies:
   audioplayers: ^5.0.0
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   synchronized: ^3.1.0
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0

--- a/packages/flame_bloc/CHANGELOG.md
+++ b/packages/flame_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.1
+
+ - Update a dependency to the latest release.
+
 ## 1.10.0
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_bloc/example/pubspec.yaml
+++ b/packages/flame_bloc/example/pubspec.yaml
@@ -10,14 +10,14 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  flame: ^1.8.1
-  flame_bloc: ^1.10.0
+  flame: ^1.8.2
+  flame_bloc: ^1.10.1
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_bloc
 description: Integration for the Bloc state management library to Flame games.
-version: 1.10.0
+version: 1.10.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_bloc
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   bloc: ^8.1.1
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2
@@ -21,8 +21,8 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
-  flame_test: ^1.12.0
+  flame_lint: ^1.1.0
+  flame_test: ^1.12.1
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter

--- a/packages/flame_fire_atlas/CHANGELOG.md
+++ b/packages/flame_fire_atlas/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.8
+
+ - Update a dependency to the latest release.
+
 ## 1.3.7
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_fire_atlas/example/pubspec.yaml
+++ b/packages/flame_fire_atlas/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
-  flame_fire_atlas: ^1.3.7
+  flame: ^1.8.2
+  flame_fire_atlas: ^1.3.8
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_fire_atlas
 description: Easy to use texture atlases for the flame engine created with the fire atlas editor
-version: 1.3.7
+version: 1.3.8
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_fire_atlas
 funding:
   - https://opencollective.com/blue-fire
@@ -13,13 +13,13 @@ environment:
 
 dependencies:
   archive: ^3.3.7
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.1+1
+
+ - Update a dependency to the latest release.
+
 ## 0.14.1
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -11,13 +11,13 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.8.1
-  flame_forge2d: ^0.14.1
+  flame: ^1.8.2
+  flame_forge2d: ^0.14.1+1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_forge2d
 description: Forge2D (Box2D) support for the Flame game engine. This uses the forge2d package and provides wrappers and components to be used inside Flame.
-version: 0.14.1
+version: 0.14.1+1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_forge2d
 funding:
   - https://opencollective.com/blue-fire
@@ -12,15 +12,15 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: 1.8.1
+  flame: 1.8.2
   flutter:
     sdk: flutter
   forge2d: ">=0.11.0 <0.12.0"
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
-  flame_test: ^1.12.0
+  flame_lint: ^1.1.0
+  flame_test: ^1.12.1
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_isolate/CHANGELOG.md
+++ b/packages/flame_isolate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+2
+
+ - Update a dependency to the latest release.
+
 ## 0.4.0+1
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_isolate/example/pubspec.yaml
+++ b/packages/flame_isolate/example/pubspec.yaml
@@ -10,15 +10,15 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.8.1
-  flame_isolate: ^0.4.0+1
+  flame: ^1.8.2
+  flame_isolate: ^0.4.0+2
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0
   quiver: ^3.2.1
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
 flutter:
   assets:
     - assets/images/

--- a/packages/flame_isolate/pubspec.yaml
+++ b/packages/flame_isolate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_isolate
 description: Flame wrapper for integral_isolates making multi-threading easy in Flame
-version: 0.4.0+1
+version: 0.4.0+2
 homepage: https://github.com/lohnn/integral_isolates
 
 environment:
@@ -8,14 +8,14 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0
 
 dev_dependencies:
-  flame_lint: ^1.0.0
-  flame_test: ^1.12.0
+  flame_lint: ^1.1.0
+  flame_test: ^1.12.1
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_jenny/jenny/pubspec.yaml
+++ b/packages/flame_jenny/jenny/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   test: any

--- a/packages/flame_jenny/pubspec.yaml
+++ b/packages/flame_jenny/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   jenny: ^1.0.4
@@ -22,5 +22,5 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   test: any

--- a/packages/flame_lint/CHANGELOG.md
+++ b/packages/flame_lint/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **PERF**: Pool `CollisionProspect`s and remove some list creations from the collision detection ([#2625](https://github.com/flame-engine/flame/issues/2625)). ([e430b6cd](https://github.com/flame-engine/flame/commit/e430b6cdf2e6be52bf384efb3428bcb41ae13d30))
+
 ## 1.0.0
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_lint/pubspec.yaml
+++ b/packages/flame_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_lint
 description: Flame lint package
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_lint
 funding:
   - https://opencollective.com/blue-fire

--- a/packages/flame_lottie/CHANGELOG.md
+++ b/packages/flame_lottie/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1+1
+
+ - Update a dependency to the latest release.
+
 ## 0.2.1
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_lottie/example/pubspec.yaml
+++ b/packages/flame_lottie/example/pubspec.yaml
@@ -8,14 +8,14 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
-  flame_lottie: ^0.2.1
+  flame: ^1.8.2
+  flame_lottie: ^0.2.1+1
   flutter:
     sdk: flutter
   lottie:
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
 
 flutter:
   uses-material-design: true

--- a/packages/flame_lottie/pubspec.yaml
+++ b/packages/flame_lottie/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_lottie
 description: Flame wrapper for Lottie by AirBnB. This package implements a bridge between Lottie and Flame, allowing to load and display Lottie animations.
-version: 0.2.1
+version: 0.2.1+1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_lottie
 funding:
   - https://opencollective.com/blue-fire
@@ -12,14 +12,14 @@ environment:
   flutter: '>=3.3.0'
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   lottie: ^2.3.2
 
 dev_dependencies:
-  flame_lint: ^1.0.0
-  flame_test: ^1.12.0
+  flame_lint: ^1.1.0
+  flame_test: ^1.12.1
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_network_assets/CHANGELOG.md
+++ b/packages/flame_network_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+4
+
+ - Update a dependency to the latest release.
+
 ## 0.2.0+3
 
  - Update a dependency to the latest release.

--- a/packages/flame_network_assets/example/pubspec.yaml
+++ b/packages/flame_network_assets/example/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  flame: ^1.8.1
-  flame_network_assets: ^0.2.0+3
+  flame: ^1.8.2
+  flame_network_assets: ^0.2.0+4
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0

--- a/packages/flame_network_assets/pubspec.yaml
+++ b/packages/flame_network_assets/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_network_assets
 description: Network assets support for Flame.
-version: 0.2.0+3
+version: 0.2.0+4
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_network_assets
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   dev: ^1.0.0
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   http: ^0.13.6
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_noise/CHANGELOG.md
+++ b/packages/flame_noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+4
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+3
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_noise/pubspec.yaml
+++ b/packages/flame_noise/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_noise
 description: Integrate the fast_noise package into Flame
-version: 0.1.1+3
+version: 0.1.1+4
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_noise
 funding:
   - https://opencollective.com/blue-fire
@@ -13,12 +13,12 @@ environment:
 
 dependencies:
   fast_noise: ^1.0.1
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
-  flame_test: ^1.12.0
+  flame_lint: ^1.1.0
+  flame_test: ^1.12.1
   test: any

--- a/packages/flame_oxygen/CHANGELOG.md
+++ b/packages/flame_oxygen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8+5
+
+ - Update a dependency to the latest release.
+
 ## 0.1.8+4
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_oxygen/example/pubspec.yaml
+++ b/packages/flame_oxygen/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
-  flame_oxygen: ^0.1.8+4
+  flame: ^1.8.2
+  flame_oxygen: ^0.1.8+5
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
 flutter:
   uses-material-design: true
   assets:

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_oxygen
 description: Integrate the Oxygen ECS with the Flame Engine.
-version: 0.1.8+4
+version: 0.1.8+5
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_oxygen
 funding:
   - https://opencollective.com/blue-fire
@@ -12,11 +12,11 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   oxygen: ^0.2.0
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0

--- a/packages/flame_rive/CHANGELOG.md
+++ b/packages/flame_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.1
+
+ - **FIX**: Respect artboard clip value ([#2639](https://github.com/flame-engine/flame/issues/2639)). ([4e664245](https://github.com/flame-engine/flame/commit/4e6642458494b4d4544bcc03b568476faeb0a71f))
+
 ## 1.9.0
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
-  flame_rive: ^1.9.0
+  flame: ^1.8.2
+  flame_rive: ^1.9.1
   flutter:
     sdk: flutter
   rive: ^0.11.1
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_rive
 description: Rive support for the Flame game engine. This uses the rive package and provides wrappers and components to be used inside Flame.
 homepage: https://github.com/flame-engine/flame
-version: 1.9.0
+version: 1.9.1
 funding:
   - https://opencollective.com/blue-fire
   - https://github.com/sponsors/bluefireteam
@@ -12,14 +12,14 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   rive: ^0.11.1
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
-  flame_test: ^1.12.0
+  flame_lint: ^1.1.0
+  flame_test: ^1.12.1
   flutter_test:
     sdk: flutter

--- a/packages/flame_spine/CHANGELOG.md
+++ b/packages/flame_spine/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+1
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_spine/example/pubspec.yaml
+++ b/packages/flame_spine/example/pubspec.yaml
@@ -7,13 +7,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
-  flame_spine: ^0.1.1
+  flame: ^1.8.2
+  flame_spine: ^0.1.1+1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_spine/pubspec.yaml
+++ b/packages/flame_spine/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_spine
 description: Spine support for the Flame game engine. This uses the spine_flutter package and provides wrappers and components to be used inside Flame.
-version: 0.1.1
+version: 0.1.1+1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_sprine
 funding:
   - https://opencollective.com/blue-fire
@@ -13,13 +13,13 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   spine_flutter: ^4.1.2
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_studio/pubspec.yaml
+++ b/packages/flame_studio/pubspec.yaml
@@ -14,14 +14,14 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.3.6
   meta: ^1.9.1
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_svg/CHANGELOG.md
+++ b/packages/flame_svg/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.1
+
+ - Update a dependency to the latest release.
+
 ## 1.8.0
 
  - **FIX**: Update sdk constraints to >=3.0.0 ([#2554](https://github.com/flame-engine/flame/issues/2554)). ([2f71e06e](https://github.com/flame-engine/flame/commit/2f71e06eb86ffc65cd459c4d722eee2470be13e5))

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
-  flame_svg: ^1.8.0
+  flame: ^1.8.2
+  flame_svg: ^1.8.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_svg
 description: Package to add SVG rendering support for the Flame game engine
-version: 1.8.0
+version: 1.8.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_svg
 funding:
   - https://opencollective.com/blue-fire
@@ -12,14 +12,14 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.5
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_test/CHANGELOG.md
+++ b/packages/flame_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.1
+
+ - Update a dependency to the latest release.
+
 ## 1.12.0
 
 > Note: This release has breaking changes.

--- a/packages/flame_test/example/pubspec.yaml
+++ b/packages/flame_test/example/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
-  flame_test: ^1.12.0
+  flame_lint: ^1.1.0
+  flame_test: ^1.12.1
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_test
 description: A package with classes to help testing applications using Flame
-version: 1.12.0
+version: 1.12.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_test
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   flutter_test:
@@ -23,4 +23,4 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0

--- a/packages/flame_tiled/CHANGELOG.md
+++ b/packages/flame_tiled/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.13.0
+
+ - **FIX**: Compute scale in TileLayers based on native map tile size rather than image sizes to support oversized/undersized tiles. ([#2634](https://github.com/flame-engine/flame/issues/2634)). ([1c4d6cd0](https://github.com/flame-engine/flame/commit/1c4d6cd0654f133771a7af5795cc1de2343268c1))
+ - **FEAT**: Possiblity to pass in FilterQuality to tiled layers ([#2627](https://github.com/flame-engine/flame/issues/2627)). ([f3de6650](https://github.com/flame-engine/flame/commit/f3de66507e623e2fe0100cfd4d002dea14f72470))
+
 ## 1.12.0
 
  - **FIX**: Tiled component orthogonal test ([#2549](https://github.com/flame-engine/flame/issues/2549)). ([34e5f0e4](https://github.com/flame-engine/flame/commit/34e5f0e443e21923c311120ce8634a14339bc71d))

--- a/packages/flame_tiled/example/pubspec.yaml
+++ b/packages/flame_tiled/example/pubspec.yaml
@@ -7,13 +7,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.8.1
-  flame_tiled: ^1.12.0
+  flame: ^1.8.2
+  flame_tiled: ^1.13.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
 flutter:
   uses-material-design: true
   assets:

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_tiled
 description: Tiled support for the Flame game engine. This uses the tiled package and provides wrappers and components to be used inside Flame.
-version: 1.12.0
+version: 1.13.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_tiled
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.8.1
+  flame: ^1.8.2
   flutter:
     sdk: flutter
   meta: ^1.9.1
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.2.2
-  flame_lint: ^1.0.0
+  flame_lint: ^1.1.0
   flutter_test:
     sdk: flutter
   test: any


### PR DESCRIPTION
 - flame@1.8.2
 - flame_lint@1.1.0
 - flame_rive@1.9.1
 - flame_tiled@1.13.0
 - flame_isolate@0.4.0+2
 - flame_audio@2.0.5
 - flame_spine@0.1.1+1
 - flame_svg@1.8.1
 - flame_test@1.12.1
 - flame_oxygen@0.1.8+5
 - flame_bloc@1.10.1
 - flame_fire_atlas@1.3.8
 - flame_forge2d@0.14.1+1
 - flame_noise@0.1.1+4
 - flame_network_assets@0.2.0+4
 - flame_lottie@0.2.1+1