### PR TITLE
fix: Un-register component keys down the component tree

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -896,17 +896,13 @@ class Component {
   void _remove() {
     assert(_parent != null, 'Trying to remove a component with no parent');
 
-    if (_key != null) {
-      final game = findGame();
-      if (game is FlameGame) {
-        game.unregisterKey(_key!);
-      }
-    }
+    _nukeKey();
     _parent!.children.remove(this);
     propagateToChildren(
       (Component component) {
         component
           ..onRemove()
+          .._nukeKey()
           .._clearMountedBit()
           .._clearRemovingBit()
           .._setRemovedBit()
@@ -918,6 +914,15 @@ class Component {
       },
       includeSelf: true,
     );
+  }
+
+  void _nukeKey() {
+    if (_key != null) {
+      final game = findGame();
+      if (game is FlameGame) {
+        game.unregisterKey(_key!);
+      }
+    }
   }
 
   //#endregion

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -896,7 +896,6 @@ class Component {
   void _remove() {
     assert(_parent != null, 'Trying to remove a component with no parent');
 
-    _nukeKey();
     _parent!.children.remove(this);
     propagateToChildren(
       (Component component) {

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -901,7 +901,7 @@ class Component {
       (Component component) {
         component
           ..onRemove()
-          .._nukeKey()
+          .._unregisterKey()
           .._clearMountedBit()
           .._clearRemovingBit()
           .._setRemovedBit()
@@ -915,7 +915,7 @@ class Component {
     );
   }
 
-  void _nukeKey() {
+  void _unregisterKey() {
     if (_key != null) {
       final game = findGame();
       if (game is FlameGame) {

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -1382,6 +1382,29 @@ void main() {
       );
 
       testWithFlameGame(
+        'Removed keys can be reused by components',
+        (game) async {
+          final key = ComponentKey.named('A');
+          final parent1 = Component(children: [ComponentA(key: key)]);
+
+          game.world.add(parent1);
+          await game.ready();
+
+          parent1.removeFromParent();
+          await game.ready();
+
+          final component = ComponentA(key: key);
+          final parent2 = Component(children: [component]);
+
+          game.world.add(parent2);
+          await game.ready();
+
+          final retrieved1 = game.findByKey(key);
+          expect(retrieved1, equals(component));
+        },
+      );
+
+      testWithFlameGame(
         'Throws assertion error when registering a component with the same key',
         (game) async {
           final component = ComponentA(key: ComponentKey.named('A'));


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

ComponentKey for children components were not getting unregistered when the sub-tree was removed from the game. As a result:

- same key couldn't be reused
- components with such keys couldn't be readded once removed
- component with such keys were not being garbage collected (didn't actually verify this one though)


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
