### PR TITLE
fix: Allow setting `bounds` while `BoundedPositionBehavior`'s target is null

### DIFF
--- a/packages/flame/lib/src/camera/behaviors/bounded_position_behavior.dart
+++ b/packages/flame/lib/src/camera/behaviors/bounded_position_behavior.dart
@@ -36,7 +36,9 @@ class BoundedPositionBehavior extends Component {
     _bounds = newBounds;
     if (!isValidPoint(_previousPosition)) {
       _previousPosition.setFrom(_bounds.center);
-      update(0);
+      if (_target != null) {
+        update(0);
+      }
     }
   }
 

--- a/packages/flame/test/camera/behaviors/bounded_position_behavior_test.dart
+++ b/packages/flame/test/camera/behaviors/bounded_position_behavior_test.dart
@@ -38,6 +38,13 @@ void main() {
       );
     });
 
+    test('update bounds while target is null', () {
+      final circle1 = Circle(Vector2.zero(), 10);
+      final circle2 = Circle(Vector2.all(30), 10);
+      final boundedPositionBehavior = BoundedPositionBehavior(bounds: circle1);
+      expect(() => boundedPositionBehavior.bounds = circle2, returnsNormally);
+    });
+
     testWithFlameGame('bad parent', (game) async {
       final shape = Circle(Vector2.zero(), 10);
       final parent = Component()..addToParent(game);


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
The `bounds` setter of `BoundedPositionBehavior` tries to update the target's position when bounds are updated. But it wasn't checking if the target is null. This was causing null exceptions while updating bounds of an unmounted `BoundedPositionBehavior` with null target (as seen in [this failing test case](https://github.com/flame-engine/flame/actions/runs/7231182930/job/19704091006#step:5:1291)). This PR fixes that by checking if the target is null before updating the position.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->
Closes #2655 

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
