### PR TITLE
fix: Allow AssetCache to load json files with array at root

### DIFF
--- a/packages/flame/lib/src/cache/assets_cache.dart
+++ b/packages/flame/lib/src/cache/assets_cache.dart
@@ -47,9 +47,9 @@ class AssetsCache {
   }
 
   /// Reads a json file from the assets folder.
-  Future<Map<String, dynamic>> readJson(String fileName) async {
+  Future<dynamic> readJson(String fileName) async {
     final content = await readFile(fileName);
-    return jsonDecode(content) as Map<String, dynamic>;
+    return jsonDecode(content);
   }
 
   Future<_StringAsset> _readFile(String fileName) async {

--- a/packages/flame/test/_resources/test_1.json
+++ b/packages/flame/test/_resources/test_1.json
@@ -1,0 +1,16 @@
+[
+    1,
+    2.0,
+    true,
+    null,
+    "Hello",
+    {
+        "key": "value"
+    },
+    [
+        1,
+        2.0,
+        "three",
+        false
+    ]
+]

--- a/packages/flame/test/_resources/test_2.json
+++ b/packages/flame/test/_resources/test_2.json
@@ -1,0 +1,16 @@
+{
+    "int": 1,
+    "double": 2.0,
+    "bool": true,
+    "null": null,
+    "string": "Hello",
+    "object": {
+        "key": "value"
+    },
+    "array": [
+        1,
+        2.0,
+        "three",
+        false
+    ]
+}

--- a/packages/flame/test/cache/assets_cache_test.dart
+++ b/packages/flame/test/cache/assets_cache_test.dart
@@ -26,10 +26,16 @@ void main() {
       );
     });
 
-    test('readJson', () async {
+    test('readJson with object root', () async {
       final assetsCache = AssetsCache(prefix: '');
-      final file = await assetsCache.readJson(fixture('chopper.json').path);
+      final file = await assetsCache.readJson(fixture('test_1.json').path);
       expect(file, isA<Map<String, dynamic>>());
+    });
+
+    test('readJson with array root', () async {
+      final assetsCache = AssetsCache(prefix: '');
+      final file = await assetsCache.readJson(fixture('test_2.json').path);
+      expect(file, isA<List<dynamic>>());
     });
 
     test('readBinaryFile', () async {


### PR DESCRIPTION
# Description

- Fix `AssetCache.readJson` to allow reading json files with either an object or an array at the root. 
- Added simple tests for both scenarios.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Closes #2682 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
