### PR TITLE
fix: Fix TextBoxComponent alignment bug

### DIFF
--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -282,7 +282,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
             (boxHeight - nLines * _lineHeight) * align.y +
             i * _lineHeight,
       );
-      textElement.render(canvas, position, anchor: anchor);
+      textElement.render(canvas, position);
 
       charCount += lines[i].length;
     }

--- a/packages/flame/test/components/text_box_component_test.dart
+++ b/packages/flame/test/components/text_box_component_test.dart
@@ -163,9 +163,10 @@ void main() {
           _FramedTextBox(
             text: 'That shows thee a weak slave; for the weakest goes to the '
                 'wall.',
-            position: Vector2(410, 320),
+            position: Vector2(410, 320) + Vector2(380, 270),
             size: Vector2(380, 270),
             align: Anchor.centerRight,
+            anchor: Anchor.bottomRight,
           ),
         ]);
       },
@@ -194,6 +195,7 @@ class _FramedTextBox extends TextBoxComponent {
     super.align,
     super.position,
     super.size,
+    super.anchor,
   }) : super(
           textRenderer: DebugTextRenderer(fontSize: 22),
         );


### PR DESCRIPTION
# Description

Fix `TextBoxComponent` alignment bug
The `anchor` is the anchor of the text box component itself.
It has nothing to do with the alignment of the text within the box.
The position computed for rendering the text on the above lines is assuming `topLeft` anchor for the text.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

* [discord thread](https://discord.com/channels/509714518008528896/516639688581316629/1157552876936233031)

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
