### PR TITLE
feat: Create flame_markdown [Proposal]

### DIFF
--- a/packages/flame_markdown/LICENSE
+++ b/packages/flame_markdown/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2023 Blue Fire
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/flame_markdown/README.md
+++ b/packages/flame_markdown/README.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD013 -->
+<p align="center">
+  <a href="https://flame-engine.org">
+    <img alt="flame" width="200px" src="https://user-images.githubusercontent.com/6718144/101553774-3bc7b000-39ad-11eb-8a6a-de2daa31bd64.png">
+  </a>
+</p>
+
+<p align="center">
+Adds audio support for <a href="https://github.com/flame-engine/flame">Flame</a> using the <a href="https://github.com/luanpotter/audioplayers">audioplayers</a> package.
+</p>
+
+<p align="center">
+  <a title="Pub" href="https://pub.dev/packages/flame_audio" ><img src="https://img.shields.io/pub/v/flame_audio.svg?style=popout" /></a>
+  <a title="Test" href="https://github.com/flame-engine/flame/actions?query=workflow%3Acicd+branch%3Amain"><img src="https://github.com/flame-engine/flame/workflows/cicd/badge.svg?branch=main&event=push"/></a>
+  <a title="Discord" href="https://discord.gg/pxrBmy4"><img src="https://img.shields.io/discord/509714518008528896.svg"/></a>
+  <a title="Melos" href="https://github.com/invertase/melos"><img src="https://img.shields.io/badge/maintained%20with-melos-f700ff.svg"/></a>
+</p>
+
+---
+<!-- markdownlint-enable MD013 -->
+
+<!-- markdownlint-disable-next-line MD002 -->
+# flame_audio
+
+This package makes it easy to add audio capabilities to your games, integrating
+[Audioplayers](https://github.com/bluefireteam/audioplayers) features seamless into your Flame game
+code.
+
+Add this as a dependency to your Flame game if you want to play background music,
+ambient sounds, sound effects, etc.

--- a/packages/flame_markdown/analysis_options.yaml
+++ b/packages/flame_markdown/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flame_lint/analysis_options_with_dcm.yaml
+
+linter:
+  rules:
+    - public_member_api_docs

--- a/packages/flame_markdown/example/.gitignore
+++ b/packages/flame_markdown/example/.gitignore
@@ -1,0 +1,44 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release

--- a/packages/flame_markdown/example/.metadata
+++ b/packages/flame_markdown/example/.metadata
@@ -1,0 +1,30 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "e1e47221e86272429674bec4f1bd36acc4fc7b77"
+  channel: "stable"
+
+project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: e1e47221e86272429674bec4f1bd36acc4fc7b77
+      base_revision: e1e47221e86272429674bec4f1bd36acc4fc7b77
+    - platform: macos
+      create_revision: e1e47221e86272429674bec4f1bd36acc4fc7b77
+      base_revision: e1e47221e86272429674bec4f1bd36acc4fc7b77
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/packages/flame_markdown/example/README.md
+++ b/packages/flame_markdown/example/README.md
@@ -1,0 +1,3 @@
+# flame markdown example
+
+Simple project to showcase the usage of flame_markdown

--- a/packages/flame_markdown/example/analysis_options.yaml
+++ b/packages/flame_markdown/example/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flame_lint/analysis_options_with_dcm.yaml
+
+linter:
+  rules:
+    public_member_api_docs: false

--- a/packages/flame_markdown/example/assets/fire_and_ice.md
+++ b/packages/flame_markdown/example/assets/fire_and_ice.md
@@ -1,0 +1,9 @@
+# Fire and Ice
+
+Some say the world will end in **fire**,
+
+Some say in _ice_.
+
+From what I've tasted of desire
+
+I hold with those who favor **fire**.

--- a/packages/flame_markdown/example/lib/main.dart
+++ b/packages/flame_markdown/example/lib/main.dart
@@ -1,0 +1,11 @@
+import 'package:flame/game.dart';
+import 'package:flutter/widgets.dart' hide Animation;
+
+void main() {
+  runApp(GameWidget(game: MarkdownGame()));
+}
+
+/// This example game showcases ...
+class MarkdownGame extends FlameGame {
+  //
+}

--- a/packages/flame_markdown/example/lib/main.dart
+++ b/packages/flame_markdown/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
+import 'package:flame/text.dart';
 import 'package:flame_markdown/flame_markdown.dart';
 import 'package:flutter/widgets.dart' hide Animation;
 
@@ -10,7 +11,8 @@ void main() {
   runApp(GameWidget(game: MarkdownGame()));
 }
 
-/// This example game showcases ...
+/// This example game showcases the use of the FlameMarkdown package
+/// to render rich-text components using a simple markdown syntax.
 class MarkdownGame extends FlameGame {
   @override
   Future<void> onLoad() async {
@@ -18,11 +20,12 @@ class MarkdownGame extends FlameGame {
     await add(
       TextElementComponent.fromDocument(
         document: FlameMarkdown.toDocument(markdown),
+        style: DocumentStyle(
+          padding: const EdgeInsets.all(16),
+        ),
+        size: size,
       ),
     );
     await super.onLoad();
   }
-}
-
-class TextElementComponent extends PositionComponent {
 }

--- a/packages/flame_markdown/example/lib/main.dart
+++ b/packages/flame_markdown/example/lib/main.dart
@@ -1,4 +1,9 @@
+import 'dart:async';
+
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
+import 'package:flame_markdown/flame_markdown.dart';
 import 'package:flutter/widgets.dart' hide Animation;
 
 void main() {
@@ -7,5 +12,17 @@ void main() {
 
 /// This example game showcases ...
 class MarkdownGame extends FlameGame {
-  //
+  @override
+  Future<void> onLoad() async {
+    final markdown = await Flame.assets.readFile('fire_and_ice.md');
+    await add(
+      TextElementComponent.fromDocument(
+        document: FlameMarkdown.toDocument(markdown),
+      ),
+    );
+    await super.onLoad();
+  }
+}
+
+class TextElementComponent extends PositionComponent {
 }

--- a/packages/flame_markdown/example/pubspec.yaml
+++ b/packages/flame_markdown/example/pubspec.yaml
@@ -15,3 +15,8 @@ dependencies:
 
 dev_dependencies:
   flame_lint: ^1.1.0
+
+flutter:
+  uses-material-design: false
+  assets:
+    - assets/

--- a/packages/flame_markdown/example/pubspec.yaml
+++ b/packages/flame_markdown/example/pubspec.yaml
@@ -1,0 +1,17 @@
+name: flame_markdown_example
+description: Simple project to showcase the usage of flame_markdown
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  flame: ^1.8.2
+  flame_markdown:
+    path: ../
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flame_lint: ^1.1.0

--- a/packages/flame_markdown/lib/flame_markdown.dart
+++ b/packages/flame_markdown/lib/flame_markdown.dart
@@ -1,0 +1,87 @@
+import 'package:flame/text.dart';
+import 'package:markdown/markdown.dart' as md;
+
+class FlameMarkdown {
+  static List<md.Node> parse(String text) {
+    return md.Document().parse(text);
+  }
+
+  static DocumentNode convert(List<md.Node> nodes) {
+    return DocumentNode(nodes.map(_convertNode).toList());
+  }
+  
+  static BlockNode _convertNode(md.Node node) {
+    if (node is md.Element) {
+      return _convertElement(node);
+    } else if (node is md.Text) {
+      return _convertText(node);
+    } else {
+      throw Exception('Unknown node type: ${node.runtimeType}');
+    }
+  }
+
+  static BlockNode _convertElement(md.Element element) {
+    final children = (element.children ?? []).map(_convertNode).toList();
+    switch (element.tag) {
+      case 'h1':
+        final singleChild = children.single as TextNode;
+        return HeaderNode(singleChild, level: 1);
+      case 'h2':
+        return HeaderNode(children, level: 2);
+      case 'h3':
+        return HeaderNode(children, level: 3);
+      case 'h4':
+        return HeaderNode(children, level: 4);
+      case 'h5':
+        return HeaderNode(children, level: 5);
+      case 'h6':
+        return HeaderNode(children, level: 6);
+      case 'p':
+        return ParagraphNode(children);
+      case 'ul':
+        return UnorderedListNode(children);
+      case 'ol':
+        return OrderedListNode(children);
+      case 'li':
+        return ListItemNode(children);
+      case 'a':
+        return AnchorNode(children, element.attributes['href']);
+      case 'img':
+        return ImageNode(element.attributes['src']);
+      case 'code':
+        return CodeNode(children);
+      case 'pre':
+        return PreNode(children);
+      case 'blockquote':
+        return BlockquoteNode(children);
+      case 'hr':
+        return HorizontalRuleNode();
+      case 'em':
+        return EmphasisNode(children);
+      case 'strong':
+        return StrongNode(children);
+      case 'del':
+        return StrikethroughNode(children);
+      case 'br':
+        return LineBreakNode();
+      case 'table':
+        return TableNode(children);
+      case 'thead':
+        return TableHeadNode(children);
+      case 'tbody':
+        return TableBodyNode(children);
+      case 'tr':
+        return TableRowNode(children);
+      case 'th':
+        return TableHeaderNode(children);
+      case 'td':
+        return TableCellNode(children);
+      default:
+        throw Exception('Unknown element tag: ${element.tag}');
+    }
+  }
+
+  static PlainTextNode _convertText(md.Text text) {
+    return PlainTextNode(text.text);
+  }
+}

--- a/packages/flame_markdown/pubspec.yaml
+++ b/packages/flame_markdown/pubspec.yaml
@@ -21,3 +21,5 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.2.2
   flame_lint: ^1.1.0
+  flutter_test:
+    sdk: flutter

--- a/packages/flame_markdown/pubspec.yaml
+++ b/packages/flame_markdown/pubspec.yaml
@@ -1,0 +1,23 @@
+name: flame_markdown
+description: |
+  Markdown support for the Flame game engine, bridging the markdown package into Flame's text rendering pipeline.
+version: 0.1.0
+homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_markdown
+funding:
+  - https://opencollective.com/blue-fire
+  - https://github.com/sponsors/bluefireteam
+  - https://patreon.com/bluefireoss
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.3.0"
+
+dependencies:
+  flame: ^1.8.2
+  flutter:
+    sdk: flutter
+  markdown: ^7.1.1
+
+dev_dependencies:
+  dartdoc: ^6.2.2
+  flame_lint: ^1.1.0

--- a/packages/flame_markdown/test/flame_markdown_test.dart
+++ b/packages/flame_markdown/test/flame_markdown_test.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'package:flame/text.dart';
+import 'package:flame_markdown/flame_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FlameMarkdown#toDocument', () {
+    test('just plain text', () {
+      final doc = FlameMarkdown.toDocument('Hello world!');
+
+      _expectDocument(doc, [
+        (node) => _expectSimpleParagraph(node, 'Hello world!'),
+      ]);
+    });
+
+    test('rich text', () {
+      final doc = FlameMarkdown.toDocument('**Flame**: Hello, _world_!');
+
+      _expectDocument(doc, [
+        (node) => _expectParagraph(node, (p) {
+              _expectGroup(p, [
+                (node) => _expectBold(node, 'Flame'),
+                (node) => _expectPlain(node, ': Hello, '),
+                (node) => _expectItalic(node, 'world'),
+                (node) => _expectPlain(node, '!'),
+              ]);
+            }),
+      ]);
+    });
+
+    test('all header levels', () {
+      final doc = FlameMarkdown.toDocument(
+        '# h1\n'
+        '## h2\n'
+        '### h3\n'
+        '#### h4\n'
+        '##### h5\n'
+        '###### h6\n',
+      );
+
+      _expectDocument(doc, [
+        (node) => _expectHeader(node, 1, 'h1'),
+        (node) => _expectHeader(node, 2, 'h2'),
+        (node) => _expectHeader(node, 3, 'h3'),
+        (node) => _expectHeader(node, 4, 'h4'),
+        (node) => _expectHeader(node, 5, 'h5'),
+        (node) => _expectHeader(node, 6, 'h6'),
+      ]);
+    });
+
+    test('several paragraphs with header', () {
+      final markdown = File('example/assets/fire_and_ice.md').readAsStringSync();
+      final doc = FlameMarkdown.toDocument(markdown);
+
+      _expectDocument(doc, [
+        (node) => _expectHeader(node, 1, 'Fire and Ice'),
+        (node) => _expectParagraph(node, (p) {
+              _expectGroup(p, [
+                (node) => _expectPlain(node, 'Some say the world will end in '),
+                (node) => _expectBold(node, 'fire'),
+                (node) => _expectPlain(node, ','),
+              ]);
+            }),
+        (node) => _expectParagraph(
+              node,
+              (p) => _expectGroup(p, [
+                (node) => _expectPlain(node, 'Some say in '),
+                (node) => _expectItalic(node, 'ice'),
+                (node) => _expectPlain(node, '.'),
+              ]),
+            ),
+        (node) => _expectSimpleParagraph(
+              node,
+              "From what I've tasted of desire",
+            ),
+        (node) => _expectParagraph(node, (p) {
+              _expectGroup(p, [
+                (node) => _expectPlain(node, 'I hold with those who favor '),
+                (node) => _expectBold(node, 'fire'),
+                (node) => _expectPlain(node, '.'),
+              ]);
+            }),
+      ]);
+    });
+  });
+}
+
+void _expectBold(InlineTextNode node, String text) {
+  expect(node, isA<BoldTextNode>());
+  final content = (node as BoldTextNode).child;
+  expect(content, isA<PlainTextNode>());
+  expect((content as PlainTextNode).text, text);
+}
+
+void _expectItalic(InlineTextNode node, String text) {
+  expect(node, isA<ItalicTextNode>());
+  final content = (node as ItalicTextNode).child;
+  expect(content, isA<PlainTextNode>());
+  expect((content as PlainTextNode).text, text);
+}
+
+void _expectPlain(InlineTextNode node, String text) {
+  expect(node, isA<PlainTextNode>());
+  final span = node as PlainTextNode;
+  expect(span.text, text);
+}
+
+void _expectParagraph(
+  BlockNode node,
+  void Function(InlineTextNode) expectChild,
+) {
+  expect(node, isA<ParagraphNode>());
+  final p = node as ParagraphNode;
+  expectChild(p.child);
+}
+
+void _expectSimpleParagraph(BlockNode node, String text) {
+  _expectParagraph(node, (child) => _expectPlain(child, text));
+}
+
+void _expectHeader(BlockNode node, int level, String text) {
+  expect(node, isA<HeaderNode>());
+  final header = node as HeaderNode;
+  expect(header.level, level);
+  expect(header.child, isA<PlainTextNode>());
+  expect((header.child as PlainTextNode).text, text);
+}
+
+void _expectGroup(
+  InlineTextNode node,
+  List<void Function(InlineTextNode)> expectChildren,
+) {
+  expect(node, isA<GroupTextNode>());
+  final group = node as GroupTextNode;
+  expect(group.children, hasLength(expectChildren.length));
+  for (final (idx, expectChild) in expectChildren.indexed) {
+    expectChild(group.children[idx]);
+  }
+}
+
+void _expectDocument(
+  DocumentRoot root,
+  List<void Function(BlockNode)> expectChildren,
+) {
+  expect(root.children, hasLength(expectChildren.length));
+  for (final (idx, expectChild) in expectChildren.indexed) {
+    expectChild(root.children[idx]);
+  }
+}


### PR DESCRIPTION
# Description

Add a bridge package `flame_markdown` to the [`markdown` package](pub.dev/packages/markdown) to allow for easily creating `TextElementComponent`s (or `TextNode`s in general) using the markdown syntax.

This will vastly facilitate working with rich text, specially for simple formatting like bold and italics, without requiring the user to manually specify the node tree structure.

![image](https://github.com/flame-engine/flame/assets/882703/b9a68949-56b6-400e-bb4d-56f3742984aa)

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
