### PR TITLE
fix: Ambiguation is not needed in render box anymore

### DIFF
--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -131,11 +131,11 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
   }
 
   void _bindLifecycleListener() {
-    _ambiguate(WidgetsBinding.instance)!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   void _unbindLifecycleListener() {
-    _ambiguate(WidgetsBinding.instance)!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
   }
 
   @override
@@ -143,13 +143,3 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
     game.lifecycleStateChange(state);
   }
 }
-
-/// This allows a value of type T or T?
-/// to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become
-/// non-nullable can still be used with `!` and `?`
-/// to support older versions of the API as well.
-///
-/// See more: https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0
-T? _ambiguate<T>(T? value) => value;

--- a/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
@@ -36,6 +36,18 @@ class _MyGame extends FlameGame {
     super.onDispose();
     events.add('onDispose');
   }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    events.add('update');
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    events.add('render');
+  }
 }
 
 class _TitlePage extends StatelessWidget {

--- a/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_lifecycle_test.dart
@@ -36,18 +36,6 @@ class _MyGame extends FlameGame {
     super.onDispose();
     events.add('onDispose');
   }
-
-  @override
-  void update(double dt) {
-    super.update(dt);
-    events.add('update');
-  }
-
-  @override
-  void render(Canvas canvas) {
-    super.render(canvas);
-    events.add('render');
-  }
 }
 
 class _TitlePage extends StatelessWidget {


### PR DESCRIPTION
# Description
Since we are requiring a SDK higher than when the instance could be null we don't need to do the ambiguate call anymore.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
