### PR TITLE
docs: Fix Hover Callbacks so the tap used in the example respects the zoom

### DIFF
--- a/examples/lib/stories/input/hover_callbacks_example.dart
+++ b/examples/lib/stories/input/hover_callbacks_example.dart
@@ -4,22 +4,31 @@ import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 
-class HoverCallbacksExample extends FlameGame with TapCallbacks {
+class HoverCallbacksExample extends FlameGame {
   static const String description = '''
     This example shows how to use `HoverCallbacks`s.\n\n
     Add more squares by clicking and hover them to change their color.
   ''';
 
+  HoverCallbacksExample() : super(world: HoverCallbacksWorld());
+
   @override
   Future<void> onLoad() async {
     camera.viewfinder.anchor = Anchor.topLeft;
-    world.add(HoverSquare(Vector2(200, 500)));
-    world.add(HoverSquare(Vector2(700, 300)));
+    camera.viewfinder.zoom = 1.5;
+  }
+}
+
+class HoverCallbacksWorld extends World with TapCallbacks {
+  @override
+  Future<void> onLoad() async {
+    add(HoverSquare(Vector2(200, 500)));
+    add(HoverSquare(Vector2(700, 300)));
   }
 
   @override
   void onTapDown(TapDownEvent event) {
-    world.add(HoverSquare(event.localPosition));
+    add(HoverSquare(event.localPosition));
   }
 }
 


### PR DESCRIPTION
<!-- Exclude from commit message -->

# Description
<!-- End of exclude from commit message -->

Fix Hover Callbacks so the tap used in the example respects the zoom.

The example happens to use a tap event to create new squares. However, since the tap event is bound to the Game instead of the World, had it had any zoom applied (which it didn't), or any other camera transform, the squares would have been created on the wrong place. This sends a bad example to new users and can cause confusion.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
