### PR TITLE
fix: Package flame_riverpod, setState() or markNeedsBuild() called during build.

### DIFF
--- a/packages/flame_riverpod/lib/src/widget.dart
+++ b/packages/flame_riverpod/lib/src/widget.dart
@@ -35,7 +35,8 @@ class RiverpodAwareGameWidget<T extends Game> extends GameWidget<T> {
 }
 
 class RiverpodAwareGameWidgetState<T extends Game> extends GameWidgetState<T>
-    with WidgetsBindingObserver implements WidgetRef {
+    with WidgetsBindingObserver
+    implements WidgetRef {
   RiverpodGameMixin get game => widget.game! as RiverpodGameMixin;
 
   bool _isForceBuilding = false;
@@ -51,10 +52,10 @@ class RiverpodAwareGameWidgetState<T extends Game> extends GameWidgetState<T>
 
   /// Rebuilds the [RiverpodAwareGameWidget] by calling [setState].
   // Undesirable to call [setState] while the widget may be building.
-  // Honour requests to rebuild by setting a flag. 
+  // Honour requests to rebuild by setting a flag.
   void forceBuild() {
-    if (_isForceBuilding) { 
-      _hasQueuedBuild = true; 
+    if (_isForceBuilding) {
+      _hasQueuedBuild = true;
       return;
     }
     _isForceBuilding = true;
@@ -73,7 +74,7 @@ class RiverpodAwareGameWidgetState<T extends Game> extends GameWidgetState<T>
         forceBuild();
       } else {
         _isForceBuilding = false;
-      } 
+      }
     });
   }
 
@@ -156,8 +157,8 @@ class RiverpodAwareGameWidgetState<T extends Game> extends GameWidgetState<T>
 
       return _container.listen<Res>(
         target,
-        // setState call has been replaced with forceBuild, 
-        // to prevent setState calls while the widget is 
+        // setState call has been replaced with forceBuild,
+        // to prevent setState calls while the widget is
         // building, which throws a framework error.
         (_, __) => forceBuild(),
       );

--- a/packages/flame_riverpod/lib/src/widget.dart
+++ b/packages/flame_riverpod/lib/src/widget.dart
@@ -51,8 +51,9 @@ class RiverpodAwareGameWidgetState<T extends Game> extends GameWidgetState<T>
   List<_ListenManual<Object?>>? _manualListeners;
 
   /// Rebuilds the [RiverpodAwareGameWidget] by calling [setState].
-  // Undesirable to call [setState] while the widget may be building.
-  // Honour requests to rebuild by setting a flag.
+  /// As it is undesirable to call [setState] while the widget may be building,
+  /// this function honours (potential) subsequent requests to rebuild by
+  /// setting a flag.
   void forceBuild() {
     if (_isForceBuilding) {
       _hasQueuedBuild = true;


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
The forceRebuild function now has an "isDirty" check to determine whether setState should be called. Previously, setState was uncritically invoked which *could* produce the Flutter framework error that occurs when setState is called while widgets are still being rebuilt. 

The setState call inside ref.watch has been replaced with a call to forceRebuild, and forceRebuild now has checks to prevent setState from being called while a build is in progress. A persistent frame callback has been added to reset supporting flags. 

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->
N/A. Customer reported issue[ via Discord.](https://discord.com/channels/509714518008528896/1186421112217813062/1186908306179100723) 

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
