### PR TITLE
fix: Make `debugCoordinatesPrecision` into a variable instead of a getter

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -930,7 +930,7 @@ class Component {
   /// How many decimal digits to print when displaying coordinates in the
   /// debug mode. Setting this to null will suppress all coordinates from
   /// the output.
-  int? get debugCoordinatesPrecision => 0;
+  int? debugCoordinatesPrecision = 0;
 
   /// A key that can be used to identify this component in the tree.
   ///

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -919,7 +919,7 @@ void main() {
           ..position = Vector2(23, 17)
           ..size = Vector2.all(10)
           ..anchor = Anchor.center
-          ..precision = null;
+          ..debugCoordinatesPrecision = null;
         final canvas = MockCanvas();
         component.renderTree(canvas);
         expect(
@@ -929,6 +929,40 @@ void main() {
             ..drawRect(const Rect.fromLTWH(0, 0, 10, 10))
             ..drawLine(const Offset(5, 3), const Offset(5, 7))
             ..drawLine(const Offset(3, 5), const Offset(7, 5))
+            ..translate(0, 0), // canvas.restore
+        );
+      });
+
+      test('render without coordinates and then render with coordinates', () {
+        final component = _MyDebugComponent()
+          ..position = Vector2(23, 17)
+          ..size = Vector2.all(10)
+          ..anchor = Anchor.center
+          ..debugCoordinatesPrecision = null;
+        final withoutCoordinatesCanvas = MockCanvas();
+        component.renderTree(withoutCoordinatesCanvas);
+        expect(
+          withoutCoordinatesCanvas,
+          MockCanvas()
+            ..translate(18, 12)
+            ..drawRect(const Rect.fromLTWH(0, 0, 10, 10))
+            ..drawLine(const Offset(5, 3), const Offset(5, 7))
+            ..drawLine(const Offset(3, 5), const Offset(7, 5))
+            ..translate(0, 0), // canvas.restore
+        );
+
+        component.debugCoordinatesPrecision = 0;
+        final withCoordinatesCanvas = MockCanvas();
+        component.renderTree(withCoordinatesCanvas);
+        expect(
+          withCoordinatesCanvas,
+          MockCanvas()
+            ..translate(18, 12)
+            ..drawRect(const Rect.fromLTWH(0, 0, 10, 10))
+            ..drawLine(const Offset(5, 3), const Offset(5, 7))
+            ..drawLine(const Offset(3, 5), const Offset(7, 5))
+            ..drawParagraph(null, const Offset(-30, -15))
+            ..drawParagraph(null, const Offset(-20, 10))
             ..translate(0, 0), // canvas.restore
         );
       });
@@ -1003,11 +1037,6 @@ void main() {
 class _MyHitboxComponent extends PositionComponent with GestureHitboxes {}
 
 class _MyDebugComponent extends PositionComponent {
-  int? precision = 0;
-
   @override
   bool get debugMode => true;
-
-  @override
-  int? get debugCoordinatesPrecision => precision;
 }


### PR DESCRIPTION
# Description
Since you might want to set `debugCoordinatesPrecision` without having to override it, it is better to have it as a variable than a getter.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
