### PR TITLE
chore(release): Flame v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,80 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-12-19
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`flame` - `v1.13.0`](#flame---v1130)
+ - [`flame_rive` - `v1.9.9`](#flame_rive---v199)
+ - [`flame_riverpod` - `v5.1.1`](#flame_riverpod---v511)
+ - [`flame_tiled` - `v1.18.2`](#flame_tiled---v1182)
+ - [`flame_test` - `v1.15.2`](#flame_test---v1152)
+ - [`flame_oxygen` - `v0.1.9+6`](#flame_oxygen---v0196)
+ - [`flame_isolate` - `v0.5.0+6`](#flame_isolate---v0506)
+ - [`flame_fire_atlas` - `v1.4.6`](#flame_fire_atlas---v146)
+ - [`flame_audio` - `v2.1.6`](#flame_audio---v216)
+ - [`flame_spine` - `v0.1.1+8`](#flame_spine---v0118)
+ - [`flame_bloc` - `v1.10.8`](#flame_bloc---v1108)
+ - [`flame_lottie` - `v0.3.0+6`](#flame_lottie---v0306)
+ - [`flame_markdown` - `v0.1.1+6`](#flame_markdown---v0116)
+ - [`flame_svg` - `v1.8.8`](#flame_svg---v188)
+ - [`flame_forge2d` - `v0.16.0+3`](#flame_forge2d---v01603)
+ - [`flame_noise` - `v0.1.1+11`](#flame_noise---v01111)
+ - [`flame_network_assets` - `v0.2.0+11`](#flame_network_assets---v02011)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `flame_test` - `v1.15.2`
+ - `flame_oxygen` - `v0.1.9+6`
+ - `flame_isolate` - `v0.5.0+6`
+ - `flame_fire_atlas` - `v1.4.6`
+ - `flame_audio` - `v2.1.6`
+ - `flame_spine` - `v0.1.1+8`
+ - `flame_bloc` - `v1.10.8`
+ - `flame_lottie` - `v0.3.0+6`
+ - `flame_markdown` - `v0.1.1+6`
+ - `flame_svg` - `v1.8.8`
+ - `flame_forge2d` - `v0.16.0+3`
+ - `flame_noise` - `v0.1.1+11`
+ - `flame_network_assets` - `v0.2.0+11`
+
+---
+
+#### `flame` - `v1.13.0`
+
+ - **FIX**: Logic error in MemoryCache.setValue() ([#2931](https://github.com/flame-engine/flame/issues/2931)). ([8cee80c3](https://github.com/flame-engine/flame/commit/8cee80c35ca676ad25a25c771f0aade88b58150b))
+ - **FIX**: Export `ScalingParticle` ([#2928](https://github.com/flame-engine/flame/issues/2928)). ([3730cb1d](https://github.com/flame-engine/flame/commit/3730cb1d834c73c87dc3597554039fd0f0a32bae))
+ - **FIX**: Misalignment of the hittest area of PolygonHitbox ([#2930](https://github.com/flame-engine/flame/issues/2930)). ([dbdb1379](https://github.com/flame-engine/flame/commit/dbdb1379d0bc1b6ac02b3ee27f62263bd1be3fc3))
+ - **FIX**: Allow setting `bounds` while `BoundedPositionBehavior`'s target is null ([#2926](https://github.com/flame-engine/flame/issues/2926)). ([bab9be6e](https://github.com/flame-engine/flame/commit/bab9be6e7051b7be6c84fc9760c7347692dbf140))
+ - **FEAT**: Ability to use `selfPositioning` in `SpawnComponent` ([#2927](https://github.com/flame-engine/flame/issues/2927)). ([b526aa14](https://github.com/flame-engine/flame/commit/b526aa1488c0f891edb356007ebc2c5c2de596b5))
+ - **FEAT**: Add `margin` and `spacing` properties to `SpriteSheet` ([#2925](https://github.com/flame-engine/flame/issues/2925)). ([67f7c126](https://github.com/flame-engine/flame/commit/67f7c126b4c8052df99ffa8c657a90cc7fb6f867))
+ - **FEAT**: Add `children` to `SpriteAnimationComponent.fromFrameData` ([#2914](https://github.com/flame-engine/flame/issues/2914)). ([caf2b909](https://github.com/flame-engine/flame/commit/caf2b90930ca500c85b9f9f63e7d3d7a5d82c18e))
+ - **DOCS**: Remove references to Tappable and Draggable ([#2912](https://github.com/flame-engine/flame/issues/2912)). ([d12e4544](https://github.com/flame-engine/flame/commit/d12e45444e49bbe0b24a7acbd24f0cda20a13755))
+
+#### `flame_rive` - `v1.9.9`
+
+ - **DOCS**: Remove references to Tappable and Draggable ([#2912](https://github.com/flame-engine/flame/issues/2912)). ([d12e4544](https://github.com/flame-engine/flame/commit/d12e45444e49bbe0b24a7acbd24f0cda20a13755))
+
+#### `flame_riverpod` - `v5.1.1`
+
+ - **FIX**: Add super constructor fields to RiverpodAwareGameWidget ([#2932](https://github.com/flame-engine/flame/issues/2932)). ([c2e6ea71](https://github.com/flame-engine/flame/commit/c2e6ea71e5c3c5f0d7ae6bc01a6c2f1f4d4d563b))
+
+#### `flame_tiled` - `v1.18.2`
+
+ - **FIX**: Image layers repeat indefinitely if repeated in Tiled ([#2921](https://github.com/flame-engine/flame/issues/2921)). ([6f79bc5e](https://github.com/flame-engine/flame/commit/6f79bc5ef920ace17d09c88156a73043357d514f))
+
+
 ## 2023-12-08
 
 ### Changes

--- a/doc/flame/examples/pubspec.yaml
+++ b/doc/flame/examples/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_rive: ^1.9.8
+  flame: ^1.13.0
+  flame_rive: ^1.9.9
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/klondike/app/pubspec.yaml
+++ b/doc/tutorials/klondike/app/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/platformer/app/pubspec.yaml
+++ b/doc/tutorials/platformer/app/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/space_shooter/app/pubspec.yaml
+++ b/doc/tutorials/space_shooter/app/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
 

--- a/examples/games/padracing/pubspec.yaml
+++ b/examples/games/padracing/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.12.0
-  flame_forge2d: ^0.16.0+2
+  flame: ^1.13.0
+  flame_forge2d: ^0.16.0+3
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/examples/games/rogue_shooter/pubspec.yaml
+++ b/examples/games/rogue_shooter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
 

--- a/examples/games/trex/pubspec.yaml
+++ b/examples/games/trex/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
 

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -11,15 +11,15 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.12.0
-  flame_audio: ^2.1.5
-  flame_forge2d: ^0.16.0+2
-  flame_isolate: ^0.5.0+5
-  flame_lottie: ^0.3.0+5
-  flame_noise: ^0.1.1+10
-  flame_spine: ^0.1.1+7
-  flame_svg: ^1.8.7
-  flame_tiled: ^1.18.1
+  flame: ^1.13.0
+  flame_audio: ^2.1.6
+  flame_forge2d: ^0.16.0+3
+  flame_isolate: ^0.5.0+6
+  flame_lottie: ^0.3.0+6
+  flame_noise: ^0.1.1+11
+  flame_spine: ^0.1.1+8
+  flame_svg: ^1.8.8
+  flame_tiled: ^1.18.2
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.13.0
+
+ - **FIX**: Logic error in MemoryCache.setValue() ([#2931](https://github.com/flame-engine/flame/issues/2931)). ([8cee80c3](https://github.com/flame-engine/flame/commit/8cee80c35ca676ad25a25c771f0aade88b58150b))
+ - **FIX**: Export `ScalingParticle` ([#2928](https://github.com/flame-engine/flame/issues/2928)). ([3730cb1d](https://github.com/flame-engine/flame/commit/3730cb1d834c73c87dc3597554039fd0f0a32bae))
+ - **FIX**: Misalignment of the hittest area of PolygonHitbox ([#2930](https://github.com/flame-engine/flame/issues/2930)). ([dbdb1379](https://github.com/flame-engine/flame/commit/dbdb1379d0bc1b6ac02b3ee27f62263bd1be3fc3))
+ - **FIX**: Allow setting `bounds` while `BoundedPositionBehavior`'s target is null ([#2926](https://github.com/flame-engine/flame/issues/2926)). ([bab9be6e](https://github.com/flame-engine/flame/commit/bab9be6e7051b7be6c84fc9760c7347692dbf140))
+ - **FEAT**: Ability to use `selfPositioning` in `SpawnComponent` ([#2927](https://github.com/flame-engine/flame/issues/2927)). ([b526aa14](https://github.com/flame-engine/flame/commit/b526aa1488c0f891edb356007ebc2c5c2de596b5))
+ - **FEAT**: Add `margin` and `spacing` properties to `SpriteSheet` ([#2925](https://github.com/flame-engine/flame/issues/2925)). ([67f7c126](https://github.com/flame-engine/flame/commit/67f7c126b4c8052df99ffa8c657a90cc7fb6f867))
+ - **FEAT**: Add `children` to `SpriteAnimationComponent.fromFrameData` ([#2914](https://github.com/flame-engine/flame/issues/2914)). ([caf2b909](https://github.com/flame-engine/flame/commit/caf2b90930ca500c85b9f9f63e7d3d7a5d82c18e))
+ - **DOCS**: Remove references to Tappable and Draggable ([#2912](https://github.com/flame-engine/flame/issues/2912)). ([d12e4544](https://github.com/flame-engine/flame/commit/d12e45444e49bbe0b24a7acbd24f0cda20a13755))
+
 ## 1.12.0
 
  - **FIX**: SpriteAnimationWidget was resetting the ticker even when the playing didn't changed ([#2891](https://github.com/flame-engine/flame/issues/2891)). ([9aed8b4d](https://github.com/flame-engine/flame/commit/9aed8b4dea3074c9ca708ad991cdc90b12707fbe))

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
 

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 1.12.0
+version: 1.13.0
 homepage: https://github.com/flame-engine/flame
 funding:
   - https://opencollective.com/blue-fire
@@ -23,7 +23,7 @@ dev_dependencies:
   canvas_test: ^0.2.0
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.1
+  flame_test: ^1.15.2
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.1

--- a/packages/flame_audio/CHANGELOG.md
+++ b/packages/flame_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.6
+
+ - Update a dependency to the latest release.
+
 ## 2.1.5
 
  - Update a dependency to the latest release.

--- a/packages/flame_audio/example/pubspec.yaml
+++ b/packages/flame_audio/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_audio: ^2.1.5
+  flame: ^1.13.0
+  flame_audio: ^2.1.6
   flutter:
     sdk: flutter
 

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_audio
 description: |
   Audio support for the Flame game engine, basically a thin wrapper around the audioplayers package.
-version: 2.1.5
+version: 2.1.6
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_audio
 funding:
   - https://opencollective.com/blue-fire
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   audioplayers: ^5.0.0
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   synchronized: ^3.1.0

--- a/packages/flame_bloc/CHANGELOG.md
+++ b/packages/flame_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.8
+
+ - Update a dependency to the latest release.
+
 ## 1.10.7
 
  - Update a dependency to the latest release.

--- a/packages/flame_bloc/example/pubspec.yaml
+++ b/packages/flame_bloc/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  flame: ^1.12.0
-  flame_bloc: ^1.10.7
+  flame: ^1.13.0
+  flame_bloc: ^1.10.8
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_bloc
 description: Integration for the Bloc state management library to Flame games.
-version: 1.10.7
+version: 1.10.8
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_bloc
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   bloc: ^8.1.1
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.1
+  flame_test: ^1.15.2
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter

--- a/packages/flame_fire_atlas/CHANGELOG.md
+++ b/packages/flame_fire_atlas/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.6
+
+ - Update a dependency to the latest release.
+
 ## 1.4.5
 
  - Update a dependency to the latest release.

--- a/packages/flame_fire_atlas/example/pubspec.yaml
+++ b/packages/flame_fire_atlas/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_fire_atlas: ^1.4.5
+  flame: ^1.13.0
+  flame_fire_atlas: ^1.4.6
   flutter:
     sdk: flutter
 

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_fire_atlas
 description: Easy to use texture atlases for the flame engine created with the
   fire atlas editor
-version: 1.4.5
+version: 1.4.6
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_fire_atlas
 funding:
   - https://opencollective.com/blue-fire
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   archive: ^3.3.9
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.0+3
+
+ - Update a dependency to the latest release.
+
 ## 0.16.0+2
 
  - Update a dependency to the latest release.

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.12.0
-  flame_forge2d: ^0.16.0+2
+  flame: ^1.13.0
+  flame_forge2d: ^0.16.0+3
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_forge2d
 description: Forge2D (Box2D) support for the Flame game engine. This uses the forge2d package and provides wrappers and components to be used inside Flame.
-version: 0.16.0+2
+version: 0.16.0+3
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_forge2d
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   forge2d: ">=0.12.2 <0.13.0"
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.1
+  flame_test: ^1.15.2
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.1

--- a/packages/flame_isolate/CHANGELOG.md
+++ b/packages/flame_isolate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+6
+
+ - Update a dependency to the latest release.
+
 ## 0.5.0+5
 
  - Update a dependency to the latest release.

--- a/packages/flame_isolate/example/pubspec.yaml
+++ b/packages/flame_isolate/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.12.0
-  flame_isolate: ^0.5.0+5
+  flame: ^1.13.0
+  flame_isolate: ^0.5.0+6
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0

--- a/packages/flame_isolate/pubspec.yaml
+++ b/packages/flame_isolate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_isolate
 description: Flame wrapper for integral_isolates making multi-threading easy in Flame
-version: 0.5.0+5
+version: 0.5.0+6
 repository: https://github.com/flame-engine/flame/blob/main/packages/flame_isolate
 
 environment:
@@ -8,14 +8,14 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0
 
 dev_dependencies:
   flame_lint: ^1.1.2
-  flame_test: ^1.15.1
+  flame_test: ^1.15.2
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_jenny/pubspec.yaml
+++ b/packages/flame_jenny/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   jenny: ^1.2.1

--- a/packages/flame_lottie/CHANGELOG.md
+++ b/packages/flame_lottie/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+6
+
+ - Update a dependency to the latest release.
+
 ## 0.3.0+5
 
  - Update a dependency to the latest release.

--- a/packages/flame_lottie/example/pubspec.yaml
+++ b/packages/flame_lottie/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_lottie: ^0.3.0+5
+  flame: ^1.13.0
+  flame_lottie: ^0.3.0+6
   flutter:
     sdk: flutter
   lottie:

--- a/packages/flame_lottie/pubspec.yaml
+++ b/packages/flame_lottie/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_lottie
 description: Flame wrapper for Lottie by AirBnB. This package implements a bridge between Lottie and Flame, allowing to load and display Lottie animations.
-version: 0.3.0+5
+version: 0.3.0+6
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_lottie
 funding:
   - https://opencollective.com/blue-fire
@@ -12,14 +12,14 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   lottie: ^2.3.2
 
 dev_dependencies:
   flame_lint: ^1.1.2
-  flame_test: ^1.15.1
+  flame_test: ^1.15.2
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_markdown/CHANGELOG.md
+++ b/packages/flame_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+6
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+5
 
  - Update a dependency to the latest release.

--- a/packages/flame_markdown/example/pubspec.yaml
+++ b/packages/flame_markdown/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_markdown: ^0.1.1+5
+  flame: ^1.13.0
+  flame_markdown: ^0.1.1+6
   flutter:
     sdk: flutter
 

--- a/packages/flame_markdown/pubspec.yaml
+++ b/packages/flame_markdown/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_markdown
 description: |
   Markdown support for the Flame game engine, bridging the markdown package into Flame's text rendering pipeline.
-version: 0.1.1+5
+version: 0.1.1+6
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_markdown
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   markdown: ^7.1.1

--- a/packages/flame_network_assets/CHANGELOG.md
+++ b/packages/flame_network_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+11
+
+ - Update a dependency to the latest release.
+
 ## 0.2.0+10
 
  - Update a dependency to the latest release.

--- a/packages/flame_network_assets/example/pubspec.yaml
+++ b/packages/flame_network_assets/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_network_assets: ^0.2.0+10
+  flame: ^1.13.0
+  flame_network_assets: ^0.2.0+11
   flutter:
     sdk: flutter
 

--- a/packages/flame_network_assets/pubspec.yaml
+++ b/packages/flame_network_assets/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_network_assets
 description: Network assets support for Flame.
-version: 0.2.0+10
+version: 0.2.0+11
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_network_assets
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   dev: ^1.0.0
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   http: ^0.13.6

--- a/packages/flame_noise/CHANGELOG.md
+++ b/packages/flame_noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+11
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+10
 
  - Update a dependency to the latest release.

--- a/packages/flame_noise/pubspec.yaml
+++ b/packages/flame_noise/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_noise
 description: Integrate the fast_noise package into Flame
-version: 0.1.1+10
+version: 0.1.1+11
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_noise
 funding:
   - https://opencollective.com/blue-fire
@@ -13,12 +13,12 @@ environment:
 
 dependencies:
   fast_noise: ^1.0.1
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.1
+  flame_test: ^1.15.2
   test: any

--- a/packages/flame_oxygen/CHANGELOG.md
+++ b/packages/flame_oxygen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.9+6
+
+ - Update a dependency to the latest release.
+
 ## 0.1.9+5
 
  - Update a dependency to the latest release.

--- a/packages/flame_oxygen/example/pubspec.yaml
+++ b/packages/flame_oxygen/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_oxygen: ^0.1.9+5
+  flame: ^1.13.0
+  flame_oxygen: ^0.1.9+6
   flutter:
     sdk: flutter
 

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_oxygen
 description: Integrate the Oxygen ECS with the Flame Engine.
-version: 0.1.9+5
+version: 0.1.9+6
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_oxygen
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   oxygen: ^0.2.0

--- a/packages/flame_rive/CHANGELOG.md
+++ b/packages/flame_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.9
+
+ - **DOCS**: Remove references to Tappable and Draggable ([#2912](https://github.com/flame-engine/flame/issues/2912)). ([d12e4544](https://github.com/flame-engine/flame/commit/d12e45444e49bbe0b24a7acbd24f0cda20a13755))
+
 ## 1.9.8
 
  - Update a dependency to the latest release.

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_rive: ^1.9.8
+  flame: ^1.13.0
+  flame_rive: ^1.9.9
   flutter:
     sdk: flutter
   rive: ^0.12.3

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_rive
 description: Rive support for the Flame game engine. This uses the rive package and provides wrappers and components to be used inside Flame.
 homepage: https://github.com/flame-engine/flame
-version: 1.9.8
+version: 1.9.9
 funding:
   - https://opencollective.com/blue-fire
   - https://github.com/sponsors/bluefireteam
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   rive: ^0.12.3
@@ -20,6 +20,6 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.1
+  flame_test: ^1.15.2
   flutter_test:
     sdk: flutter

--- a/packages/flame_riverpod/CHANGELOG.md
+++ b/packages/flame_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.1
+
+ - **FIX**: Add super constructor fields to RiverpodAwareGameWidget ([#2932](https://github.com/flame-engine/flame/issues/2932)). ([c2e6ea71](https://github.com/flame-engine/flame/commit/c2e6ea71e5c3c5f0d7ae6bc01a6c2f1f4d4d563b))
+
 ## 5.1.0
 
  - **FIX**: SpriteAnimationWidget was resetting the ticker even when the playing didn't changed ([#2891](https://github.com/flame-engine/flame/issues/2891)). ([9aed8b4d](https://github.com/flame-engine/flame/commit/9aed8b4dea3074c9ca708ad991cdc90b12707fbe))

--- a/packages/flame_riverpod/example/pubspec.yaml
+++ b/packages/flame_riverpod/example/pubspec.yaml
@@ -5,8 +5,8 @@ version: 1.0.0+1
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
-  flame: ^1.12.0
-  flame_riverpod: ^5.1.0
+  flame: ^1.13.0
+  flame_riverpod: ^5.1.1
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.1.3

--- a/packages/flame_riverpod/pubspec.yaml
+++ b/packages/flame_riverpod/pubspec.yaml
@@ -1,13 +1,13 @@
 name: flame_riverpod
 description: Helpers for using Riverpod - a reactive caching and data-binding framework, 
   in conjunction with Flame.
-version: 5.1.0
+version: 5.1.1
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_riverpod
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.1.3

--- a/packages/flame_spine/CHANGELOG.md
+++ b/packages/flame_spine/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+8
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+7
 
  - Update a dependency to the latest release.

--- a/packages/flame_spine/example/pubspec.yaml
+++ b/packages/flame_spine/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_spine: ^0.1.1+7
+  flame: ^1.13.0
+  flame_spine: ^0.1.1+8
   flutter:
     sdk: flutter
 

--- a/packages/flame_spine/pubspec.yaml
+++ b/packages/flame_spine/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_spine
 description: Spine support for the Flame game engine. This uses the spine_flutter package and provides wrappers and components to be used inside Flame.
-version: 0.1.1+7
+version: 0.1.1+8
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_sprine
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   spine_flutter: ^4.2.18

--- a/packages/flame_studio/pubspec.yaml
+++ b/packages/flame_studio/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.3.6

--- a/packages/flame_svg/CHANGELOG.md
+++ b/packages/flame_svg/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.8
+
+ - Update a dependency to the latest release.
+
 ## 1.8.7
 
  - Update a dependency to the latest release.

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_svg: ^1.8.7
+  flame: ^1.13.0
+  flame_svg: ^1.8.8
   flutter:
     sdk: flutter
 

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_svg
 description: Package to add SVG rendering support for the Flame game engine
-version: 1.8.7
+version: 1.8.8
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_svg
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.5

--- a/packages/flame_test/CHANGELOG.md
+++ b/packages/flame_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.2
+
+ - Update a dependency to the latest release.
+
 ## 1.15.1
 
  - Update a dependency to the latest release.

--- a/packages/flame_test/example/pubspec.yaml
+++ b/packages/flame_test/example/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flame_lint: ^1.1.2
-  flame_test: ^1.15.1
+  flame_test: ^1.15.2
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_test
 description: A package with classes to help testing applications using Flame
-version: 1.15.1
+version: 1.15.2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_test
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/flame_tiled/CHANGELOG.md
+++ b/packages/flame_tiled/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.2
+
+ - **FIX**: Image layers repeat indefinitely if repeated in Tiled ([#2921](https://github.com/flame-engine/flame/issues/2921)). ([6f79bc5e](https://github.com/flame-engine/flame/commit/6f79bc5ef920ace17d09c88156a73043357d514f))
+
 ## 1.18.1
 
  - Update a dependency to the latest release.

--- a/packages/flame_tiled/example/pubspec.yaml
+++ b/packages/flame_tiled/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.12.0
-  flame_tiled: ^1.18.1
+  flame: ^1.13.0
+  flame_tiled: ^1.18.2
   flutter:
     sdk: flutter
 

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_tiled
 description: Tiled support for the Flame game engine. This uses the tiled package and provides wrappers and components to be used inside Flame.
-version: 1.18.1
+version: 1.18.2
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_tiled
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.12.0
+  flame: ^1.13.0
   flutter:
     sdk: flutter
   meta: ^1.9.1


### PR DESCRIPTION
```
Package Name           Current Version   Updated Version   Update Reason
flame                  1.12.0            1.13.0            updated with minor changes
flame_rive             1.9.8             1.9.9             updated with patch changes
flame_riverpod         5.1.0             5.1.1             updated with patch changes
flame_tiled            1.18.1            1.18.2            updated with patch changes
flame_test             1.15.1            1.15.2            dependency was updated
flame_oxygen           0.1.9+5           0.1.9+6           dependency was updated
flame_isolate          0.5.0+5           0.5.0+6           dependency was updated
flame_fire_atlas       1.4.5             1.4.6             dependency was updated
flame_audio            2.1.5             2.1.6             dependency was updated
flame_spine            0.1.1+7           0.1.1+8           dependency was updated
flame_bloc             1.10.7            1.10.8            dependency was updated
flame_lottie           0.3.0+5           0.3.0+6           dependency was updated
flame_markdown         0.1.1+5           0.1.1+6           dependency was updated
flame_svg              1.8.7             1.8.8             dependency was updated
flame_forge2d          0.16.0+2          0.16.0+3          dependency was updated
flame_noise            0.1.1+10          0.1.1+11          dependency was updated
flame_network_assets   0.2.0+10          0.2.0+11          dependency was updated
```