### PR TITLE
docs: Extend the contributing guidelines with more usable markdown suggestions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,12 @@ If you want to lint the markdown files you have to install
 can run `melos markdown-check` to check if the markdown follows the rules. Some markdown linting
 errors can be automatically fixed with `melos markdown-fix`.
 
+Note that, sadly, a particularly laborious rule, MD013, [does not provide an auto-fix
+option](https://github.com/DavidAnson/markdownlint/issues/535). However, you can use other tools to
+circumvent this. For example, the extension [Rewrap](https://stkb.github.io/Rewrap/) for VSCode, when
+[configured with](https://stkb.github.io/Rewrap/configuration/) `rewrap.wrappingColumn=100`, will do
+the trick for you.
+
 
 ### Performing changes
 


### PR DESCRIPTION
# Description

Extend the contributing guidelines with more usable markdown suggestions.
In particular suggest the `Rewrap` VS-code extension since the existing tooling cannot fix laborious markdown line length issues.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
