### PR TITLE
fix: Correctly refreshes the widget after new mouse detector

### DIFF
--- a/packages/flame/lib/src/game/game.dart
+++ b/packages/flame/lib/src/game/game.dart
@@ -38,7 +38,12 @@ abstract mixin class Game {
 
   /// Set by the PointerMoveDispatcher to receive mouse events from the
   /// game widget.
-  void Function(PointerHoverEvent event)? mouseDetector;
+  void Function(PointerHoverEvent event)? get mouseDetector => _mouseDetector;
+  void Function(PointerHoverEvent event)? _mouseDetector;
+  set mouseDetector(void Function(PointerHoverEvent event)? newMouseDetector) {
+    _mouseDetector = newMouseDetector;
+    refreshWidget();
+  }
 
   /// This should update the state of the game.
   void update(double dt);


### PR DESCRIPTION
# Description
Since the widget wasn't refreshed when a new mouse detector was added it only worked if for example `HoverCallbacks` components were added directly in the game's `onLoad`.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
Closes #2760

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
