### PR TITLE
chore: Fix warnings and lint issues across the codebase

### DIFF
--- a/packages/flame/lib/src/components/core/component_key.dart
+++ b/packages/flame/lib/src/components/core/component_key.dart
@@ -20,6 +20,6 @@ class ComponentKey {
   int get hashCode => _internalHash;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is ComponentKey && other._internalHash == _internalHash;
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
@@ -14,7 +14,7 @@ class DoubleTapDispatcherKey implements ComponentKey {
   int get hashCode => 20260645; // 'DoubleTapDispatcherKey' as hashCode
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is DoubleTapDispatcherKey && other.hashCode == hashCode;
 }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
@@ -20,7 +20,7 @@ class MultiDragDispatcherKey implements ComponentKey {
   int get hashCode => 91604879; // 'MultiDragDispatcherKey' as hashCode
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is MultiDragDispatcherKey && other.hashCode == hashCode;
 }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
@@ -17,7 +17,7 @@ class MultiTapDispatcherKey implements ComponentKey {
   int get hashCode => 401913931; // 'MultiTapDispatcherKey' as hashCode
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is MultiTapDispatcherKey && other.hashCode == hashCode;
 }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/pointer_move_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/pointer_move_dispatcher.dart
@@ -66,6 +66,6 @@ class MouseMoveDispatcherKey implements ComponentKey {
   int get hashCode => 'MouseMoveDispatcherKey'.hashCode;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is MouseMoveDispatcherKey && other.hashCode == hashCode;
 }

--- a/packages/flame/test/extensions/_help.dart
+++ b/packages/flame/test/extensions/_help.dart
@@ -1,6 +1,0 @@
-mixin NullableEqualsMixin on Object {
-  @override
-  bool operator ==(Object? other) {
-    return super == other;
-  }
-}

--- a/packages/flame/test/extensions/matrix4_test.dart
+++ b/packages/flame/test/extensions/matrix4_test.dart
@@ -5,8 +5,6 @@ import 'package:flame_test/flame_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-import '_help.dart';
-
 void main() {
   group('Matrix4Extension', () {
     final matrix4 = Matrix4.fromList([
@@ -104,6 +102,4 @@ void main() {
   });
 }
 
-// This need the mixin because Mock's == parameter is not nullable
-// but Matrix4's == parameter is nullable
-class MockMatrix4 extends Mock with NullableEqualsMixin implements Matrix4 {}
+class MockMatrix4 extends Mock implements Matrix4 {}

--- a/packages/flame_lint/lib/analysis_options.yaml
+++ b/packages/flame_lint/lib/analysis_options.yaml
@@ -13,7 +13,6 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
-    - always_require_non_null_named_parameters
     - always_use_package_imports
     - annotate_overrides
     - avoid_bool_literals_in_conditional_expressions

--- a/packages/flame_lint/lib/analysis_options_with_dcm.yaml
+++ b/packages/flame_lint/lib/analysis_options_with_dcm.yaml
@@ -5,7 +5,6 @@ include: analysis_options.yaml
 dart_code_metrics:
   rules:
   # dart rules
-    - avoid-banned-imports
     - avoid-cascade-after-if-null
     - avoid-collection-methods-with-unrelated-types
   # flutter rules


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Fix warnings and lint issues across the codebase.

This includes:
* equals should now be Object instead of dynamic (and thus we don't need _help.dart anymore)
* the `always_require_non_null_named_parameters` lint rule is removed
* the `avoid-banned-imports` rule from DCM actually doesn't do anything unless configured

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
