### PR TITLE
fix: Do not scale debug texts with zoom

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -974,9 +974,10 @@ class Component {
   /// Returns a [TextPaint] object with the [debugColor] set as color for the
   /// text.
   TextPaint get debugTextPaint {
+    final zoom = CameraComponent.currentCamera?.viewfinder.zoom ?? 1.0;
     if (!_debugTextPaintCache.isCacheValid([debugColor])) {
       final textPaint = TextPaint(
-        style: TextStyle(color: debugColor, fontSize: 12),
+        style: TextStyle(color: debugColor, fontSize: 12 / zoom),
       );
       _debugTextPaintCache.updateCache(textPaint, [debugColor]);
     }

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'dart:ui' hide Offset;
 
 import 'package:collection/collection.dart';
+import 'package:flame/camera.dart';
 import 'package:flame/src/anchor.dart';
 import 'package:flame/src/components/core/component.dart';
 import 'package:flame/src/components/mixins/coordinate_transform.dart';
@@ -429,6 +430,7 @@ class PositionComponent extends Component
 
   @override
   void renderDebugMode(Canvas canvas) {
+    final zoom = CameraComponent.currentCamera?.viewfinder.zoom ?? 1.0;
     super.renderDebugMode(canvas);
     final precision = debugCoordinatesPrecision;
     canvas.drawRect(size.toRect(), debugPaint);
@@ -444,7 +446,7 @@ class PositionComponent extends Component
       debugTextPaint.render(
         canvas,
         'x:$x1str y:$y1str',
-        Vector2(-10 * (precision + 3), -15),
+        Vector2(-10 * (precision + 3) / zoom, -15 / zoom),
       );
       // print coordinates at the bottom-right corner
       final p2 = absolutePositionOfAnchor(Anchor.bottomRight);
@@ -453,7 +455,7 @@ class PositionComponent extends Component
       debugTextPaint.render(
         canvas,
         'x:$x2str y:$y2str',
-        Vector2(size.x - 10 * (precision + 3), size.y),
+        Vector2(size.x - 10 * (precision + 3) / zoom, size.y),
       );
     }
   }


### PR DESCRIPTION
# Description
Right now the debug texts (certain coordinates of components) use 12px size, but `zoom: 10` turns that into `120px`. This PR fixes that, debug informations are displayed using 12px size font, regardless of zoom.

## Checklist
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [x] No, this PR is not a breaking change.