### PR TITLE
feat(flame_jenny): Remove functions and commands

### DIFF
--- a/doc/other_modules/jenny/runtime/command_storage.md
+++ b/doc/other_modules/jenny/runtime/command_storage.md
@@ -42,6 +42,24 @@ In order to register a function as a yarn command, the function must satisfy sev
 : Registers a command `name` which is not backed by any Dart function. Such command will still be
   delivered to [DialogueView]s via the `onCommand()` callback, but its arguments will not be parsed.
 
+**clear**
+: Removes all user-defined commands
+
+**remove**(`String name`)
+: Removes the user-defined command with the specified `name`.
+
+
+## Properties
+
+**length** → `int`
+: The number of user-defined commands registered so far.
+
+**isEmpty** → `bool`
+: Returns `true` if no user-defined commands were registered.
+
+**isNotEmpty** → `bool`
+: Returns `true` if any commands have been registered
+
 
 ## Examples
 

--- a/doc/other_modules/jenny/runtime/function_storage.md
+++ b/doc/other_modules/jenny/runtime/function_storage.md
@@ -54,6 +54,12 @@ Keep in mind that the name of the user-defined function must be:
 **addFunction4**(`String name`, `T0 Function(T1, T2, T3, T4) fn4`)
 : Registers a four-argument function `fn4` as `name`.
 
+**clear**
+: Removes all user-defined functions
+
+**remove**(`String name`)
+: Removes the user-defined function with the specified `name`.
+
 
 ## Properties
 

--- a/packages/flame_jenny/jenny/lib/src/command_storage.dart
+++ b/packages/flame_jenny/jenny/lib/src/command_storage.dart
@@ -18,6 +18,11 @@ class CommandStorage {
 
   final Map<String, _Cmd?> _commands;
 
+  /// Number of commands that have been registered.
+  int get length => _commands.length;
+  bool get isEmpty => _commands.isEmpty;
+  bool get isNotEmpty => _commands.isNotEmpty;
+
   /// Returns `true` if command with the given [name] has been registered.
   bool hasCommand(String name) => _commands.containsKey(name);
 
@@ -81,6 +86,16 @@ class CommandStorage {
       _rxId.firstMatch(name) != null,
       'Command name "$name" is not an identifier',
     );
+  }
+
+  /// Clear all commands from storage.
+  void clear() {
+    _commands.clear();
+  }
+
+  /// Remove a command by [name].
+  void remove(String name) {
+    _commands.remove(name);
   }
 
   static final _rxId = RegExp(r'^[a-zA-Z_]\w*$');

--- a/packages/flame_jenny/jenny/lib/src/function_storage.dart
+++ b/packages/flame_jenny/jenny/lib/src/function_storage.dart
@@ -24,6 +24,7 @@ import 'package:meta/meta.dart';
 ///   argument is present, then it will be passed automatically. For example,
 ///   if you have a function `fn(YarnProject, int)`, then it can be invoked
 ///   from the yarn script simply as `fn(1)`.
+/// - the name does not match any of the built-in functions
 ///
 /// The functions must be added to the YarnProject before parsing the yarn
 /// scripts, since the parser would throw an error if it sees a function which
@@ -122,6 +123,16 @@ class FunctionStorage {
       _rxId.firstMatch(name) != null,
       'Function name "$name" is not an identifier',
     );
+  }
+
+  /// Clear all functions from storage.
+  void clear() {
+    _functions.clear();
+  }
+
+  /// Remove a function by [name].
+  void remove(String name) {
+    _functions.remove(name);
   }
 
   /// Regular expression that matches a valid identifier.

--- a/packages/flame_jenny/jenny/test/command_storage_test.dart
+++ b/packages/flame_jenny/jenny/test/command_storage_test.dart
@@ -230,6 +230,32 @@ void main() {
           ),
         );
       });
+
+      test('Clear all commands', () {
+        final storage = CommandStorage();
+        storage.addCommand0('foo', () => null);
+        storage.addCommand1('bar', (int n) => n);
+
+        expect(storage.isEmpty, false);
+
+        storage.clear();
+
+        expect(storage.isEmpty, true);
+      });
+
+      test('Remove a command', () {
+        final storage = CommandStorage();
+        storage.addCommand0('foo', () => null);
+        storage.addCommand1('bar', (int n) => n);
+
+        expect(storage.hasCommand('foo'), true);
+        expect(storage.hasCommand('bar'), true);
+
+        storage.remove('foo');
+
+        expect(storage.hasCommand('foo'), false);
+        expect(storage.hasCommand('bar'), true);
+      });
     });
   });
 

--- a/packages/flame_jenny/jenny/test/function_storage_test.dart
+++ b/packages/flame_jenny/jenny/test/function_storage_test.dart
@@ -308,6 +308,30 @@ void main() {
           ),
         );
       });
+
+      test('clear all functions', () {
+        final functions = FunctionStorage();
+        functions.addFunction0('t0', () => 0);
+        functions.addFunction1('add2', (int n) => n + 2);
+        expect(functions.isEmpty, false);
+
+        functions.clear();
+
+        expect(functions.isEmpty, true);
+      });
+
+      test('remove a function', () {
+        final functions = FunctionStorage();
+        functions.addFunction0('t0', () => 0);
+        functions.addFunction1('add2', (int n) => n + 2);
+        expect(functions.hasFunction('t0'), true);
+        expect(functions.hasFunction('add2'), true);
+
+        functions.remove('t0');
+
+        expect(functions.hasFunction('t0'), false);
+        expect(functions.hasFunction('add2'), true);
+      });
     });
   });
 }


### PR DESCRIPTION
# Description

Allow functions and commands to be removed from storage, or function and/or command storage to be cleared.

This is useful if different parts of the game have different implementations of a command or a function. Currently registering a function or command with the same name fails (i.e. it is not overwritten). Removing the function or command allows it to be replaced.


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

Relates to #2686 which will be split to multiple PRs to keep them manageable :) 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
