### PR TITLE
refactor: Mark semantically final variables as final (or const) proper [DCM]

### DIFF
--- a/examples/lib/stories/camera_and_viewport/follow_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/follow_component_example.dart
@@ -132,7 +132,7 @@ class MovableEmber extends Ember<FollowComponentExample>
 class Map extends Component {
   static const double size = 1500;
   static const Rect _bounds = Rect.fromLTRB(-size, -size, size, size);
-  static Rectangle bounds = Rectangle.fromLTRB(-size, -size, size, size);
+  static final Rectangle bounds = Rectangle.fromLTRB(-size, -size, size, size);
 
   static final Paint _paintBorder = Paint()
     ..color = Colors.white12

--- a/examples/lib/stories/components/clip_component_example.dart
+++ b/examples/lib/stories/components/clip_component_example.dart
@@ -28,7 +28,8 @@ class _Rectangle extends RectangleComponent {
 }
 
 class ClipComponentExample extends FlameGame with TapDetector {
-  static String description = 'Tap on the objects to increase their size.';
+  static const String description =
+      'Tap on the objects to increase their size.';
 
   @override
   Future<void> onLoad() async {

--- a/examples/lib/stories/components/components_notifier_provider_example.dart
+++ b/examples/lib/stories/components/components_notifier_provider_example.dart
@@ -7,7 +7,7 @@ import 'package:provider/provider.dart';
 class ComponentsNotifierProviderExampleWidget extends StatefulWidget {
   const ComponentsNotifierProviderExampleWidget({super.key});
 
-  static String description = '''
+  static const String description = '''
       Similar to the Components Notifier example, but uses provider
       instead of the built in ComponentsNotifierBuilder widget.
 ''';

--- a/examples/lib/stories/components/spawn_component_example.dart
+++ b/examples/lib/stories/components/spawn_component_example.dart
@@ -7,7 +7,7 @@ import 'package:flame/input.dart';
 import 'package:flame/math.dart';
 
 class SpawnComponentExample extends FlameGame with TapDetector {
-  static String description =
+  static const String description =
       'Tap on the screen to start spawning Embers within different shapes.';
 
   @override

--- a/examples/lib/stories/rendering/rich_text_example.dart
+++ b/examples/lib/stories/rendering/rich_text_example.dart
@@ -4,8 +4,8 @@ import 'package:flame/text.dart';
 import 'package:flutter/painting.dart';
 
 class RichTextExample extends FlameGame {
-  static String description = 'A non-interactive example of how to render rich '
-      'text in Flame.';
+  static const String description =
+      'A non-interactive example of how to render rich text in Flame.';
 
   @override
   Color backgroundColor() => const Color(0xFF888888);

--- a/packages/flame/example/lib/main.dart
+++ b/packages/flame/example/lib/main.dart
@@ -38,8 +38,8 @@ class Square extends RectangleComponent with TapCallbacks {
   static const squareSize = 128.0;
   static const indicatorSize = 6.0;
 
-  static Paint red = BasicPalette.red.paint();
-  static Paint blue = BasicPalette.blue.paint();
+  static final Paint red = BasicPalette.red.paint();
+  static final Paint blue = BasicPalette.blue.paint();
 
   Square(Vector2 position)
       : super(

--- a/packages/flame_audio/example/lib/main.dart
+++ b/packages/flame_audio/example/lib/main.dart
@@ -18,9 +18,9 @@ void main() {
 /// for tapping elsewhere.
 /// 3. Uses the Bgm utility for background music.
 class AudioGame extends FlameGame with TapDetector {
-  static Paint black = BasicPalette.black.paint();
-  static Paint gray = const PaletteEntry(Color(0xFFCCCCCC)).paint();
-  static TextPaint text = TextPaint(
+  static final Paint black = BasicPalette.black.paint();
+  static final Paint gray = const PaletteEntry(Color(0xFFCCCCCC)).paint();
+  static final TextPaint text = TextPaint(
     style: TextStyle(color: BasicPalette.white.color),
   );
 

--- a/packages/flame_isolate/example/lib/game_map/game_map.dart
+++ b/packages/flame_isolate/example/lib/game_map/game_map.dart
@@ -18,9 +18,9 @@ class GameMap extends Component with HasGameReference<ColonistsGame> {
   static const mapSizeY = 50;
   static const totalPositions = mapSizeX * mapSizeY;
 
-  static int cheeseSpread = (0.03 * totalPositions).toInt();
-  static int breadSpread = (0.05 * totalPositions).toInt();
-  static int workerSpread = (0.1 * totalPositions).toInt();
+  static final int cheeseSpread = (0.03 * totalPositions).toInt();
+  static final int breadSpread = (0.05 * totalPositions).toInt();
+  static final int workerSpread = (0.1 * totalPositions).toInt();
 
   static const double workerMinSpeed = 25;
   static const double workerMaxSpeed = 75;


### PR DESCRIPTION
# Description

I was playing around with the rule [avoid-global-state](https://dcm.dev/docs/rules/common/avoid-global-state/)
While I don't think we should enable it, because we do have several totally legitimate cases of what the rule considers global state, it did help me find any current cases where the things just _should_ be final constants.
So this PR will mark semantically final variables as final (or const) proper, exclusively on examples (no violations on actual src code are legit).

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
