### PR TITLE
fix: Fix namespace conflict with new Flutter class Split

### DIFF
--- a/packages/flame_devtools/lib/widgets/component_tree.dart
+++ b/packages/flame_devtools/lib/widgets/component_tree.dart
@@ -2,7 +2,7 @@ import 'package:animated_tree_view/animated_tree_view.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:flame_devtools/widgets/component_tree_model.dart';
 import 'package:flame_devtools/widgets/debug_mode_button.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Split;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class ComponentTree extends StatelessWidget {


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description
<!-- End of exclude from commit message -->
Fix namespace conflict with new Flutter class Split.

Newer versions of Flutter seem to have introduced a Split class within animation curves which causes a compilation issue within Flame:

> The name 'Split' is defined in the libraries 'package:devtools_app_shared/src/ui/split.dart (via package:devtools_app_shared/ui.dart)' and 'package:flutter/src/animation/curves.dart'.
> Try using 'as prefix' for one of the import directives, or hiding the name from all but one of the imports.
<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
