### PR TITLE
fix: Updated PolygonComponent.containsPoint to account for concave polygons

### DIFF
--- a/packages/flame/lib/src/geometry/polygon_component.dart
+++ b/packages/flame/lib/src/geometry/polygon_component.dart
@@ -207,30 +207,44 @@ class PolygonComponent extends ShapeComponent {
       return false;
     }
 
-    // Count the amount of edges crossed by a straight horizontal line going left from the point
-    int count = 0;
+    // Count the amount of edges crossed by going left from the point
+    var count = 0;
     for (var i = 0; i < vertices.length; i++) {
       final edge = getEdge(i, vertices: vertices);
 
-      // If the edge is entirely to the right, above or below the point then it can't be crossed
+      // Skip if the edge is entirely to the right, above or below the point
       if (edge.from.x > point.x && edge.to.x > point.x ||
           min(edge.from.y, edge.to.y) > point.y ||
           max(edge.from.y, edge.to.y) < point.y) {
         continue;
       }
 
-      // If the edge is crossed by the line, increase the count
-      if (edge.from.y == edge.to.y ||
-          ((point.y - edge.from.y) * (edge.to.x - edge.from.x)) /
-                      (edge.to.y - edge.from.y) +
-                  edge.from.x <
-              point.x) {
-        count++;
+      // Get x coordinate of where the edge intersects with the horizontal line
+      double intersectionX;
+      if (edge.from.y == edge.to.y) {
+        intersectionX = min(edge.from.x, edge.to.x);
+      } else {
+        intersectionX = ((point.y - edge.from.y) * (edge.to.x - edge.from.x)) /
+                (edge.to.y - edge.from.y) +
+            edge.from.x;
+      }
+
+      if (intersectionX == point.x) {
+        // If the point is on the edge, return true
+        return true;
+      } else if (intersectionX < point.x) {
+        // Only count one edge if vertex is crossed
+        // Only count if edges cross the line, not just touch it and go back
+        if ((edge.from.y != point.y && edge.to.y != point.y) ||
+            edge.to.y == edge.from.y ||
+            point.y == max(edge.from.y, edge.to.y)) {
+          count++;
+        }
       }
     }
 
-    // If the amount of edges crossed is odd then the point is inside the polygon
-    return count % 2 == 1;
+    // If the amount of edges crossed is odd, the point is inside the polygon
+    return (count % 2).isOdd;
   }
 
   @override

--- a/packages/flame/lib/src/geometry/polygon_component.dart
+++ b/packages/flame/lib/src/geometry/polygon_component.dart
@@ -210,23 +210,23 @@ class PolygonComponent extends ShapeComponent {
     // Count the amount of edges crossed by going left from the point
     var count = 0;
     for (var i = 0; i < vertices.length; i++) {
-      final edge = getEdge(i, vertices: vertices);
+      final from = vertices[i];
+      final to = vertices[(i + 1) % vertices.length];
 
       // Skip if the edge is entirely to the right, above or below the point
-      if (edge.from.x > point.x && edge.to.x > point.x ||
-          min(edge.from.y, edge.to.y) > point.y ||
-          max(edge.from.y, edge.to.y) < point.y) {
+      if (from.x > point.x && to.x > point.x ||
+          min(from.y, to.y) > point.y ||
+          max(from.y, to.y) < point.y) {
         continue;
       }
 
       // Get x coordinate of where the edge intersects with the horizontal line
       double intersectionX;
-      if (edge.from.y == edge.to.y) {
-        intersectionX = min(edge.from.x, edge.to.x);
+      if (from.y == to.y) {
+        intersectionX = min(from.x, to.x);
       } else {
-        intersectionX = ((point.y - edge.from.y) * (edge.to.x - edge.from.x)) /
-                (edge.to.y - edge.from.y) +
-            edge.from.x;
+        intersectionX =
+            ((point.y - from.y) * (to.x - from.x)) / (to.y - from.y) + from.x;
       }
 
       if (intersectionX == point.x) {
@@ -235,9 +235,9 @@ class PolygonComponent extends ShapeComponent {
       } else if (intersectionX < point.x) {
         // Only count one edge if vertex is crossed
         // Only count if edges cross the line, not just touch it and go back
-        if ((edge.from.y != point.y && edge.to.y != point.y) ||
-            edge.to.y == edge.from.y ||
-            point.y == max(edge.from.y, edge.to.y)) {
+        if ((from.y != point.y && to.y != point.y) ||
+            to.y == from.y ||
+            point.y == max(from.y, to.y)) {
           count++;
         }
       }

--- a/packages/flame/test/components/shape_component_test.dart
+++ b/packages/flame/test/components/shape_component_test.dart
@@ -180,6 +180,33 @@ void main() {
       );
     });
 
+    test('concave polygon contains point', () {
+      final component = PolygonComponent(
+        [
+          Vector2(0, 0),
+          Vector2(-2, -4),
+          Vector2(2, 0),
+          Vector2(-2, 4),
+        ],
+      );
+      expect(
+        component.containsPoint(Vector2(-1, 0)),
+        isFalse,
+      );
+      expect(
+        component.containsPoint(Vector2(-1, 1)),
+        isFalse,
+      );
+      expect(
+        component.containsPoint(Vector2(2, 0)),
+        isTrue,
+      );
+      expect(
+        component.containsPoint(Vector2(1, 1)),
+        isTrue,
+      );
+    });
+
     test('horizontally flipped rectangle contains point', () {
       final component = RectangleComponent(
         position: Vector2.all(1.0),


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Previously, the `PolygonComponent.containsPoint()` and `.containsLocalPoint()` functions consisted of duplicate code that checked whether a given point lies within a convex polygon. They didn't function properly with concave polygons.

I created a new `_containsPoint()` function that is called from both functions to reduce redundancies. This new function uses a different approach to figure out whether a point lies within a polygon, which should also work for concave polygons, or even polygons with holes. The algorithm is vaguely explained within code comments, and is visualized in this post: https://stackoverflow.com/a/218081/5008997

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
