### PR TITLE
fix: Issue #2889, Klondike Step5, incorrect animation of the deal.

### DIFF
--- a/doc/tutorials/klondike/app/lib/step5/components/card.dart
+++ b/doc/tutorials/klondike/app/lib/step5/components/card.dart
@@ -359,20 +359,18 @@ class Card extends PositionComponent
     Vector2 to, {
     double speed = 10.0,
     double start = 0.0,
+    int startPriority = 100,
     Curve curve = Curves.easeOutQuad,
     VoidCallback? onComplete,
-    bool bumpPriority = true,
   }) {
     assert(speed > 0.0, 'Speed must be > 0 widths per second');
     final dt = (to - position).length / (speed * size.x);
     assert(dt > 0, 'Distance to move must be > 0');
-    if (bumpPriority) {
-      priority = 100;
-    }
     add(
-      MoveToEffect(
+      CardMoveEffect(
         to,
         EffectController(duration: dt, startDelay: start, curve: curve),
+        transitPriority: startPriority,
         onComplete: () {
           onComplete?.call();
         },
@@ -442,4 +440,21 @@ class Card extends PositionComponent
   }
 
   //#endregion
+}
+
+class CardMoveEffect extends MoveToEffect {
+  CardMoveEffect(
+    super.destination,
+    super.controller, {
+    super.onComplete,
+    this.transitPriority = 100,
+  });
+
+  final int transitPriority;
+
+  @override
+  void onStart() {
+    super.onStart(); // Flame connects MoveToEffect to EffectController.
+    parent?.priority = transitPriority;
+  }
 }

--- a/doc/tutorials/klondike/app/lib/step5/components/tableau_pile.dart
+++ b/doc/tutorials/klondike/app/lib/step5/components/tableau_pile.dart
@@ -75,7 +75,7 @@ class TableauPile extends PositionComponent implements Pile {
       _cards.add(card);
       card.doMove(
         nextPosition,
-        bumpPriority: false, // Priorities have been set: don't change them.
+        startPriority: card.priority,
         onComplete: () {
           nCardsToMove--;
           if (nCardsToMove == 0) {

--- a/doc/tutorials/klondike/app/lib/step5/klondike_world.dart
+++ b/doc/tutorials/klondike/app/lib/step5/klondike_world.dart
@@ -114,6 +114,13 @@ class KlondikeWorld extends World with HasGameReference<KlondikeGame> {
     // For the "Same deal" option, re-use the previous seed, else use a new one.
     cards.shuffle(Random(game.seed));
 
+    // Each card dealt must be seen to come from the top of the deck!
+    var dealPriority = 1;
+    for (final card in cards) {
+      card.priority = dealPriority++;
+    }
+
+    // Change priority as cards take off: so later cards fly above earlier ones.
     var cardToDeal = cards.length - 1;
     var nMovingCards = 0;
     for (var i = 0; i < 7; i++) {
@@ -121,7 +128,9 @@ class KlondikeWorld extends World with HasGameReference<KlondikeGame> {
         final card = cards[cardToDeal--];
         card.doMove(
           tableauPiles[j].position,
+          speed: 15.0,
           start: nMovingCards * 0.15,
+          startPriority: 100 + nMovingCards,
           onComplete: () {
             tableauPiles[j].acquireCard(card);
             nMovingCards--;


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->

When the cards are dealt at the start of a Klondike Step 5 game there are multiple occurrences of unrealistic behaviors:

- Several cards being dealt may come from the middle of the Stock Pile,
- Cards that are dealt early can be seen moving in front of cards that are dealt later.

Each card dealt should be rendered on the top of the Stock Pile and should be seen to come from there. During the deal, later cards dealt are placed on top of earlier ones, so later cards should be seen to move in front of earlier ones when they are travelling from the Stock Pile to their positions in the layout.
<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Closes #2889.

To observe the problem and solution easily, temporarily change the `speed:` and `start:` parameters in `KlondikeWorld.deal()`.
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #2889
!-->
<!-- End of exclude from commit message -->

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
