### PR TITLE
docs: Improve comments and documentation for text-rendering Nodes

### DIFF
--- a/packages/flame/lib/src/text/nodes/block_node.dart
+++ b/packages/flame/lib/src/text/nodes/block_node.dart
@@ -10,6 +10,10 @@ import 'package:flame/src/text/styles/flame_text_style.dart';
 /// the method [fillStyles], and then based on that style build the
 /// corresponding element in the [format] method. Both of these methods must be
 /// implemented by subclasses.
+///
+/// Implementations include:
+/// * ColumnNode
+/// * TextBlockNode (which itself can be a HeaderNode or ParagraphNode)
 abstract class BlockNode {
   /// The runtime style applied to this node, this will be set by [fillStyles].
   late BlockStyle style;

--- a/packages/flame/lib/src/text/nodes/column_node.dart
+++ b/packages/flame/lib/src/text/nodes/column_node.dart
@@ -1,5 +1,4 @@
 import 'package:flame/src/text/common/utils.dart';
-import 'package:flame/src/text/elements/block_element.dart';
 import 'package:flame/src/text/elements/element.dart';
 import 'package:flame/src/text/elements/group_element.dart';
 import 'package:flame/src/text/nodes/block_node.dart';
@@ -18,7 +17,7 @@ abstract class ColumnNode extends BlockNode {
   final List<BlockNode> children;
 
   @override
-  BlockElement format(double availableWidth) {
+  GroupElement format(double availableWidth) {
     final out = <Element>[];
     final blockWidth = availableWidth;
     final padding = style.padding;

--- a/packages/flame/lib/src/text/nodes/document_node.dart
+++ b/packages/flame/lib/src/text/nodes/document_node.dart
@@ -12,11 +12,12 @@ class DocumentNode {
 
   final List<BlockNode> children;
 
-  /// Applies [style] to this document, producing an object that can be rendered
-  /// on a canvas. Parameters [width] and [height] serve as the fallback values
-  /// if they were not specified in the style itself. However, they are ignored
-  /// if `style.width` and `style.height` are provided.
-  Element format(DocumentStyle style, {double? width, double? height}) {
+  /// Applies [style] to this document, producing an Element that can be
+  /// rendered on a canvas. Parameters [width] and [height] serve as the
+  /// fallback values if they were not specified in the style itself.
+  /// However, they are ignored if `style.width` and `style.height` are
+  /// provided.
+  GroupElement format(DocumentStyle style, {double? width, double? height}) {
     assert(
       style.width != null || width != null,
       'Width must be either provided explicitly or set in the stylesheet',

--- a/packages/flame/lib/src/text/nodes/header_node.dart
+++ b/packages/flame/lib/src/text/nodes/header_node.dart
@@ -39,17 +39,14 @@ class HeaderNode extends TextBlockNode {
 
   @override
   void fillStyles(DocumentStyle stylesheet, FlameTextStyle parentTextStyle) {
-    style = level == 1
-        ? stylesheet.header1
-        : level == 2
-            ? stylesheet.header2
-            : level == 3
-                ? stylesheet.header3
-                : level == 4
-                    ? stylesheet.header4
-                    : level == 5
-                        ? stylesheet.header5
-                        : stylesheet.header6;
+    style = switch (level) {
+      1 => stylesheet.header1,
+      2 => stylesheet.header2,
+      3 => stylesheet.header3,
+      4 => stylesheet.header4,
+      5 => stylesheet.header5,
+      _ => stylesheet.header6,
+    };
     final textStyle = Style.merge(parentTextStyle, style.text)!;
     super.fillStyles(stylesheet, textStyle);
   }

--- a/packages/flame/lib/src/text/nodes/text_node.dart
+++ b/packages/flame/lib/src/text/nodes/text_node.dart
@@ -2,6 +2,15 @@ import 'package:flame/src/text/elements/text_element.dart';
 import 'package:flame/src/text/styles/document_style.dart';
 import 'package:flame/src/text/styles/flame_text_style.dart';
 
+/// [TextNode] is a base class for all nodes with "inline" placement rules; it
+/// roughly corresponds to `<span/>` in HTML.
+///
+/// Implementations include:
+/// * PlainTextNode - just a string of plain text, no special formatting.
+/// * BoldTextNode - bolded string
+/// * ItalicTextNode - italic string
+/// * GroupTextNode - collection of multiple [TextNode]'s to be joined one
+///                   after the other.
 abstract class TextNode {
   late FlameTextStyle textStyle;
 


### PR DESCRIPTION
# Description

Improve comments and documentation for text-rendering Nodes
Super-specify return types whenever possible
Minor refactorings to improve legibility

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
