### PR TITLE
fix: Add necessary generics on mixins on FlameGame

### DIFF
--- a/packages/flame/lib/src/collisions/broadphase/quadtree/has_quadtree_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/broadphase/quadtree/has_quadtree_collision_detection.dart
@@ -1,3 +1,4 @@
+import 'package:flame/camera.dart';
 import 'package:flame/collisions.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
@@ -15,7 +16,7 @@ import 'package:flame/game.dart';
 ///
 /// [initializeCollisionDetection] should be called in the game's [onLoad]
 /// method.
-mixin HasQuadTreeCollisionDetection on FlameGame
+mixin HasQuadTreeCollisionDetection<W extends World> on FlameGame<W>
     implements HasCollisionDetection<QuadTreeBroadphase> {
   late QuadTreeCollisionDetection _collisionDetection;
 

--- a/packages/flame/lib/src/game/mixins/keyboard.dart
+++ b/packages/flame/lib/src/game/mixins/keyboard.dart
@@ -1,6 +1,5 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
-import 'package:flame/src/components/mixins/keyboard_handler.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/packages/flame/lib/src/game/mixins/keyboard.dart
+++ b/packages/flame/lib/src/game/mixins/keyboard.dart
@@ -9,7 +9,8 @@ import 'package:flutter/services.dart';
 ///
 /// Attention: should not be used alongside [KeyboardEvents] in a game subclass.
 /// Using this mixin remove the necessity of [KeyboardEvents].
-mixin HasKeyboardHandlerComponents on FlameGame implements KeyboardEvents {
+mixin HasKeyboardHandlerComponents<W extends World> on FlameGame<W>
+    implements KeyboardEvents {
   @override
   @mustCallSuper
   KeyEventResult onKeyEvent(


### PR DESCRIPTION
# Description
Since FlameGame now takes in `W extends World` the mixins that are `on FlameGame` needs to be able to take in the same generics.

Later the `HasKeyboardHandlerComponents` wont be necessary, but let's do this intermediary step.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Closes #2761

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
