### PR TITLE
chore: Enable DCM rules avoid-duplicate-exports and avoid-unnecessary-type-casts

### DIFF
--- a/packages/flame_lint/lib/analysis_options_with_dcm.yaml
+++ b/packages/flame_lint/lib/analysis_options_with_dcm.yaml
@@ -8,5 +8,7 @@ dart_code_metrics:
     - avoid-banned-imports
     - avoid-cascade-after-if-null
     - avoid-collection-methods-with-unrelated-types
+    - avoid-duplicate-exports
+    - avoid-unnecessary-type-casts
   # flutter rules
     - prefer-define-hero-tag


### PR DESCRIPTION
# Description

Enable DCM rules avoid-duplicate-exports and avoid-unnecessary-type-casts.

I don't think there is any controversy with these. There is also no current violations.

## avoid-duplicate-exports

Forbid duplicate exports (same file) on a module file

Ref: https://dcm.dev/docs/rules/common/avoid-duplicate-exports

## avoid-unnecessary-type-casts

Forbid unnecessary casts

Ref: https://dcm.dev/docs/rules/common/avoid-unnecessary-type-casts

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
