### PR TITLE
docs: Klondike Step5, re-work drags and taps

### DIFF
--- a/doc/tutorials/klondike/app/lib/step5/components/card.dart
+++ b/doc/tutorials/klondike/app/lib/step5/components/card.dart
@@ -27,12 +27,13 @@ class Card extends PositionComponent
   final Rank rank;
   final Suit suit;
   Pile? pile;
-  final bool isBaseCard;
+
   // A Base Card is rendered in outline only and is NOT playable. It can be
   // added to the base of a Pile (e.g. the Stock Pile) to allow it to handle
   // taps and short drags (on an empty Pile) with the same behavior and
   // tolerances as for regular cards (see KlondikeGame.dragTolerance) and using
   // the same event-handling code, but with different handleTapUp() methods.
+  final bool isBaseCard;
 
   bool _faceUp = false;
   bool _isAnimatedFlip = false;
@@ -271,8 +272,8 @@ class Card extends PositionComponent
       _isDragging = false;
       return;
     }
-    // Copy each co-ord, else _whereCardStarted changes as the position does.
-    _whereCardStarted = Vector2(position.x, position.y);
+    // Clone the position, else _whereCardStarted changes as the position does.
+    _whereCardStarted = position.clone();
     attachedCards.clear();
     if (pile?.canMoveCard(this, MoveMethod.drag) ?? false) {
       _isDragging = true;

--- a/doc/tutorials/klondike/app/lib/step5/components/card.dart
+++ b/doc/tutorials/klondike/app/lib/step5/components/card.dart
@@ -17,7 +17,7 @@ import 'tableau_pile.dart';
 
 class Card extends PositionComponent
     with DragCallbacks, TapCallbacks, HasWorldReference<KlondikeWorld> {
-  Card(int intRank, int intSuit)
+  Card(int intRank, int intSuit, {this.isBaseCard = false})
       : rank = Rank.fromInt(intRank),
         suit = Suit.fromInt(intSuit),
         super(
@@ -27,6 +27,13 @@ class Card extends PositionComponent
   final Rank rank;
   final Suit suit;
   Pile? pile;
+  final bool isBaseCard;
+  // A Base Card is rendered in outline only and is NOT playable. It can be
+  // added to the base of a Pile (e.g. the Stock Pile) to allow it to handle
+  // taps and short drags (on an empty Pile) with the same behavior and
+  // tolerances as for regular cards (see KlondikeGame.dragTolerance) and using
+  // the same event-handling code, but with different handleTapUp() methods.
+
   bool _faceUp = false;
   bool _isAnimatedFlip = false;
   bool _isFaceUpView = false;
@@ -55,6 +62,10 @@ class Card extends PositionComponent
 
   @override
   void render(Canvas canvas) {
+    if (isBaseCard) {
+      _renderBaseCard(canvas);
+      return;
+    }
     if (_isFaceUpView) {
       _renderFront(canvas);
     } else {
@@ -84,6 +95,10 @@ class Card extends PositionComponent
     canvas.drawRRect(cardRRect, backBorderPaint1);
     canvas.drawRRect(backRRectInner, backBorderPaint2);
     flameSprite.render(canvas, position: size / 2, anchor: Anchor.center);
+  }
+
+  void _renderBaseCard(Canvas canvas) {
+    canvas.drawRRect(cardRRect, backBorderPaint1);
   }
 
   static final Paint frontBackgroundPaint = Paint()
@@ -242,15 +257,27 @@ class Card extends PositionComponent
   //#region Card-Dragging
 
   @override
+  void onTapCancel(TapCancelEvent event) {
+    if (pile is StockPile) {
+      _isDragging = false;
+      handleTapUp();
+    }
+  }
+
+  @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
+    if (pile is StockPile) {
+      _isDragging = false;
+      return;
+    }
+    // Copy each co-ord, else _whereCardStarted changes as the position does.
+    _whereCardStarted = Vector2(position.x, position.y);
+    attachedCards.clear();
     if (pile?.canMoveCard(this, MoveMethod.drag) ?? false) {
       _isDragging = true;
       priority = 100;
-      // Copy each co-ord, else _whereCardStarted changes as the position does.
-      _whereCardStarted = Vector2(position.x, position.y);
       if (pile is TableauPile) {
-        attachedCards.clear();
         final extraCards = (pile! as TableauPile).cardsOnTop(this);
         for (final card in extraCards) {
           card.priority = attachedCards.length + 101;
@@ -277,6 +304,22 @@ class Card extends PositionComponent
       return;
     }
     _isDragging = false;
+
+    // If short drag, return card to Pile and treat it as having been tapped.
+    final shortDrag =
+        (position - _whereCardStarted).length < KlondikeGame.dragTolerance;
+    if (shortDrag && attachedCards.isEmpty) {
+      doMove(
+        _whereCardStarted,
+        onComplete: () {
+          pile!.returnCard(this);
+          // Card moves to its Foundation Pile next, if valid, or it stays put.
+          handleTapUp();
+        },
+      );
+      return;
+    }
+
     // Find out what is under the center-point of this card when it is dropped.
     final dropPiles = parent!
         .componentsAtPoint(position + size / 2)
@@ -284,8 +327,7 @@ class Card extends PositionComponent
         .toList();
     if (dropPiles.isNotEmpty) {
       if (dropPiles.first.canAcceptCard(this)) {
-        // Found a Pile.
-        // Move card(s) gracefully into position on the receiving pile.
+        // Found a Pile: move card(s) the rest of the way onto it.
         pile!.removeCard(this, MoveMethod.drag);
         if (dropPiles.first is TableauPile) {
           // Get TableauPile to handle positions, priorities and moves of cards.
@@ -335,6 +377,12 @@ class Card extends PositionComponent
 
   @override
   void onTapUp(TapUpEvent event) {
+    handleTapUp();
+  }
+
+  void handleTapUp() {
+    // Can be called by onTapUp or after a very short (failed) drag-and-drop.
+    // We need to be more user-friendly towards taps that include a short drag.
     if (pile?.canMoveCard(this, MoveMethod.tap) ?? false) {
       final suitIndex = suit.value;
       if (world.foundations[suitIndex].canAcceptCard(this)) {
@@ -347,7 +395,7 @@ class Card extends PositionComponent
         );
       }
     } else if (pile is StockPile) {
-      world.stock.onTapUp(event);
+      world.stock.handleTapUp(this);
     }
   }
 

--- a/doc/tutorials/klondike/app/lib/step5/components/stock_pile.dart
+++ b/doc/tutorials/klondike/app/lib/step5/components/stock_pile.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
-import 'package:flame/events.dart';
 
 import '../klondike_game.dart';
 import '../pile.dart';
@@ -9,7 +8,7 @@ import 'card.dart';
 import 'waste_pile.dart';
 
 class StockPile extends PositionComponent
-    with TapCallbacks, HasGameReference<KlondikeGame>
+    with HasGameReference<KlondikeGame>
     implements Pile {
   StockPile({super.position}) : super(size: KlondikeGame.cardSize);
 
@@ -31,7 +30,8 @@ class StockPile extends PositionComponent
       throw StateError('cannot remove cards');
 
   @override
-  void returnCard(Card card) => throw StateError('cannot remove cards');
+  // Card cannot be removed but could have been dragged out of place.
+  void returnCard(Card card) => card.priority = _cards.indexOf(card);
 
   @override
   void acquireCard(Card card) {
@@ -44,10 +44,11 @@ class StockPile extends PositionComponent
 
   //#endregion
 
-  @override
-  void onTapUp(TapUpEvent event) {
+  void handleTapUp(Card card) {
     final wastePile = parent!.firstChild<WastePile>()!;
     if (_cards.isEmpty) {
+      assert(card.isBaseCard, 'Stock Pile is empty, but no Base Card present');
+      card.position = position; // Force Base Card (back) into correct position.
       wastePile.removeAllCards().reversed.forEach((card) {
         card.flip();
         acquireCard(card);

--- a/doc/tutorials/klondike/app/lib/step5/klondike_game.dart
+++ b/doc/tutorials/klondike/app/lib/step5/klondike_game.dart
@@ -22,6 +22,9 @@ class KlondikeGame extends FlameGame<KlondikeWorld> {
     const Radius.circular(cardRadius),
   );
 
+  // Constant used to decide when a short drag will be treated as a TapUp event.
+  static const double dragTolerance = cardWidth / 5;
+
   // Constant used when creating Random seed.
   static const int maxInt = 0xFFFFFFFE; // = (2 to the power 32) - 1
 

--- a/doc/tutorials/klondike/app/lib/step5/klondike_game.dart
+++ b/doc/tutorials/klondike/app/lib/step5/klondike_game.dart
@@ -22,10 +22,10 @@ class KlondikeGame extends FlameGame<KlondikeWorld> {
     const Radius.circular(cardRadius),
   );
 
-  // Constant used to decide when a short drag will be treated as a TapUp event.
+  /// Constant used to decide when a short drag is treated as a TapUp event.
   static const double dragTolerance = cardWidth / 5;
 
-  // Constant used when creating Random seed.
+  /// Constant used when creating Random seed.
   static const int maxInt = 0xFFFFFFFE; // = (2 to the power 32) - 1
 
   // This KlondikeGame constructor also initiates the first KlondikeWorld.

--- a/doc/tutorials/klondike/app/lib/step5/klondike_world.dart
+++ b/doc/tutorials/klondike/app/lib/step5/klondike_world.dart
@@ -51,6 +51,14 @@ class KlondikeWorld extends World with HasGameReference<KlondikeGame> {
         ),
       );
     }
+
+    // Add a Base Card to the Stock Pile, above the pile and below other cards.
+    final baseCard = Card(1, 0, isBaseCard: true);
+    baseCard.position = stock.position;
+    baseCard.priority = -1;
+    baseCard.pile = stock;
+    stock.priority = -2;
+
     for (var rank = 1; rank <= 13; rank++) {
       for (var suit = 0; suit < 4; suit++) {
         final card = Card(rank, suit);
@@ -64,6 +72,7 @@ class KlondikeWorld extends World with HasGameReference<KlondikeGame> {
     addAll(foundations);
     addAll(tableauPiles);
     addAll(cards);
+    add(baseCard);
 
     playAreaSize =
         Vector2(7 * cardSpaceWidth + cardGap, 4 * cardSpaceHeight + topGap);


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
The objective of this fix is to make a tap on a card more positive-feeling for the player and not to disappear silently if it is interpreted as a drag.

It adds a Base Card to make an empty Stock Pile behave as a Card and use the tap and drag logic of the `Card` class. Any attempted drag on a Stock Pile card, including the Base Card, is now changed to a tap in onTapCancel() and the drag is not followed. The Base Card is rendered in outline only and does *not* take part in gameplay.

In other Piles a short drag is either treated as a tap or ignored. Only the Waste and Tableau Piles allow such taps. As before in Klondike Step5, they result in the tapped card moving automatically to its Foundation Pile if it is eligible to "go out".

As before in Klondike Step4 and Step5, all piles except the Stock Pile allow drags to start on them and they can finish on a Foundation Pile or a Tableau Pile.


<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->

Closes #2890.

When testing, try sliding the finger or mouse slightly while making a tap.

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
