### PR TITLE
fix: Use world on tap_callbacks_example

### DIFF
--- a/examples/lib/stories/input/tap_callbacks_example.dart
+++ b/examples/lib/stories/input/tap_callbacks_example.dart
@@ -13,8 +13,8 @@ class TapCallbacksExample extends FlameGame {
 
   @override
   Future<void> onLoad() async {
-    add(TappableSquare()..anchor = Anchor.center);
-    add(TappableSquare()..y = 350);
+    world.add(TappableSquare()..anchor = Anchor.center);
+    world.add(TappableSquare()..y = 350);
   }
 }
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Use world on tap_callbacks_example. We should just standardize all examples to use the world unless there is a reason not to, in order to avoid confusing users.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
