### PR TITLE
fix: Setting world on FlameGame camera setter

### DIFF
--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -65,6 +65,9 @@ class FlameGame<W extends World> extends ComponentTreeRoot
   ///
   /// You don't have to add the CameraComponent to the tree after setting it
   /// here, it is done automatically.
+  ///
+  /// When setting the camera, if it doesn't already have a world it will be
+  /// set to match the game's world.
   CameraComponent get camera => _camera;
   set camera(CameraComponent newCameraComponent) {
     _camera.removeFromParent();

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -72,6 +72,7 @@ class FlameGame<W extends World> extends ComponentTreeRoot
     if (_camera.parent == null) {
       add(_camera);
     }
+    _camera.world = world;
   }
 
   CameraComponent _camera;

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -72,7 +72,7 @@ class FlameGame<W extends World> extends ComponentTreeRoot
     if (_camera.parent == null) {
       add(_camera);
     }
-    _camera.world = world;
+    _camera.world ??= world;
   }
 
   CameraComponent _camera;

--- a/packages/flame/test/game/flame_game_test.dart
+++ b/packages/flame/test/game/flame_game_test.dart
@@ -215,6 +215,53 @@ void main() {
         );
       },
     );
+
+    group('world and camera', () {
+      testWithFlameGame(
+        'game world setter',
+        (game) async {
+          final newWorld = World();
+          game.world = newWorld;
+          expect(game.world, newWorld);
+          expect(game.camera.world, newWorld);
+        },
+      );
+
+      testWithFlameGame(
+        'game camera setter',
+        (game) async {
+          final newCamera = CameraComponent();
+          game.camera = newCamera;
+          expect(game.camera, newCamera);
+          expect(game.world, isNotNull);
+          expect(game.camera.world, game.world);
+        },
+      );
+
+      testWithFlameGame(
+        'game camera setter with another world',
+        (game) async {
+          final camera1 = game.camera;
+          final world1 = game.world;
+          expect(world1, isNotNull);
+          expect(camera1, isNotNull);
+
+          final camera2 = CameraComponent();
+          final world2 = World();
+          camera2.world = world2;
+
+          game.camera = camera2;
+          expect(game.camera, camera2);
+          expect(game.camera.world, world2);
+          expect(game.world, world1);
+
+          game.camera = camera1;
+          expect(game.camera, camera1);
+          expect(game.camera.world, world1);
+          expect(game.world, world1);
+        },
+      );
+    });
   });
 
   group('Render box attachment', () {


### PR DESCRIPTION
# Description

Currently setting a new `FlameGame.camera` can cause `camera.world` to no long match `game.world`, which I think it's safe to assume is never desirable.

This PR sets the `camera.world` to the game's `world` when setting a new Camera, this matches what happens when a new World is set on the game (`world.camera` is set automatically).

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

