### PR TITLE
docs: Add missing import in klondike tutorial

### DIFF
--- a/doc/tutorials/klondike/step2.md
+++ b/doc/tutorials/klondike/step2.md
@@ -16,6 +16,7 @@ declare the `KlondikeGame` class inside:
 
 ```dart
 import 'package:flame/game.dart';
+import 'package:flame/flame.dart';
 
 class KlondikeGame extends FlameGame {
   @override


### PR DESCRIPTION
missing the 
import 'package:flame/flame.dart';
for this step
