### PR TITLE
fix: Resolve logic error with assignment of ComponentRef's game property in flame_riverpod

### DIFF
--- a/packages/flame_riverpod/lib/src/consumer.dart
+++ b/packages/flame_riverpod/lib/src/consumer.dart
@@ -79,13 +79,6 @@ mixin RiverpodComponentMixin on Component {
   /// this component is removed.
   bool rebuildOnRemoveWhen(ComponentRef ref) => true;
 
-  @mustCallSuper
-  @override
-  FutureOr<void> onLoad() {
-    ref.game = findGame()! as RiverpodGameMixin;
-    super.onLoad();
-  }
-
   /// Adds a callback method to be invoked in the build method of
   /// [RiverpodAwareGameWidgetState].
   void addToGameWidgetBuild(Function() cb) {
@@ -96,6 +89,7 @@ mixin RiverpodComponentMixin on Component {
   @override
   void onMount() {
     super.onMount();
+    ref.game = findGame()! as RiverpodGameMixin;
     ref.game!._onBuildCallbacks.addAll(_onBuildCallbacks);
 
     if (rebuildOnMountWhen(ref) == true) {


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Assignment of the game property on Components using RiverpodComponentMixin was being performed inside the onLoad method, meaning if components were unmounted and mounted once again, attempts to invoke callbacks to the GameWidget's build method would throw an exception. 

This functionality has been moved to the onMount method, where it always should have been.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
!-->
Closes #3025

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
