### PR TITLE
feat: Make `Component.key` public

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -69,9 +69,8 @@ class Component {
   Component({
     Iterable<Component>? children,
     int? priority,
-    ComponentKey? key,
-  })  : _priority = priority ?? 0,
-        _key = key {
+    this.key,
+  }) : _priority = priority ?? 0 {
     if (children != null) {
       addAll(children);
     }
@@ -897,10 +896,10 @@ class Component {
     _parent!.onChildrenChanged(this, ChildrenChangeType.added);
     _clearMountingBit();
 
-    if (_key != null) {
+    if (key != null) {
       final currentGame = findGame();
       if (currentGame is FlameGame) {
-        currentGame.registerKey(_key!, this);
+        currentGame.registerKey(key!, this);
       }
     }
   }
@@ -958,10 +957,10 @@ class Component {
   }
 
   void _unregisterKey() {
-    if (_key != null) {
+    if (key != null) {
       final game = findGame();
       if (game is FlameGame) {
-        game.unregisterKey(_key!);
+        game.unregisterKey(key!);
       }
     }
   }
@@ -989,7 +988,7 @@ class Component {
   /// A key that can be used to identify this component in the tree.
   ///
   /// It can be used to retrieve this component from anywhere in the tree.
-  final ComponentKey? _key;
+  final ComponentKey? key;
 
   /// The color that the debug output should be rendered with.
   Color debugColor = const Color(0xFFFF00FF);

--- a/packages/flame_riverpod/lib/src/consumer.dart
+++ b/packages/flame_riverpod/lib/src/consumer.dart
@@ -14,7 +14,7 @@ class ComponentRef implements WidgetRef {
   BuildContext get context => game!.buildContext!;
 
   RiverpodAwareGameWidgetState? get _container {
-    return game?.key?.currentState;
+    return game?.widgetKey?.currentState;
   }
 
   @override
@@ -127,7 +127,7 @@ mixin RiverpodComponentMixin on Component {
   void rebuildGameWidget() {
     assert(ref.game!.isMounted == true);
     if (ref.game!.isMounted) {
-      ref.game!.key!.currentState!.forceBuild();
+      ref.game!.widgetKey!.currentState!.forceBuild();
     }
   }
 }
@@ -137,7 +137,7 @@ mixin RiverpodGameMixin<W extends World> on FlameGame<W> {
   /// was provided to.
   ///
   /// Used to facilitate [Component] access to the [ProviderContainer].
-  GlobalKey<RiverpodAwareGameWidgetState>? key;
+  GlobalKey<RiverpodAwareGameWidgetState>? widgetKey;
 
   final List<void Function()> _onBuildCallbacks = [];
 

--- a/packages/flame_riverpod/lib/src/widget.dart
+++ b/packages/flame_riverpod/lib/src/widget.dart
@@ -65,7 +65,7 @@ class RiverpodAwareGameWidgetState<T extends Game> extends GameWidgetState<T>
   @override
   void initState() {
     super.initState();
-    game.key = (widget as RiverpodAwareGameWidget<T>).key;
+    game.widgetKey = (widget as RiverpodAwareGameWidget<T>).key;
 
     WidgetsBinding.instance.addPersistentFrameCallback((_) {
       _isForceBuilding = false;
@@ -80,7 +80,7 @@ class RiverpodAwareGameWidgetState<T extends Game> extends GameWidgetState<T>
   @override
   void didUpdateWidget(covariant GameWidget<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    game.key = (widget as RiverpodAwareGameWidget<T>).key;
+    game.widgetKey = (widget as RiverpodAwareGameWidget<T>).key;
   }
 
   @override


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Since the user might want to use the `ComponentKey` after it has been assigned it should be made public.

It also updates `Consumer.key` to `Consumer.widgetKey` in flame_riverpod to avoid a name clash. (Slightly breaking)

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.
<!-- End of exclude from commit message -->
### Migration instructions

If you are using `consumer.key` from flame_riverpod you have to now use `consumer.widgetKey` instead.

## Related Issues

Closes #2985
<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
