### PR TITLE
test: Test so that paused gameloop doesn't count dt

### DIFF
--- a/packages/flame/test/game/game_widget/game_widget_pause_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_pause_test.dart
@@ -53,10 +53,12 @@ class _WrapperState extends State<_Wrapper> {
 
 class _MyGame extends FlameGame {
   int callCount = 0;
+  double timePassed = 0;
 
   @override
   void update(double dt) {
     super.update(dt);
+    timePassed += dt;
 
     callCount++;
   }
@@ -148,6 +150,31 @@ void main() {
       await tester.pump();
 
       expect(game.callCount, equals(2));
+    },
+  );
+
+  myGame().testGameWidget(
+    'will not add time to dt when paused',
+    verify: (game, tester) async {
+      const frameLength = Duration(seconds: 1);
+      // Run two frames.
+      await tester.pump(frameLength);
+      await tester.pump(frameLength);
+
+      game.pauseEngine();
+
+      // Run two frames when the engine is paused.
+      await tester.pump(frameLength);
+      await tester.pump(frameLength);
+
+      game.resumeEngine();
+      // This time will be thrown away since the ticker hasn't received its
+      // first timestamp yet.
+      await tester.pump(const Duration(seconds: 100));
+      await tester.pump(frameLength);
+
+      expect(game.callCount, equals(4));
+      expect(game.timePassed, equals(3));
     },
   );
 }


### PR DESCRIPTION
# Description

Just adds a test that makes sure that the dt that has passed when a game is paused is not accumulated.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

#2642 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
