### PR TITLE
docs: Replace flutter format with dart format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ please read these instructions carefully.
 For a contribution to be accepted:
 
 - Follow the [Style Guide] when writing the code;
-- Format the code using `flutter format .`;
+- Format the code using `dart format .`;
 - Lint the code with `melos run analyze`;
 - Check that all tests pass: `melos run test`;
 - Documentation should always be updated or added (if applicable);

--- a/doc/development/style_guide.md
+++ b/doc/development/style_guide.md
@@ -16,7 +16,7 @@ commands to ensure the code is conformant and to fix any easy formatting problem
 
 ```shell
 flutter analyze
-flutter format .
+dart format .
 ```
 
 

--- a/examples/games/padracing/scripts/merge_files.sh
+++ b/examples/games/padracing/scripts/merge_files.sh
@@ -18,7 +18,7 @@ LC_COLLATE=c sort -u imports.dart | grep -v padracing > imports_tmp.dart
 cat imports_tmp.dart tmp.dart > main.dart
 rm tmp.dart imports_tmp.dart imports.dart
 echo '//ignore_for_file: avoid_web_libraries_in_flutter' >> main.dart
-flutter format main.dart
+dart format main.dart
 
 if command -v xclip &> /dev/null
 then


### PR DESCRIPTION
# Description

`flutter format` will generate a deprecation warning:

```
The "format" command is deprecated. Please use the "dart format" sub-command instead, which has the same command-line usage as "flutter format".
```

It should be replaced with `dart format`.

Have updated two places in the docs, and in a shell script (please verify this one for me!)


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
