### PR TITLE
fix: Allow null passthrough parent

### DIFF
--- a/packages/flame/lib/src/collisions/collision_passthrough.dart
+++ b/packages/flame/lib/src/collisions/collision_passthrough.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:meta/meta.dart';
@@ -14,9 +15,9 @@ mixin CollisionPassthrough on CollisionCallbacks {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    passthroughParent = ancestors().firstWhere(
+    passthroughParent = ancestors().firstWhereOrNull(
       (c) => c is CollisionCallbacks,
-    ) as CollisionCallbacks;
+    ) as CollisionCallbacks?;
   }
 
   @override

--- a/packages/flame/test/collisions/collision_passthrough_test.dart
+++ b/packages/flame/test/collisions/collision_passthrough_test.dart
@@ -1,5 +1,6 @@
+import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
-import 'package:flame/src/collisions/collision_passthrough.dart';
+import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
 import 'collision_test_helpers.dart';
@@ -39,6 +40,23 @@ void main() {
         expect(hitboxParent.endCounter, 1);
         expect(hitboxParent.onCollisionCounter, 1);
       },
+    });
+
+    testWithFlameGame('Null passthrough', (game) async {
+      final hitbox = CompositeHitbox(children: [RectangleHitbox()]);
+      final component = PositionComponent(children: [hitbox]);
+      final testBlock = TestBlock(Vector2.zero(), Vector2.all(10));
+
+      await game.addAll([component, testBlock]);
+      await game.ready();
+
+      expect(hitbox.passthroughParent, isNull);
+
+      hitbox.removeFromParent();
+      testBlock.add(hitbox);
+      await game.ready();
+
+      expect(hitbox.passthroughParent, testBlock);
     });
   });
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->

In `CollisionPassthrough`, while searching for an ancestor with `CollisionCallbacks` mixin, `firstWhere` was used. This was causing it to fail when no such ancestor was found. But having a passthrough parent is not necessary, at least rest of the code wasn't designed on that assumption. So this PR replaced `firstWhere` with `firstWhereOrNull` allowing the passthrough to be null.

This was discovered in one of the [discord discussions](https://discord.com/channels/509714518008528896/516639688581316629/1163600349643411467).

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->
Replace or remove this text.

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
