### PR TITLE
chore(release): Publish Flame v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,69 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-01-04
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`flame` - `v1.14.0`](#flame---v1140)
+
+Packages with other changes:
+
+ - [`flame_forge2d` - `v0.16.0+4`](#flame_forge2d---v01604)
+ - [`flame_test` - `v1.15.3`](#flame_test---v1153)
+ - [`flame_tiled` - `v1.18.3`](#flame_tiled---v1183)
+ - [`flame_oxygen` - `v0.1.9+7`](#flame_oxygen---v0197)
+ - [`flame_isolate` - `v0.5.0+7`](#flame_isolate---v0507)
+ - [`flame_fire_atlas` - `v1.4.7`](#flame_fire_atlas---v147)
+ - [`flame_audio` - `v2.1.7`](#flame_audio---v217)
+ - [`flame_spine` - `v0.1.1+9`](#flame_spine---v0119)
+ - [`flame_bloc` - `v1.10.9`](#flame_bloc---v1109)
+ - [`flame_lottie` - `v0.3.0+7`](#flame_lottie---v0307)
+ - [`flame_markdown` - `v0.1.1+7`](#flame_markdown---v0117)
+ - [`flame_rive` - `v1.9.10`](#flame_rive---v1910)
+ - [`flame_noise` - `v0.1.1+12`](#flame_noise---v01112)
+ - [`flame_riverpod` - `v5.1.4`](#flame_riverpod---v514)
+ - [`flame_svg` - `v1.8.9`](#flame_svg---v189)
+ - [`flame_network_assets` - `v0.2.0+12`](#flame_network_assets---v02012)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `flame_test` - `v1.15.3`
+ - `flame_tiled` - `v1.18.3`
+ - `flame_oxygen` - `v0.1.9+7`
+ - `flame_isolate` - `v0.5.0+7`
+ - `flame_fire_atlas` - `v1.4.7`
+ - `flame_audio` - `v2.1.7`
+ - `flame_spine` - `v0.1.1+9`
+ - `flame_bloc` - `v1.10.9`
+ - `flame_lottie` - `v0.3.0+7`
+ - `flame_markdown` - `v0.1.1+7`
+ - `flame_rive` - `v1.9.10`
+ - `flame_noise` - `v0.1.1+12`
+ - `flame_riverpod` - `v5.1.4`
+ - `flame_svg` - `v1.8.9`
+ - `flame_network_assets` - `v0.2.0+12`
+
+---
+
+#### `flame` - `v1.14.0`
+
+ - **FIX**: Consider displaced hitboxes in GestureHitboxes mixin ([#2957](https://github.com/flame-engine/flame/issues/2957)). ([1085518f](https://github.com/flame-engine/flame/commit/1085518fe279e674bef9a7b938d59926472511f3))
+ - **FIX**: PolygonComponent.containsLocalPoint to use anchor ([#2953](https://github.com/flame-engine/flame/issues/2953)). ([7969321e](https://github.com/flame-engine/flame/commit/7969321e8662515aa9efe305831ff36d51dd43cb))
+ - **FEAT**: Notifier for changing current sprite/animation in group components ([#2956](https://github.com/flame-engine/flame/issues/2956)). ([75cf2390](https://github.com/flame-engine/flame/commit/75cf23908e5d509a25cd794d6810162f22b978cb))
+ - **BREAKING** **REFACTOR**: Remove the Projector interface that is no longer used for coordinate transformations ([#2955](https://github.com/flame-engine/flame/issues/2955)). ([0979dc97](https://github.com/flame-engine/flame/commit/0979dc97f54af1b71b200ced609d874d390c1ca6))
+
+#### `flame_forge2d` - `v0.16.0+4`
+
+ - **FIX**: Wake up bodies on gravity change ([#2954](https://github.com/flame-engine/flame/issues/2954)). ([4f58329c](https://github.com/flame-engine/flame/commit/4f58329ceacef84d91cd41019d72bc2351bc50cd))
+
+
 ## 2023-12-22
 
 ### Changes

--- a/doc/flame/examples/pubspec.yaml
+++ b/doc/flame/examples/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_rive: ^1.9.9
+  flame: ^1.14.0
+  flame_rive: ^1.9.10
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/klondike/app/pubspec.yaml
+++ b/doc/tutorials/klondike/app/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/platformer/app/pubspec.yaml
+++ b/doc/tutorials/platformer/app/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/space_shooter/app/pubspec.yaml
+++ b/doc/tutorials/space_shooter/app/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 

--- a/examples/games/padracing/pubspec.yaml
+++ b/examples/games/padracing/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.13.0
-  flame_forge2d: ^0.16.0+3
+  flame: ^1.14.0
+  flame_forge2d: ^0.16.0+4
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/examples/games/rogue_shooter/pubspec.yaml
+++ b/examples/games/rogue_shooter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 

--- a/examples/games/trex/pubspec.yaml
+++ b/examples/games/trex/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -11,15 +11,15 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.13.0
-  flame_audio: ^2.1.6
-  flame_forge2d: ^0.16.0+3
-  flame_isolate: ^0.5.0+6
-  flame_lottie: ^0.3.0+6
-  flame_noise: ^0.1.1+11
-  flame_spine: ^0.1.1+8
-  flame_svg: ^1.8.8
-  flame_tiled: ^1.18.2
+  flame: ^1.14.0
+  flame_audio: ^2.1.7
+  flame_forge2d: ^0.16.0+4
+  flame_isolate: ^0.5.0+7
+  flame_lottie: ^0.3.0+7
+  flame_noise: ^0.1.1+12
+  flame_spine: ^0.1.1+9
+  flame_svg: ^1.8.9
+  flame_tiled: ^1.18.3
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.14.0
+
+> Note: This release has breaking changes.
+
+ - **FIX**: Consider displaced hitboxes in GestureHitboxes mixin ([#2957](https://github.com/flame-engine/flame/issues/2957)). ([1085518f](https://github.com/flame-engine/flame/commit/1085518fe279e674bef9a7b938d59926472511f3))
+ - **FIX**: PolygonComponent.containsLocalPoint to use anchor ([#2953](https://github.com/flame-engine/flame/issues/2953)). ([7969321e](https://github.com/flame-engine/flame/commit/7969321e8662515aa9efe305831ff36d51dd43cb))
+ - **FEAT**: Notifier for changing current sprite/animation in group components ([#2956](https://github.com/flame-engine/flame/issues/2956)). ([75cf2390](https://github.com/flame-engine/flame/commit/75cf23908e5d509a25cd794d6810162f22b978cb))
+ - **BREAKING** **REFACTOR**: Remove the Projector interface that is no longer used for coordinate transformations ([#2955](https://github.com/flame-engine/flame/issues/2955)). ([0979dc97](https://github.com/flame-engine/flame/commit/0979dc97f54af1b71b200ced609d874d390c1ca6))
+
 ## 1.13.1
 
  - **FIX**: The `visibleGameSize` should be based on `viewport.virtualSize` ([#2945](https://github.com/flame-engine/flame/issues/2945)). ([bd130b71](https://github.com/flame-engine/flame/commit/bd130b711b5cb486b8f05225711c6e6c3fe574e6))

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 1.13.1
+version: 1.14.0
 homepage: https://github.com/flame-engine/flame
 funding:
   - https://opencollective.com/blue-fire
@@ -23,7 +23,7 @@ dev_dependencies:
   canvas_test: ^0.2.0
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.2
+  flame_test: ^1.15.3
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.1

--- a/packages/flame_audio/CHANGELOG.md
+++ b/packages/flame_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.7
+
+ - Update a dependency to the latest release.
+
 ## 2.1.6
 
  - Update a dependency to the latest release.

--- a/packages/flame_audio/example/pubspec.yaml
+++ b/packages/flame_audio/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_audio: ^2.1.6
+  flame: ^1.14.0
+  flame_audio: ^2.1.7
   flutter:
     sdk: flutter
 

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_audio
 description: |
   Audio support for the Flame game engine, basically a thin wrapper around the audioplayers package.
-version: 2.1.6
+version: 2.1.7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_audio
 funding:
   - https://opencollective.com/blue-fire
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   audioplayers: ^5.0.0
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   synchronized: ^3.1.0

--- a/packages/flame_bloc/CHANGELOG.md
+++ b/packages/flame_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.9
+
+ - Update a dependency to the latest release.
+
 ## 1.10.8
 
  - Update a dependency to the latest release.

--- a/packages/flame_bloc/example/pubspec.yaml
+++ b/packages/flame_bloc/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  flame: ^1.13.0
-  flame_bloc: ^1.10.8
+  flame: ^1.14.0
+  flame_bloc: ^1.10.9
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_bloc
 description: Integration for the Bloc state management library to Flame games.
-version: 1.10.8
+version: 1.10.9
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_bloc
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   bloc: ^8.1.1
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.2
+  flame_test: ^1.15.3
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter

--- a/packages/flame_fire_atlas/CHANGELOG.md
+++ b/packages/flame_fire_atlas/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.7
+
+ - Update a dependency to the latest release.
+
 ## 1.4.6
 
  - Update a dependency to the latest release.

--- a/packages/flame_fire_atlas/example/pubspec.yaml
+++ b/packages/flame_fire_atlas/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_fire_atlas: ^1.4.6
+  flame: ^1.14.0
+  flame_fire_atlas: ^1.4.7
   flutter:
     sdk: flutter
 

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_fire_atlas
 description: Easy to use texture atlases for the flame engine created with the
   fire atlas editor
-version: 1.4.6
+version: 1.4.7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_fire_atlas
 funding:
   - https://opencollective.com/blue-fire
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   archive: ^3.3.9
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.0+4
+
+ - **FIX**: Wake up bodies on gravity change ([#2954](https://github.com/flame-engine/flame/issues/2954)). ([4f58329c](https://github.com/flame-engine/flame/commit/4f58329ceacef84d91cd41019d72bc2351bc50cd))
+
 ## 0.16.0+3
 
  - Update a dependency to the latest release.

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   dashbook: ^0.1.12
-  flame: ^1.13.0
-  flame_forge2d: ^0.16.0+3
+  flame: ^1.14.0
+  flame_forge2d: ^0.16.0+4
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_forge2d
 description: Forge2D (Box2D) support for the Flame game engine. This uses the forge2d package and provides wrappers and components to be used inside Flame.
-version: 0.16.0+3
+version: 0.16.0+4
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_forge2d
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   forge2d: ">=0.12.2 <0.13.0"
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.2
+  flame_test: ^1.15.3
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.1

--- a/packages/flame_isolate/CHANGELOG.md
+++ b/packages/flame_isolate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+7
+
+ - Update a dependency to the latest release.
+
 ## 0.5.0+6
 
  - Update a dependency to the latest release.

--- a/packages/flame_isolate/example/pubspec.yaml
+++ b/packages/flame_isolate/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.13.0
-  flame_isolate: ^0.5.0+6
+  flame: ^1.14.0
+  flame_isolate: ^0.5.0+7
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0

--- a/packages/flame_isolate/pubspec.yaml
+++ b/packages/flame_isolate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_isolate
 description: Flame wrapper for integral_isolates making multi-threading easy in Flame
-version: 0.5.0+6
+version: 0.5.0+7
 repository: https://github.com/flame-engine/flame/blob/main/packages/flame_isolate
 
 environment:
@@ -8,14 +8,14 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   integral_isolates: ^0.3.0
 
 dev_dependencies:
   flame_lint: ^1.1.2
-  flame_test: ^1.15.2
+  flame_test: ^1.15.3
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_jenny/pubspec.yaml
+++ b/packages/flame_jenny/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   jenny: ^1.2.1

--- a/packages/flame_lottie/CHANGELOG.md
+++ b/packages/flame_lottie/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+7
+
+ - Update a dependency to the latest release.
+
 ## 0.3.0+6
 
  - Update a dependency to the latest release.

--- a/packages/flame_lottie/example/pubspec.yaml
+++ b/packages/flame_lottie/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_lottie: ^0.3.0+6
+  flame: ^1.14.0
+  flame_lottie: ^0.3.0+7
   flutter:
     sdk: flutter
   lottie:

--- a/packages/flame_lottie/pubspec.yaml
+++ b/packages/flame_lottie/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_lottie
 description: Flame wrapper for Lottie by AirBnB. This package implements a bridge between Lottie and Flame, allowing to load and display Lottie animations.
-version: 0.3.0+6
+version: 0.3.0+7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_lottie
 funding:
   - https://opencollective.com/blue-fire
@@ -12,14 +12,14 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   lottie: ^2.3.2
 
 dev_dependencies:
   flame_lint: ^1.1.2
-  flame_test: ^1.15.2
+  flame_test: ^1.15.3
   flutter_test:
     sdk: flutter
   lint: ^2.1.2

--- a/packages/flame_markdown/CHANGELOG.md
+++ b/packages/flame_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+7
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+6
 
  - Update a dependency to the latest release.

--- a/packages/flame_markdown/example/pubspec.yaml
+++ b/packages/flame_markdown/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_markdown: ^0.1.1+6
+  flame: ^1.14.0
+  flame_markdown: ^0.1.1+7
   flutter:
     sdk: flutter
 

--- a/packages/flame_markdown/pubspec.yaml
+++ b/packages/flame_markdown/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_markdown
 description: |
   Markdown support for the Flame game engine, bridging the markdown package into Flame's text rendering pipeline.
-version: 0.1.1+6
+version: 0.1.1+7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_markdown
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   markdown: ^7.1.1

--- a/packages/flame_network_assets/CHANGELOG.md
+++ b/packages/flame_network_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+12
+
+ - Update a dependency to the latest release.
+
 ## 0.2.0+11
 
  - Update a dependency to the latest release.

--- a/packages/flame_network_assets/example/pubspec.yaml
+++ b/packages/flame_network_assets/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_network_assets: ^0.2.0+11
+  flame: ^1.14.0
+  flame_network_assets: ^0.2.0+12
   flutter:
     sdk: flutter
 

--- a/packages/flame_network_assets/pubspec.yaml
+++ b/packages/flame_network_assets/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_network_assets
 description: Network assets support for Flame.
-version: 0.2.0+11
+version: 0.2.0+12
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_network_assets
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   dev: ^1.0.0
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   http: ^0.13.6

--- a/packages/flame_noise/CHANGELOG.md
+++ b/packages/flame_noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+12
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+11
 
  - Update a dependency to the latest release.

--- a/packages/flame_noise/pubspec.yaml
+++ b/packages/flame_noise/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_noise
 description: Integrate the fast_noise package into Flame
-version: 0.1.1+11
+version: 0.1.1+12
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_noise
 funding:
   - https://opencollective.com/blue-fire
@@ -13,12 +13,12 @@ environment:
 
 dependencies:
   fast_noise: ^1.0.1
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.2
+  flame_test: ^1.15.3
   test: any

--- a/packages/flame_oxygen/CHANGELOG.md
+++ b/packages/flame_oxygen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.9+7
+
+ - Update a dependency to the latest release.
+
 ## 0.1.9+6
 
  - Update a dependency to the latest release.

--- a/packages/flame_oxygen/example/pubspec.yaml
+++ b/packages/flame_oxygen/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_oxygen: ^0.1.9+6
+  flame: ^1.14.0
+  flame_oxygen: ^0.1.9+7
   flutter:
     sdk: flutter
 

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_oxygen
 description: Integrate the Oxygen ECS with the Flame Engine.
-version: 0.1.9+6
+version: 0.1.9+7
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_oxygen
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   oxygen: ^0.2.0

--- a/packages/flame_rive/CHANGELOG.md
+++ b/packages/flame_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.10
+
+ - Update a dependency to the latest release.
+
 ## 1.9.9
 
  - **DOCS**: Remove references to Tappable and Draggable ([#2912](https://github.com/flame-engine/flame/issues/2912)). ([d12e4544](https://github.com/flame-engine/flame/commit/d12e45444e49bbe0b24a7acbd24f0cda20a13755))

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_rive: ^1.9.9
+  flame: ^1.14.0
+  flame_rive: ^1.9.10
   flutter:
     sdk: flutter
   rive: ^0.12.3

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_rive
 description: Rive support for the Flame game engine. This uses the rive package and provides wrappers and components to be used inside Flame.
 homepage: https://github.com/flame-engine/flame
-version: 1.9.9
+version: 1.9.10
 funding:
   - https://opencollective.com/blue-fire
   - https://github.com/sponsors/bluefireteam
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   rive: ^0.12.3
@@ -20,6 +20,6 @@ dependencies:
 dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
-  flame_test: ^1.15.2
+  flame_test: ^1.15.3
   flutter_test:
     sdk: flutter

--- a/packages/flame_riverpod/CHANGELOG.md
+++ b/packages/flame_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.4
+
+ - Update a dependency to the latest release.
+
 ## 5.1.3
 
  - **FIX**: Fix logic inside flame_riverpod persistent frame callback. ([#2950](https://github.com/flame-engine/flame/issues/2950)). ([230fb88f](https://github.com/flame-engine/flame/commit/230fb88fa9f9d82711461d10fe4aff9f8520cd29))

--- a/packages/flame_riverpod/example/pubspec.yaml
+++ b/packages/flame_riverpod/example/pubspec.yaml
@@ -5,8 +5,8 @@ version: 1.0.0+1
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
-  flame: ^1.13.0
-  flame_riverpod: ^5.1.1
+  flame: ^1.14.0
+  flame_riverpod: ^5.1.4
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.1.3

--- a/packages/flame_riverpod/pubspec.yaml
+++ b/packages/flame_riverpod/pubspec.yaml
@@ -1,13 +1,13 @@
 name: flame_riverpod
 description: Helpers for using Riverpod - a reactive caching and data-binding framework, 
   in conjunction with Flame.
-version: 5.1.3
+version: 5.1.4
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_riverpod
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.1.3

--- a/packages/flame_spine/CHANGELOG.md
+++ b/packages/flame_spine/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+9
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+8
 
  - Update a dependency to the latest release.

--- a/packages/flame_spine/example/pubspec.yaml
+++ b/packages/flame_spine/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_spine: ^0.1.1+8
+  flame: ^1.14.0
+  flame_spine: ^0.1.1+9
   flutter:
     sdk: flutter
 

--- a/packages/flame_spine/pubspec.yaml
+++ b/packages/flame_spine/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_spine
 description: Spine support for the Flame game engine. This uses the spine_flutter package and provides wrappers and components to be used inside Flame.
-version: 0.1.1+8
+version: 0.1.1+9
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_sprine
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   spine_flutter: ^4.2.18

--- a/packages/flame_studio/pubspec.yaml
+++ b/packages/flame_studio/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.3.6

--- a/packages/flame_svg/CHANGELOG.md
+++ b/packages/flame_svg/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.9
+
+ - Update a dependency to the latest release.
+
 ## 1.8.8
 
  - Update a dependency to the latest release.

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_svg: ^1.8.8
+  flame: ^1.14.0
+  flame_svg: ^1.8.9
   flutter:
     sdk: flutter
 

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_svg
 description: Package to add SVG rendering support for the Flame game engine
-version: 1.8.8
+version: 1.8.9
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_svg
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.5

--- a/packages/flame_test/CHANGELOG.md
+++ b/packages/flame_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.3
+
+ - Update a dependency to the latest release.
+
 ## 1.15.2
 
  - Update a dependency to the latest release.

--- a/packages/flame_test/example/pubspec.yaml
+++ b/packages/flame_test/example/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flame_lint: ^1.1.2
-  flame_test: ^1.15.2
+  flame_test: ^1.15.3
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_test
 description: A package with classes to help testing applications using Flame
-version: 1.15.2
+version: 1.15.3
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_test
 funding:
   - https://opencollective.com/blue-fire
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/flame_tiled/CHANGELOG.md
+++ b/packages/flame_tiled/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.3
+
+ - Update a dependency to the latest release.
+
 ## 1.18.2
 
  - **FIX**: Image layers repeat indefinitely if repeated in Tiled ([#2921](https://github.com/flame-engine/flame/issues/2921)). ([6f79bc5e](https://github.com/flame-engine/flame/commit/6f79bc5ef920ace17d09c88156a73043357d514f))

--- a/packages/flame_tiled/example/pubspec.yaml
+++ b/packages/flame_tiled/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flame: ^1.13.0
-  flame_tiled: ^1.18.2
+  flame: ^1.14.0
+  flame_tiled: ^1.18.3
   flutter:
     sdk: flutter
 

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_tiled
 description: Tiled support for the Flame game engine. This uses the tiled package and provides wrappers and components to be used inside Flame.
-version: 1.18.2
+version: 1.18.3
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_tiled
 funding:
   - https://opencollective.com/blue-fire
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.13.0
+  flame: ^1.14.0
   flutter:
     sdk: flutter
   meta: ^1.9.1


### PR DESCRIPTION
```
Package Name           Current Version   Updated Version   Update Reason
flame                  1.13.1            1.14.0            manual versioning
flame_forge2d          0.16.0+3          0.16.0+4          updated with patch changes
flame_test             1.15.2            1.15.3            dependency was updated
flame_tiled            1.18.2            1.18.3            dependency was updated
flame_oxygen           0.1.9+6           0.1.9+7           dependency was updated
flame_isolate          0.5.0+6           0.5.0+7           dependency was updated
flame_fire_atlas       1.4.6             1.4.7             dependency was updated
flame_audio            2.1.6             2.1.7             dependency was updated
flame_spine            0.1.1+8           0.1.1+9           dependency was updated
flame_bloc             1.10.8            1.10.9            dependency was updated
flame_lottie           0.3.0+6           0.3.0+7           dependency was updated
flame_markdown         0.1.1+6           0.1.1+7           dependency was updated
flame_rive             1.9.9             1.9.10            dependency was updated
flame_noise            0.1.1+11          0.1.1+12          dependency was updated
flame_riverpod         5.1.3             5.1.4             dependency was updated
flame_svg              1.8.8             1.8.9             dependency was updated
flame_network_assets   0.2.0+11          0.2.0+12          dependency was updated
```