### PR TITLE
fix: HasGameReference should default to FlameGame

### DIFF
--- a/doc/tutorials/klondike/app/lib/step4/components/card.dart
+++ b/doc/tutorials/klondike/app/lib/step4/components/card.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
-import 'package:flame/game.dart';
 import '../klondike_game.dart';
 import '../pile.dart';
 import '../rank.dart';
@@ -242,10 +241,8 @@ class Card extends PositionComponent with DragCallbacks {
     if (!_isDragging) {
       return;
     }
-    final cameraZoom = (findGame()! as FlameGame)
-        .firstChild<CameraComponent>()!
-        .viewfinder
-        .zoom;
+    final cameraZoom =
+        findGame()!.firstChild<CameraComponent>()!.viewfinder.zoom;
     final delta = event.delta / cameraZoom;
     position.add(delta);
     attachedCards.forEach((card) => card.position.add(delta));

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -273,7 +273,7 @@ class Component {
     } else if (_parent == null) {
       addToParent(newParent);
     } else {
-      final root = findGame()! as ComponentTreeRoot;
+      final root = findGame()!;
       root.enqueueMove(this, newParent);
     }
   }
@@ -384,9 +384,16 @@ class Component {
 
   @internal
   static Game? staticGameInstance;
-  Game? findGame() {
-    return staticGameInstance ??
-        ((this is Game) ? (this as Game) : _parent?.findGame());
+  FlameGame? findGame() {
+    assert(
+      staticGameInstance is FlameGame,
+      'A component needs to have a FlameGame as the root.',
+    );
+    final gameInstance = staticGameInstance is FlameGame
+        ? staticGameInstance! as FlameGame
+        : null;
+    return gameInstance ??
+        ((this is FlameGame) ? (this as FlameGame) : _parent?.findGame());
   }
 
   /// Whether the children list contains the given component.
@@ -581,7 +588,7 @@ class Component {
     child._parent = this;
     final game = findGame();
     if (isMounted && !child.isMounted) {
-      (game! as FlameGame).enqueueAdd(child, this);
+      game!.enqueueAdd(child, this);
     } else {
       // This will be reconciled during the mounting stage
       children.add(child);
@@ -627,7 +634,7 @@ class Component {
       "$this, component's parent = ${child._parent}",
     );
     if (isMounted) {
-      final root = findGame()! as ComponentTreeRoot;
+      final root = findGame()!;
       if (child.isMounted || child.isMounting) {
         if (!child.isRemoving) {
           root.enqueueRemove(child, this);
@@ -740,7 +747,7 @@ class Component {
       _priority = newPriority;
       final game = findGame();
       if (game != null && _parent != null) {
-        (game as FlameGame).enqueueRebalance(_parent!);
+        game.enqueueRebalance(_parent!);
       }
     }
   }

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -386,7 +386,7 @@ class Component {
   static Game? staticGameInstance;
   FlameGame? findGame() {
     assert(
-      staticGameInstance is FlameGame,
+      staticGameInstance is FlameGame || staticGameInstance == null,
       'A component needs to have a FlameGame as the root.',
     );
     final gameInstance = staticGameInstance is FlameGame

--- a/packages/flame/lib/src/components/mixins/has_game_ref.dart
+++ b/packages/flame/lib/src/components/mixins/has_game_ref.dart
@@ -1,7 +1,6 @@
 import 'package:flame/src/components/core/component.dart';
 import 'package:flame/src/experimental/has_game_reference.dart';
 import 'package:flame/src/game/flame_game.dart';
-import 'package:flame/src/game/game.dart';
 import 'package:flame/src/game/mixins/single_game_instance.dart';
 
 /// [HasGameRef] mixin provides property [game] (or [gameRef]), which is the
@@ -32,7 +31,7 @@ mixin HasGameRef<T extends FlameGame> on Component {
   T get gameRef => game;
 
   @override
-  Game? findGame() => _game ?? super.findGame();
+  FlameGame? findGame() => _game ?? super.findGame();
 
   T _findGameAndCheck() {
     final game = findGame();

--- a/packages/flame/lib/src/components/mixins/notifier.dart
+++ b/packages/flame/lib/src/components/mixins/notifier.dart
@@ -12,11 +12,8 @@ import 'package:meta/meta.dart';
 mixin Notifier on Component {
   FlameGame get _gameRef {
     final game = findGame();
-    assert(
-      game == null || game is FlameGame,
-      "Notifier can't be used without FlameGame",
-    );
-    return game! as FlameGame;
+    assert(game != null, "Notifier can't be used without FlameGame");
+    return game!;
   }
 
   @override

--- a/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
@@ -1,4 +1,3 @@
-import 'package:flame/game.dart';
 import 'package:flame/src/components/core/component.dart';
 import 'package:flame/src/events/flame_game_mixins/double_tap_dispatcher.dart';
 import 'package:flame/src/events/messages/double_tap_cancel_event.dart';
@@ -29,7 +28,7 @@ mixin DoubleTapCallbacks on Component {
   @override
   void onMount() {
     super.onMount();
-    final game = findGame()! as FlameGame;
+    final game = findGame()!;
     if (game.findByKey(const DoubleTapDispatcherKey()) == null) {
       final dispatcher = DoubleTapDispatcher();
       game.registerKey(const DoubleTapDispatcherKey(), dispatcher);

--- a/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
@@ -4,7 +4,6 @@ import 'package:flame/src/events/messages/drag_cancel_event.dart';
 import 'package:flame/src/events/messages/drag_end_event.dart';
 import 'package:flame/src/events/messages/drag_start_event.dart';
 import 'package:flame/src/events/messages/drag_update_event.dart';
-import 'package:flame/src/game/flame_game.dart';
 import 'package:meta/meta.dart';
 
 /// This mixin can be added to a [Component] allowing it to receive drag events.
@@ -66,7 +65,7 @@ mixin DragCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    final game = findGame()! as FlameGame;
+    final game = findGame()!;
     if (game.findByKey(const MultiDragDispatcherKey()) == null) {
       final dispatcher = MultiDragDispatcher();
       game.registerKey(const MultiDragDispatcherKey(), dispatcher);

--- a/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
@@ -1,4 +1,3 @@
-import 'package:flame/game.dart';
 import 'package:flame/src/components/core/component.dart';
 import 'package:flame/src/events/flame_game_mixins/has_tappable_components.dart';
 import 'package:flame/src/events/messages/tap_cancel_event.dart';
@@ -23,7 +22,7 @@ mixin TapCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    final game = findGame()! as FlameGame;
+    final game = findGame()!;
     if (game.findByKey(const MultiTapDispatcherKey()) == null) {
       final dispatcher = MultiTapDispatcher();
       game.registerKey(const MultiTapDispatcherKey(), dispatcher);

--- a/packages/flame/lib/src/experimental/has_game_reference.dart
+++ b/packages/flame/lib/src/experimental/has_game_reference.dart
@@ -1,6 +1,5 @@
 import 'package:flame/src/components/core/component.dart';
 import 'package:flame/src/game/flame_game.dart';
-import 'package:flame/src/game/game.dart';
 import 'package:flame/src/game/mixins/single_game_instance.dart';
 
 /// [HasGameReference] mixin provides property [game], which is the cached
@@ -25,7 +24,7 @@ mixin HasGameReference<T extends FlameGame> on Component {
   set game(T? value) => _game = value;
 
   @override
-  Game? findGame() => _game ?? super.findGame();
+  FlameGame? findGame() => _game ?? super.findGame();
 
   T _findGameAndCheck() {
     final game = findGame();

--- a/packages/flame/lib/src/experimental/has_game_reference.dart
+++ b/packages/flame/lib/src/experimental/has_game_reference.dart
@@ -1,5 +1,4 @@
 import 'package:flame/src/components/core/component.dart';
-import 'package:flame/src/components/mixins/has_game_ref.dart';
 import 'package:flame/src/game/flame_game.dart';
 import 'package:flame/src/game/game.dart';
 import 'package:flame/src/game/mixins/single_game_instance.dart';
@@ -10,9 +9,6 @@ import 'package:flame/src/game/mixins/single_game_instance.dart';
 /// The type [T] on the mixin is the type of your game class. This type will be
 /// the type of the [game] reference, and the mixin will check at runtime that
 /// the actual type matches the expectation.
-///
-/// This class is equivalent to [HasGameRef] in all respects except that its
-/// generic parameter [T] can be any [Game], not just a "FlameGame".
 mixin HasGameReference<T extends FlameGame> on Component {
   T? _game;
 

--- a/packages/flame/lib/src/experimental/has_game_reference.dart
+++ b/packages/flame/lib/src/experimental/has_game_reference.dart
@@ -1,5 +1,6 @@
 import 'package:flame/src/components/core/component.dart';
 import 'package:flame/src/components/mixins/has_game_ref.dart';
+import 'package:flame/src/game/flame_game.dart';
 import 'package:flame/src/game/game.dart';
 import 'package:flame/src/game/mixins/single_game_instance.dart';
 
@@ -12,7 +13,7 @@ import 'package:flame/src/game/mixins/single_game_instance.dart';
 ///
 /// This class is equivalent to [HasGameRef] in all respects except that its
 /// generic parameter [T] can be any [Game], not just a "FlameGame".
-mixin HasGameReference<T extends Game> on Component {
+mixin HasGameReference<T extends FlameGame> on Component {
   T? _game;
 
   /// Reference to the top-level Game instance that owns this component.

--- a/packages/flame/test/experimental/has_game_reference_test.dart
+++ b/packages/flame/test/experimental/has_game_reference_test.dart
@@ -5,13 +5,16 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
+class _GameReferenceGame extends FlameGame {}
+
 void main() {
   group('HasGameReference', () {
-    testWithFlameGame(
+    testWithGame(
       'component with default HasGameReference',
+      _GameReferenceGame.new,
       (game) async {
         final component1 = _Component<FlameGame>();
-        final component2 = _Component<Game>();
+        final component2 = _Component<_GameReferenceGame>();
         game.addAll([component1, component2]);
         expect(component1.game, game);
         expect(component2.game, game);
@@ -102,7 +105,8 @@ void main() {
   });
 }
 
-class _Component<T extends Game> extends Component with HasGameReference<T> {}
+class _Component<T extends FlameGame> extends Component
+    with HasGameReference<T> {}
 
 class _MyGame extends FlameGame {
   bool calledFoo = false;

--- a/packages/flame_test/lib/src/flame_test.dart
+++ b/packages/flame_test/lib/src/flame_test.dart
@@ -17,28 +17,28 @@ extension FlameGameExtension on Component {
   /// returned future to resolve.
   Future<void> ensureAdd(Component component) async {
     await add(component);
-    await (component.findGame()! as FlameGame).ready();
+    await component.findGame()!.ready();
   }
 
   /// Makes sure that the [components] are added to the tree if you wait for the
   /// returned future to resolve.
   Future<void> ensureAddAll(Iterable<Component> components) async {
     await addAll(components);
-    await (components.first.findGame()! as FlameGame).ready();
+    await components.first.findGame()!.ready();
   }
 
   /// Makes sure that the [component] is removed from the tree if you wait for
   /// the returned future to resolve.
   Future<void> ensureRemove(Component component) async {
     remove(component);
-    await (component.findGame()! as FlameGame).ready();
+    await component.findGame()!.ready();
   }
 
   /// Makes sure that the [components] are removed from the tree if you wait for
   /// the returned future to resolve.
   Future<void> ensureRemoveAll(Iterable<Component> components) async {
     removeAll(components);
-    await (components.first.findGame()! as FlameGame).ready();
+    await components.first.findGame()!.ready();
   }
 }
 


### PR DESCRIPTION
# Description

It doesn't make any sense for `HasGameReference` to have `Game` as a base instead of `FlameGame` since the mixin is `on Component` and clearly in a component tree context, so this PR sets the base to be `FlameGame` (like `HasGameRef`).

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

It kind of is a breaking change, but I can not imagine anyone using it in a way that this would become breaking for them, so I'm counting it as a non-breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
