### PR TITLE
docs: Make Viewfinder and Viewport comply with CoordinateTransform interface

### DIFF
--- a/packages/flame/lib/src/camera/viewfinder.dart
+++ b/packages/flame/lib/src/camera/viewfinder.dart
@@ -1,9 +1,7 @@
 import 'dart:math';
 
+import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
-import 'package:flame/src/anchor.dart';
-import 'package:flame/src/camera/camera_component.dart';
-import 'package:flame/src/components/core/component.dart';
 import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:flame/src/game/transform2d.dart';
 import 'package:meta/meta.dart';
@@ -18,7 +16,12 @@ import 'package:meta/meta.dart';
 /// If you add children to the [Viewfinder] they will appear like HUDs i.e.
 /// statically in front of the world.
 class Viewfinder extends Component
-    implements AnchorProvider, AngleProvider, PositionProvider, ScaleProvider {
+    implements
+        AnchorProvider,
+        AngleProvider,
+        PositionProvider,
+        ScaleProvider,
+        CoordinateTransform {
   /// Transform matrix used by the viewfinder.
   final Transform2D transform = Transform2D();
 
@@ -178,6 +181,16 @@ class Viewfinder extends Component
       final zoomY = viewportSize.y / _visibleGameSize!.y;
       zoom = min(zoomX, zoomY);
     }
+  }
+
+  @override
+  Vector2 parentToLocal(Vector2 point) {
+    return globalToLocal(point);
+  }
+
+  @override
+  Vector2 localToParent(Vector2 point) {
+    return localToGlobal(point);
   }
 
   @override

--- a/packages/flame/lib/src/camera/viewport.dart
+++ b/packages/flame/lib/src/camera/viewport.dart
@@ -1,9 +1,7 @@
+import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
-import 'package:flame/src/anchor.dart';
-import 'package:flame/src/camera/camera_component.dart';
 import 'package:flame/src/camera/viewports/fixed_resolution_viewport.dart';
-import 'package:flame/src/components/core/component.dart';
 import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:meta/meta.dart';
 
@@ -21,7 +19,11 @@ import 'package:meta/meta.dart';
 /// A viewport establishes its own local coordinate system, with the origin at
 /// the top left corner of the viewport's bounding box.
 abstract class Viewport extends Component
-    implements AnchorProvider, PositionProvider, SizeProvider {
+    implements
+        AnchorProvider,
+        PositionProvider,
+        SizeProvider,
+        CoordinateTransform {
   Viewport({super.children});
 
   final Vector2 _size = Vector2.zero();
@@ -146,6 +148,16 @@ abstract class Viewport extends Component
     final x = point.x + position.x - anchor.x * size.x;
     final y = point.y + position.y - anchor.y * size.y;
     return (output?..setValues(x, y)) ?? Vector2(x, y);
+  }
+
+  @override
+  Vector2 parentToLocal(Vector2 point) {
+    return globalToLocal(point);
+  }
+
+  @override
+  Vector2 localToParent(Vector2 point) {
+    return localToGlobal(point);
   }
 
   void transformCanvas(Canvas canvas) {


### PR DESCRIPTION
<!-- Exclude from commit message -->

# Description
<!-- End of exclude from commit message -->

Make `Viewfinder` and `Viewport` comply with `CoordinateTransform` interface; they already perform the coordinate transform operation but didn't technically implement then interface.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
