### PR TITLE
fix: AlignComponent set child (remove compare)

### DIFF
--- a/packages/flame/lib/src/layout/align_component.dart
+++ b/packages/flame/lib/src/layout/align_component.dart
@@ -70,9 +70,6 @@ class AlignComponent extends PositionComponent {
   PositionComponent? get child => _child;
 
   set child(PositionComponent? value) {
-    if (_child == value) {
-      return;
-    }
     if (_child?.parent == this) {
       _child?.removeFromParent();
     }


### PR DESCRIPTION
At the moment, I have removed the additional check, because an object deleted outside its parent may not be checked and the reference is not reset in the onChildrenChanged method