### PR TITLE
docs: Update PR template so "Migration instructions" is after the breaking change checkbox

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,16 +33,17 @@ Would your PR require Flame users to update their apps following your change?
 If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
 [Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
 instructions" section below.
-
-### Migration instructions
-
-If the PR is breaking, uncomment this header and add instructions for how to migrate from the
-currently released version to the new proposed way.
 -->
 
 - [ ] Yes, this PR is a breaking change.
 - [ ] No, this PR is not a breaking change.
 
+<!--
+### Migration instructions
+
+If the PR is breaking, uncomment this header and add instructions for how to migrate from the
+currently released version to the new proposed way.
+-->
 
 ## Related Issues
 <!--


### PR DESCRIPTION
# Description

Update PR template so "Migration instructions" is after the breaking change checkbox.
I believe that was where it was intended to be, but please assess if this makes sense.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
