### PR TITLE
chore: Fix some broken flame_forge2d links

### DIFF
--- a/doc/bridge_packages/flame_forge2d/forge2d.md
+++ b/doc/bridge_packages/flame_forge2d/forge2d.md
@@ -142,4 +142,4 @@ Every time `Ball` and `Wall` begin to come in contact `beginContact` will be cal
 fixtures cease being in contact, `endContact` will be called.
 
 An implementation example can be seen in the [Flame Forge2D
-example](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/bridge_libraries/forge2d/utils/balls.dart).
+example](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/bridge_libraries/flame_forge2d/utils/balls.dart).

--- a/doc/bridge_packages/flame_forge2d/joints.md
+++ b/doc/bridge_packages/flame_forge2d/joints.md
@@ -53,7 +53,7 @@ It can for example be useful when simulating "soft-bodies".
 
 ```{flutter-app}
 :sources: ../../examples
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :page: constant_volume_joint
 :show: code popup
 ```
@@ -87,7 +87,7 @@ world.createJoint(DistanceJoint(distanceJointDef));
 ```{flutter-app}
 :sources: ../../examples
 :page: distance_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 
@@ -142,7 +142,7 @@ final frictionJointDef = FrictionJointDef()
 ```{flutter-app}
 :sources: ../../examples
 :page: friction_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 
@@ -183,7 +183,7 @@ world.createJoint(GearJoint(gearJointDef));
 ```{flutter-app}
 :sources: ../../examples
 :page: gear_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 
@@ -233,7 +233,7 @@ final motorJointDef = MotorJointDef()
 ```{flutter-app}
 :sources: ../../examples
 :page: motor_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 
@@ -306,7 +306,7 @@ final mouseJointDef = MouseJointDef()
 ```{flutter-app}
 :sources: ../../examples
 :page: mouse_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 
@@ -356,7 +356,7 @@ final prismaticJointDef = PrismaticJointDef()
 ```{flutter-app}
 :sources: ../../examples
 :page: prismatic_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 
@@ -461,7 +461,7 @@ world.createJoint(PulleyJoint(pulleyJointDef));
 ```{flutter-app}
 :sources: ../../examples
 :page: pulley_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 
@@ -505,7 +505,7 @@ world.createJoint(RevoluteJoint(jointDef));
 ```{flutter-app}
 :sources: ../../examples
 :page: revolute_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 
@@ -586,7 +586,7 @@ world.createJoint(RopeJoint(ropeJointDef));
 ```{flutter-app}
 :sources: ../../examples
 :page: rope_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 
@@ -618,7 +618,7 @@ world.createJoint(WeldJoint(weldJointDef));
 ```{flutter-app}
 :sources: ../../examples
 :page: weld_joint
-:subfolder: stories/bridge_libraries/forge2d/joints
+:subfolder: stories/bridge_libraries/flame_forge2d/joints
 :show: code popup
 ```
 

--- a/examples/lib/stories/bridge_libraries/flame_forge2d/flame_forge2d.dart
+++ b/examples/lib/stories/bridge_libraries/flame_forge2d/flame_forge2d.dart
@@ -25,7 +25,8 @@ import 'package:examples/stories/bridge_libraries/flame_forge2d/tap_callbacks_ex
 import 'package:examples/stories/bridge_libraries/flame_forge2d/widget_example.dart';
 import 'package:flame/game.dart';
 
-String link(String example) => baseLink('bridge_libraries/forge2d/$example');
+String link(String example) =>
+    baseLink('bridge_libraries/flame_forge2d/$example');
 
 void addForge2DStories(Dashbook dashbook) {
   dashbook.storiesOf('flame_forge2d')

--- a/packages/flame_forge2d/README.md
+++ b/packages/flame_forge2d/README.md
@@ -37,7 +37,7 @@ remember to add the latest version of [Flame](https://pub.dev/packages/flame/ins
 ## Examples
 
 In the example folder of this directory you can find some
-[examples](https://github.com/flame-engine/flame/tree/main/examples/lib/stories/bridge_libraries/forge2d),
+[examples](https://github.com/flame-engine/flame/tree/main/examples/lib/stories/bridge_libraries/flame_forge2d),
 and you can also find some examples in the
 [Forge2D repository](https://github.com/flame-engine/forge2d/tree/main/packages/forge2d/example).
 
@@ -45,5 +45,5 @@ and you can also find some examples in the
 ## Documentation
 
 Some more documentation can be found
-[here](https://docs.flame-engine.org/main/other_modules/forge2d.html).
+[here](https://docs.flame-engine.org/main/bridge_packages/flame_forge2d/flame_forge2d.html).
 


### PR DESCRIPTION
# Description
Some links were not converted when we renamed a directory from forge2d to flame_forge2d.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
