### PR TITLE
docs: Update t-rex game to use TapCallbacks

### DIFF
--- a/.github/.cspell/words_dictionary.txt
+++ b/.github/.cspell/words_dictionary.txt
@@ -11,7 +11,6 @@ gamepads
 gameplay
 gapless
 grayscale
-highscore
 hoverable
 hoverables
 inactives

--- a/examples/games/trex/lib/trex_game.dart
+++ b/examples/games/trex/lib/trex_game.dart
@@ -15,7 +15,7 @@ import 'package:trex_game/player.dart';
 enum GameState { playing, intro, gameOver }
 
 class TRexGame extends FlameGame
-    with KeyboardEvents, TapDetector, HasCollisionDetection {
+    with KeyboardEvents, TapCallbacks, HasCollisionDetection {
   static const String description = '''
     A game similar to the game in chrome that you get to play while offline.
     Press space or tap/click the screen to jump, the more obstacles you manage
@@ -33,11 +33,11 @@ class TRexGame extends FlameGame
   late final TextComponent scoreText;
 
   int _score = 0;
-  int _highscore = 0;
+  int _highScore = 0;
   int get score => _score;
   set score(int newScore) {
     _score = newScore;
-    scoreText.text = '${scoreString(_score)}  HI ${scoreString(_highscore)}';
+    scoreText.text = '${scoreString(_score)}  HI ${scoreString(_highScore)}';
   }
 
   String scoreString(int score) => score.toString().padLeft(5, '0');
@@ -99,7 +99,7 @@ class TRexGame extends FlameGame
   }
 
   @override
-  void onTapDown(TapDownInfo info) {
+  void onTapDown(TapDownEvent event) {
     onAction();
   }
 
@@ -125,8 +125,8 @@ class TRexGame extends FlameGame
     currentSpeed = startSpeed;
     gameOverPanel.visible = false;
     timePlaying = 0.0;
-    if (score > _highscore) {
-      _highscore = score;
+    if (score > _highScore) {
+      _highScore = score;
     }
     score = 0;
     _distanceTraveled = 0;


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->

Update t-rex game to use `TapCallbacks` instead of `TapDetector`,  in anticipation of [deprecating the latter](https://github.com/flame-engine/flame/pull/2886).

Also update the term high score to avoid a dictionary entry.

<!-- Exclude from commit message -->

Tested by running the game.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
