### PR TITLE
fix: Allow moving to a new parent in the same tick

### DIFF
--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -21,14 +21,6 @@ class ComponentTreeRoot extends Component {
 
   @internal
   void enqueueAdd(Component child, Component parent) {
-    if (child.isRemoving) {
-      // If the child is going to be added to the same parent as it previously
-      // had we need to remove it from the previous remove event from the queue.
-      final wasRemoved = dequeueRemove(child, parent);
-      if (wasRemoved) {
-        return;
-      }
-    }
     _queue.addLast()
       ..kind = _LifecycleEventKind.add
       ..child = child
@@ -59,16 +51,12 @@ class ComponentTreeRoot extends Component {
   }
 
   @internal
-  bool dequeueRemove(Component child, Component parent) {
+  void dequeueRemove(Component child) {
     for (final event in _queue) {
-      if (event.kind == _LifecycleEventKind.remove &&
-          event.child == child &&
-          event.parent == parent) {
+      if (event.kind == _LifecycleEventKind.remove && event.child == child) {
         event.kind = _LifecycleEventKind.unknown;
-        return true;
       }
     }
-    return false;
   }
 
   @internal

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -412,6 +412,8 @@ void main() {
           game.update(0);
           expect(child.parent, parent);
           expect(parent.children, [child]);
+          expect(child.isMounted, isTrue);
+          expect(child.isRemoving, isFalse);
         },
       );
 
@@ -427,6 +429,46 @@ void main() {
           game.update(0);
           expect(child.parent, parent);
           expect(parent.children, [child]);
+          expect(child.isMounted, isTrue);
+          expect(child.isRemoving, isFalse);
+        },
+      );
+
+      testWithFlameGame(
+        'removing a component and adding it to another parent in the same tick',
+        (game) async {
+          final child = Component();
+          final parent = Component(children: [child]);
+          final otherParent = Component();
+          await game.ensureAddAll([parent, otherParent]);
+          child.removeFromParent();
+          otherParent.add(child);
+          game.update(0);
+          expect(child.parent, otherParent);
+          expect(parent.children, []);
+          expect(otherParent.children, [child]);
+          expect(child.isMounted, isTrue);
+        },
+      );
+
+      testWithFlameGame(
+        'swapping between multiple parents in the same tick',
+        (game) async {
+          final child = Component();
+          final parents = [
+            Component(children: [child]),
+            Component(),
+            Component(),
+          ];
+          await game.ensureAddAll(parents);
+          child.parent = parents[1];
+          child.parent = parents[2];
+          game.update(0);
+          expect(child.parent, parents[2]);
+          expect(parents[0].children, []);
+          expect(parents[1].children, []);
+          expect(parents[2].children, [child]);
+          expect(child.isMounted, isTrue);
         },
       );
 


### PR DESCRIPTION
# Description

This PR no longer treats it as an invalid action to add a child to a parent even if it already has a parent, it simply triggers a move instead, which makes it possible to simplify the logic.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
