### PR TITLE
refactor: Enable new DCM rule: avoid-cascade-after-if-null

### DIFF
--- a/packages/flame_jenny/jenny/test/test_scenario.dart
+++ b/packages/flame_jenny/jenny/test/test_scenario.dart
@@ -19,7 +19,7 @@ Future<void> testScenario({
   List<String>? commands,
   YarnProject? yarn,
 }) async {
-  final yarnProject = yarn ?? YarnProject()
+  final yarnProject = (yarn ?? YarnProject())
     ..strictCharacterNames = false;
   commands?.forEach(yarnProject.commands.addOrphanedCommand);
 

--- a/packages/flame_jenny/jenny/test/test_scenario.dart
+++ b/packages/flame_jenny/jenny/test/test_scenario.dart
@@ -19,8 +19,7 @@ Future<void> testScenario({
   List<String>? commands,
   YarnProject? yarn,
 }) async {
-  final yarnProject = (yarn ?? YarnProject())
-    ..strictCharacterNames = false;
+  final yarnProject = (yarn ?? YarnProject())..strictCharacterNames = false;
   commands?.forEach(yarnProject.commands.addOrphanedCommand);
 
   Future<void> testBody() async {

--- a/packages/flame_lint/lib/analysis_options_with_dcm.yaml
+++ b/packages/flame_lint/lib/analysis_options_with_dcm.yaml
@@ -6,5 +6,6 @@ dart_code_metrics:
   rules:
   # dart rules
     - avoid-banned-imports
+    - avoid-cascade-after-if-null
   # flutter rules
     - prefer-define-hero-tag


### PR DESCRIPTION
# Description

Enable new DCM rule: avoid-cascade-after-if-null
Reference: https://dcm.dev/docs/rules/common/avoid-cascade-after-if-null/

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
