### PR TITLE
fix!: Viewfinder children statically on top of the world

### DIFF
--- a/doc/flame/camera_component.md
+++ b/doc/flame/camera_component.md
@@ -28,6 +28,10 @@ Then, a [](#cameracomponent) class that "looks at" the `World`. The
 flexibility of rendering the world at any place on the screen, and also control
 the viewing location and angle.
 
+If you add children to the `Viewfinder` they will appear as static HUDs in
+front of the world and if you add children to the `Viewport` they will appear
+statically behind the world.
+
 
 ## World
 

--- a/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_and_viewport.dart
@@ -6,6 +6,7 @@ import 'package:examples/stories/camera_and_viewport/camera_follow_and_world_bou
 import 'package:examples/stories/camera_and_viewport/coordinate_systems_example.dart';
 import 'package:examples/stories/camera_and_viewport/fixed_resolution_example.dart';
 import 'package:examples/stories/camera_and_viewport/follow_component_example.dart';
+import 'package:examples/stories/camera_and_viewport/static_components_example.dart';
 import 'package:examples/stories/camera_and_viewport/zoom_example.dart';
 import 'package:flame/game.dart';
 
@@ -55,6 +56,21 @@ void addCameraAndViewportStories(Dashbook dashbook) {
       },
       codeLink: baseLink('camera_and_viewport/fixed_resolution_example.dart'),
       info: FixedResolutionExample.description,
+    )
+    ..add(
+      'HUDs and static components',
+      (context) {
+        return GameWidget(
+          game: StaticComponentsExample(
+            viewportResolution: Vector2(
+              context.numberProperty('viewport width', 500),
+              context.numberProperty('viewport height', 500),
+            ),
+          ),
+        );
+      },
+      codeLink: baseLink('camera_and_viewport/static_components_example.dart'),
+      info: StaticComponentsExample.description,
     )
     ..add(
       'Coordinate Systems',

--- a/examples/lib/stories/camera_and_viewport/static_components_example.dart
+++ b/examples/lib/stories/camera_and_viewport/static_components_example.dart
@@ -1,0 +1,134 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
+import 'package:flame/events.dart';
+import 'package:flame/extensions.dart';
+import 'package:flame/game.dart';
+import 'package:flame/input.dart';
+import 'package:flame/parallax.dart';
+
+class StaticComponentsExample extends FlameGame
+    with ScrollDetector, ScaleDetector {
+  static const description = '''
+  This example shows a parallax which is attached to the viewport (behind the
+  world), four Flame logos that are added to the world, and a player added to
+  the world which is also followed by the camera when you click somewhere.
+  The text components that are added are self-explanatory.
+  ''';
+
+  late final ParallaxComponent myParallax;
+
+  StaticComponentsExample({
+    required Vector2 viewportResolution,
+  }) : super(
+          camera: CameraComponent.withFixedResolution(
+            width: viewportResolution.x,
+            height: viewportResolution.y,
+          ),
+          world: _StaticComponentWorld(),
+        );
+
+  @override
+  Future<void> onLoad() async {
+    myParallax = MyParallaxComponent()..parallax?.baseVelocity.setZero();
+    camera.viewport.addAll([
+      myParallax,
+      TextComponent(
+        text: 'My Corner Viewport Component',
+        position: camera.viewport.size - Vector2.all(10),
+        anchor: Anchor.bottomRight,
+      ),
+    ]);
+    camera.viewfinder.addAll(
+      [
+        TextComponent(
+          text: 'My Corner HUD Component',
+          position: Vector2.all(10),
+        ),
+        TextComponent(
+          text: 'My HUD Viewfinder Component',
+          position: camera.viewport.size / 2,
+          anchor: Anchor.center,
+        ),
+      ],
+    );
+  }
+}
+
+class _StaticComponentWorld extends World
+    with
+        HasGameReference<StaticComponentsExample>,
+        TapCallbacks,
+        DoubleTapCallbacks {
+  late SpriteComponent player;
+  @override
+  Future<void> onLoad() async {
+    final playerSprite = await game.loadSprite('layers/player.png');
+    final flameSprite = await game.loadSprite('flame.png');
+    final visibleSize = game.camera.visibleWorldRect.toVector2();
+    add(player = SpriteComponent(sprite: playerSprite, anchor: Anchor.center));
+    addAll([
+      SpriteComponent(
+        sprite: flameSprite,
+        anchor: Anchor.center,
+        position: -visibleSize / 8,
+        size: Vector2(20, 30),
+      ),
+      SpriteComponent(
+        sprite: flameSprite,
+        anchor: Anchor.center,
+        position: visibleSize / 8,
+        size: Vector2(20, 30),
+      ),
+      SpriteComponent(
+        sprite: flameSprite,
+        anchor: Anchor.center,
+        position: (visibleSize / 8)..multiply(Vector2(-1, 1)),
+        size: Vector2(20, 30),
+      ),
+      SpriteComponent(
+        sprite: flameSprite,
+        anchor: Anchor.center,
+        position: (visibleSize / 8)..multiply(Vector2(1, -1)),
+        size: Vector2(20, 30),
+      ),
+    ]);
+    game.camera.follow(player, maxSpeed: 100);
+  }
+
+  @override
+  void onTapDown(TapDownEvent event) {
+    const moveDuration = 1.0;
+    final deltaX = (event.localPosition - player.position).x;
+    player.add(
+      MoveToEffect(
+        event.localPosition,
+        EffectController(
+          duration: moveDuration,
+        ),
+        onComplete: () => game.myParallax.parallax?.baseVelocity.setZero(),
+      ),
+    );
+    final moveSpeedX = deltaX / moveDuration;
+    game.myParallax.parallax?.baseVelocity.setValues(moveSpeedX, 0);
+  }
+}
+
+class MyParallaxComponent extends ParallaxComponent {
+  @override
+  Future<void> onLoad() async {
+    parallax = await game.loadParallax(
+      [
+        ParallaxImageData('parallax/bg.png'),
+        ParallaxImageData('parallax/mountain-far.png'),
+        ParallaxImageData('parallax/mountains.png'),
+        ParallaxImageData('parallax/trees.png'),
+        ParallaxImageData('parallax/foreground-trees.png'),
+      ],
+      baseVelocity: Vector2(0, 0),
+      velocityMultiplierDelta: Vector2(1.8, 1.0),
+      filterQuality: FilterQuality.none,
+    );
+  }
+}

--- a/packages/flame/lib/src/camera/viewfinder.dart
+++ b/packages/flame/lib/src/camera/viewfinder.dart
@@ -15,6 +15,9 @@ import 'package:vector_math/vector_math_64.dart';
 /// The viewfinder contains the game point that is currently at the
 /// "cross-hairs" of the viewport ([position]), the [zoom] level, and the
 /// [angle] of rotation of the camera.
+///
+/// If you add children to the [Viewfinder] they will appear like HUDs i.e.
+/// statically in front of the world.
 class Viewfinder extends Component
     implements AnchorProvider, AngleProvider, PositionProvider, ScaleProvider {
   /// Internal transform matrix used by the viewfinder.

--- a/packages/flame/lib/src/camera/viewports/fixed_aspect_ratio_viewport.dart
+++ b/packages/flame/lib/src/camera/viewports/fixed_aspect_ratio_viewport.dart
@@ -31,7 +31,9 @@ class FixedAspectRatioViewport extends Viewport {
 
   @override
   void onGameResize(Vector2 size) {
-    super.onGameResize(size);
+    if (isLoaded) {
+      super.onGameResize(size);
+    }
     _handleResize(size);
   }
 


### PR DESCRIPTION
# Description

This PR changes the order in which the `CameraComponent` renders its internal components; the viewport and the viewfinder.
With this change the rendering order looks like this:
```
viewport - Good for adding static background components to.
world
viewfinder - Good for adding HUD components to.
```

In the following example you can see a `ParallaxComponent` attached to the viewport, a player and some other components attached to the world, and some texts attached to the viewfinder and viewport:
![image](https://github.com/flame-engine/flame/assets/744771/7681b23b-059d-4a20-8648-3be75187b17c)


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.


### Migration instructions

If you were previously adding your HUDs directly to the viewport, add them to the viewfinder instead.
If you added your HUDs through the `hudComponents` argument in the `CameraComponent` constructor the change has already been made for you.

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
