### PR TITLE
refactor!: Replace `Offset` with `opacityFrom` and `opacityTo` in ColorEffect

### DIFF
--- a/doc/flame/effects.md
+++ b/doc/flame/effects.md
@@ -535,13 +535,14 @@ Usage example:
 ```dart
 final effect = ColorEffect(
   const Color(0xFF00FF00),
-  const Offset(0.0, 0.8),
   EffectController(duration: 1.5),
+  opacityfrom = 0.2,
+  opacityTo: 0.8,
 );
 ```
 
-The `Offset` argument will determine "how much" of the color that will be applied to the component,
-in this example the effect will start with 0% and will go up to 80%.
+The `opacityfrom` and `opacityTo` arguments will determine "how much" of the color that will be
+applied to the component. In this example the effect will start with 20% and will go up to 80%.
 
 **Note:** Due to how this effect is implemented, and how Flutter's `ColorFilter` class works, this
 effect can't be mixed with other `ColorEffect`s, when more than one is added to the component, only

--- a/doc/flame/examples/lib/color_effect.dart
+++ b/doc/flame/examples/lib/color_effect.dart
@@ -18,16 +18,16 @@ class ColorEffectExample extends FlameGame {
           ember.add(
             ColorEffect(
               const Color(0xFF00FF00),
-              const Offset(0.0, 0.6),
               EffectController(duration: 1.5),
+              opacityTo: 0.6,
             ),
           );
         } else {
           ember.add(
             ColorEffect(
               const Color(0xFF1039DB),
-              const Offset(0.0, 0.6),
               EffectController(duration: 1.5),
+              opacityTo: 0.6,
             ),
           );
         }

--- a/examples/lib/stories/collision_detection/multiple_worlds_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_worlds_example.dart
@@ -69,11 +69,11 @@ class CollidableEmber extends Ember with CollisionCallbacks {
     add(
       ColorEffect(
         index < 2 ? Colors.red : Colors.green,
-        const Offset(0, 0.9),
         EffectController(
           duration: 0.2,
           alternate: true,
         ),
+        opacityTo: 0.9,
       ),
     );
   }

--- a/examples/lib/stories/effects/color_effect_example.dart
+++ b/examples/lib/stories/effects/color_effect_example.dart
@@ -22,15 +22,13 @@ class ColorEffectExample extends FlameGame with TapDetector {
       )..add(
           ColorEffect(
             Colors.blue,
-            const Offset(
-              0.0,
-              0.8,
-            ), // Means, applies from 0% to 80% of the color
             EffectController(
               duration: 1.5,
               reverseDuration: 1.5,
               infinite: true,
             ),
+            // Means, applies from 0% to 80% of the color
+            opacityTo: 0.8,
           ),
         ),
     );

--- a/examples/lib/stories/effects/dual_effect_removal_example.dart
+++ b/examples/lib/stories/effects/dual_effect_removal_example.dart
@@ -33,8 +33,8 @@ class DualEffectRemovalExample extends FlameGame with TapDetector {
     );
     colorEffect = ColorEffect(
       Colors.blue,
-      const Offset(0.0, 0.8),
       colorController,
+      opacityTo: 0.8,
     );
     mySprite.add(colorEffect);
 

--- a/packages/flame/lib/src/effects/color_effect.dart
+++ b/packages/flame/lib/src/effects/color_effect.dart
@@ -18,11 +18,12 @@ class ColorEffect extends ComponentEffect<HasPaint> {
 
   ColorEffect(
     this.color,
-    Offset offset,
     EffectController controller, {
+    double opacityfrom = 0,
+    double opacityTo = 1,
     this.paintId,
     void Function()? onComplete,
-  })  : _tween = Tween(begin: offset.dx, end: offset.dy),
+  })  : _tween = Tween(begin: opacityfrom, end: opacityTo),
         super(controller, onComplete: onComplete);
 
   @override

--- a/packages/flame/lib/src/effects/color_effect.dart
+++ b/packages/flame/lib/src/effects/color_effect.dart
@@ -23,7 +23,15 @@ class ColorEffect extends ComponentEffect<HasPaint> {
     double opacityTo = 1,
     this.paintId,
     void Function()? onComplete,
-  })  : _tween = Tween(begin: opacityfrom, end: opacityTo),
+  })  :
+   assert(
+          opacityfrom >= 0 &&
+              opacityfrom <= 1 &&
+              opacityTo >= 0 &&
+              opacityTo <= 1,
+          'Opacity value should be between 0 and 1',
+        ),
+        _tween = Tween(begin: opacityfrom, end: opacityTo),
         super(controller, onComplete: onComplete);
 
   @override

--- a/packages/flame/test/effects/color_effect_test.dart
+++ b/packages/flame/test/effects/color_effect_test.dart
@@ -13,7 +13,7 @@ void main() {
       await game.ensureAdd(component);
       const color = Colors.red;
       await component.add(
-        ColorEffect(color, const Offset(0, 1), EffectController(duration: 1)),
+        ColorEffect(color, EffectController(duration: 1)),
       );
       game.update(0);
       expect(
@@ -43,7 +43,6 @@ void main() {
 
         final effect = ColorEffect(
           color,
-          const Offset(0, 1),
           EffectController(duration: 1),
         );
         await component.add(effect);
@@ -71,7 +70,6 @@ void main() {
 
         final effect = ColorEffect(
           Colors.red,
-          const Offset(0, 1),
           EffectController(duration: 1),
         );
         await component.ensureAdd(effect);

--- a/packages/flame/test/effects/color_effect_test.dart
+++ b/packages/flame/test/effects/color_effect_test.dart
@@ -83,5 +83,53 @@ void main() {
         );
       },
     );
+
+    test('Validates opacity values', () {
+      expect(
+        () => ColorEffect(
+          Colors.blue,
+          EffectController(duration: 1),
+          opacityTo: 1.1,
+        ),
+        throwsAssertionError,
+      );
+
+      expect(
+        () => ColorEffect(
+          Colors.blue,
+          EffectController(duration: 1),
+          opacityfrom: 255,
+        ),
+        throwsAssertionError,
+      );
+
+      expect(
+        () => ColorEffect(
+          Colors.blue,
+          EffectController(duration: 1),
+          opacityTo: -254,
+        ),
+        throwsAssertionError,
+      );
+
+      expect(
+        () => ColorEffect(
+          Colors.blue,
+          EffectController(duration: 1),
+          opacityfrom: -0.5,
+        ),
+        throwsAssertionError,
+      );
+
+      expect(
+        () => ColorEffect(
+          Colors.blue,
+          EffectController(duration: 1),
+          opacityfrom: 0.1,
+          opacityTo: 0.9,
+        ),
+        returnsNormally,
+      );
+    });
   });
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->

`ColorEffect`'s API was a bit confusing because it used `Offset` for getting values of opacity start and end from user. This PR changes that to use optional `opacityFrom` and `opacityTo` double parameters. It also adds validate checks on these value to make sure that are between 0 and 1.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.


### Migration instructions

To specify start and end opacities for `ColorEffect` use the optional named parameters `opacityFrom` and `opacityTo`. So `offset.dx` should be set as `opacityFrom` and `offset.dy` should be set as `opacityTo`.

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->

NA

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
