### PR TITLE
docs: Add index page with routing links to doc/flame/examples

### DIFF
--- a/doc/flame/examples/lib/main.dart
+++ b/doc/flame/examples/lib/main.dart
@@ -37,55 +37,78 @@ import 'package:doc_flame_examples/value_route.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/widgets.dart';
 
+final routes = <String, Game Function()>{
+  'anchor_by_effect': AnchorByEffectGame.new,
+  'anchor_to_effect': AnchorToEffectGame.new,
+  'anchor': AnchorGame.new,
+  'collision_detection': CollisionDetectionGame.new,
+  'color_effect': ColorEffectExample.new,
+  'decorator_blur': DecoratorBlurGame.new,
+  'decorator_grayscale': DecoratorGrayscaleGame.new,
+  'decorator_rotate3d': DecoratorRotate3DGame.new,
+  'decorator_shadow3d': DecoratorShadowGame.new,
+  'decorator_tint': DecoratorTintGame.new,
+  'drag_events': DragEventsGame.new,
+  'glow_effect': GlowEffectExample.new,
+  'move_along_path_effect': MoveAlongPathEffectGame.new,
+  'move_by_effect': MoveByEffectGame.new,
+  'move_to_effect': MoveToEffectGame.new,
+  'opacity_by_effect': OpacityByEffectGame.new,
+  'opacity_effect_with_target': OpacityEffectWithTargetGame.new,
+  'opacity_to_effect': OpacityToEffectGame.new,
+  'pointer_events': PointerEventsGame.new,
+  'ray_cast': RayCastExample.new,
+  'ray_trace': RayTraceExample.new,
+  'remove_effect': RemoveEffectGame.new,
+  'rive_example': RiveExampleGame.new,
+  'rotate_by_effect': RotateByEffectGame.new,
+  'rotate_to_effect': RotateToEffectGame.new,
+  'router': RouterGame.new,
+  'scale_by_effect': ScaleByEffectGame.new,
+  'scale_to_effect': ScaleToEffectGame.new,
+  'sequence_effect': SequenceEffectGame.new,
+  'size_by_effect': SizeByEffectGame.new,
+  'size_to_effect': SizeToEffectGame.new,
+  'tap_events': TapEventsGame.new,
+  'time_scale': TimeScaleGame.new,
+  'value_route': ValueRouteExample.new,
+};
+
 void main() {
   var page = window.location.search ?? '';
   if (page.startsWith('?')) {
     page = page.substring(1);
   }
-  final routes = <String, Game Function()>{
-    'anchor_by_effect': AnchorByEffectGame.new,
-    'anchor_to_effect': AnchorToEffectGame.new,
-    'anchor': AnchorGame.new,
-    'collision_detection': CollisionDetectionGame.new,
-    'color_effect': ColorEffectExample.new,
-    'decorator_blur': DecoratorBlurGame.new,
-    'decorator_grayscale': DecoratorGrayscaleGame.new,
-    'decorator_rotate3d': DecoratorRotate3DGame.new,
-    'decorator_shadow3d': DecoratorShadowGame.new,
-    'decorator_tint': DecoratorTintGame.new,
-    'drag_events': DragEventsGame.new,
-    'glow_effect': GlowEffectExample.new,
-    'move_along_path_effect': MoveAlongPathEffectGame.new,
-    'move_by_effect': MoveByEffectGame.new,
-    'move_to_effect': MoveToEffectGame.new,
-    'opacity_by_effect': OpacityByEffectGame.new,
-    'opacity_effect_with_target': OpacityEffectWithTargetGame.new,
-    'opacity_to_effect': OpacityToEffectGame.new,
-    'pointer_events': PointerEventsGame.new,
-    'ray_cast': RayCastExample.new,
-    'ray_trace': RayTraceExample.new,
-    'remove_effect': RemoveEffectGame.new,
-    'rive_example': RiveExampleGame.new,
-    'rotate_by_effect': RotateByEffectGame.new,
-    'rotate_to_effect': RotateToEffectGame.new,
-    'router': RouterGame.new,
-    'scale_by_effect': ScaleByEffectGame.new,
-    'scale_to_effect': ScaleToEffectGame.new,
-    'sequence_effect': SequenceEffectGame.new,
-    'size_by_effect': SizeByEffectGame.new,
-    'size_to_effect': SizeToEffectGame.new,
-    'tap_events': TapEventsGame.new,
-    'time_scale': TimeScaleGame.new,
-    'value_route': ValueRouteExample.new,
-  };
   final game = routes[page]?.call();
   if (game != null) {
     runApp(GameWidget(game: game));
   } else {
-    runApp(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Text('Error: unknown page name "$page"'),
+    runApp(_IndexRoute(page: page));
+  }
+}
+
+class _IndexRoute extends StatelessWidget {
+  final String page;
+
+  const _IndexRoute({
+    required this.page,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Column(
+        children: [
+          Text('Error: unknown page name "$page"'),
+          const Text('Select an option below:'),
+          ...routes.keys.map((route) {
+            return GestureDetector(
+              onTap: () => window.location.replace('/?$route'),
+              child: Text(route),
+            );
+          }),
+        ],
       ),
     );
   }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Add an ad-hoc index page with routing links to all examples within doc/flame/examples.

Before, it would just show a cryptic error message that would require checking the code to understand how to access a specific one.

These examples are used with route pre-set within the docs so they are not normally accessed by users directly, however this is helpful when you refactor something and wish to double-check the examples still work.

![image](https://github.com/flame-engine/flame/assets/882703/10212a11-6c2b-4308-a8cd-5a05658bec71)

Obviously it could be improved further, but this already helps finding what you seek quickly.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
