### PR TITLE
fix: Resolve breaking changes from Riverpod affecting flame_riverpod

### DIFF
--- a/packages/flame_riverpod/example/pubspec.yaml
+++ b/packages/flame_riverpod/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flame_riverpod: ^5.3.0
   flutter:
     sdk: flutter
-  flutter_riverpod: ^2.1.3
+  flutter_riverpod: ^2.5.1
 
 dev_dependencies:
   flame_lint: ^0.2.0


### PR DESCRIPTION

<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Changes to how support for manual listeners is implemented in flutter_riverpod 2.5.1 (released 4 days ago) have affected flame_riverpod - specifically, the implementation of ProviderSubscription. 

This PR updates the implementation of manual listeners in flame_riverpod in the same manner that flutter_riverpod has. 

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
No one has reported this as an issue yet. Evidence of the problem is[ visible on pub.dev](https://pub.dev/packages/flame_riverpod). 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
