### PR TITLE
docs: Fix typo in TextComponent sample code

### DIFF
--- a/doc/flame/rendering/text_rendering.md
+++ b/doc/flame/rendering/text_rendering.md
@@ -29,7 +29,7 @@ class MyGame extends FlameGame {
     add(
       TextComponent(
         text: 'Hello, Flame',
-        position = Vector2.all(16.0),
+        position: Vector2.all(16.0),
       ),
     );
   }


### PR DESCRIPTION
This changed `=` to `:` when calling named parameter `position`.
