### PR TITLE
docs: Remove outdated references to the flame_flare package from our docs

### DIFF
--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -757,65 +757,6 @@ Future<void> onLoad() async {
 ```
 
 
-## FlareActorComponent
-
-**Note**: The previous implementation of a Flare integration API using `FlareAnimation` and
-`FlareComponent` has been deprecated.
-
-To use Flare within Flame, use the [`flame_flare`](https://github.com/flame-engine/flame_flare)
-package.
-
-This is the interface for using a [flare animation](https://pub.dev/packages/flare_flutter) within
-flame. `FlareActorComponent` has almost the same API as of flare's `FlareActor` widget. It receives
-the animation filename (that is loaded by default with `Flame.bundle`), it can also receive a
-FlareController that can play multiple animations and control nodes.
-
-```dart
-import 'package:flame_flare/flame_flare.dart';
-
-class YourFlareController extends FlareControls {
-
-  late ActorNode rightHandNode;
-
-  void initialize(FlutterActorArtboard artboard) {
-    super.initialize(artboard);
-
-    // get flare node
-    rightHand = artboard.getNode('right_hand');
-  }
-}
-
-final fileName = 'assets/george_washington.flr';
-final size = Vector2(1776, 1804);
-final controller = YourFlareController();
-
-FlareActorComponent flareAnimation = FlareActorComponent(
-  fileName,
-  controller: controller,
-  width: 306,
-  height: 228,
-);
-
-flareAnimation.x = 50;
-flareAnimation.y = 240;
-add(flareAnimation);
-
-// to play an animation
-controller.play('rise_up');
-
-// you can add another animation to play at the same time
-controller.play('close_door_way_out');
-
-// also, you can get a flare node and modify it
-controller.rightHandNode.rotation = math.pi;
-```
-
-You can also change the current playing animation by using the `updateAnimation` method.
-
-For a working example, check the example in the
-[flame_flare repository](https://github.com/flame-engine/flame/tree/main/packages/flame_flare/example).
-
-
 ## ParallaxComponent
 
 This `Component` can be used to render backgrounds with a depth feeling by drawing several

--- a/doc/flame/rendering/images.md
+++ b/doc/flame/rendering/images.md
@@ -321,58 +321,6 @@ A complete example of using animations as widgets can be found
 [here](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/widgets/sprite_animation_widget_example.dart).
 
 
-## FlareAnimation
-
-Do note that Flare is discontinued and [Rive](https://github.com/flame-engine/flame/tree/main/packages/flame_rive)
-is preferred.
-
-Flame provides a simple wrapper of [Flare](https://flare.rive.app/) animations so you can use
-them in Flame games.
-
-Check the following snippet on how to use this wrapper:
-
-```dart
-class MyGame extends Game {
-  FlareAnimation flareAnimation;
-  bool loaded = false;
-
-  MyGame() {
-    _start();
-  }
-
-  void _start() async {
-    flareAnimation = await FlareAnimation.load("assets/FLARE_FILE.flr");
-    flareAnimation.updateAnimation("ANIMATION_NAME");
-
-    flareAnimation.width = 306;
-    flareAnimation.height = 228;
-
-    loaded = true;
-  }
-
-  @override
-  void render(Canvas canvas) {
-    if (loaded) {
-      flareAnimation.render(canvas, x: 50, y: 50);
-    }
-  }
-
-  @override
-  void update(double dt) {
-    if (loaded) {
-      flareAnimation.update(dt);
-    }
-  }
-}
-```
-
-FlareAnimations are normally used inside `FlareComponent`s, that way `FlameGame` will handle calling
-`render` and `update` automatically.
-
-You can see a full example of how to use Flare together with Flame in the example
-[here](https://github.com/flame-engine/flame/tree/main/packages/flame_flare/example).
-
-
 ## SpriteSheet
 
 Sprite sheets are big images with several frames of the same sprite on it and is a very good way to

--- a/doc/flame/rendering/particles.md
+++ b/doc/flame/rendering/particles.md
@@ -356,32 +356,6 @@ class RectComponent extends Component {
 ```
 
 
-## FlareParticle
-
-To use Flare within Flame, use the
-[`flame_flare`](https://github.com/flame-engine/flame/tree/main/packages/flame_flare) package.
-
-It will provide a class called `FlareParticle` that is a container for `FlareActorAnimation`, it
-propagates the `update` and `render` methods to its child.
-
-```dart
-import 'package:flame_flare/flame_flare.dart';
-
-// Within your game or component's `onLoad` method
-const flareSize = 32.0;
-final flareAnimation = FlareActorAnimation('assets/sparkle.flr');
-flareAnimation.width = flareSize;
-flareAnimation.height = flareSize;
-
-// Somewhere in game
-game.add(
-  ParticleSystemComponent(
-    particle: FlareParticle(flare: flareAnimation),
-  ),
-);
-```
-
-
 ## ComputedParticle
 
 A `Particle` which could help you when:


### PR DESCRIPTION
# Description

Remove outdated references to the flame_flare package from our docs

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
