### PR TITLE
fix!: Removed unused parameters from SpriteWidget

### DIFF
--- a/packages/flame/lib/src/widgets/sprite_widget.dart
+++ b/packages/flame/lib/src/widgets/sprite_widget.dart
@@ -19,12 +19,6 @@ class SpriteWidget extends StatelessWidget {
   /// The angle to rotate this [Sprite], in rad. (default = 0)
   final double angle;
 
-  /// Holds the position of the sprite on the image
-  final Vector2? srcPosition;
-
-  /// Holds the size of the sprite on the image
-  final Vector2? srcSize;
-
   /// A builder function that is called if the loading fails
   final WidgetBuilder? errorBuilder;
 
@@ -33,12 +27,13 @@ class SpriteWidget extends StatelessWidget {
 
   final FutureOr<Sprite> _spriteFuture;
 
+  /// renders the [sprite] as a Widget.
+  ///
+  /// To change the source size and position, see [Sprite.new]
   const SpriteWidget({
     required Sprite sprite,
     this.anchor = Anchor.topLeft,
     this.angle = 0,
-    this.srcPosition,
-    this.srcSize,
     this.errorBuilder,
     this.loadingBuilder,
     super.key,
@@ -55,8 +50,8 @@ class SpriteWidget extends StatelessWidget {
     Images? images,
     this.anchor = Anchor.topLeft,
     this.angle = 0,
-    this.srcPosition,
-    this.srcSize,
+    Vector2? srcPosition,
+    Vector2? srcSize,
     this.errorBuilder,
     this.loadingBuilder,
     super.key,


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
The unused fields of "SpriteWidget", "srcPosition" and "srcSize" and their matching parameter in the default constructor has been removed.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [X] I have followed the [Contributor Guide] when preparing my PR.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [X] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
If SpriteWidget is used, remove the parameter srcPosition and srcSize as they have not been used in the default constructor.
(This does not belong to SpriteWidget.asset())
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #3071 
!-->
Closes #3071 
<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
