### PR TITLE
chore(release): Publish Flame v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,127 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-10-12
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`flame` - `v1.10.0`](#flame---v1100)
+ - [`flame_audio` - `v2.1.2`](#flame_audio---v212)
+ - [`flame_bloc` - `v1.10.4`](#flame_bloc---v1104)
+ - [`flame_fire_atlas` - `v1.4.2`](#flame_fire_atlas---v142)
+ - [`flame_forge2d` - `v0.15.1`](#flame_forge2d---v0151)
+ - [`flame_isolate` - `v0.5.0+2`](#flame_isolate---v0502)
+ - [`flame_lottie` - `v0.3.0+2`](#flame_lottie---v0302)
+ - [`flame_network_assets` - `v0.2.0+7`](#flame_network_assets---v0207)
+ - [`flame_rive` - `v1.9.4`](#flame_rive---v194)
+ - [`flame_svg` - `v1.8.4`](#flame_svg---v184)
+ - [`flame_test` - `v1.13.2`](#flame_test---v1132)
+ - [`flame_tiled` - `v1.15.0`](#flame_tiled---v1150)
+ - [`jenny` - `v1.1.1`](#jenny---v111)
+ - [`flame_spine` - `v0.1.1+4`](#flame_spine---v0114)
+ - [`flame_markdown` - `v0.1.1+2`](#flame_markdown---v0112)
+ - [`flame_oxygen` - `v0.1.9+2`](#flame_oxygen---v0192)
+ - [`flame_noise` - `v0.1.1+7`](#flame_noise---v0117)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `flame_spine` - `v0.1.1+4`
+ - `flame_markdown` - `v0.1.1+2`
+ - `flame_oxygen` - `v0.1.9+2`
+ - `flame_noise` - `v0.1.1+7`
+
+---
+
+#### `flame` - `v1.10.0`
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **REFACTOR**: Avoid nested conditional expressions whenever possible [DCM] ([#2784](https://github.com/flame-engine/flame/issues/2784)). ([7b6a5712](https://github.com/flame-engine/flame/commit/7b6a571263ece3aa1a8267644d9118230a850830))
+ - **REFACTOR**: Mark semantically final variables as final (or const) proper [DCM] ([#2783](https://github.com/flame-engine/flame/issues/2783)). ([71f7b475](https://github.com/flame-engine/flame/commit/71f7b475e33dd6fa7224c4a3ab29ffdb89702c34))
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+ - **FIX**: Un-register component keys down the component tree ([#2792](https://github.com/flame-engine/flame/issues/2792)). ([0f679b3f](https://github.com/flame-engine/flame/commit/0f679b3f3d4a643ff4c29569388941c459e35021))
+ - **FIX**: AlignComponent set child (remove compare) ([#2774](https://github.com/flame-engine/flame/issues/2774)). ([20aaf656](https://github.com/flame-engine/flame/commit/20aaf656617cef6538b49c067a562f9daf0a5972))
+ - **FIX**: Hardcode initCurrentGame lifecycle state as resumed ([#2775](https://github.com/flame-engine/flame/issues/2775)). ([0cd5037c](https://github.com/flame-engine/flame/commit/0cd5037c6a837706891d5f1b85a91715cf85ebb1))
+ - **FIX**: Fix TextBoxComponent alignment bug ([#2781](https://github.com/flame-engine/flame/issues/2781)). ([0fb53efb](https://github.com/flame-engine/flame/commit/0fb53efb661ae2a3b4a39407655efb69e92dced0))
+ - **FIX**(flame): The `component.removeFromParent` method should use `parent.remove` internally ([#2779](https://github.com/flame-engine/flame/issues/2779)). ([bdb1c79a](https://github.com/flame-engine/flame/commit/bdb1c79a0524801ab425982dae206915c691e4b2))
+ - **FIX**: Take unmounted adds into consideration ([#2770](https://github.com/flame-engine/flame/issues/2770)). ([be28a440](https://github.com/flame-engine/flame/commit/be28a4405f4024a3066b764d6dbad0713665665d))
+ - **FEAT**: Add `IgnoreEvents` mixin to ignore events for the whole subtree ([#2811](https://github.com/flame-engine/flame/issues/2811)). ([313411c3](https://github.com/flame-engine/flame/commit/313411c311a6a3c2d36e12abf16bdd27ae801f29))
+ - **FEAT**: Add advanced button component ([#2742](https://github.com/flame-engine/flame/issues/2742)). ([97fff0ed](https://github.com/flame-engine/flame/commit/97fff0ed2baab53f2780eca29a9d08ea5d90426a))
+ - **FEAT**: Introduce the `FixedResolutionViewport` ([#2796](https://github.com/flame-engine/flame/issues/2796)). ([4c762f94](https://github.com/flame-engine/flame/commit/4c762f94d40d200bb2b8a102867b0859a345dbf0))
+ - **FEAT**: AssetsBundle can be customized in Images and AssetsCache. ([#2807](https://github.com/flame-engine/flame/issues/2807)). ([a23f80e9](https://github.com/flame-engine/flame/commit/a23f80e94a5d935fc8ba232956fe02e001d5a8f9))
+ - **FEAT**: Backdrop (static backgrounds) component for CameraComponent ([#2787](https://github.com/flame-engine/flame/issues/2787)). ([ab329f71](https://github.com/flame-engine/flame/commit/ab329f718a581b8331749fed6f942b6ade0da5ac))
+ - **FEAT**: Align component refactoring ([#2767](https://github.com/flame-engine/flame/issues/2767)). ([bde34efe](https://github.com/flame-engine/flame/commit/bde34efef7264c91f49b237b589c74ba80a1554e))
+ - **DOCS**: Remove last broad cSpell bypass regex and fix all violations ([#2802](https://github.com/flame-engine/flame/issues/2802)). ([9b16b178](https://github.com/flame-engine/flame/commit/9b16b178048eb19b6596273fcf4daec83277c3b5))
+
+#### `flame_audio` - `v2.1.2`
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **REFACTOR**: Mark semantically final variables as final (or const) proper [DCM] ([#2783](https://github.com/flame-engine/flame/issues/2783)). ([71f7b475](https://github.com/flame-engine/flame/commit/71f7b475e33dd6fa7224c4a3ab29ffdb89702c34))
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+
+#### `flame_bloc` - `v1.10.4`
+
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+
+#### `flame_fire_atlas` - `v1.4.2`
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+
+#### `flame_forge2d` - `v0.15.1`
+
+ - **FEAT**: Allow for bodyDef and fixtureDefs to be prepared earlier ([#2768](https://github.com/flame-engine/flame/issues/2768)). ([21357bca](https://github.com/flame-engine/flame/commit/21357bcac1e7e1cebfa6f2a496ec4b627d62d0e7))
+
+#### `flame_isolate` - `v0.5.0+2`
+
+ - **REFACTOR**: Mark semantically final variables as final (or const) proper [DCM] ([#2783](https://github.com/flame-engine/flame/issues/2783)). ([71f7b475](https://github.com/flame-engine/flame/commit/71f7b475e33dd6fa7224c4a3ab29ffdb89702c34))
+
+#### `flame_lottie` - `v0.3.0+2`
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **FIX**: Duration in `LottieRenderer` rounds down milliseconds ([#2808](https://github.com/flame-engine/flame/issues/2808)). ([cccae2e1](https://github.com/flame-engine/flame/commit/cccae2e1476de456c15ee3779b746f5fe6dadee2))
+
+#### `flame_network_assets` - `v0.2.0+7`
+
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+
+#### `flame_rive` - `v1.9.4`
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+
+#### `flame_svg` - `v1.8.4`
+
+ - **FIX**: Do not render SVGs bigger than requested when pixelRatio > 1 and no match in _imageCache ([#2795](https://github.com/flame-engine/flame/issues/2795)). ([5fa4e09f](https://github.com/flame-engine/flame/commit/5fa4e09f7c464ce2f676df81049a95dad46bf2bd))
+
+#### `flame_test` - `v1.13.2`
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+
+#### `flame_tiled` - `v1.15.0`
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+ - **FIX**: Parallax offset calculations in flame_tiled don't scale properly ([#2766](https://github.com/flame-engine/flame/issues/2766)). ([89e8427a](https://github.com/flame-engine/flame/commit/89e8427a7a34258ec20276e4ec64d4a484277cdd))
+ - **FEAT**(flame_tiled): Allowing tilesets with images in the same folder to load ([#2814](https://github.com/flame-engine/flame/issues/2814)). ([3b0d7e65](https://github.com/flame-engine/flame/commit/3b0d7e65c2bf158db378d66c4f7e687dd05b46e1))
+ - **FEAT**: AssetsBundle can be customized in Images and AssetsCache. ([#2807](https://github.com/flame-engine/flame/issues/2807)). ([a23f80e9](https://github.com/flame-engine/flame/commit/a23f80e94a5d935fc8ba232956fe02e001d5a8f9))
+ - **FEAT**: Add overriding of Images and Bundle in all classes ([#2806](https://github.com/flame-engine/flame/issues/2806)). ([2df90c9b](https://github.com/flame-engine/flame/commit/2df90c9ba8f2b1cc088c5270df571eee7e18bb57))
+
+#### `jenny` - `v1.1.1`
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **REFACTOR**: Avoid nested conditional expressions whenever possible [DCM] ([#2784](https://github.com/flame-engine/flame/issues/2784)). ([7b6a5712](https://github.com/flame-engine/flame/commit/7b6a571263ece3aa1a8267644d9118230a850830))
+ - **DOCS**: Remove last broad cSpell bypass regex and fix all violations ([#2802](https://github.com/flame-engine/flame/issues/2802)). ([9b16b178](https://github.com/flame-engine/flame/commit/9b16b178048eb19b6596273fcf4daec83277c3b5))
+
+
 ## 2023-09-22
 
 ### Changes

--- a/doc/flame/examples/pubspec.yaml
+++ b/doc/flame/examples/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_rive: ^1.9.3
+  flame: ^1.10.0
+  flame_rive: ^1.9.4
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/klondike/app/pubspec.yaml
+++ b/doc/tutorials/klondike/app/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/platformer/app/pubspec.yaml
+++ b/doc/tutorials/platformer/app/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/space_shooter/app/pubspec.yaml
+++ b/doc/tutorials/space_shooter/app/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
 

--- a/examples/games/padracing/pubspec.yaml
+++ b/examples/games/padracing/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.9.1
-  flame_forge2d: ^0.15.0+1
+  flame: ^1.10.0
+  flame_forge2d: ^0.15.1
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/examples/games/rogue_shooter/pubspec.yaml
+++ b/examples/games/rogue_shooter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
 

--- a/examples/games/trex/pubspec.yaml
+++ b/examples/games/trex/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
 

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -11,15 +11,15 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.9.1
-  flame_audio: ^2.1.1
-  flame_forge2d: ^0.15.0+1
-  flame_isolate: ^0.5.0+1
-  flame_lottie: ^0.3.0+1
-  flame_noise: ^0.1.1+6
-  flame_spine: ^0.1.1+3
-  flame_svg: ^1.8.3
-  flame_tiled: ^1.14.1
+  flame: ^1.10.0
+  flame_audio: ^2.1.2
+  flame_forge2d: ^0.15.1
+  flame_isolate: ^0.5.0+2
+  flame_lottie: ^0.3.0+2
+  flame_noise: ^0.1.1+7
+  flame_spine: ^0.1.1+4
+  flame_svg: ^1.8.4
+  flame_tiled: ^1.15.0
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 1.10.0
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **REFACTOR**: Avoid nested conditional expressions whenever possible [DCM] ([#2784](https://github.com/flame-engine/flame/issues/2784)). ([7b6a5712](https://github.com/flame-engine/flame/commit/7b6a571263ece3aa1a8267644d9118230a850830))
+ - **REFACTOR**: Mark semantically final variables as final (or const) proper [DCM] ([#2783](https://github.com/flame-engine/flame/issues/2783)). ([71f7b475](https://github.com/flame-engine/flame/commit/71f7b475e33dd6fa7224c4a3ab29ffdb89702c34))
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+ - **FIX**: Un-register component keys down the component tree ([#2792](https://github.com/flame-engine/flame/issues/2792)). ([0f679b3f](https://github.com/flame-engine/flame/commit/0f679b3f3d4a643ff4c29569388941c459e35021))
+ - **FIX**: AlignComponent set child (remove compare) ([#2774](https://github.com/flame-engine/flame/issues/2774)). ([20aaf656](https://github.com/flame-engine/flame/commit/20aaf656617cef6538b49c067a562f9daf0a5972))
+ - **FIX**: Hardcode initCurrentGame lifecycle state as resumed ([#2775](https://github.com/flame-engine/flame/issues/2775)). ([0cd5037c](https://github.com/flame-engine/flame/commit/0cd5037c6a837706891d5f1b85a91715cf85ebb1))
+ - **FIX**: Fix TextBoxComponent alignment bug ([#2781](https://github.com/flame-engine/flame/issues/2781)). ([0fb53efb](https://github.com/flame-engine/flame/commit/0fb53efb661ae2a3b4a39407655efb69e92dced0))
+ - **FIX**(flame): The `component.removeFromParent` method should use `parent.remove` internally ([#2779](https://github.com/flame-engine/flame/issues/2779)). ([bdb1c79a](https://github.com/flame-engine/flame/commit/bdb1c79a0524801ab425982dae206915c691e4b2))
+ - **FIX**: Take unmounted adds into consideration ([#2770](https://github.com/flame-engine/flame/issues/2770)). ([be28a440](https://github.com/flame-engine/flame/commit/be28a4405f4024a3066b764d6dbad0713665665d))
+ - **FEAT**: Add `IgnoreEvents` mixin to ignore events for the whole subtree ([#2811](https://github.com/flame-engine/flame/issues/2811)). ([313411c3](https://github.com/flame-engine/flame/commit/313411c311a6a3c2d36e12abf16bdd27ae801f29))
+ - **FEAT**: Add advanced button component ([#2742](https://github.com/flame-engine/flame/issues/2742)). ([97fff0ed](https://github.com/flame-engine/flame/commit/97fff0ed2baab53f2780eca29a9d08ea5d90426a))
+ - **FEAT**: Introduce the `FixedResolutionViewport` ([#2796](https://github.com/flame-engine/flame/issues/2796)). ([4c762f94](https://github.com/flame-engine/flame/commit/4c762f94d40d200bb2b8a102867b0859a345dbf0))
+ - **FEAT**: AssetsBundle can be customized in Images and AssetsCache. ([#2807](https://github.com/flame-engine/flame/issues/2807)). ([a23f80e9](https://github.com/flame-engine/flame/commit/a23f80e94a5d935fc8ba232956fe02e001d5a8f9))
+ - **FEAT**: Backdrop (static backgrounds) component for CameraComponent ([#2787](https://github.com/flame-engine/flame/issues/2787)). ([ab329f71](https://github.com/flame-engine/flame/commit/ab329f718a581b8331749fed6f942b6ade0da5ac))
+ - **FEAT**: Align component refactoring ([#2767](https://github.com/flame-engine/flame/issues/2767)). ([bde34efe](https://github.com/flame-engine/flame/commit/bde34efef7264c91f49b237b589c74ba80a1554e))
+ - **DOCS**: Remove last broad cSpell bypass regex and fix all violations ([#2802](https://github.com/flame-engine/flame/issues/2802)). ([9b16b178](https://github.com/flame-engine/flame/commit/9b16b178048eb19b6596273fcf4daec83277c3b5))
+
 ## 1.9.1
 
  - **FIX**: Add necessary generics on mixins on FlameGame ([#2763](https://github.com/flame-engine/flame/issues/2763)). ([b1f5ff26](https://github.com/flame-engine/flame/commit/b1f5ff269441d55b09ce12d5ce99656f2d88a978))

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
 

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 1.9.1
+version: 1.10.0
 homepage: https://github.com/flame-engine/flame
 funding:
   - https://opencollective.com/blue-fire
@@ -23,7 +23,7 @@ dev_dependencies:
   canvas_test: ^0.2.0
   dartdoc: ^6.2.2
   flame_lint: ^1.1.1
-  flame_test: ^1.13.1
+  flame_test: ^1.13.2
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_audio/CHANGELOG.md
+++ b/packages/flame_audio/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.2
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **REFACTOR**: Mark semantically final variables as final (or const) proper [DCM] ([#2783](https://github.com/flame-engine/flame/issues/2783)). ([71f7b475](https://github.com/flame-engine/flame/commit/71f7b475e33dd6fa7224c4a3ab29ffdb89702c34))
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+
 ## 2.1.1
 
  - Update a dependency to the latest release.

--- a/packages/flame_audio/example/pubspec.yaml
+++ b/packages/flame_audio/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_audio: ^2.1.1
+  flame: ^1.10.0
+  flame_audio: ^2.1.2
   flutter:
     sdk: flutter
 

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_audio
 description: |
   Audio support for the Flame game engine, basically a thin wrapper around the audioplayers package.
-version: 2.1.1
+version: 2.1.2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_audio
 funding:
   - https://opencollective.com/blue-fire
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   audioplayers: ^5.0.0
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   synchronized: ^3.1.0

--- a/packages/flame_bloc/CHANGELOG.md
+++ b/packages/flame_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.4
+
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+
 ## 1.10.3
 
  - Update a dependency to the latest release.

--- a/packages/flame_bloc/example/pubspec.yaml
+++ b/packages/flame_bloc/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  flame: ^1.9.1
-  flame_bloc: ^1.10.3
+  flame: ^1.10.0
+  flame_bloc: ^1.10.4
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_bloc
 description: Integration for the Bloc state management library to Flame games.
-version: 1.10.3
+version: 1.10.4
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_bloc
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   bloc: ^8.1.1
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.2.2
   flame_lint: ^1.1.1
-  flame_test: ^1.13.1
+  flame_test: ^1.13.2
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter

--- a/packages/flame_fire_atlas/CHANGELOG.md
+++ b/packages/flame_fire_atlas/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.2
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+
 ## 1.4.1
 
  - Update a dependency to the latest release.

--- a/packages/flame_fire_atlas/example/pubspec.yaml
+++ b/packages/flame_fire_atlas/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_fire_atlas: ^1.4.1
+  flame: ^1.10.0
+  flame_fire_atlas: ^1.4.2
   flutter:
     sdk: flutter
 

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_fire_atlas
 description: Easy to use texture atlases for the flame engine created with the
   fire atlas editor
-version: 1.4.1
+version: 1.4.2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_fire_atlas
 funding:
   - https://opencollective.com/blue-fire
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   archive: ^3.3.9
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.1
+
+ - **FEAT**: Allow for bodyDef and fixtureDefs to be prepared earlier ([#2768](https://github.com/flame-engine/flame/issues/2768)). ([21357bca](https://github.com/flame-engine/flame/commit/21357bcac1e7e1cebfa6f2a496ec4b627d62d0e7))
+
 ## 0.15.0+1
 
  - Update a dependency to the latest release.

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.9.1
-  flame_forge2d: ^0.15.0+1
+  flame: ^1.10.0
+  flame_forge2d: ^0.15.1
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_forge2d
 description: Forge2D (Box2D) support for the Flame game engine. This uses the forge2d package and provides wrappers and components to be used inside Flame.
-version: 0.15.0+1
+version: 0.15.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_forge2d
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   forge2d: ">=0.11.0 <0.12.0"
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.2.2
   flame_lint: ^1.1.1
-  flame_test: ^1.13.1
+  flame_test: ^1.13.2
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0

--- a/packages/flame_isolate/CHANGELOG.md
+++ b/packages/flame_isolate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+2
+
+ - **REFACTOR**: Mark semantically final variables as final (or const) proper [DCM] ([#2783](https://github.com/flame-engine/flame/issues/2783)). ([71f7b475](https://github.com/flame-engine/flame/commit/71f7b475e33dd6fa7224c4a3ab29ffdb89702c34))
+
 ## 0.5.0+1
 
  - Update a dependency to the latest release.

--- a/packages/flame_isolate/example/pubspec.yaml
+++ b/packages/flame_isolate/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.9.1
-  flame_isolate: ^0.5.0+1
+  flame: ^1.10.0
+  flame_isolate: ^0.5.0+2
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0

--- a/packages/flame_isolate/pubspec.yaml
+++ b/packages/flame_isolate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_isolate
 description: Flame wrapper for integral_isolates making multi-threading easy in Flame
-version: 0.5.0+1
+version: 0.5.0+2
 homepage: https://github.com/lohnn/integral_isolates
 
 environment:
@@ -8,14 +8,14 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0
 
 dev_dependencies:
   flame_lint: ^1.1.1
-  flame_test: ^1.13.1
+  flame_test: ^1.13.2
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_jenny/jenny/CHANGELOG.md
+++ b/packages/flame_jenny/jenny/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.1
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **REFACTOR**: Avoid nested conditional expressions whenever possible [DCM] ([#2784](https://github.com/flame-engine/flame/issues/2784)). ([7b6a5712](https://github.com/flame-engine/flame/commit/7b6a571263ece3aa1a8267644d9118230a850830))
+ - **DOCS**: Remove last broad cSpell bypass regex and fix all violations ([#2802](https://github.com/flame-engine/flame/issues/2802)). ([9b16b178](https://github.com/flame-engine/flame/commit/9b16b178048eb19b6596273fcf4daec83277c3b5))
+
 ## 1.1.0
 
  - **REFACTOR**: Enable new DCM rule: avoid-cascade-after-if-null ([#2676](https://github.com/flame-engine/flame/issues/2676)). ([158fc34c](https://github.com/flame-engine/flame/commit/158fc34cae858cf8d0b5d3b5155763e02454779a))

--- a/packages/flame_jenny/jenny/pubspec.yaml
+++ b/packages/flame_jenny/jenny/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jenny
 description: YarnSpinner equivalent for Dart.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_jenny/jenny
 funding:
   - https://opencollective.com/blue-fire

--- a/packages/flame_jenny/pubspec.yaml
+++ b/packages/flame_jenny/pubspec.yaml
@@ -14,10 +14,10 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
-  jenny: ^1.1.0
+  jenny: ^1.1.1
   meta: ^1.9.1
 
 dev_dependencies:

--- a/packages/flame_lottie/CHANGELOG.md
+++ b/packages/flame_lottie/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0+2
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **FIX**: Duration in `LottieRenderer` rounds down milliseconds ([#2808](https://github.com/flame-engine/flame/issues/2808)). ([cccae2e1](https://github.com/flame-engine/flame/commit/cccae2e1476de456c15ee3779b746f5fe6dadee2))
+
 ## 0.3.0+1
 
  - Update a dependency to the latest release.

--- a/packages/flame_lottie/example/pubspec.yaml
+++ b/packages/flame_lottie/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_lottie: ^0.3.0+1
+  flame: ^1.10.0
+  flame_lottie: ^0.3.0+2
   flutter:
     sdk: flutter
   lottie:

--- a/packages/flame_lottie/pubspec.yaml
+++ b/packages/flame_lottie/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_lottie
 description: Flame wrapper for Lottie by AirBnB. This package implements a bridge between Lottie and Flame, allowing to load and display Lottie animations.
-version: 0.3.0+1
+version: 0.3.0+2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_lottie
 funding:
   - https://opencollective.com/blue-fire
@@ -12,14 +12,14 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   lottie: ^2.3.2
 
 dev_dependencies:
   flame_lint: ^1.1.1
-  flame_test: ^1.13.1
+  flame_test: ^1.13.2
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_markdown/CHANGELOG.md
+++ b/packages/flame_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+2
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+1
 
  - Update a dependency to the latest release.

--- a/packages/flame_markdown/example/pubspec.yaml
+++ b/packages/flame_markdown/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_markdown: ^0.1.1+1
+  flame: ^1.10.0
+  flame_markdown: ^0.1.1+2
   flutter:
     sdk: flutter
 

--- a/packages/flame_markdown/pubspec.yaml
+++ b/packages/flame_markdown/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_markdown
 description: |
   Markdown support for the Flame game engine, bridging the markdown package into Flame's text rendering pipeline.
-version: 0.1.1+1
+version: 0.1.1+2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_markdown
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   markdown: ^7.1.1

--- a/packages/flame_network_assets/CHANGELOG.md
+++ b/packages/flame_network_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+7
+
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+
 ## 0.2.0+6
 
  - Update a dependency to the latest release.

--- a/packages/flame_network_assets/example/pubspec.yaml
+++ b/packages/flame_network_assets/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  flame: ^1.9.1
-  flame_network_assets: ^0.2.0+6
+  flame: ^1.10.0
+  flame_network_assets: ^0.2.0+7
   flutter:
     sdk: flutter
 

--- a/packages/flame_network_assets/pubspec.yaml
+++ b/packages/flame_network_assets/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_network_assets
 description: Network assets support for Flame.
-version: 0.2.0+6
+version: 0.2.0+7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_network_assets
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   dev: ^1.0.0
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   http: ^0.13.6

--- a/packages/flame_noise/CHANGELOG.md
+++ b/packages/flame_noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+7
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+6
 
  - Update a dependency to the latest release.

--- a/packages/flame_noise/pubspec.yaml
+++ b/packages/flame_noise/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_noise
 description: Integrate the fast_noise package into Flame
-version: 0.1.1+6
+version: 0.1.1+7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_noise
 funding:
   - https://opencollective.com/blue-fire
@@ -13,12 +13,12 @@ environment:
 
 dependencies:
   fast_noise: ^1.0.1
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^6.2.2
   flame_lint: ^1.1.1
-  flame_test: ^1.13.1
+  flame_test: ^1.13.2
   test: any

--- a/packages/flame_oxygen/CHANGELOG.md
+++ b/packages/flame_oxygen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.9+2
+
+ - Update a dependency to the latest release.
+
 ## 0.1.9+1
 
  - Update a dependency to the latest release.

--- a/packages/flame_oxygen/example/pubspec.yaml
+++ b/packages/flame_oxygen/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_oxygen: ^0.1.9+1
+  flame: ^1.10.0
+  flame_oxygen: ^0.1.9+2
   flutter:
     sdk: flutter
 

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_oxygen
 description: Integrate the Oxygen ECS with the Flame Engine.
-version: 0.1.9+1
+version: 0.1.9+2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_oxygen
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   oxygen: ^0.2.0

--- a/packages/flame_rive/CHANGELOG.md
+++ b/packages/flame_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.4
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+
 ## 1.9.3
 
  - Update a dependency to the latest release.

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_rive: ^1.9.3
+  flame: ^1.10.0
+  flame_rive: ^1.9.4
   flutter:
     sdk: flutter
   rive: ^0.11.16

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_rive
 description: Rive support for the Flame game engine. This uses the rive package and provides wrappers and components to be used inside Flame.
 homepage: https://github.com/flame-engine/flame
-version: 1.9.3
+version: 1.9.4
 funding:
   - https://opencollective.com/blue-fire
   - https://github.com/sponsors/bluefireteam
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   rive: ^0.11.16
@@ -20,6 +20,6 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.2.2
   flame_lint: ^1.1.1
-  flame_test: ^1.13.1
+  flame_test: ^1.13.2
   flutter_test:
     sdk: flutter

--- a/packages/flame_spine/CHANGELOG.md
+++ b/packages/flame_spine/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+4
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+3
 
  - Update a dependency to the latest release.

--- a/packages/flame_spine/example/pubspec.yaml
+++ b/packages/flame_spine/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_spine: ^0.1.1+3
+  flame: ^1.10.0
+  flame_spine: ^0.1.1+4
   flutter:
     sdk: flutter
 

--- a/packages/flame_spine/pubspec.yaml
+++ b/packages/flame_spine/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_spine
 description: Spine support for the Flame game engine. This uses the spine_flutter package and provides wrappers and components to be used inside Flame.
-version: 0.1.1+3
+version: 0.1.1+4
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_sprine
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   spine_flutter: ^4.1.2

--- a/packages/flame_studio/pubspec.yaml
+++ b/packages/flame_studio/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.3.6

--- a/packages/flame_svg/CHANGELOG.md
+++ b/packages/flame_svg/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.4
+
+ - **FIX**: Do not render SVGs bigger than requested when pixelRatio > 1 and no match in _imageCache ([#2795](https://github.com/flame-engine/flame/issues/2795)). ([5fa4e09f](https://github.com/flame-engine/flame/commit/5fa4e09f7c464ce2f676df81049a95dad46bf2bd))
+
 ## 1.8.3
 
  - Update a dependency to the latest release.

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_svg: ^1.8.3
+  flame: ^1.10.0
+  flame_svg: ^1.8.4
   flutter:
     sdk: flutter
 

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_svg
 description: Package to add SVG rendering support for the Flame game engine
-version: 1.8.3
+version: 1.8.4
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_svg
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.5

--- a/packages/flame_test/CHANGELOG.md
+++ b/packages/flame_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.13.2
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+
 ## 1.13.1
 
  - Update a dependency to the latest release.

--- a/packages/flame_test/example/pubspec.yaml
+++ b/packages/flame_test/example/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flame_lint: ^1.1.1
-  flame_test: ^1.13.1
+  flame_test: ^1.13.2
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_test
 description: A package with classes to help testing applications using Flame
-version: 1.13.1
+version: 1.13.2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_test
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/flame_tiled/CHANGELOG.md
+++ b/packages/flame_tiled/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.15.0
+
+ - **REFACTOR**: Remove unnecessary 'async' keyword across the codebase [DCM] ([#2803](https://github.com/flame-engine/flame/issues/2803)). ([2dfe0e5a](https://github.com/flame-engine/flame/commit/2dfe0e5a431213c7148ab6389e3e8c8dc49fbf3d))
+ - **FIX**: Remove deprecations for 1.10.0 ([#2809](https://github.com/flame-engine/flame/issues/2809)). ([5b67b8f1](https://github.com/flame-engine/flame/commit/5b67b8f14ad4fdb38a249d0a41ecba49ba2fcc44))
+ - **FIX**: Parallax offset calculations in flame_tiled don't scale properly ([#2766](https://github.com/flame-engine/flame/issues/2766)). ([89e8427a](https://github.com/flame-engine/flame/commit/89e8427a7a34258ec20276e4ec64d4a484277cdd))
+ - **FEAT**(flame_tiled): Allowing tilesets with images in the same folder to load ([#2814](https://github.com/flame-engine/flame/issues/2814)). ([3b0d7e65](https://github.com/flame-engine/flame/commit/3b0d7e65c2bf158db378d66c4f7e687dd05b46e1))
+ - **FEAT**: AssetsBundle can be customized in Images and AssetsCache. ([#2807](https://github.com/flame-engine/flame/issues/2807)). ([a23f80e9](https://github.com/flame-engine/flame/commit/a23f80e94a5d935fc8ba232956fe02e001d5a8f9))
+ - **FEAT**: Add overriding of Images and Bundle in all classes ([#2806](https://github.com/flame-engine/flame/issues/2806)). ([2df90c9b](https://github.com/flame-engine/flame/commit/2df90c9ba8f2b1cc088c5270df571eee7e18bb57))
+
 ## 1.14.1
 
  - Update a dependency to the latest release.

--- a/packages/flame_tiled/example/pubspec.yaml
+++ b/packages/flame_tiled/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.9.1
-  flame_tiled: ^1.14.1
+  flame: ^1.10.0
+  flame_tiled: ^1.15.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_tiled
 description: Tiled support for the Flame game engine. This uses the tiled package and provides wrappers and components to be used inside Flame.
-version: 1.14.1
+version: 1.15.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_tiled
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.9.1
+  flame: ^1.10.0
   flutter:
     sdk: flutter
   meta: ^1.9.1


### PR DESCRIPTION
 - flame@1.10.0
 - flame_audio@2.1.2
 - flame_bloc@1.10.4
 - flame_fire_atlas@1.4.2
 - flame_forge2d@0.15.1
 - flame_isolate@0.5.0+2
 - flame_lottie@0.3.0+2
 - flame_network_assets@0.2.0+7
 - flame_rive@1.9.4
 - flame_svg@1.8.4
 - flame_test@1.13.2
 - flame_tiled@1.15.0
 - jenny@1.1.1
 - flame_spine@0.1.1+4
 - flame_markdown@0.1.1+2
 - flame_oxygen@0.1.9+2
 - flame_noise@0.1.1+7