### PR TITLE
feat!: Update flame_noise to use latest version of fast_noise

### DIFF
--- a/packages/flame_noise/lib/src/effects.dart
+++ b/packages/flame_noise/lib/src/effects.dart
@@ -1,1 +1,1 @@
-export 'effects/perlin_noise_effect_controller.dart';
+export 'effects/noise_effect_controller.dart';

--- a/packages/flame_noise/lib/src/effects/noise_effect_controller.dart
+++ b/packages/flame_noise/lib/src/effects/noise_effect_controller.dart
@@ -2,7 +2,7 @@ import 'package:fast_noise/fast_noise.dart';
 import 'package:flame/effects.dart';
 import 'package:flutter/animation.dart' show Curve, Curves;
 
-/// Effect controller that oscillates around 0 following a noise curve.
+/// Effect controller that oscillates around following a noise curve.
 ///
 /// The [taperingCurve] describes how the effect fades out over time. The
 /// curve that you supply will be flipped along the X axis, so that the effect
@@ -12,25 +12,21 @@ import 'package:flutter/animation.dart' show Curve, Curves;
 /// example, putting into a `MoveEffect.by` will create a shake motion, where
 /// the magnitude and the direction of shaking is controlled by the effect's
 /// `offset`.
-class PerlinNoiseEffectController extends DurationEffectController {
-  PerlinNoiseEffectController({
-    required double duration,
-    int octaves = 3,
-    double frequency = 0.05,
-    this.taperingCurve = Curves.easeInOutCubic,
-    int seed = 1337,
-  })  : assert(duration > 0, 'duration must be positive'),
-        assert(frequency > 0, 'frequency parameter must be positive'),
-        noise = PerlinNoise(seed: seed, octaves: octaves, frequency: frequency),
-        super(duration);
-
+class NoiseEffectController extends DurationEffectController {
   final Curve taperingCurve;
-  final PerlinNoise noise;
+  final Noise2 noise;
+
+  NoiseEffectController({
+    required double duration,
+    this.taperingCurve = Curves.easeInOutCubic,
+    Noise2? noise,
+  })  : noise = noise ?? PerlinNoise(),
+        super(duration);
 
   @override
   double get progress {
     final x = timer / duration;
     final amplitude = taperingCurve.transform(1 - x);
-    return noise.getPerlin2(x, 1) * amplitude;
+    return noise.getNoise2(x, 1) * amplitude;
   }
 }

--- a/packages/flame_noise/pubspec.yaml
+++ b/packages/flame_noise/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  fast_noise: ^1.0.1
+  fast_noise: ^2.0.0
   flame: ^1.14.0
   flutter:
     sdk: flutter

--- a/packages/flame_noise/test/noise_effect_controller_test.dart
+++ b/packages/flame_noise/test/noise_effect_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:fast_noise/fast_noise.dart';
 import 'package:flame_noise/flame_noise.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/animation.dart';
@@ -6,7 +7,10 @@ import 'package:test/test.dart';
 void main() {
   group('PerlinNoiseEffectController', () {
     test('general properties', () {
-      final ec = PerlinNoiseEffectController(duration: 1, frequency: 12);
+      final ec = NoiseEffectController(
+        duration: 1,
+        noise: PerlinNoise(frequency: 12),
+      );
       expect(ec.duration, 1.0);
       expect(ec.taperingCurve, Curves.easeInOutCubic);
       expect(ec.started, true);
@@ -16,7 +20,10 @@ void main() {
     });
 
     test('progression', () {
-      final ec = PerlinNoiseEffectController(duration: 1);
+      final ec = NoiseEffectController(
+        duration: 1,
+        noise: PerlinNoise(frequency: 0.05),
+      );
       final observed = <double>[];
       for (var t = 0.0; t < 1.0; t += 0.1) {
         observed.add(ec.progress);
@@ -39,12 +46,8 @@ void main() {
 
     test('errors', () {
       expect(
-        () => PerlinNoiseEffectController(duration: 0, frequency: 1),
-        failsAssert('duration must be positive'),
-      );
-      expect(
-        () => PerlinNoiseEffectController(duration: 1, frequency: 0),
-        failsAssert('frequency parameter must be positive'),
+        () => NoiseEffectController(duration: -1),
+        failsAssert('Duration cannot be negative: -1.0'),
       );
     });
   });


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Update flame_noise to use the latest version of fast_noise, basically replacing the Perlin-specific effect controller with a generic `NoiseEffectController` that can take in any noise class (leveraging the new Noise2 interface).
<!-- Exclude from commit message -->

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

<!-- End of exclude from commit message -->
Just update from `PerlinNoiseEffectController` to `NoiseEffectController` and provide the noise/parameters you want directly into the `noise` field.
<!-- Exclude from commit message -->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
