### PR TITLE
fix: Finishing touches to use v1.9.x+ world and camera and complete Issue #2799

### DIFF
--- a/doc/tutorials/klondike/app/lib/step2/klondike_game.dart
+++ b/doc/tutorials/klondike/app/lib/step2/klondike_game.dart
@@ -41,19 +41,15 @@ class KlondikeGame extends FlameGame {
         ),
     );
 
-    final world = World()
-      ..add(stock)
-      ..add(waste)
-      ..addAll(foundations)
-      ..addAll(piles);
-    add(world);
+    world.add(stock);
+    world.add(waste);
+    world.addAll(foundations);
+    world.addAll(piles);
 
-    final camera = CameraComponent(world: world)
-      ..viewfinder.visibleGameSize =
-          Vector2(cardWidth * 7 + cardGap * 8, 4 * cardHeight + 3 * cardGap)
-      ..viewfinder.position = Vector2(cardWidth * 3.5 + cardGap * 4, 0)
-      ..viewfinder.anchor = Anchor.topCenter;
-    add(camera);
+    camera.viewfinder.visibleGameSize =
+        Vector2(cardWidth * 7 + cardGap * 8, 4 * cardHeight + 3 * cardGap);
+    camera.viewfinder.position = Vector2(cardWidth * 3.5 + cardGap * 4, 0);
+    camera.viewfinder.anchor = Anchor.topCenter;
   }
 }
 

--- a/doc/tutorials/klondike/app/lib/step3/klondike_game.dart
+++ b/doc/tutorials/klondike/app/lib/step3/klondike_game.dart
@@ -44,19 +44,15 @@ class KlondikeGame extends FlameGame {
         ),
     );
 
-    final world = World()
-      ..add(stock)
-      ..add(waste)
-      ..addAll(foundations)
-      ..addAll(piles);
-    add(world);
+    world.add(stock);
+    world.add(waste);
+    world.addAll(foundations);
+    world.addAll(piles);
 
-    final camera = CameraComponent(world: world)
-      ..viewfinder.visibleGameSize =
-          Vector2(cardWidth * 7 + cardGap * 8, 4 * cardHeight + 3 * cardGap)
-      ..viewfinder.position = Vector2(cardWidth * 3.5 + cardGap * 4, 0)
-      ..viewfinder.anchor = Anchor.topCenter;
-    add(camera);
+    camera.viewfinder.visibleGameSize =
+        Vector2(cardWidth * 7 + cardGap * 8, 4 * cardHeight + 3 * cardGap);
+    camera.viewfinder.position = Vector2(cardWidth * 3.5 + cardGap * 4, 0);
+    camera.viewfinder.anchor = Anchor.topCenter;
 
     final random = Random();
     for (var i = 0; i < 7; i++) {


### PR DESCRIPTION
# Description
Previously, as part of Issue #2798, I fixed the Klondike Tutorial app's step4 executable to use the Flame 1.9.x `world` and `camera` built-in objects and described the new code in the Step 2 tutorial, where it first appears in the discussion. However, the Step 2 and Step 3 tutorial texts have options to execute code and those did not include the new code. Accordingly, I have cloned the relevant code into `app/lib/step2/klondike_game.dart` and `app/lib/step3/klondike_game.dart`. I have also checked that there are no `*.md` files to be updated. The `step2.md` tutorial file covers Issue #2799 AFAICS.

## Checklist
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?
Would your PR require Flame users to update their apps following your change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues
Closes #2799

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
