### PR TITLE
fix: Correct FlameGame lifecycle diagram and description

### DIFF
--- a/doc/_sphinx/Makefile
+++ b/doc/_sphinx/Makefile
@@ -1,5 +1,15 @@
 # Minimal makefile for Sphinx documentation
 
+#
+# To build the documentation you need to have Python3 installed
+# and working with pip, as well as Flutter of course. Then run
+# the following:
+#
+#     dart pub global activate melos
+#     dart pub global activate dartdoc_json
+#     pip install sphinx sphinxcontrib sphinxcontrib-mermaid sphinxcontrib-jquery myst_parser sphinx-autobuild sphinx-copybutton
+#
+
 # You can set these variables from the command line.
 # SPHINXOPTS and SPHINXBUILD can also be set from the environment.
 SOURCEDIR     = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/..

--- a/doc/flame/diagrams/flame_game_life_cycle.md
+++ b/doc/flame/diagrams/flame_game_life_cycle.md
@@ -26,8 +26,8 @@
 
     %% Nodes %%
 
-    A(onLoad):::yellow
-    B(onGameResize):::lightYellow
+    A(onGameResize):::lightYellow
+    B(onLoad):::yellow
     C(onMount):::yellow
     D(update)
     E(render)

--- a/doc/flame/game.md
+++ b/doc/flame/game.md
@@ -88,18 +88,23 @@ after the call to `super.onGameResize(canvasSize);`.
 
 ## Lifecycle
 
-```{include} diagrams/component_life_cycle.md
+The `FlameGame` lifecycle callbacks, `onLoad`, `render`, etc. are called in the following sequence:
+
+```{include} diagrams/flame_game_life_cycle.md
 ```
 
-When a game is first added to a Flutter widget tree the following lifecycle methods will be called
-in order: `onLoad`, `onGameResize` and `onMount`. After that, it goes on to call `update` and
-`render` back and forth every tick, until the widget is removed from the tree.
-Once the `GameWidget` is removed from the tree, `onRemove` is called, just like when a normal
-component is removed from the component tree.
+When a `FlameGame` is first added to a `GameWidget` the lifecycle methods `onGameResize`, `onLoad`
+and `onMount` will be called in that order. Then `update` and `render` are called in sequence for
+every game tick.  If the `FlameGame` is removed from the `GameWidget`  then `onRemove` is called.
+If the `FlameGame` is added to a new `GameWidget` the sequence repeats from `onGameResize`.
 
 ```{note}
-The `onRemove` can be used to clean up potential memory leaks such as the following:
+The order of `onGameResize`and `onLoad` are reversed from that of other
+`Component`s. This is to allow game element sizes to be calculated before
+resources are loaded or generated.
 ```
+
+The `onRemove` callback can be used to clean up children and cached data:
 
 ```dart
   @override
@@ -111,6 +116,11 @@ The `onRemove` can be used to clean up potential memory leaks such as the follow
     Flame.assets.clearCache();
     // Any other code that you want to run when the game is removed.
   }
+```
+
+```{note}
+Clean-up of children and resources in a `FlameGame` is not done automatically
+and must be explicitly added to the `onRemove` call.
 ```
 
 


### PR DESCRIPTION
# Description

The `FlameGame` lifecycle diagram is incorrect.  The lifecycle for a `FlameGame` is as follows:

```
onGameResize
onLoad
onMount
render
update
onRemove
onGameResize
onLoad
onMount
render
update
```

Note in particular the `onGameResize` is before `onLoad` and the `render` and `update` are reversed.  Because they are different, this PR creates a new lifecycle diagram that is not shared with `Component`.  It also fixes the `Component` lifecycle diagram to be consistent with the `FlameGame` lifecycle diagram formatting and terms.  

## Checklist

- [x ] I have followed the [Contributor Guide] when preparing my PR.
- [] I have updated/added tests for ALL new/updated/fixed functionality.
- [] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x ] No, this PR is not a breaking change.

## Related Issues
Closes #2674

[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
