### PR TITLE
chore(release): Flame v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,72 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-12-08
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`flame` - `v1.12.0`](#flame---v1120)
+ - [`flame_riverpod` - `v5.1.0`](#flame_riverpod---v510)
+ - [`flame_test` - `v1.15.1`](#flame_test---v1151)
+ - [`flame_tiled` - `v1.18.1`](#flame_tiled---v1181)
+ - [`flame_oxygen` - `v0.1.9+5`](#flame_oxygen---v0195)
+ - [`flame_isolate` - `v0.5.0+5`](#flame_isolate---v0505)
+ - [`flame_fire_atlas` - `v1.4.5`](#flame_fire_atlas---v145)
+ - [`flame_audio` - `v2.1.5`](#flame_audio---v215)
+ - [`flame_spine` - `v0.1.1+7`](#flame_spine---v0117)
+ - [`flame_bloc` - `v1.10.7`](#flame_bloc---v1107)
+ - [`flame_lottie` - `v0.3.0+5`](#flame_lottie---v0305)
+ - [`flame_markdown` - `v0.1.1+5`](#flame_markdown---v0115)
+ - [`flame_rive` - `v1.9.8`](#flame_rive---v198)
+ - [`flame_forge2d` - `v0.16.0+2`](#flame_forge2d---v01602)
+ - [`flame_noise` - `v0.1.1+10`](#flame_noise---v01110)
+ - [`flame_svg` - `v1.8.7`](#flame_svg---v187)
+ - [`flame_network_assets` - `v0.2.0+10`](#flame_network_assets---v02010)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `flame_test` - `v1.15.1`
+ - `flame_tiled` - `v1.18.1`
+ - `flame_oxygen` - `v0.1.9+5`
+ - `flame_isolate` - `v0.5.0+5`
+ - `flame_fire_atlas` - `v1.4.5`
+ - `flame_audio` - `v2.1.5`
+ - `flame_spine` - `v0.1.1+7`
+ - `flame_bloc` - `v1.10.7`
+ - `flame_lottie` - `v0.3.0+5`
+ - `flame_markdown` - `v0.1.1+5`
+ - `flame_rive` - `v1.9.8`
+ - `flame_forge2d` - `v0.16.0+2`
+ - `flame_noise` - `v0.1.1+10`
+ - `flame_svg` - `v1.8.7`
+ - `flame_network_assets` - `v0.2.0+10`
+
+---
+
+#### `flame` - `v1.12.0`
+
+ - **FIX**: SpriteAnimationWidget was resetting the ticker even when the playing didn't changed ([#2891](https://github.com/flame-engine/flame/issues/2891)). ([9aed8b4d](https://github.com/flame-engine/flame/commit/9aed8b4dea3074c9ca708ad991cdc90b12707fbe))
+ - **FEAT**: Scrollable TextBoxComponent ([#2901](https://github.com/flame-engine/flame/issues/2901)). ([8c3cb725](https://github.com/flame-engine/flame/commit/8c3cb725413c46089854713f6ecc4617e1f15600))
+ - **FEAT**: Add collision completed listener ([#2896](https://github.com/flame-engine/flame/issues/2896)). ([957db3c1](https://github.com/flame-engine/flame/commit/957db3c1ed476b22f7cc62d4df22595449f8756c))
+ - **FEAT**: Adding autoResetTicker option to SpriteAnimationGroupComponent ([#2899](https://github.com/flame-engine/flame/issues/2899)). ([001c870d](https://github.com/flame-engine/flame/commit/001c870d61be6e7e7aae798df0dc33e5321ed882))
+ - **FEAT**: Add clearSnapshot function ([#2897](https://github.com/flame-engine/flame/issues/2897)). ([d4decd21](https://github.com/flame-engine/flame/commit/d4decd21eb7506ffd6d84ab5a3ebf1f2067083b6))
+
+#### `flame_riverpod` - `v5.1.0`
+
+ - **FIX**: SpriteAnimationWidget was resetting the ticker even when the playing didn't changed ([#2891](https://github.com/flame-engine/flame/issues/2891)). ([9aed8b4d](https://github.com/flame-engine/flame/commit/9aed8b4dea3074c9ca708ad991cdc90b12707fbe))
+ - **FEAT**: Integration of flame_riverpod ([#2367](https://github.com/flame-engine/flame/issues/2367)). ([0c74560b](https://github.com/flame-engine/flame/commit/0c74560b2e25e86163c6c678ef6515bc11f9c3e7))
+
+
 ## 2023-11-30
 
 ### Changes

--- a/doc/flame/examples/pubspec.yaml
+++ b/doc/flame/examples/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_rive: ^1.9.7
+  flame: ^1.12.0
+  flame_rive: ^1.9.8
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/klondike/app/pubspec.yaml
+++ b/doc/tutorials/klondike/app/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/platformer/app/pubspec.yaml
+++ b/doc/tutorials/platformer/app/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/space_shooter/app/pubspec.yaml
+++ b/doc/tutorials/space_shooter/app/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
 

--- a/examples/games/padracing/pubspec.yaml
+++ b/examples/games/padracing/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.11.0
-  flame_forge2d: ^0.16.0+1
+  flame: ^1.12.0
+  flame_forge2d: ^0.16.0+2
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/examples/games/rogue_shooter/pubspec.yaml
+++ b/examples/games/rogue_shooter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
 

--- a/examples/games/trex/pubspec.yaml
+++ b/examples/games/trex/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
 

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -11,15 +11,15 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.11.0
-  flame_audio: ^2.1.4
-  flame_forge2d: ^0.16.0+1
-  flame_isolate: ^0.5.0+4
-  flame_lottie: ^0.3.0+4
-  flame_noise: ^0.1.1+9
-  flame_spine: ^0.1.1+6
-  flame_svg: ^1.8.6
-  flame_tiled: ^1.18.0
+  flame: ^1.12.0
+  flame_audio: ^2.1.5
+  flame_forge2d: ^0.16.0+2
+  flame_isolate: ^0.5.0+5
+  flame_lottie: ^0.3.0+5
+  flame_noise: ^0.1.1+10
+  flame_spine: ^0.1.1+7
+  flame_svg: ^1.8.7
+  flame_tiled: ^1.18.1
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.12.0
+
+ - **FIX**: SpriteAnimationWidget was resetting the ticker even when the playing didn't changed ([#2891](https://github.com/flame-engine/flame/issues/2891)). ([9aed8b4d](https://github.com/flame-engine/flame/commit/9aed8b4dea3074c9ca708ad991cdc90b12707fbe))
+ - **FEAT**: Scrollable TextBoxComponent ([#2901](https://github.com/flame-engine/flame/issues/2901)). ([8c3cb725](https://github.com/flame-engine/flame/commit/8c3cb725413c46089854713f6ecc4617e1f15600))
+ - **FEAT**: Add collision completed listener ([#2896](https://github.com/flame-engine/flame/issues/2896)). ([957db3c1](https://github.com/flame-engine/flame/commit/957db3c1ed476b22f7cc62d4df22595449f8756c))
+ - **FEAT**: Adding autoResetTicker option to SpriteAnimationGroupComponent ([#2899](https://github.com/flame-engine/flame/issues/2899)). ([001c870d](https://github.com/flame-engine/flame/commit/001c870d61be6e7e7aae798df0dc33e5321ed882))
+ - **FEAT**: Add clearSnapshot function ([#2897](https://github.com/flame-engine/flame/issues/2897)). ([d4decd21](https://github.com/flame-engine/flame/commit/d4decd21eb7506ffd6d84ab5a3ebf1f2067083b6))
+
 ## 1.11.0
 
 > Note: This release has breaking changes.

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
 

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 1.11.0
+version: 1.12.0
 homepage: https://github.com/flame-engine/flame
 funding:
   - https://opencollective.com/blue-fire
@@ -23,7 +23,7 @@ dev_dependencies:
   canvas_test: ^0.2.0
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.0
+  flame_test: ^1.15.1
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.1

--- a/packages/flame_audio/CHANGELOG.md
+++ b/packages/flame_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5
+
+ - Update a dependency to the latest release.
+
 ## 2.1.4
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_audio/example/pubspec.yaml
+++ b/packages/flame_audio/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_audio: ^2.1.4
+  flame: ^1.12.0
+  flame_audio: ^2.1.5
   flutter:
     sdk: flutter
 

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_audio
 description: |
   Audio support for the Flame game engine, basically a thin wrapper around the audioplayers package.
-version: 2.1.4
+version: 2.1.5
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_audio
 funding:
   - https://opencollective.com/blue-fire
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   audioplayers: ^5.0.0
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   synchronized: ^3.1.0

--- a/packages/flame_bloc/CHANGELOG.md
+++ b/packages/flame_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.7
+
+ - Update a dependency to the latest release.
+
 ## 1.10.6
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_bloc/example/pubspec.yaml
+++ b/packages/flame_bloc/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  flame: ^1.11.0
-  flame_bloc: ^1.10.6
+  flame: ^1.12.0
+  flame_bloc: ^1.10.7
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_bloc
 description: Integration for the Bloc state management library to Flame games.
-version: 1.10.6
+version: 1.10.7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_bloc
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   bloc: ^8.1.1
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.0
+  flame_test: ^1.15.1
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter

--- a/packages/flame_fire_atlas/CHANGELOG.md
+++ b/packages/flame_fire_atlas/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.5
+
+ - Update a dependency to the latest release.
+
 ## 1.4.4
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_fire_atlas/example/pubspec.yaml
+++ b/packages/flame_fire_atlas/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_fire_atlas: ^1.4.4
+  flame: ^1.12.0
+  flame_fire_atlas: ^1.4.5
   flutter:
     sdk: flutter
 

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_fire_atlas
 description: Easy to use texture atlases for the flame engine created with the
   fire atlas editor
-version: 1.4.4
+version: 1.4.5
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_fire_atlas
 funding:
   - https://opencollective.com/blue-fire
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   archive: ^3.3.9
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.0+2
+
+ - Update a dependency to the latest release.
+
 ## 0.16.0+1
 
  - Update a dependency to the latest release.

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.11.0
-  flame_forge2d: ^0.16.0+1
+  flame: ^1.12.0
+  flame_forge2d: ^0.16.0+2
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_forge2d
 description: Forge2D (Box2D) support for the Flame game engine. This uses the forge2d package and provides wrappers and components to be used inside Flame.
-version: 0.16.0+1
+version: 0.16.0+2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_forge2d
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   forge2d: ">=0.12.2 <0.13.0"
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.0
+  flame_test: ^1.15.1
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.1

--- a/packages/flame_isolate/CHANGELOG.md
+++ b/packages/flame_isolate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+5
+
+ - Update a dependency to the latest release.
+
 ## 0.5.0+4
 
  - **DOCS**: Update flame_isolate to point at repository ([#2880](https://github.com/flame-engine/flame/issues/2880)). ([06fdeac6](https://github.com/flame-engine/flame/commit/06fdeac684b2be26206d50282e6a7f2cbac4264c))

--- a/packages/flame_isolate/example/pubspec.yaml
+++ b/packages/flame_isolate/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.11.0
-  flame_isolate: ^0.5.0+4
+  flame: ^1.12.0
+  flame_isolate: ^0.5.0+5
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0

--- a/packages/flame_isolate/pubspec.yaml
+++ b/packages/flame_isolate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_isolate
 description: Flame wrapper for integral_isolates making multi-threading easy in Flame
-version: 0.5.0+4
+version: 0.5.0+5
 repository: https://github.com/flame-engine/flame/blob/main/packages/flame_isolate
 
 environment:
@@ -8,14 +8,14 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0
 
 dev_dependencies:
   flame_lint: ^1.1.2
-  flame_test: ^1.15.0
+  flame_test: ^1.15.1
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_jenny/pubspec.yaml
+++ b/packages/flame_jenny/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   jenny: ^1.2.1

--- a/packages/flame_lottie/CHANGELOG.md
+++ b/packages/flame_lottie/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+5
+
+ - Update a dependency to the latest release.
+
 ## 0.3.0+4
 
  - Update a dependency to the latest release.

--- a/packages/flame_lottie/example/pubspec.yaml
+++ b/packages/flame_lottie/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_lottie: ^0.3.0+4
+  flame: ^1.12.0
+  flame_lottie: ^0.3.0+5
   flutter:
     sdk: flutter
   lottie:

--- a/packages/flame_lottie/pubspec.yaml
+++ b/packages/flame_lottie/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_lottie
 description: Flame wrapper for Lottie by AirBnB. This package implements a bridge between Lottie and Flame, allowing to load and display Lottie animations.
-version: 0.3.0+4
+version: 0.3.0+5
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_lottie
 funding:
   - https://opencollective.com/blue-fire
@@ -12,14 +12,14 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   lottie: ^2.3.2
 
 dev_dependencies:
   flame_lint: ^1.1.2
-  flame_test: ^1.15.0
+  flame_test: ^1.15.1
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_markdown/CHANGELOG.md
+++ b/packages/flame_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+5
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+4
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_markdown/example/pubspec.yaml
+++ b/packages/flame_markdown/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_markdown: ^0.1.1+4
+  flame: ^1.12.0
+  flame_markdown: ^0.1.1+5
   flutter:
     sdk: flutter
 

--- a/packages/flame_markdown/pubspec.yaml
+++ b/packages/flame_markdown/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_markdown
 description: |
   Markdown support for the Flame game engine, bridging the markdown package into Flame's text rendering pipeline.
-version: 0.1.1+4
+version: 0.1.1+5
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_markdown
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   markdown: ^7.1.1

--- a/packages/flame_network_assets/CHANGELOG.md
+++ b/packages/flame_network_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+10
+
+ - Update a dependency to the latest release.
+
 ## 0.2.0+9
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_network_assets/example/pubspec.yaml
+++ b/packages/flame_network_assets/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_network_assets: ^0.2.0+9
+  flame: ^1.12.0
+  flame_network_assets: ^0.2.0+10
   flutter:
     sdk: flutter
 

--- a/packages/flame_network_assets/pubspec.yaml
+++ b/packages/flame_network_assets/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_network_assets
 description: Network assets support for Flame.
-version: 0.2.0+9
+version: 0.2.0+10
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_network_assets
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   dev: ^1.0.0
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   http: ^0.13.6

--- a/packages/flame_noise/CHANGELOG.md
+++ b/packages/flame_noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+10
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+9
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_noise/pubspec.yaml
+++ b/packages/flame_noise/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_noise
 description: Integrate the fast_noise package into Flame
-version: 0.1.1+9
+version: 0.1.1+10
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_noise
 funding:
   - https://opencollective.com/blue-fire
@@ -13,12 +13,12 @@ environment:
 
 dependencies:
   fast_noise: ^1.0.1
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.0
+  flame_test: ^1.15.1
   test: any

--- a/packages/flame_oxygen/CHANGELOG.md
+++ b/packages/flame_oxygen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.9+5
+
+ - Update a dependency to the latest release.
+
 ## 0.1.9+4
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_oxygen/example/pubspec.yaml
+++ b/packages/flame_oxygen/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_oxygen: ^0.1.9+4
+  flame: ^1.12.0
+  flame_oxygen: ^0.1.9+5
   flutter:
     sdk: flutter
 

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_oxygen
 description: Integrate the Oxygen ECS with the Flame Engine.
-version: 0.1.9+4
+version: 0.1.9+5
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_oxygen
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   oxygen: ^0.2.0

--- a/packages/flame_rive/CHANGELOG.md
+++ b/packages/flame_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.8
+
+ - Update a dependency to the latest release.
+
 ## 1.9.7
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_rive: ^1.9.7
+  flame: ^1.12.0
+  flame_rive: ^1.9.8
   flutter:
     sdk: flutter
   rive: ^0.12.3

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_rive
 description: Rive support for the Flame game engine. This uses the rive package and provides wrappers and components to be used inside Flame.
 homepage: https://github.com/flame-engine/flame
-version: 1.9.7
+version: 1.9.8
 funding:
   - https://opencollective.com/blue-fire
   - https://github.com/sponsors/bluefireteam
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   rive: ^0.12.3
@@ -20,6 +20,6 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.0
+  flame_test: ^1.15.1
   flutter_test:
     sdk: flutter

--- a/packages/flame_riverpod/CHANGELOG.md
+++ b/packages/flame_riverpod/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.1.0
+
+ - **FIX**: SpriteAnimationWidget was resetting the ticker even when the playing didn't changed ([#2891](https://github.com/flame-engine/flame/issues/2891)). ([9aed8b4d](https://github.com/flame-engine/flame/commit/9aed8b4dea3074c9ca708ad991cdc90b12707fbe))
+ - **FEAT**: Integration of flame_riverpod ([#2367](https://github.com/flame-engine/flame/issues/2367)). ([0c74560b](https://github.com/flame-engine/flame/commit/0c74560b2e25e86163c6c678ef6515bc11f9c3e7))
+
 ## 5.0.0
 
 * New API with breaking changes. Added [RiverpodAwareGameWidget], [RiverpodGameMixin], [RiverpodComponentMixin]. See the example for details.

--- a/packages/flame_riverpod/example/pubspec.yaml
+++ b/packages/flame_riverpod/example/pubspec.yaml
@@ -5,8 +5,8 @@ version: 1.0.0+1
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
-  flame: ^1.10.1
-  flame_riverpod: ^5.0.0
+  flame: ^1.12.0
+  flame_riverpod: ^5.1.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.1.3

--- a/packages/flame_riverpod/pubspec.yaml
+++ b/packages/flame_riverpod/pubspec.yaml
@@ -1,13 +1,13 @@
 name: flame_riverpod
 description: Helpers for using Riverpod - a reactive caching and data-binding framework, 
   in conjunction with Flame.
-version: 5.0.0
+version: 5.1.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_riverpod
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"
 dependencies:
-  flame: ^1.10.1
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.1.3

--- a/packages/flame_spine/CHANGELOG.md
+++ b/packages/flame_spine/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+7
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+6
 
  - **FIX**: Removing spine flutter overriding ([#2877](https://github.com/flame-engine/flame/issues/2877)). ([f4ff3117](https://github.com/flame-engine/flame/commit/f4ff31174a0498dd8af90f815ad9c098df3b30b7))

--- a/packages/flame_spine/example/pubspec.yaml
+++ b/packages/flame_spine/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_spine: ^0.1.1+6
+  flame: ^1.12.0
+  flame_spine: ^0.1.1+7
   flutter:
     sdk: flutter
 

--- a/packages/flame_spine/pubspec.yaml
+++ b/packages/flame_spine/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_spine
 description: Spine support for the Flame game engine. This uses the spine_flutter package and provides wrappers and components to be used inside Flame.
-version: 0.1.1+6
+version: 0.1.1+7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_sprine
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   spine_flutter: ^4.2.18

--- a/packages/flame_studio/pubspec.yaml
+++ b/packages/flame_studio/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.3.6

--- a/packages/flame_svg/CHANGELOG.md
+++ b/packages/flame_svg/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.7
+
+ - Update a dependency to the latest release.
+
 ## 1.8.6
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_svg: ^1.8.6
+  flame: ^1.12.0
+  flame_svg: ^1.8.7
   flutter:
     sdk: flutter
 

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_svg
 description: Package to add SVG rendering support for the Flame game engine
-version: 1.8.6
+version: 1.8.7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_svg
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.5

--- a/packages/flame_test/CHANGELOG.md
+++ b/packages/flame_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.1
+
+ - Update a dependency to the latest release.
+
 ## 1.15.0
 
  - **FIX**: Minor issues due Flutter 3.16 ([#2856](https://github.com/flame-engine/flame/issues/2856)). ([d51cd584](https://github.com/flame-engine/flame/commit/d51cd584c71a27c242c2f4600282cf8359daaa17))

--- a/packages/flame_test/example/pubspec.yaml
+++ b/packages/flame_test/example/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flame_lint: ^1.1.2
-  flame_test: ^1.15.0
+  flame_test: ^1.15.1
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_test
 description: A package with classes to help testing applications using Flame
-version: 1.15.0
+version: 1.15.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_test
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/flame_tiled/CHANGELOG.md
+++ b/packages/flame_tiled/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.1
+
+ - Update a dependency to the latest release.
+
 ## 1.18.0
 
  - **FIX**: TiledComponent.atlases had duplicated values ([#2867](https://github.com/flame-engine/flame/issues/2867)). ([e56ad187](https://github.com/flame-engine/flame/commit/e56ad1878333ba19e0c8af3fb9c9758603662330))

--- a/packages/flame_tiled/example/pubspec.yaml
+++ b/packages/flame_tiled/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.11.0
-  flame_tiled: ^1.18.0
+  flame: ^1.12.0
+  flame_tiled: ^1.18.1
   flutter:
     sdk: flutter
 

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_tiled
 description: Tiled support for the Flame game engine. This uses the tiled package and provides wrappers and components to be used inside Flame.
-version: 1.18.0
+version: 1.18.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_tiled
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.11.0
+  flame: ^1.12.0
   flutter:
     sdk: flutter
   meta: ^1.9.1


### PR DESCRIPTION
```
The following 17 packages will be updated:

Package Name           Current Version   Updated Version   Update Reason
flame                  1.11.0            1.12.0            updated with minor changes
flame_riverpod         5.0.0             5.1.0             updated with minor changes
flame_test             1.15.0            1.15.1            dependency was updated
flame_tiled            1.18.0            1.18.1            dependency was updated
flame_oxygen           0.1.9+4           0.1.9+5           dependency was updated
flame_isolate          0.5.0+4           0.5.0+5           dependency was updated
flame_fire_atlas       1.4.4             1.4.5             dependency was updated
flame_audio            2.1.4             2.1.5             dependency was updated
flame_spine            0.1.1+6           0.1.1+7           dependency was updated
flame_bloc             1.10.6            1.10.7            dependency was updated
flame_lottie           0.3.0+4           0.3.0+5           dependency was updated
flame_markdown         0.1.1+4           0.1.1+5           dependency was updated
flame_rive             1.9.7             1.9.8             dependency was updated
flame_forge2d          0.16.0+1          0.16.0+2          dependency was updated
flame_noise            0.1.1+9           0.1.1+10          dependency was updated
flame_svg              1.8.6             1.8.7             dependency was updated
flame_network_assets   0.2.0+9           0.2.0+10          dependency was updated
```