### PR TITLE
fix: Change return type of RiverpodComponentMixin.onLoad to FutureOr<void>

### DIFF
--- a/.github/.cspell/gamedev_dictionary.txt
+++ b/.github/.cspell/gamedev_dictionary.txt
@@ -6,7 +6,6 @@ AHSV # alpha hue saturation value
 antialiasing # set of techniques to combat the problems of aliasing
 ARGB # alpha red green blue
 arities # plural of arity
-arity # number of parameters a function takes
 autofocus # auto focus event
 backgrounded # moving the app to the background
 backgrounding # moving the app to the background

--- a/packages/flame_riverpod/lib/src/consumer.dart
+++ b/packages/flame_riverpod/lib/src/consumer.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame_riverpod/src/widget.dart';

--- a/packages/flame_riverpod/lib/src/consumer.dart
+++ b/packages/flame_riverpod/lib/src/consumer.dart
@@ -80,7 +80,7 @@ mixin RiverpodComponentMixin on Component {
 
   @mustCallSuper
   @override
-  void onLoad() {
+  FutureOr<void> onLoad() {
     ref.game = findGame()! as RiverpodGameMixin;
     super.onLoad();
   }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
This PR changes the return type of RiverpodComponentMixin.onLoad to match that of Component.onLoad. 

This resolves #2961 which describes an error preventing use of RiverpodComponentMixin on Component subclasses that return a Future in their implementation of onLoad due to a signature mismatch. 

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->
Closes #2961.

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
