### PR TITLE
chore: Bump to Flutter 3.13

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,11 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.13.2'
-          channel: 'stable'
-          cache: true
-      - uses: bluefireteam/melos-action@main
+      - uses: bluefireteam/melos-action@v2
       - run: melos run format-check
 
   analyze:
@@ -27,10 +23,20 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.2'
-          channel: 'stable'
+          flutter-version: '3.13.0'
       - uses: bluefireteam/melos-action@v2
-      - name: "Analyze"
+      - name: "Analyze with lowest supported version"
+        uses: invertase/github-action-dart-analyzer@v2.0.0
+        with:
+          fatal-infos: true
+
+  analyze-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+      - uses: bluefireteam/melos-action@v2
+      - name: "Analyze with latest stable"
         uses: invertase/github-action-dart-analyzer@v2.0.0
         with:
           fatal-infos: true
@@ -50,11 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.13.2'
-          channel: 'stable'
       - uses: bluefireteam/melos-action@v2
-
       - name: Install DCM
         uses: CQLabs/setup-dcm@v1
         with:
@@ -71,10 +73,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.2'
-          channel: 'stable'
           cache: true
-      - uses: bluefireteam/melos-action@main
+      - uses: bluefireteam/melos-action@v2
       - name: Run tests
         run: melos test
   # END TESTING STAGE

--- a/doc/flame/examples/pubspec.yaml
+++ b/doc/flame/examples/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flame: ^1.9.1

--- a/doc/tutorials/bare_flame_game.md
+++ b/doc/tutorials/bare_flame_game.md
@@ -3,7 +3,7 @@
 This tutorial assumes that you have basic familiarity with using the command line, and the following
 programs on your computer (all of them are free):
 
-- [Flutter], version 3.3.0 or above.
+- [Flutter], version 3.13.0 or above.
 - [Android Studio], or any other IDE for example [Visual Studio Code].
 - [git] (optional), to save your project on GitHub.
 
@@ -25,7 +25,7 @@ $ flutter doctor
 ```
 
 Your output will be slightly different, but the important thing is to verify that no errors are
-reported and that your Flutter version is at least **3.3.0**.
+reported and that your Flutter version is at least **3.13.0**.
 
 
 ## 2. Create the Project Directory

--- a/examples/games/rogue_shooter/pubspec.yaml
+++ b/examples/games/rogue_shooter/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.1.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flame: ^1.9.1

--- a/examples/games/trex/pubspec.yaml
+++ b/examples/games/trex/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.1.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   collection: ^1.16.0

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.1.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   dashbook: ^0.1.12

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flame: ^1.9.1

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   collection: ^1.17.1

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -10,7 +10,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   audioplayers: ^5.0.0

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -10,7 +10,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   archive: ^3.3.9

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   dashbook: ^0.1.12

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flame: ^1.9.1

--- a/packages/flame_jenny/pubspec.yaml
+++ b/packages/flame_jenny/pubspec.yaml
@@ -10,7 +10,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   collection: ^1.17.1

--- a/packages/flame_lottie/pubspec.yaml
+++ b/packages/flame_lottie/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: '>=3.3.0'
+  flutter: ">=3.13.0"
 
 dependencies:
   flame: ^1.9.1

--- a/packages/flame_markdown/pubspec.yaml
+++ b/packages/flame_markdown/pubspec.yaml
@@ -10,7 +10,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flame: ^1.9.1

--- a/packages/flame_noise/pubspec.yaml
+++ b/packages/flame_noise/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   fast_noise: ^1.0.1

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flame: ^1.9.1

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flame: ^1.9.1

--- a/packages/flame_spine/pubspec.yaml
+++ b/packages/flame_spine/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   collection: ^1.17.1

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flame: ^1.9.1

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   collection: ^1.17.1


### PR DESCRIPTION
# Description

Due to [this](https://docs.flutter.dev/release/breaking-changes/add-applifecyclestate-hidden) breaking change we have to bump our lowest supported Flutter version to 3.13.

This PR also adds so that we both analyze with the latest stable flutter version and our lowest supported one.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

Closes #2778 

### Migration instructions

Simply upgrade to a stable version equal to or greater than Flutter 3.13 by running `flutter upgrade`.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
