### PR TITLE
feat: Prevent looping over full components tree on every tap event

### DIFF
--- a/examples/lib/stories/input/draggables_multiple_example.dart
+++ b/examples/lib/stories/input/draggables_multiple_example.dart
@@ -1,0 +1,62 @@
+import 'package:examples/commons/ember.dart';
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
+import 'package:flame/game.dart';
+import 'package:flutter/material.dart' show Colors;
+
+class DraggablesMultipleExample extends FlameGame {
+  static const String description = '''
+    In this example we show you can use the `DragCallbacks` mixin on
+    `PositionComponent`s. Drag around the Embers and see their position
+    changing.
+  ''';
+
+  DraggablesMultipleExample({required this.zoom});
+
+  final double zoom;
+  late final DraggableEmber square;
+  static const int maxItems = 1000000;
+
+  @override
+  Future<void> onLoad() async {
+    camera.viewfinder.zoom = zoom;
+    final interactiveComponents = Component();
+    interactiveComponents.add(square = DraggableEmber());
+    interactiveComponents.add(DraggableEmber()..y = 350);
+    world.add(interactiveComponents);
+
+    componentsAtPointRoot = interactiveComponents;
+
+    for (var i = 1; i < maxItems + 1; i++) {
+      world.add(Component());
+    }
+  }
+}
+
+// Note: this component does not consider the possibility of multiple
+// simultaneous drags with different pointerIds.
+class DraggableEmber extends Ember with DragCallbacks {
+  @override
+  bool debugMode = true;
+
+  DraggableEmber({super.position}) : super(size: Vector2.all(100));
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    debugColor = isDragged && findGame() is DraggablesMultipleExample
+        ? Colors.greenAccent
+        : Colors.purple;
+  }
+
+  @override
+  void onDragUpdate(DragUpdateEvent event) {
+    if (findGame() is! DraggablesMultipleExample) {
+      event.continuePropagation = true;
+      return;
+    }
+
+    position.add(event.delta);
+    event.continuePropagation = false;
+  }
+}

--- a/examples/lib/stories/input/input.dart
+++ b/examples/lib/stories/input/input.dart
@@ -2,6 +2,7 @@ import 'package:dashbook/dashbook.dart';
 import 'package:examples/commons/commons.dart';
 import 'package:examples/stories/input/double_tap_callbacks_example.dart';
 import 'package:examples/stories/input/draggables_example.dart';
+import 'package:examples/stories/input/draggables_multiple_example.dart';
 import 'package:examples/stories/input/gesture_hitboxes_example.dart';
 import 'package:examples/stories/input/hardware_keyboard_example.dart';
 import 'package:examples/stories/input/hover_callbacks_example.dart';
@@ -29,7 +30,7 @@ void addInputStories(Dashbook dashbook) {
       info: TapCallbacksExample.description,
     )
     ..add(
-      'Tappables - optimize for many items',
+      'Tappables with many components',
       (_) => GameWidget(game: TapCallbacksMultipleExample()),
       codeLink: baseLink('input/tap_callbacks_multiple_example.dart'),
       info: TapCallbacksMultipleExample.description,
@@ -45,6 +46,18 @@ void addInputStories(Dashbook dashbook) {
       },
       codeLink: baseLink('input/draggables_example.dart'),
       info: DraggablesExample.description,
+    )
+    ..add(
+      'Draggables with many components',
+      (context) {
+        return GameWidget(
+          game: DraggablesMultipleExample(
+            zoom: context.listProperty('zoom', 1, [0.5, 1, 1.5]),
+          ),
+        );
+      },
+      codeLink: baseLink('input/draggables_example.dart'),
+      info: DraggablesMultipleExample.description,
     )
     ..add(
       'Double Tap (Component)',

--- a/examples/lib/stories/input/input.dart
+++ b/examples/lib/stories/input/input.dart
@@ -16,6 +16,7 @@ import 'package:examples/stories/input/multitap_example.dart';
 import 'package:examples/stories/input/overlapping_tappables_example.dart';
 import 'package:examples/stories/input/scroll_example.dart';
 import 'package:examples/stories/input/tap_callbacks_example.dart';
+import 'package:examples/stories/input/tap_callbacks_multiple_example.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 
@@ -26,6 +27,12 @@ void addInputStories(Dashbook dashbook) {
       (_) => GameWidget(game: TapCallbacksExample()),
       codeLink: baseLink('input/tap_callbacks_example.dart'),
       info: TapCallbacksExample.description,
+    )
+    ..add(
+      'Tappables - optimize for many items',
+      (_) => GameWidget(game: TapCallbacksMultipleExample()),
+      codeLink: baseLink('input/tap_callbacks_multiple_example.dart'),
+      info: TapCallbacksMultipleExample.description,
     )
     ..add(
       'Draggables',

--- a/examples/lib/stories/input/tap_callbacks_multiple_example.dart
+++ b/examples/lib/stories/input/tap_callbacks_multiple_example.dart
@@ -8,25 +8,35 @@ import 'package:flutter/material.dart';
 
 class TapCallbacksMultipleExample extends FlameGame {
   static const String description = '''
-    In this example we show the `Tappable` mixin functionality. You can add the
-    `Tappable` mixin to any `PositionComponent`.\n\n
-    Tap the squares to see them change their angle around their anchor.
+    This example do the same thing as tap_callbacks_example, but with big count
+    of non-interactive components at background. In such cause you will 
+    experience a freeze while tapping anywhere on screen because of scanning
+    all component tree.
+    The example shows a way to avoid this freeze: 
+    1. Place all components into game's world or camera's viewport or 
+       viewfinder. This is important requirement!
+    2. Place all interactive components into special grouping component.
+    3. Assign this component to `componentsAtPointRoot` variable of FlameGame.
+    4. Place all other components anywhere you want
+    This steps makes `componentsAtPoint` function to search only 
+    `componentsAtPointRoot` children and skip looping over other tree branches.
   ''';
 
   static const int maxItems = 1000000;
-  final tappableRootComponent = Component(priority: 1);
 
   @override
   Future<void> onLoad() async {
-    tappableRootComponent.add(TappableSquare(active: true)
+    final interactiveComponents = Component();
+    interactiveComponents.add(TappableSquare(active: true)
       ..anchor = Anchor.center
-      ..x = 500);
+      ..x = 1000
+      ..y = 500);
 
     final bottomSquare = TappableSquare(active: true)
-      ..x = 500
-      ..y = 350;
-    tappableRootComponent.add(bottomSquare);
-    world.add(tappableRootComponent);
+      ..x = 1000
+      ..y = 750;
+    interactiveComponents.add(bottomSquare);
+    world.add(interactiveComponents);
 
     final random = Random();
     for (var i = 1; i < maxItems + 1; i++) {
@@ -41,7 +51,7 @@ class TapCallbacksMultipleExample extends FlameGame {
 
     camera.follow(bottomSquare);
 
-    componentsAtPointRoot = tappableRootComponent;
+    componentsAtPointRoot = interactiveComponents;
   }
 }
 

--- a/examples/lib/stories/input/tap_callbacks_multiple_example.dart
+++ b/examples/lib/stories/input/tap_callbacks_multiple_example.dart
@@ -1,0 +1,97 @@
+import 'dart:math';
+
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
+import 'package:flame/extensions.dart';
+import 'package:flame/game.dart';
+import 'package:flutter/material.dart';
+
+class TapCallbacksMultipleExample extends FlameGame {
+  static const String description = '''
+    In this example we show the `Tappable` mixin functionality. You can add the
+    `Tappable` mixin to any `PositionComponent`.\n\n
+    Tap the squares to see them change their angle around their anchor.
+  ''';
+
+  static const int maxItems = 1000000;
+  final tappableRootComponent = Component(priority: 1);
+
+  @override
+  Future<void> onLoad() async {
+    tappableRootComponent.add(TappableSquare(active: true)
+      ..anchor = Anchor.center
+      ..x = 500);
+
+    final bottomSquare = TappableSquare(active: true)
+      ..x = 500
+      ..y = 350;
+    tappableRootComponent.add(bottomSquare);
+    world.add(tappableRootComponent);
+
+    final random = Random();
+    for (var i = 1; i < maxItems + 1; i++) {
+      final square = TappableSquare(
+        position: Vector2(
+          random.nextInt(i).toDouble(),
+          random.nextInt(i).toDouble(),
+        ),
+      )..anchor = Anchor.center;
+      world.add(square);
+    }
+
+    camera.follow(bottomSquare);
+
+    componentsAtPointRoot = tappableRootComponent;
+  }
+}
+
+class TappableSquare extends PositionComponent
+    with
+        TapCallbacks,
+        HasVisibility,
+        HasGameReference<TapCallbacksMultipleExample> {
+  static final Paint _white = Paint()..color = const Color(0xFFFFFFFF);
+  static final Paint _grey = Paint()..color = const Color(0xFFA5A5A5);
+  static final Paint _blue = Paint()..color = const Color(0xFFC4D9FF);
+
+  bool _beenPressed = false;
+  late Paint _defaultColor;
+  var _visibilityCheckDone = false;
+
+  TappableSquare({
+    Vector2? position,
+    bool active = false,
+  }) : super(
+          position: position ?? Vector2.all(100),
+          size: Vector2.all(100),
+        ) {
+    _defaultColor = active ? _grey : _blue;
+  }
+
+  @override
+  void render(Canvas canvas) {
+    if (!_visibilityCheckDone) {
+      if (!game.camera.canSee(this)) {
+        isVisible = false;
+      }
+      _visibilityCheckDone = true;
+    }
+    canvas.drawRect(size.toRect(), _beenPressed ? _white : _defaultColor);
+  }
+
+  @override
+  void onTapUp(_) {
+    _beenPressed = false;
+  }
+
+  @override
+  void onTapDown(_) {
+    _beenPressed = true;
+    angle += 1.0;
+  }
+
+  @override
+  void onTapCancel(_) {
+    _beenPressed = false;
+  }
+}

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -188,26 +188,35 @@ class Component {
 
   /// Whether the component is currently executing its [onLoad] step.
   bool get isLoading => (_state & _loading) != 0;
+
   void _setLoadingBit() => _state |= _loading;
+
   void _clearLoadingBit() => _state &= ~_loading;
 
   /// Whether this component has completed its [onLoad] step.
   bool get isLoaded => (_state & _loaded) != 0;
+
   void _setLoadedBit() => _state |= _loaded;
 
   @internal
   bool get isMounting => (_state & _mounting) != 0;
+
   void _setMountingBit() => _state |= _mounting;
+
   void _clearMountingBit() => _state &= ~_mounting;
 
   /// Whether this component is currently added to a component tree.
   bool get isMounted => (_state & _mounted) != 0;
+
   void _setMountedBit() => _state |= _mounted;
+
   void _clearMountedBit() => _state &= ~_mounted;
 
   /// Whether the component is scheduled to be removed.
   bool get isRemoving => (_state & _removing) != 0;
+
   void _setRemovingBit() => _state |= _removing;
+
   void _clearRemovingBit() => _state &= ~_removing;
 
   /// Whether the component has been removed. Originally this flag is `false`,
@@ -215,7 +224,9 @@ class Component {
   /// from its parent. The flag becomes `false` again when the component is
   /// mounted to a new parent.
   bool get isRemoved => (_state & _removed) != 0;
+
   void _setRemovedBit() => _state |= _removed;
+
   void _clearRemovedBit() => _state &= ~_removed;
 
   Completer<void>? _loadCompleter;
@@ -264,6 +275,7 @@ class Component {
   /// Setting this property to null is equivalent to [removeFromParent].
   Component? get parent => _parent;
   Component? _parent;
+
   set parent(Component? newParent) {
     if (newParent == null) {
       removeFromParent();
@@ -278,6 +290,7 @@ class Component {
   /// the current object if it didn't exist before. Check the [hasChildren]
   /// property in order to avoid instantiating the children container.
   ComponentSet get children => _children ??= createComponentSet();
+
   bool get hasChildren => _children?.isNotEmpty ?? false;
   ComponentSet? _children;
 
@@ -704,16 +717,32 @@ class Component {
   Iterable<Component> componentsAtPoint(
     Vector2 point, [
     List<Vector2>? nestedPoints,
+    List<Component>? ancestors,
   ]) sync* {
     nestedPoints?.add(point);
     if (_children != null) {
-      for (final child in _children!.reversed()) {
+      if (ancestors != null && ancestors.isNotEmpty) {
+        final ancestor = ancestors.removeLast();
         Vector2? childPoint = point;
-        if (child is CoordinateTransform) {
-          childPoint = (child as CoordinateTransform).parentToLocal(point);
+        if (ancestor is CoordinateTransform) {
+          childPoint = (ancestor as CoordinateTransform).parentToLocal(point);
         }
         if (childPoint != null) {
-          yield* child.componentsAtPoint(childPoint, nestedPoints);
+          yield* ancestor.componentsAtPoint(
+            childPoint,
+            nestedPoints,
+            ancestors,
+          );
+        }
+      } else {
+        for (final child in _children!.reversed()) {
+          Vector2? childPoint = point;
+          if (child is CoordinateTransform) {
+            childPoint = (child as CoordinateTransform).parentToLocal(point);
+          }
+          if (childPoint != null) {
+            yield* child.componentsAtPoint(childPoint, nestedPoints);
+          }
         }
       }
     }
@@ -743,6 +772,7 @@ class Component {
   /// to the parent.
   int get priority => _priority;
   int _priority;
+
   set priority(int newPriority) {
     if (_priority != newPriority) {
       _priority = newPriority;
@@ -1006,7 +1036,7 @@ class Component {
     }
   }
 
-  //#endregion
+//#endregion
 }
 
 typedef ComponentSetFactory = ComponentSet Function();

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -704,7 +704,9 @@ class Component {
   /// element in the list is the point in the coordinate space of the returned
   /// component, the element before the last is in that component's parent's
   /// coordinate space, and so on. The [nestedPoints] list must be growable and
-  /// modifiable.
+  /// modifiable. [ancestors] list allows to avoid looping over all component's
+  /// tree. So the function firstly process all ancestors and then scan all
+  /// children components of last ancestor.
   ///
   /// The default implementation relies on the [CoordinateTransform] interface
   /// to translate from the parent's coordinate system into the local one. Make

--- a/packages/flame/lib/src/components/route.dart
+++ b/packages/flame/lib/src/components/route.dart
@@ -47,6 +47,7 @@ class Route extends PositionComponent with ParentIsA<RouterComponent> {
   /// The name of the route (set by the [RouterComponent]).
   String? get name => _name;
   String? _name;
+
   @internal
   set name(String? value) => _name = value;
 
@@ -169,13 +170,14 @@ class Route extends PositionComponent with ParentIsA<RouterComponent> {
   Iterable<Component> componentsAtPoint(
     Vector2 point, [
     List<Vector2>? nestedPoints,
+    List<Component>? ancestors,
   ]) {
     if (isRendered) {
-      return super.componentsAtPoint(point, nestedPoints);
+      return super.componentsAtPoint(point, nestedPoints, ancestors);
     } else {
       return const Iterable<Component>.empty();
     }
   }
 
-  //#endregion
+//#endregion
 }

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -118,6 +118,20 @@ class FlameGame<W extends World> extends ComponentTreeRoot
   @override
   Vector2 get size => oldCamera.gameSize;
 
+  /// Grouping component which contains all interactive components, that should
+  /// react on tap events, drag events and so on.
+  ///
+  /// The component prevents `componentsAtPoint` looping over whole components
+  /// tree. Instead, only  `componentsAtPointRoot` subtree will be scanned.
+  /// This helps framework to react on touch events faster by excluding
+  /// unnecessary components from process.
+  ///
+  /// The component can be changed at any time. It should be mounted to make
+  /// thinks work, otherwise `componentsAtPoint` behavior will fallback to
+  /// scanning whole components tree. This also will happen if component is
+  /// null, and this is default behavior.
+  Component? componentsAtPointRoot;
+
   @override
   @internal
   void mount() {
@@ -297,8 +311,6 @@ class FlameGame<W extends World> extends ComponentTreeRoot
     _pausedBecauseBackgrounded = false;
     super.resumeEngine();
   }
-
-  Component? componentsAtPointRoot;
 
   @override
   Iterable<Component> componentsAtPoint(

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -51,6 +51,7 @@ class FlameGame<W extends World> extends ComponentTreeRoot
   /// You don't have to add the world to the tree after setting it here, it is
   /// done automatically.
   W get world => _world;
+
   set world(W newWorld) {
     if (newWorld == _world) {
       return;
@@ -73,6 +74,7 @@ class FlameGame<W extends World> extends ComponentTreeRoot
   /// You don't have to add the CameraComponent to the tree after setting it
   /// here, it is done automatically.
   CameraComponent get camera => _camera;
+
   set camera(CameraComponent newCameraComponent) {
     _camera.removeFromParent();
     _camera = newCameraComponent;
@@ -294,5 +296,32 @@ class FlameGame<W extends World> extends ComponentTreeRoot
   void resumeEngine() {
     _pausedBecauseBackgrounded = false;
     super.resumeEngine();
+  }
+
+  Component? componentsAtPointRoot;
+
+  @override
+  Iterable<Component> componentsAtPoint(
+    Vector2 point, [
+    List<Vector2>? nestedPoints,
+    List<Component>? ancestors,
+  ]) sync* {
+    if (componentsAtPointRoot != null && componentsAtPointRoot!.isMounted) {
+      final ancestorsOfRoot =
+          componentsAtPointRoot!.ancestors(includeSelf: true).toList();
+      ancestorsOfRoot.removeLast(); // remove game component
+      for (final child in children.reversed()) {
+        Vector2? childPoint = point;
+        if (child is CoordinateTransform) {
+          childPoint = (child as CoordinateTransform).parentToLocal(point);
+        }
+        if (childPoint != null) {
+          yield* child.componentsAtPoint(
+              childPoint, nestedPoints, ancestorsOfRoot);
+        }
+      }
+    } else {
+      yield* super.componentsAtPoint(point, nestedPoints, ancestors);
+    }
   }
 }


### PR DESCRIPTION
# Description

In current implementation every touch event produces at least one full-scanning of whole components tree. This is cause when every simple HUD button can hang the game for a moment or more...

There are several approaches to fix that, but many of them requires significant changes and tracking component's state changes, parent changes and so on. This can produce additional errors, so I chosed more simple way.

Game developer now can choose a component, which will contain all interactable components. All tappable, draggable components (and so on) should be placed inside this root component. After taht, components lookup on touch event will be limited by this root component and it's descendants. 

This optimisation requires user do not place components ingo game directly, but everithing is optional. Developer can skip components grouping if performance is ok.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


