### PR TITLE
refactor: Remove unnecessary 'async' keyword across the codebase [DCM]

### DIFF
--- a/examples/games/padracing/lib/lap_line.dart
+++ b/examples/games/padracing/lib/lap_line.dart
@@ -57,7 +57,7 @@ class LapLine extends BodyComponent with ContactCallbacks {
   late final Rect _scaledRect = (size * 10).toRect();
   late final Rect _drawRect = size.toRect();
 
-  Future<Image> createFinishOverlay() async {
+  Future<Image> createFinishOverlay() {
     final recorder = PictureRecorder();
     final canvas = Canvas(recorder, _scaledRect);
     final step = _scaledRect.width / 2;

--- a/examples/games/rogue_shooter/lib/main.dart
+++ b/examples/games/rogue_shooter/lib/main.dart
@@ -2,6 +2,6 @@ import 'package:flame/game.dart';
 import 'package:flutter/widgets.dart';
 import 'package:rogue_shooter/rogue_shooter_game.dart';
 
-void main() async {
+void main() {
   runApp(GameWidget(game: RogueShooterGame()));
 }

--- a/packages/flame/lib/src/components/parallax_component.dart
+++ b/packages/flame/lib/src/components/parallax_component.dart
@@ -26,7 +26,7 @@ extension ParallaxComponentExtension on FlameGame {
     int? priority,
     FilterQuality? filterQuality,
     ComponentKey? key,
-  }) async {
+  }) {
     return ParallaxComponent.load(
       dataList,
       baseVelocity: baseVelocity,

--- a/packages/flame/lib/src/image_composition.dart
+++ b/packages/flame/lib/src/image_composition.dart
@@ -83,7 +83,7 @@ class ImageComposition {
   void clear() => _composes.clear();
 
   /// Compose all the images into a single composition.
-  Future<Image> compose() async {
+  Future<Image> compose() {
     final result = _composeCore();
 
     return result.picture.toImageSafe(

--- a/packages/flame/lib/src/sprite.dart
+++ b/packages/flame/lib/src/sprite.dart
@@ -126,7 +126,7 @@ class Sprite {
   /// **Note:** This is a heavy async operation and should not be called inside
   /// the game loop. Remember to call dispose on the [Image] object once you
   /// aren't going to use it anymore.
-  Future<Image> toImage() async {
+  Future<Image> toImage() {
     final composition = ImageComposition()
       ..add(image, _zeroPosition, source: src);
     return composition.compose();

--- a/packages/flame/test/cache/assets_cache_test.dart
+++ b/packages/flame/test/cache/assets_cache_test.dart
@@ -20,8 +20,7 @@ void main() {
       expect(file, isA<String>());
 
       expect(
-        () async =>
-            assetsCache.readBinaryFile(fixture('test_text_file.txt').path),
+        () => assetsCache.readBinaryFile(fixture('test_text_file.txt').path),
         failsAssert('"$fileName" was previously loaded as a text file'),
       );
     });
@@ -39,7 +38,7 @@ void main() {
       expect(file, isA<Uint8List>());
 
       expect(
-        () async => assetsCache.readFile(fixture('cave_ace.fa').path),
+        () => assetsCache.readFile(fixture('cave_ace.fa').path),
         failsAssert('"$fileName" was previously loaded as a binary file'),
       );
     });

--- a/packages/flame/test/cache/memory_cache_test.dart
+++ b/packages/flame/test/cache/memory_cache_test.dart
@@ -29,7 +29,7 @@ void main() {
       expect(cache.size, 1);
     });
 
-    test('clear', () async {
+    test('clear', () {
       final cache = MemoryCache<int, String>();
       cache.setValue(0, 'bla');
       expect(cache.containsKey(0), true);
@@ -39,7 +39,7 @@ void main() {
       expect(cache.size, 0);
     });
 
-    test('clearCache', () async {
+    test('clearCache', () {
       final cache = MemoryCache<int, String>();
       cache.setValue(0, 'bla');
       cache.setValue(1, 'ble');

--- a/packages/flame/test/components/text_box_component_test.dart
+++ b/packages/flame/test/components/text_box_component_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('TextBoxComponent', () {
-    test('size is properly computed', () async {
+    test('size is properly computed', () {
       final c = TextBoxComponent(
         text: 'The quick brown fox jumps over the lazy dog.',
         boxConfig: TextBoxConfig(
@@ -23,7 +23,7 @@ void main() {
       expect(c.size.y, greaterThan(1));
     });
 
-    test('size is properly computed with new line character', () async {
+    test('size is properly computed with new line character', () {
       final c = TextBoxComponent(
         text: 'The quick brown fox \n jumps over the lazy dog.',
         boxConfig: TextBoxConfig(
@@ -35,7 +35,7 @@ void main() {
       expect(c.size.y, 256);
     });
 
-    test('lines are properly computed with new line character', () async {
+    test('lines are properly computed with new line character', () {
       final c = TextBoxComponent(
         text: 'The quick brown fox \n jumps over the lazy dog.',
         boxConfig: TextBoxConfig(

--- a/packages/flame/test/game/mixins/single_game_instance_test.dart
+++ b/packages/flame/test/game/mixins/single_game_instance_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('SingleGameInstance', () {
-    test('game instance becomes statically available', () async {
+    test('game instance becomes statically available', () {
       final game = SingletonGame()
         ..onGameResize(Vector2.all(100))
         ..onMount();
@@ -13,7 +13,7 @@ void main() {
       game.onRemove();
     });
 
-    test('guard against multiple game instances', () async {
+    test('guard against multiple game instances', () {
       final game = SingletonGame()
         ..onGameResize(Vector2.all(100))
         ..onMount();

--- a/packages/flame/test/particles/curved_particle_test.dart
+++ b/packages/flame/test/particles/curved_particle_test.dart
@@ -6,13 +6,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('CurvedParticle', () {
-    test('A Particle which applies certain Curve', () async {
+    test('A Particle which applies certain Curve', () {
       final particle = CurvedParticle();
 
       expect(particle.curve, Curves.linear);
     });
 
-    test('A Particle which applies certain Curve', () async {
+    test('A Particle which applies certain Curve', () {
       final particle = CurvedParticle(curve: Curves.decelerate);
 
       expect(particle.curve, Curves.decelerate);

--- a/packages/flame/test/sprite_animation_ticker_test.dart
+++ b/packages/flame/test/sprite_animation_ticker_test.dart
@@ -101,8 +101,7 @@ void main() {
       animationTicker.update(1);
     });
 
-    test('completed completes when the animation has already completed',
-        () async {
+    test('completed completes when the animation has already completed', () {
       final sprite = MockSprite();
       final animationTicker = SpriteAnimation.spriteList(
         [sprite],
@@ -115,7 +114,7 @@ void main() {
     });
 
     test("completed doesn't complete when the animation is yet to complete",
-        () async {
+        () {
       final sprite = MockSprite();
       final animationTicker = SpriteAnimation.spriteList(
         [sprite],
@@ -126,7 +125,7 @@ void main() {
       expectLater(animationTicker.completed, doesNotComplete);
     });
 
-    test("completed doesn't complete when animation is looping", () async {
+    test("completed doesn't complete when animation is looping", () {
       final sprite = MockSprite();
       final animationTicker =
           SpriteAnimation.spriteList([sprite], stepTime: 1).createTicker();
@@ -136,7 +135,7 @@ void main() {
 
     test(
       "completed doesn't complete when animation is looping and on last frame",
-      () async {
+      () {
         final sprite = MockSprite();
         final animationTicker =
             SpriteAnimation.spriteList([sprite], stepTime: 1).createTicker();
@@ -146,7 +145,7 @@ void main() {
       },
     );
 
-    test("completed doesn't complete after the animation is reset", () async {
+    test("completed doesn't complete after the animation is reset", () {
       final sprite = MockSprite();
       final animationTicker = SpriteAnimation.spriteList(
         [sprite],
@@ -163,7 +162,7 @@ void main() {
       expect(animationTicker.completeCompleter!.isCompleted, false);
     });
 
-    test('paused pauses ticket', () async {
+    test('paused pauses ticket', () {
       final sprite = MockSprite();
       final animationTicker = SpriteAnimation.spriteList(
         [sprite, sprite],

--- a/packages/flame/test/spritesheet_test.dart
+++ b/packages/flame/test/spritesheet_test.dart
@@ -13,7 +13,7 @@ void main() {
     when(() => image.width).thenReturn(100);
     when(() => image.height).thenReturn(100);
 
-    test('calculates all field from SpriteSheet', () async {
+    test('calculates all field from SpriteSheet', () {
       final spriteSheet = SpriteSheet(
         image: image,
         srcSize: Vector2(1, 2),

--- a/packages/flame_audio/lib/flame_audio.dart
+++ b/packages/flame_audio/lib/flame_audio.dart
@@ -62,7 +62,7 @@ class FlameAudio {
   }
 
   /// Plays a single run of the given [file], with a given [volume].
-  static Future<AudioPlayer> play(String file, {double volume = 1.0}) async {
+  static Future<AudioPlayer> play(String file, {double volume = 1.0}) {
     return _preparePlayer(
       file,
       volume,
@@ -72,7 +72,7 @@ class FlameAudio {
   }
 
   /// Plays, and keeps looping the given [file].
-  static Future<AudioPlayer> loop(String file, {double volume = 1.0}) async {
+  static Future<AudioPlayer> loop(String file, {double volume = 1.0}) {
     return _preparePlayer(
       file,
       volume,

--- a/packages/flame_fire_atlas/lib/flame_fire_atlas.dart
+++ b/packages/flame_fire_atlas/lib/flame_fire_atlas.dart
@@ -12,7 +12,7 @@ import 'package:flame/sprite.dart';
 /// Adds FireAtlas loading methods to Flame [Game].
 extension FireAtlasExtensions on Game {
   /// Load a [FireAtlas] instances from the given [asset]
-  Future<FireAtlas> loadFireAtlas(String asset) async {
+  Future<FireAtlas> loadFireAtlas(String asset) {
     return FireAtlas.loadAsset(
       asset,
       assets: assets,

--- a/packages/flame_jenny/jenny/test/dialogue_runner_test.dart
+++ b/packages/flame_jenny/jenny/test/dialogue_runner_test.dart
@@ -321,7 +321,7 @@ void main() {
       commands: ['this'],
     );
 
-    test('Dialogue runs node before finishing the previous one', () async {
+    test('Dialogue runs node before finishing the previous one', () {
       final yarn = YarnProject()
         ..parse(
           dedent('''

--- a/packages/flame_jenny/jenny/test/structure/commands/jump_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/jump_command_test.dart
@@ -105,7 +105,7 @@ void main() {
       );
     });
 
-    test('<<jump>> with unknown destination', () async {
+    test('<<jump>> with unknown destination', () {
       final yarn = YarnProject()
         ..parse(
           'title:A\n'

--- a/packages/flame_jenny/jenny/test/structure/commands/visit_command_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/commands/visit_command_test.dart
@@ -204,7 +204,7 @@ void main() {
         );
       });
 
-      test('<<visit>> with unknown destination', () async {
+      test('<<visit>> with unknown destination', () {
         final yarn = YarnProject()
           ..parse(
             'title: A\n'

--- a/packages/flame_jenny/jenny/test/structure/expressions/functions/dice_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/expressions/functions/dice_test.dart
@@ -42,7 +42,7 @@ void main() {
       expect(diceFn.value, 3);
     });
 
-    test('dice(0)', () async {
+    test('dice(0)', () {
       final diceFn = DiceFn(const NumLiteral(0), YarnProject());
       expect(
         () => diceFn.value,

--- a/packages/flame_jenny/jenny/test/structure/expressions/functions/random_range_test.dart
+++ b/packages/flame_jenny/jenny/test/structure/expressions/functions/random_range_test.dart
@@ -52,7 +52,7 @@ void main() {
       expect(max, 20);
     });
 
-    test('random range with min == max', () async {
+    test('random range with min == max', () {
       final fn = RandomRangeFn(
         const NumLiteral(0),
         const NumLiteral(0),
@@ -61,7 +61,7 @@ void main() {
       expect(fn.value, 0);
     });
 
-    test('random range with min > max', () async {
+    test('random range with min > max', () {
       final fn = RandomRangeFn(
         const NumLiteral(10),
         const NumLiteral(0),

--- a/packages/flame_lottie/example/lib/main.dart
+++ b/packages/flame_lottie/example/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flame/game.dart';
 import 'package:flame_lottie/flame_lottie.dart';
 import 'package:flutter/material.dart';
 
-void main() async {
+void main() {
   runApp(GameWidget(game: LottieExampleGame()));
 }
 

--- a/packages/flame_rive/test/flame_rive_test.dart
+++ b/packages/flame_rive/test/flame_rive_test.dart
@@ -33,7 +33,7 @@ void main() {
         expect(artboard.name, artboardName);
       });
 
-      test('Load an artboard that does not exist', () async {
+      test('Load an artboard that does not exist', () {
         expect(
           () => loadArtboard(
             riveFile,

--- a/packages/flame_test/lib/src/test_flame_game.dart
+++ b/packages/flame_test/lib/src/test_flame_game.dart
@@ -72,7 +72,7 @@ Future<T> initializeGame<T extends FlameGame>(CreateFunction<T> create) async {
   return game;
 }
 
-Future<FlameGame> initializeFlameGame() async => initializeGame(FlameGame.new);
+Future<FlameGame> initializeFlameGame() => initializeGame(FlameGame.new);
 
 typedef CreateFunction<T> = T Function();
 typedef AsyncVoidFunction = Future<void> Function();

--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -315,7 +315,7 @@ class RenderableTiledMap {
     required TiledAtlas atlas,
     bool? ignoreFlip,
     Images? images,
-  }) async {
+  }) {
     final visibleLayers = layers.where((layer) => layer.visible);
 
     final layerLoaders = visibleLayers.map((layer) async {

--- a/packages/flame_tiled/test/tile_atlas_test.dart
+++ b/packages/flame_tiled/test/tile_atlas_test.dart
@@ -23,7 +23,7 @@ void main() {
     });
 
     group('loadImages', () {
-      setUp(() async {
+      setUp(() {
         TiledAtlas.atlasMap.clear();
         Flame.bundle = TestAssetBundle(
           imageNames: [
@@ -136,7 +136,7 @@ void main() {
     });
 
     group('Single tileset map', () {
-      setUp(() async {
+      setUp(() {
         TiledAtlas.atlasMap.clear();
         Flame.bundle = TestAssetBundle(
           imageNames: [

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -36,7 +36,7 @@ void main() {
       tiled = await TiledComponent.load('map.tmx', Vector2.all(16));
     });
 
-    test('correct loads the file', () async {
+    test('correct loads the file', () {
       expect(tiled.tileMap.renderableLayers.length, equals(3));
     });
 
@@ -51,7 +51,7 @@ void main() {
     });
 
     group('is positionable', () {
-      test('size, width, and height are readable - not writable', () async {
+      test('size, width, and height are readable - not writable', () {
         expect(tiled.size, Vector2(512.0, 2048.0));
         expect(tiled.width, 512);
         expect(tiled.height, 2048);
@@ -64,7 +64,7 @@ void main() {
         expect(tiled.size, Vector2(512.0, 2048.0));
       });
 
-      test('from constructor', () async {
+      test('from constructor', () {
         final map = TiledComponent(
           tiled.tileMap,
           position: Vector2(10, 20),


### PR DESCRIPTION
# Description

Proposal: remove unnecessary 'async' keyword across the codebase.
This is following the DCM rule [avoid-redundant-async](https://dcm.dev/docs/rules/common/avoid-redundant-async)
Sadly we cannot enable the rule, as it has 3 false positives (cc @incendial if you wanna take a look!)

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
