### PR TITLE
docs: Improve documentation around SpriteFontTextFormatter

### DIFF
--- a/packages/flame/lib/src/text/formatters/sprite_font_text_formatter.dart
+++ b/packages/flame/lib/src/text/formatters/sprite_font_text_formatter.dart
@@ -4,9 +4,10 @@ import 'dart:ui' hide LineMetrics;
 import 'package:flame/src/text/common/line_metrics.dart';
 import 'package:flame/src/text/common/sprite_font.dart';
 import 'package:flame/src/text/elements/sprite_font_text_element.dart';
-import 'package:flame/src/text/elements/text_element.dart';
 import 'package:flame/src/text/formatters/text_formatter.dart';
 
+/// [SpriteFontTextFormatter] will render text using a [SpriteFont] font,
+/// creating a [SpriteFontTextElement].
 class SpriteFontTextFormatter extends TextFormatter {
   SpriteFontTextFormatter.fromFont(
     this.font, {
@@ -25,7 +26,7 @@ class SpriteFontTextFormatter extends TextFormatter {
   final Paint paint;
 
   @override
-  TextElement format(String text) {
+  SpriteFontTextElement format(String text) {
     var rects = Float32List(text.length * 4);
     var transforms = Float32List(text.length * 4);
     var j = 0;


### PR DESCRIPTION
# Description

Add a class-level doc comment to `SpriteFontTextFormatter`, analogous to `TextPainterTextFormatter`.
Also, super-specify the return type of the `format` method to facilitate understanding (again, this makes it more aligned with its twin `TextPainterTextFormatter`). 

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
