### PR TITLE
docs: Update components diagram on the docs to be simpler [Proposal]

### DIFF
--- a/doc/flame/diagrams/component.md
+++ b/doc/flame/diagrams/component.md
@@ -1,34 +1,16 @@
 ``` {mermaid}
-%%{init: { 'theme': 'dark' } }%%
-  graph TD  
-
-    %% Node Color %%
-    classDef default fill:#282828,stroke:#F6BE00;
-    classDef yellow fill:#F6BE00,color:#000;
-    
-    %% Nodes %%
-
-    z(Abstract Class):::yellow
-    x(Normal Class)
-
- ```
-
-```{mermaid}
-%%{init: { 'theme': 'dark'  } }%%
 graph TD
-    %% Node Color %%
+    %% Config %%
     classDef default fill:#282828,stroke:#F6BE00;
-    classDef yellow fill:#F6BE00,color:#000;
     
     %% Nodes %%
-       
     Component(Component)
     Misc("
         TimerComponent
         ParticleComponent
         SpriteBatchComponent
     ")
-    Effects("Effects<br/>(See the effects section)"):::yellow
+    Effects("Effects<br/>(See the effects section)")
     Game(Game)
     FlameGame(FlameGame)
     PositionComponent(PositionComponent)


### PR DESCRIPTION
# Description

Update components diagram on the docs to be simpler.
It seems we no longer have any abstract classes to note (other than the abstract concept of "Effects").
I feel right now the colouring (while pretty) is just "highlighting" the effects node on the graph for no particular reason.
I think it would be simpler and more immediate to understand if we remove this distinction on this diagram.
Just a thought, though. Hard to assess what will be clearer to someone not so familiar with the concepts.

Current version:
![image](https://github.com/flame-engine/flame/assets/882703/31ec2b94-8fce-4927-91b0-8e30e2a12fe9)

New version:

``` mermaid
graph TD
    %% Config %%
    classDef default fill:#282828,stroke:#F6BE00;
    
    %% Nodes %%
    Component(Component)
    Misc("
        TimerComponent
        ParticleComponent
        SpriteBatchComponent
    ")
    Effects("Effects<br/>(See the effects section)")
    Game(Game)
    FlameGame(FlameGame)
    PositionComponent(PositionComponent)
   
    Sprites("
        SpriteComponent
        SpriteGroupComponent 
        SpriteAnimationComponent
        SpriteAnimationGroupComponent
        ParallaxComponent 
        IsoMetricTileMapComponent
    ")
    
    HudMarginComponent(HudMarginComponent)
    HudComponents("
        HudButtonComponent
        JoystickComponent
    ")
    
    OtherPositionComponents("
        ButtonComponent
        CustomPainterComponent
        ShapeComponent
        SpriteButtonComponent
        TextComponent
        TextBoxComponent
        NineTileBoxComponent
    ")
        
    %% Flow %%
    Component --> Misc
    Component --> Effects
    Component --> PositionComponent
    Component --> FlameGame
   
    Game --> FlameGame
    PositionComponent --> Sprites
    PositionComponent --> HudMarginComponent
    PositionComponent --> OtherPositionComponents
    HudMarginComponent --> HudComponents    
```

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
