### PR TITLE
feat: Add a hitboxFilter argument to raycast()

### DIFF
--- a/packages/flame/lib/src/collisions/collision_detection.dart
+++ b/packages/flame/lib/src/collisions/collision_detection.dart
@@ -101,15 +101,22 @@ abstract class CollisionDetection<T extends Hitbox<T>,
   /// [maxDistance] can be provided to limit the raycast to only return hits
   /// within this distance from the ray origin.
   ///
-  /// [ignoreHitboxes] can be used if you want to ignore certain hitboxes, i.e.
-  /// the rays will go straight through them. For example the hitbox of the
-  /// component that you might be casting the rays from.
+  /// You can provide a [hitboxFilter] callback to define which hitboxes
+  /// to consider and which to ignore. This callback will be called with
+  /// every prospective hitbox, and only if the callback returns `true`
+  /// will the hitbox be considered. Otherwise, the ray will go straight
+  /// through it. One common use case is ignoring the component that is
+  /// shooting the ray.
+  ///
+  /// If you have a list of hitboxes to ignore in advance,
+  /// you can provide them via the [ignoreHitboxes] argument.
   ///
   /// If [out] is provided that object will be modified and returned with the
   /// result.
   RaycastResult<T>? raycast(
     Ray2 ray, {
     double? maxDistance,
+    bool Function(T candidate)? hitboxFilter,
     List<T>? ignoreHitboxes,
     RaycastResult<T>? out,
   });
@@ -127,9 +134,15 @@ abstract class CollisionDetection<T extends Hitbox<T>,
   /// If there are less objects in [rays] than the operation requires, the
   /// missing [Ray2] objects will be created and added to [rays].
   ///
-  /// [ignoreHitboxes] can be used if you want to ignore certain hitboxes, i.e.
-  /// the rays will go straight through them. For example the hitbox of the
-  /// component that you might be casting the rays from.
+  /// You can provide a [hitboxFilter] callback to define which hitboxes
+  /// to consider and which to ignore. This callback will be called with
+  /// every prospective hitbox, and only if the callback returns `true`
+  /// will the hitbox be considered. Otherwise, the ray will go straight
+  /// through it. One common use case is ignoring the component that is
+  /// shooting the ray.
+  ///
+  /// If you have a list of hitboxes to ignore in advance,
+  /// you can provide them via the [ignoreHitboxes] argument.
   ///
   /// If [out] is provided the [RaycastResult]s in that list be modified and
   /// returned with the result. If there are less objects in [out] than the
@@ -141,6 +154,7 @@ abstract class CollisionDetection<T extends Hitbox<T>,
     double sweepAngle = tau,
     double? maxDistance,
     List<Ray2>? rays,
+    bool Function(T candidate)? hitboxFilter,
     List<T>? ignoreHitboxes,
     List<RaycastResult<T>>? out,
   });
@@ -152,9 +166,15 @@ abstract class CollisionDetection<T extends Hitbox<T>,
   /// [maxDepth] is how many times the ray should collide before returning a
   /// result, defaults to 10.
   ///
-  /// [ignoreHitboxes] can be used if you want to ignore certain hitboxes, i.e.
-  /// the rays will go straight through them. For example the hitbox of the
-  /// component that you might be casting the rays from.
+  /// You can provide a [hitboxFilter] callback to define which hitboxes
+  /// to consider and which to ignore. This callback will be called with
+  /// every prospective hitbox, and only if the callback returns `true`
+  /// will the hitbox be considered. Otherwise, the ray will go straight
+  /// through it. One common use case is ignoring the component that is
+  /// shooting the ray.
+  ///
+  /// If you have a list of hitboxes to ignore in advance,
+  /// you can provide them via the [ignoreHitboxes] argument.
   ///
   /// If [out] is provided the [RaycastResult]s in that list be modified and
   /// returned with the result. If there are less objects in [out] than the
@@ -162,6 +182,7 @@ abstract class CollisionDetection<T extends Hitbox<T>,
   Iterable<RaycastResult<T>> raytrace(
     Ray2 ray, {
     int maxDepth = 10,
+    bool Function(T candidate)? hitboxFilter,
     List<T>? ignoreHitboxes,
     List<RaycastResult<T>>? out,
   });

--- a/packages/flame/lib/src/collisions/standard_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/standard_collision_detection.dart
@@ -72,6 +72,7 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
   RaycastResult<ShapeHitbox>? raycast(
     Ray2 ray, {
     double? maxDistance,
+    bool Function(ShapeHitbox candidate)? hitboxFilter,
     List<ShapeHitbox>? ignoreHitboxes,
     RaycastResult<ShapeHitbox>? out,
   }) {
@@ -80,6 +81,11 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
     for (final item in items) {
       if (ignoreHitboxes?.contains(item) ?? false) {
         continue;
+      }
+      if (hitboxFilter != null) {
+        if (!hitboxFilter(item)) {
+          continue;
+        }
       }
       if (!item.aabb.intersectsWithAabb2(_temporaryRayAabb)) {
         continue;
@@ -109,6 +115,7 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
     double sweepAngle = tau,
     double? maxDistance,
     List<Ray2>? rays,
+    bool Function(ShapeHitbox candidate)? hitboxFilter,
     List<ShapeHitbox>? ignoreHitboxes,
     List<RaycastResult<ShapeHitbox>>? out,
   }) {
@@ -140,6 +147,7 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
       result = raycast(
         ray,
         maxDistance: maxDistance,
+        hitboxFilter: hitboxFilter,
         ignoreHitboxes: ignoreHitboxes,
         out: result,
       );
@@ -155,6 +163,7 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
   Iterable<RaycastResult<ShapeHitbox>> raytrace(
     Ray2 ray, {
     int maxDepth = 10,
+    bool Function(ShapeHitbox candidate)? hitboxFilter,
     List<ShapeHitbox>? ignoreHitboxes,
     List<RaycastResult<ShapeHitbox>>? out,
   }) sync* {
@@ -166,6 +175,7 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
           hasResultObject ? out![i] : RaycastResult<ShapeHitbox>();
       final currentResult = raycast(
         currentRay,
+        hitboxFilter: hitboxFilter,
         ignoreHitboxes: ignoreHitboxes,
         out: storeResult,
       );

--- a/packages/flame/test/collisions/collision_detection_test.dart
+++ b/packages/flame/test/collisions/collision_detection_test.dart
@@ -1,8 +1,8 @@
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
-import 'package:flame/geometry.dart';
 import 'package:flame/geometry.dart' as geometry;
+import 'package:flame/geometry.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:test/test.dart';
 
@@ -1083,6 +1083,37 @@ void main() {
           ignoreHitboxes: [
             world.children.first.children.first as ShapeHitbox,
           ],
+        );
+        expect(result?.hitbox?.parent, game.world.children.toList()[1]);
+        expect(
+          result?.reflectionRay?.origin,
+          closeToVector(Vector2.all(100.5)),
+        );
+        expect(
+          result?.reflectionRay?.direction,
+          closeToVector(Vector2(-1, 1)..normalize()),
+        );
+      },
+      'multiple hitboxes after each other with filter':
+          (collisionSystem) async {
+        final game = collisionSystem as FlameGame;
+        final world = game.world;
+        await world.ensureAddAll([
+          for (var i = 0.0; i < 10; i++)
+            PositionComponent(
+              position: Vector2.all(100 + i * 10),
+              size: Vector2.all(20 - i),
+              anchor: Anchor.center,
+            )..add(RectangleHitbox()),
+        ]);
+        await game.ready();
+        final ray = Ray2(
+          origin: Vector2.zero(),
+          direction: Vector2.all(1)..normalize(),
+        );
+        final result = collisionSystem.collisionDetection.raycast(
+          ray,
+          hitboxFilter: (hitbox) => hitbox.parent != world.children.first,
         );
         expect(result?.hitbox?.parent, game.world.children.toList()[1]);
         expect(


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Adds a new argument callback to all `raycast*` methods that lets the user ignore hitboxes dynamically. The callback is called with every prospective hitbox, and the hitbox is only considered when the callback returns `true`.

This is faster, in the general case, than the current `ignoreHitboxes` aproach. And it lets the developer have dynamic rules about what the rays collide with. (For example, a line-of-fire raycast should take friendlies into account, but could easily ignore other enemies that get in the way.)

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

For people who just _use_ raycasts, this is not a breaking change.

People who extend `CollisionDetection` will need to support the new argument. I'd say this is pretty rare but not unheard of.

If you have your own custom collision detection logic (a class implementing or extending Flame's `CollisionDetection`), you'll have to update its three `ray*` methods. Add the new argument to the base `raycast()` method and make sure that the ray actually only collides with hitboxes that return `true` from `hitboxFilter()`. The other two methods (`raycastAll()` and `raytrace()`) will, in most cases, just call `raycast()`, so just make sure you pass the argument.

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->

Closes #2966

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
