### PR TITLE
feat: Expose atlas limits for `TiledComponent`

### DIFF
--- a/doc/bridge_packages/flame_tiled/flame_tiled.md
+++ b/doc/bridge_packages/flame_tiled/flame_tiled.md
@@ -18,6 +18,78 @@ add(component);
 ```
 
 
+## TiledComponent
+
+Tiled is a free and open source, full-featured level and map editor for your platformer or
+RPG game. Currently we have an "in progress" implementation of a Tiled component. This API
+uses the lib [tiled.dart](https://github.com/flame-engine/tiled.dart) to parse map files and
+render visible layers using the performant `SpriteBatch` for each layer.
+
+Supported map types include: Orthogonal, Isometric, Hexagonal, and Staggered.
+
+Orthogonal | Hexagonal             |  Isomorphic
+:--:|:-------------------------:|:-------------------------:
+![An example of an orthogonal map](../../images/orthogonal.png)|![An example of hexagonal map](../../images/pointy_hex_even.png) |  ![An example of isomorphic map](../../images/tile_stack_single_move.png)
+
+An example of how to use the API can be found
+[here](https://github.com/flame-engine/flame_tiled/tree/main/example).
+
+
+### TileStack
+
+Once a `TiledComponent` is loaded, you can select any column of (x,y) tiles in a `tileStack` to
+then add animation. Removing the stack will not remove the tiles from the map.
+
+> **Note**: This currently only supports position based effects.
+
+```dart
+void onLoad() {
+  final stack = map.tileMap.tileStack(4, 0, named: {'floor_under'});
+  stack.add(
+    SequenceEffect(
+      [
+        MoveEffect.by(
+          Vector2(5, 0),
+          NoiseEffectController(duration: 1, frequency: 20),
+        ),
+        MoveEffect.by(Vector2.zero(), LinearEffectController(2)),
+      ],
+      repeatCount: 3,
+    )
+      ..onComplete = () => stack.removeFromParent(),
+  );
+  map.add(stack);
+}
+```
+
+
+### TileAtlas
+
+When a tilemap has multiple images (from multiple tilesets) `TiledComponent` uses a `TileAtlas` to
+pack all those image into a single big image (a.k.a atlas). This helps in rendering the whole map in
+a single draw call. But is there a limit on how big this atlas can be based on the target platform
+and hardware. As it is not possible to query this max size from Flame or Flutter as of now,
+`TiledComponent` limits the atlas to `4096x4096` for web and `8192x8192` for all other platforms.
+
+These limits should work well for most cases. But in case you are sure that your target platform can
+support bigger atlas and want to override the limits used by `TiledComponent` you can do so by
+passing in the `atlasMaxX` and `atlasMaxX` values to `TiledComponent.load`.
+
+NOTE: This is not recommended as such huge sizes might not work with all hardware. Instead consider
+resizing the original tileset images so that when packed they fit with the limits.
+
+```dart
+final component = await TiledComponent.load(
+  'my_map.tmx',
+  Vector2.all(32),
+  atlasMaxX: 9216,
+  atlasMaxY: 9216,
+);
+
+add(component);
+```
+
+
 ## Limitations
 
 

--- a/doc/flame/components.md
+++ b/doc/flame/components.md
@@ -1137,51 +1137,6 @@ void main() {
 ```
 
 
-## TiledComponent
-
-Tiled is a free and open source, full-featured level and map editor for your platformer or
-RPG game. Currently we have an "in progress" implementation of a Tiled component. This API
-uses the lib [tiled.dart](https://github.com/flame-engine/tiled.dart) to parse map files and
-render visible layers using the performant `SpriteBatch` for each layer.
-
-Supported map types include: Orthogonal, Isometric, Hexagonal, and Staggered.
-
-Orthogonal | Hexagonal             |  Isomorphic
-:--:|:-------------------------:|:-------------------------:
-![An example of an orthogonal map](../images/orthogonal.png)|![An example of hexagonal map](../images/pointy_hex_even.png) |  ![An example of isomorphic map](../images/tile_stack_single_move.png)
-
-An example of how to use the API can be found
-[here](https://github.com/flame-engine/flame_tiled/tree/main/example).
-
-
-### TileStack
-
-Once a `TiledComponent` is loaded, you can select any column of (x,y) tiles in a `tileStack` to
-then add animation. Removing the stack will not remove the tiles from the map.
-
-> **Note**: This currently only supports position based effects.
-
-```dart
-void onLoad() {
-  final stack = map.tileMap.tileStack(4, 0, named: {'floor_under'});
-  stack.add(
-    SequenceEffect(
-      [
-        MoveEffect.by(
-          Vector2(5, 0),
-          NoiseEffectController(duration: 1, frequency: 20),
-        ),
-        MoveEffect.by(Vector2.zero(), LinearEffectController(2)),
-      ],
-      repeatCount: 3,
-    )
-      ..onComplete = () => stack.removeFromParent(),
-  );
-  map.add(stack);
-}
-```
-
-
 ## IsometricTileMapComponent
 
 This component allows you to render an isometric map based on a cartesian matrix of blocks and an

--- a/packages/flame_tiled/lib/src/rectangle_bin_packer.dart
+++ b/packages/flame_tiled/lib/src/rectangle_bin_packer.dart
@@ -1,7 +1,5 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
-
 /// A simple solution to packing a series of rectangles into a larger bin.
 ///
 /// Packing different rectangles in the smallest area possible is an
@@ -11,10 +9,6 @@ import 'package:flutter/foundation.dart';
 /// Light reading:
 ///   * https://en.wikipedia.org/wiki/Rectangle_packing#Packing_different_rectangles_in_a_minimum-area_rectangle
 ///   * https://www.david-colson.com/2020/03/10/exploring-rect-packing.html
-///
-/// Note: Chrome on Android has a maximum texture size of 4096x4096. kIsWeb is
-/// used to select the smaller texture and might overflow. Consider using
-/// smaller textures for web targets, or, pack your own atlas.
 class RectangleBinPacker {
   final double maxX;
   final double maxY;
@@ -22,10 +16,7 @@ class RectangleBinPacker {
   /// The bins of free space that we can search.
   late final List<Rect> bins = [Rect.fromLTWH(0, 0, maxX, maxY)];
 
-  RectangleBinPacker({
-    this.maxX = kIsWeb ? 4096 : 8192,
-    this.maxY = kIsWeb ? 4096 : 8192,
-  });
+  RectangleBinPacker(this.maxX, this.maxY);
 
   /// Finds a free space for a rectangle of lengths [width] and [height] in
   /// the atlas.
@@ -40,6 +31,10 @@ class RectangleBinPacker {
     }
     // If we exhausted our search, return an empty rect.
     if (search == null || search.width < width || search.height < height) {
+      assert(
+        false,
+        '''RectangleBinPacker failed to pack an image. Consider using a bigger atlas if you are sure that your target platform can handle it.''',
+      );
       return Rect.zero;
     }
 

--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -204,6 +204,8 @@ class RenderableTiledMap {
   static Future<RenderableTiledMap> fromFile(
     String fileName,
     Vector2 destTileSize, {
+    double? atlasMaxX,
+    double? atlasMaxY,
     String prefix = 'assets/tiles/',
     CameraComponent? camera,
     bool? ignoreFlip,
@@ -214,6 +216,8 @@ class RenderableTiledMap {
     return fromString(
       contents,
       destTileSize,
+      atlasMaxX: atlasMaxX,
+      atlasMaxY: atlasMaxY,
       prefix: prefix,
       camera: camera,
       ignoreFlip: ignoreFlip,
@@ -230,6 +234,8 @@ class RenderableTiledMap {
   static Future<RenderableTiledMap> fromString(
     String contents,
     Vector2 destTileSize, {
+    double? atlasMaxX,
+    double? atlasMaxY,
     String prefix = 'assets/tiles/',
     CameraComponent? camera,
     bool? ignoreFlip,
@@ -243,6 +249,8 @@ class RenderableTiledMap {
     return fromTiledMap(
       map,
       destTileSize,
+      atlasMaxX: atlasMaxX,
+      atlasMaxY: atlasMaxY,
       camera: camera,
       ignoreFlip: ignoreFlip,
       images: images,
@@ -256,6 +264,8 @@ class RenderableTiledMap {
   static Future<RenderableTiledMap> fromTiledMap(
     TiledMap map,
     Vector2 destTileSize, {
+    double? atlasMaxX,
+    double? atlasMaxY,
     CameraComponent? camera,
     bool? ignoreFlip,
     Images? images,
@@ -277,7 +287,11 @@ class RenderableTiledMap {
       destTileSize,
       camera,
       animationFrames,
-      atlas: await TiledAtlas.fromTiledMap(map),
+      atlas: await TiledAtlas.fromTiledMap(
+        map,
+        maxX: atlasMaxX,
+        maxY: atlasMaxY,
+      ),
       ignoreFlip: ignoreFlip,
       images: images,
     );

--- a/packages/flame_tiled/lib/src/tile_atlas.dart
+++ b/packages/flame_tiled/lib/src/tile_atlas.dart
@@ -4,7 +4,7 @@ import 'package:flame/flame.dart';
 import 'package:flame/image_composition.dart';
 import 'package:flame/sprite.dart';
 import 'package:flame_tiled/src/rectangle_bin_packer.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 import 'package:tiled/tiled.dart';
 
 /// One image atlas for all Tiled image sets in a map.
@@ -81,7 +81,11 @@ class TiledAtlas {
   }
 
   /// Loads all the tileset images for the [map] into one [TiledAtlas].
-  static Future<TiledAtlas> fromTiledMap(TiledMap map) async {
+  static Future<TiledAtlas> fromTiledMap(
+    TiledMap map, {
+    double? maxX,
+    double? maxY,
+  }) async {
     final imageList = _onlyTileImages(map).toList();
 
     if (imageList.isEmpty) {
@@ -114,7 +118,13 @@ class TiledAtlas {
       );
     }
 
-    final bin = RectangleBinPacker();
+    /// Note: Chrome on Android has a maximum texture size of 4096x4096. kIsWeb
+    /// is used to select the smaller texture and might overflow. Consider using
+    /// smaller textures for web targets, or, pack your own atlas.
+    final bin = RectangleBinPacker(
+      maxX ?? (kIsWeb ? 4096 : 8192),
+      maxY ?? (kIsWeb ? 4096 : 8192),
+    );
     final recorder = PictureRecorder();
     final canvas = Canvas(recorder);
 

--- a/packages/flame_tiled/lib/src/tiled_component.dart
+++ b/packages/flame_tiled/lib/src/tiled_component.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame_tiled/src/renderable_tile_map.dart';
+import 'package:flame_tiled/src/tile_atlas.dart';
 import 'package:meta/meta.dart';
 import 'package:tiled/tiled.dart';
 
@@ -91,9 +92,15 @@ class TiledComponent<T extends FlameGame> extends PositionComponent
   ///
   /// By default, [RenderableTiledMap] renders flipped tiles if they exist.
   /// You can disable it by passing [ignoreFlip] as `true`.
+  ///
+  /// A custom [atlasMaxX] and [atlasMaxY] can be provided in case you want to
+  /// change the max size of [TiledAtlas] that [TiledComponent] creates
+  /// internally.
   static Future<TiledComponent> load(
     String fileName,
     Vector2 destTileSize, {
+    double? atlasMaxX,
+    double? atlasMaxY,
     String prefix = 'assets/tiles/',
     int? priority,
     bool? ignoreFlip,
@@ -102,6 +109,8 @@ class TiledComponent<T extends FlameGame> extends PositionComponent
       await RenderableTiledMap.fromFile(
         fileName,
         destTileSize,
+        atlasMaxX: atlasMaxX,
+        atlasMaxY: atlasMaxY,
         ignoreFlip: ignoreFlip,
         prefix: prefix,
       ),

--- a/packages/flame_tiled/test/rectangle_bin_packer_test.dart
+++ b/packages/flame_tiled/test/rectangle_bin_packer_test.dart
@@ -8,18 +8,12 @@ void main() {
   group('RectangleBinPacker', () {
     late RectangleBinPacker bin;
     setUp(() {
-      bin = RectangleBinPacker();
+      bin = RectangleBinPacker(1024, 1024);
     });
 
-    test('ignores oversized requests', () {
-      expect(
-        bin.pack(bin.maxX + 1, bin.maxY),
-        Rect.zero,
-      );
-      expect(
-        bin.pack(bin.maxX, bin.maxY + 1),
-        Rect.zero,
-      );
+    test('asserts oversized requests', () {
+      expect(() => bin.pack(bin.maxX + 1, bin.maxY), throwsAssertionError);
+      expect(() => bin.pack(bin.maxX, bin.maxY + 1), throwsAssertionError);
       expect(bin.bins, hasLength(1));
       expect(bin.bins.first.top, 0);
       expect(bin.bins.first.left, 0);


### PR DESCRIPTION
# Description

This PR add the ability for users to override the max size of `TiledAtlas` used by `TiledComponent` for packing all the images of all the tilesets used by a tilemap. The overrides can be used if one is sure that their target platform can handle huge textures.

It also adds an assert for cases when the `RectangleBinPacker` runs out of space. This is done to help users find the problem quickly.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Closes #2619 
