### PR TITLE
chore: Enable DCM rule: avoid-collection-methods-with-unrelated-types

### DIFF
--- a/packages/flame_lint/lib/analysis_options_with_dcm.yaml
+++ b/packages/flame_lint/lib/analysis_options_with_dcm.yaml
@@ -7,5 +7,6 @@ dart_code_metrics:
   # dart rules
     - avoid-banned-imports
     - avoid-cascade-after-if-null
+    - avoid-collection-methods-with-unrelated-types
   # flutter rules
     - prefer-define-hero-tag


### PR DESCRIPTION
# Description

Enable DCM rule: avoid-collection-methods-with-unrelated-types

Reference: https://dcm.dev/docs/rules/common/avoid-collection-methods-with-unrelated-types/

Hopefully we don't have any violations as-is, because this would be pretty bad.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
