### PR TITLE
fix: CameraComponent no longer throws Concurrent modification on stop

### DIFF
--- a/.github/.cspell/gamedev_dictionary.txt
+++ b/.github/.cspell/gamedev_dictionary.txt
@@ -46,6 +46,7 @@ raytracing # rendering techniques that calculates light rays as straight lines
 rects # plural of rect
 respawned # past tense of respawn
 respawn # when the player character dies and is brought back after some time and penalties
+retarget # to direct (something) toward a different target
 RGBA # red green blue alpha
 RGBO # red green blue opacity
 rrect # rounded rect
@@ -67,4 +68,3 @@ vsync # vertical sync; a graphics technology that synchronizes the software's fr
 WASD # movement keys on a keyboard
 WBMP # wireless bitmap image format
 WebP # WebP image format
-retarget # to direct (something) toward a different target

--- a/.github/.cspell/gamedev_dictionary.txt
+++ b/.github/.cspell/gamedev_dictionary.txt
@@ -67,3 +67,4 @@ vsync # vertical sync; a graphics technology that synchronizes the software's fr
 WASD # movement keys on a keyboard
 WBMP # wireless bitmap image format
 WebP # WebP image format
+retarget # to direct (something) toward a different target

--- a/packages/flame/lib/src/camera/camera_component.dart
+++ b/packages/flame/lib/src/camera/camera_component.dart
@@ -323,7 +323,7 @@ class CameraComponent extends Component {
 
   /// Removes all movement effects or behaviors from the viewfinder.
   void stop() {
-    viewfinder.children.forEach((child) {
+    viewfinder.children.toList().forEach((child) {
       if (child is FollowBehavior || child is MoveEffect) {
         child.removeFromParent();
       }

--- a/packages/flame/test/camera/camera_component_test.dart
+++ b/packages/flame/test/camera/camera_component_test.dart
@@ -61,10 +61,11 @@ void main() {
     });
 
     testWithFlameGame('camera should be able to retarget follow', (game) async {
-      final world = World()..addToParent(game);
-      final camera = CameraComponent(world: world)..addToParent(game);
-      final player = PositionComponent()..addToParent(world);
-      final player2 = PositionComponent()..addToParent(world);
+      // Creating new camera as the one included with game is not mounted and
+      // will therefore not be queued.
+      final camera = CameraComponent(world: game.world)..addToParent(game);
+      final player = PositionComponent()..addToParent(game.world);
+      final player2 = PositionComponent()..addToParent(game.world);
       camera.follow(player);
       camera.follow(player2);
       await game.ready();

--- a/packages/flame/test/camera/camera_component_test.dart
+++ b/packages/flame/test/camera/camera_component_test.dart
@@ -60,6 +60,19 @@ void main() {
       }
     });
 
+    testWithFlameGame('camera should be able to retarget follow', (game) async {
+      final world = World()..addToParent(game);
+      final camera = CameraComponent(world: world)..addToParent(game);
+      final player = PositionComponent()..addToParent(world);
+      final player2 = PositionComponent()..addToParent(world);
+      camera.follow(player);
+      camera.follow(player2);
+      await game.ready();
+
+      expect(camera.viewfinder.children.length, 1);
+      expect(camera.viewfinder.children.first, isA<FollowBehavior>());
+    });
+
     testWithFlameGame('follow with snap', (game) async {
       final world = World()..addToParent(game);
       final player = PositionComponent()


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
When camera is following a component and trying to follow another target I got an exception:
```
dart:core                                              Iterable.forEach
package:flame/src/camera/camera_component.dart 326:25  CameraComponent.stop
package:flame/src/camera/camera_component.dart 309:5   CameraComponent.follow
test/camera/camera_component_test.dart 69:14           main.<fn>.<fn>
package:flame_test/src/test_flame_game.dart 80:21      testWithGame.<fn>

Concurrent modification during iteration: _Set len:0.
```

Copying viewfinder children before iterating through it and removing child from parent does the trick, as we are not iterating through the same list as we are removing items from, but rather a copy of it.

I tried to use camera from `game` provided in the test but it is AFAIK not mounted and will hence not queue modifications (adds and removes). Hence I create a new camera and mount it.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
<!-- End of exclude from commit message -->
Replace or remove this text.

<!-- Exclude from commit message -->
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
