### PR TITLE
fix: Null gravity override by Forge2dGame

### DIFF
--- a/packages/flame_forge2d/lib/forge2d_game.dart
+++ b/packages/flame_forge2d/lib/forge2d_game.dart
@@ -12,7 +12,7 @@ class Forge2DGame<T extends Forge2DWorld> extends FlameGame<T> {
     ContactListener? contactListener,
     double zoom = 10,
   }) : super(
-          world: ((world?..gravity = gravity) ??
+          world: ((world?..gravity = gravity ?? world.gravity) ??
               Forge2DWorld(
                 gravity: gravity,
                 contactListener: contactListener,

--- a/packages/flame_forge2d/test/forge2d_game_test.dart
+++ b/packages/flame_forge2d/test/forge2d_game_test.dart
@@ -78,6 +78,12 @@ void main() {
                   game.camera.viewfinder.zoom,
         );
       });
+
+      test("Game does not override World's gravity with null", () {
+        final game = Forge2DGame(world: Forge2DWorld(gravity: Vector2(10, 0)));
+        expect(game.world.gravity.x, 10);
+        expect(game.world.gravity.y, 0);
+      });
     },
   );
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->

`Forge2dGame` overrides the world's gravity even when a gravity vector is not provided to it. This causes the world to use the default gravity.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

NA

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
