### PR TITLE
feat: Add clearSnapshot function

### DIFF
--- a/packages/flame/lib/src/components/mixins/snapshot.dart
+++ b/packages/flame/lib/src/components/mixins/snapshot.dart
@@ -69,7 +69,7 @@ mixin Snapshot on PositionComponent {
     return _picture!;
   }
 
-  /// clear the current snapshot. will trigger the creation of a new snapshot 
+  /// clear the current snapshot. will trigger the creation of a new snapshot
   /// next time renderTree is called.
   void clearSnapshot() {
     _picture = null;


### PR DESCRIPTION
# Description
The Snapshot mixin was missing a function to clear the snapshot. This is useful for when you want to invalidate the picture, but don't want to immediately pre-render the image yet.

## Checklist
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.