### PR TITLE
chore: Bump Forge2D to 0.12.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: |
         When reporting a bug, please read this complete template and fill in all the questions in order to get a better response!
- - type: textarea
+  - type: textarea
     id: what-happened
     attributes:
       label: What happened?
@@ -24,17 +24,15 @@ body:
     validations:
       required: true
 
-# Steps to reproduce
-
-- type: textarea
+  - type: textarea
     id: expectation
     attributes:
       label: How can we reproduce this?
-      description: This one is very important, please be very precise in how we can reproduce this bug
+      description: Thougougly explain how to reproduce the bug.
     validations:
       required: false
       
-- type: textarea
+  - type: textarea
     id: expectation
     attributes:
       label: What steps should take to fix this?
@@ -42,7 +40,7 @@ body:
     validations:
       required: false
       
-- type: textarea
+  - type: textarea
     id: expectation
     attributes:
       label: Do have an example of what change you want?
@@ -57,40 +55,30 @@ body:
       description: If you have any debug / error logging, please fill it here within the code block below
       render: shell
 
-
-- type: markdown
+  - type: textarea
     attributes:
-       label: Execute in a terminal and put output into the code block below 
-        value: ```
-Output of: flutter doctor -v
-```
+      label: Execute in a terminal and put output into the code block below
+      value: 'Output of: flutter doctor -v'
 
-# More environment information
-
-- type: markdown
+  - type: textarea
     attributes:
-       label: Create a list of more environment information, like:
-        value: Flame version: 1.0.0
-        value: Platform affected: android, ios, web
-        value: Platform version affected: android 9, ios 13
+      label: 'Affected platforms:'
+      description: 'Android, iOS, Linux, macOS, Windows etc'
+    validations:
+      required: false
 
-# More information
-
-- type: textarea
+  - type: textarea
     id: expectation
     attributes:
       label: What do you expect?
       description: Do you have any other useful information about this bug report? Please write it down here
     validations:
       required: false
-      
 
-- type: checkboxes
+  - type: checkboxes
     id: terms
     attributes:
       label:  Are you interested in working on a PR for this?
       options:
         - label: I want to work on this
           required: false
-
-## Possible helpful information: references to other sites/repositories

--- a/examples/games/padracing/lib/tire.dart
+++ b/examples/games/padracing/lib/tire.dart
@@ -80,7 +80,7 @@ class Tire extends BodyComponent<PadRacingGame> {
     final body = world.createBody(def)..userData = this;
 
     final polygonShape = PolygonShape()..setAsBoxXY(0.5, 1.25);
-    body.createFixtureFromShape(polygonShape, 1.0).userData = this;
+    body.createFixtureFromShape(polygonShape).userData = this;
 
     jointDef.bodyB = body;
     jointDef.localAnchorA.setFrom(jointAnchor);

--- a/examples/lib/stories/bridge_libraries/flame_forge2d/animated_body_example.dart
+++ b/examples/lib/stories/bridge_libraries/flame_forge2d/animated_body_example.dart
@@ -77,7 +77,6 @@ class ChopperBody extends BodyComponent {
       shape,
       userData: this, // To be able to determine object in collision
       restitution: 0.8,
-      density: 1.0,
       friction: 0.2,
     );
 

--- a/examples/lib/stories/bridge_libraries/flame_forge2d/blob_example.dart
+++ b/examples/lib/stories/bridge_libraries/flame_forge2d/blob_example.dart
@@ -97,7 +97,6 @@ class BlobPart extends BodyComponent {
     final shape = CircleShape()..radius = bodyRadius;
     final fixtureDef = FixtureDef(
       shape,
-      density: 1.0,
       friction: 0.2,
     );
     body.createFixture(fixtureDef);
@@ -119,7 +118,7 @@ class FallingBox extends BodyComponent {
     );
     final shape = PolygonShape()..setAsBoxXY(2, 4);
     final body = world.createBody(bodyDef);
-    body.createFixtureFromShape(shape, 1.0);
+    body.createFixtureFromShape(shape);
     return body;
   }
 }

--- a/examples/lib/stories/bridge_libraries/flame_forge2d/sprite_body_example.dart
+++ b/examples/lib/stories/bridge_libraries/flame_forge2d/sprite_body_example.dart
@@ -72,7 +72,6 @@ class Pizza extends BodyComponent {
       shape,
       userData: this, // To be able to determine object in collision
       restitution: 0.4,
-      density: 1.0,
       friction: 0.5,
     );
 

--- a/examples/lib/stories/bridge_libraries/flame_forge2d/utils/balls.dart
+++ b/examples/lib/stories/bridge_libraries/flame_forge2d/utils/balls.dart
@@ -38,7 +38,6 @@ class Ball extends BodyComponent with ContactCallbacks {
     final fixtureDef = FixtureDef(
       shape,
       restitution: 0.8,
-      density: 1.0,
       friction: 0.4,
     );
 

--- a/examples/lib/stories/bridge_libraries/flame_forge2d/widget_example.dart
+++ b/examples/lib/stories/bridge_libraries/flame_forge2d/widget_example.dart
@@ -33,7 +33,6 @@ class WidgetExample extends Forge2DGame {
     final shape = PolygonShape()..setAsBoxXY(4.6, 0.8);
     final fixtureDef = FixtureDef(
       shape,
-      density: 1.0,
       restitution: 0.8,
       friction: 0.2,
     );

--- a/melos.yaml
+++ b/melos.yaml
@@ -13,6 +13,16 @@ command:
     branch: main
     # Generates a link to a prefilled GitHub release creation page.
     releaseUrl: true
+  bootstrap:
+    environment:
+      sdk: ">=3.0.0 <4.0.0"
+    dependencies:
+      meta: ^1.9.1
+      vector_math: ^2.1.4
+    dev_dependencies:
+      dartdoc: ^6.3.0
+      mocktail: ^1.0.1
+      test: any
 
 scripts:
   lint:all:

--- a/packages/flame_forge2d/example/lib/main.dart
+++ b/packages/flame_forge2d/example/lib/main.dart
@@ -42,7 +42,6 @@ class Ball extends BodyComponent with TapCallbacks {
             FixtureDef(
               CircleShape()..radius = 5,
               restitution: 0.8,
-              density: 1.0,
               friction: 0.4,
             ),
           ],

--- a/packages/flame_forge2d/lib/forge2d_game.dart
+++ b/packages/flame_forge2d/lib/forge2d_game.dart
@@ -12,7 +12,7 @@ class Forge2DGame<T extends Forge2DWorld> extends FlameGame<T> {
     ContactListener? contactListener,
     double zoom = 10,
   }) : super(
-          world: ((world?..setGravity(gravity)) ??
+          world: ((world?..gravity = gravity) ??
               Forge2DWorld(
                 gravity: gravity,
                 contactListener: contactListener,

--- a/packages/flame_forge2d/lib/forge2d_world.dart
+++ b/packages/flame_forge2d/lib/forge2d_world.dart
@@ -59,7 +59,9 @@ class Forge2DWorld extends World {
     physicsWorld.particleSystem.raycast(callback, point1, point2);
   }
 
-  void setGravity(Vector2? gravity) {
-    physicsWorld.setGravity(gravity ?? defaultGravity);
+  Vector2 get gravity => physicsWorld.gravity;
+
+  set gravity(Vector2? gravity) {
+    physicsWorld.gravity = gravity ?? defaultGravity;
   }
 }

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -15,13 +15,13 @@ dependencies:
   flame: ^1.10.0
   flutter:
     sdk: flutter
-  forge2d: ">=0.11.0 <0.12.0"
+  forge2d: ">=0.12.2 <0.13.0"
 
 dev_dependencies:
-  dartdoc: ^6.2.2
+  dartdoc: ^6.3.0
   flame_lint: ^1.1.1
   flame_test: ^1.13.2
   flutter_test:
     sdk: flutter
-  mocktail: ^0.3.0
+  mocktail: ^1.0.1
   test: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,4 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
-  melos: ^3.0.0
+  melos: ^3.2.0


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Bumps forge2d to 0.12.2

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->
Migration instructions:
The gravity and bullet are now field setters and getters, so if you before had `setGravity(Vector2(0, -10))` then you now do `gravity = Vector2(0, -10);` and if you previously had `body.setBullet(true);` you now do `body.isBullet = true;`.

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
