### PR TITLE
fix: Use root game for gestures

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -381,6 +381,8 @@ class Component {
 
   @internal
   static Game? staticGameInstance;
+
+  /// Fetches the nearest [FlameGame] ancestor to the component.
   FlameGame? findGame() {
     assert(
       staticGameInstance is FlameGame || staticGameInstance == null,
@@ -391,6 +393,15 @@ class Component {
         : null;
     return gameInstance ??
         ((this is FlameGame) ? (this as FlameGame) : _parent?.findGame());
+  }
+
+  /// Fetches the root [FlameGame] ancestor to the component.
+  FlameGame? findRootGame() {
+    var game = findGame();
+    while (game?.parent != null) {
+      game = game!.parent!.findGame();
+    }
+    return game;
   }
 
   /// Whether the children list contains the given component.

--- a/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
@@ -28,7 +28,7 @@ mixin DoubleTapCallbacks on Component {
   @override
   void onMount() {
     super.onMount();
-    final game = findGame()!;
+    final game = findRootGame()!;
     if (game.findByKey(const DoubleTapDispatcherKey()) == null) {
       final dispatcher = DoubleTapDispatcher();
       game.registerKey(const DoubleTapDispatcherKey(), dispatcher);

--- a/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
@@ -65,7 +65,7 @@ mixin DragCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    final game = findGame()!;
+    final game = findRootGame()!;
     if (game.findByKey(const MultiDragDispatcherKey()) == null) {
       final dispatcher = MultiDragDispatcher();
       game.registerKey(const MultiDragDispatcherKey(), dispatcher);

--- a/packages/flame/lib/src/events/component_mixins/pointer_move_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/pointer_move_callbacks.dart
@@ -18,7 +18,7 @@ mixin PointerMoveCallbacks on Component {
   }
 
   static void onMountHandler(PointerMoveCallbacks instance) {
-    final game = instance.findGame()!;
+    final game = instance.findRootGame()!;
     const key = MouseMoveDispatcherKey();
     if (game.findByKey(key) == null) {
       final dispatcher = PointerMoveDispatcher();

--- a/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
@@ -22,7 +22,7 @@ mixin TapCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    final game = findGame()!;
+    final game = findRootGame()!;
     if (game.findByKey(const MultiTapDispatcherKey()) == null) {
       final dispatcher = MultiTapDispatcher();
       game.registerKey(const MultiTapDispatcherKey(), dispatcher);

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -1121,6 +1121,28 @@ void main() {
       });
     });
 
+    group('findRootGame()', () {
+      testWithFlameGame('finds root game in nested game structure',
+          (game) async {
+        final component = Component();
+        await game.ensureAdd(
+          FlameGame(
+            children: [
+              Component(children: [component]),
+            ],
+          ),
+        );
+        expect(component.findRootGame(), game);
+      });
+
+      testWithFlameGame('finds root game in non-nested game structure',
+          (game) async {
+        final component = Component();
+        await game.ensureAdd(component);
+        expect(component.findRootGame(), game);
+      });
+    });
+
     group('miscellaneous', () {
       testWithFlameGame('childrenFactory', (game) async {
         final component0 = Component();


### PR DESCRIPTION
# Description

Since registering detectors won't work on a non-root game we have to register the dispatchers on the root game.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
