### PR TITLE
fix: Do not render SVGs bigger than requested when pixelRatio > 1 and no match in _imageCache

### DIFF
--- a/packages/flame_svg/lib/svg.dart
+++ b/packages/flame_svg/lib/svg.dart
@@ -105,8 +105,8 @@ class Svg {
     );
 
     canvas.translate(
-      -(pictureInfo.size.width * scale - size.width / pixelRatio) / 2,
-      -(pictureInfo.size.height * scale - size.height / pixelRatio) / 2,
+      (size.width / pixelRatio - pictureInfo.size.width * scale) / 2,
+      (size.height / pixelRatio - pictureInfo.size.height * scale) / 2,
     );
 
     canvas.scale(scale);

--- a/packages/flame_svg/lib/svg.dart
+++ b/packages/flame_svg/lib/svg.dart
@@ -103,6 +103,12 @@ class Svg {
       size.width / pictureInfo.size.width / pixelRatio,
       size.height / pictureInfo.size.height / pixelRatio,
     );
+
+    canvas.translate(
+      -(pictureInfo.size.width * scale - size.width / pixelRatio) / 2,
+      -(pictureInfo.size.height * scale - size.height / pixelRatio) / 2,
+    );
+
     canvas.scale(scale);
     canvas.drawPicture(pictureInfo.picture);
   }

--- a/packages/flame_svg/lib/svg.dart
+++ b/packages/flame_svg/lib/svg.dart
@@ -54,6 +54,7 @@ class Svg {
 
     if (image != null) {
       canvas.save();
+      canvas.scale(1 / pixelRatio);
       final drawPaint = overridePaint ?? _paint;
       canvas.drawImage(image, Offset.zero, drawPaint);
       canvas.restore();
@@ -79,8 +80,8 @@ class Svg {
       _lock.add(size);
       final recorder = PictureRecorder();
       final canvas = Canvas(recorder);
+      canvas.scale(pixelRatio);
       _render(canvas, size);
-
       final picture = recorder.endRecording();
       picture
           .toImageSafe(
@@ -97,18 +98,14 @@ class Svg {
   }
 
   void _render(Canvas canvas, Size size) {
-    canvas.scale(pixelRatio);
-
     final scale = math.min(
-      size.width / pictureInfo.size.width / pixelRatio,
-      size.height / pictureInfo.size.height / pixelRatio,
+      size.width / pictureInfo.size.width,
+      size.height / pictureInfo.size.height,
     );
-
     canvas.translate(
-      (size.width / pixelRatio - pictureInfo.size.width * scale) / 2,
-      (size.height / pixelRatio - pictureInfo.size.height * scale) / 2,
+      (size.width - pictureInfo.size.width * scale) / 2,
+      (size.height - pictureInfo.size.height * scale) / 2,
     );
-
     canvas.scale(scale);
     canvas.drawPicture(pictureInfo.picture);
   }

--- a/packages/flame_svg/lib/svg.dart
+++ b/packages/flame_svg/lib/svg.dart
@@ -54,7 +54,6 @@ class Svg {
 
     if (image != null) {
       canvas.save();
-      canvas.scale(1 / pixelRatio);
       final drawPaint = overridePaint ?? _paint;
       canvas.drawImage(image, Offset.zero, drawPaint);
       canvas.restore();
@@ -81,6 +80,7 @@ class Svg {
       final recorder = PictureRecorder();
       final canvas = Canvas(recorder);
       _render(canvas, size);
+
       final picture = recorder.endRecording();
       picture
           .toImageSafe(
@@ -100,12 +100,8 @@ class Svg {
     canvas.scale(pixelRatio);
 
     final scale = math.min(
-      size.width / pictureInfo.size.width,
-      size.height / pictureInfo.size.height,
-    );
-    canvas.translate(
-      (size.width - pictureInfo.size.width * scale) / 2,
-      (size.height - pictureInfo.size.height * scale) / 2,
+      size.width / pictureInfo.size.width / pixelRatio,
+      size.height / pictureInfo.size.height / pixelRatio,
     );
     canvas.scale(scale);
     canvas.drawPicture(pictureInfo.picture);


### PR DESCRIPTION
# Description
When rendering the SVG for the first time, on devices with pixelRatio > 1, the image is rendered bigger. Only subsequent renders that utilize `_imageCache` are rendering the SVG properly.

## Checklist
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [x] No, this PR is not a breaking change.

Tested on screens with pixelRatio=1 (LG, 2560x1080) and =2 (MacBook Pro M1)