### PR TITLE
feat: Add ability to convert between TextPaint and InlineTextStyle

### DIFF
--- a/packages/flame/lib/src/text/renderers/text_paint.dart
+++ b/packages/flame/lib/src/text/renderers/text_paint.dart
@@ -63,4 +63,15 @@ class TextPaint extends TextRenderer {
       textDirection: textDirection ?? this.textDirection,
     );
   }
+
+  InlineTextStyle asInlineTextStyle() {
+    return InlineTextStyle(
+      color: style.color,
+      fontFamily: style.fontFamily,
+      fontSize: style.fontSize,
+      fontWeight: style.fontWeight,
+      fontStyle: style.fontStyle,
+      letterSpacing: style.letterSpacing,
+    );
+  }
 }

--- a/packages/flame/lib/src/text/styles/inline_text_style.dart
+++ b/packages/flame/lib/src/text/styles/inline_text_style.dart
@@ -37,7 +37,6 @@ class InlineTextStyle extends FlameTextStyle {
     );
   }
 
-  @internal
   TextPaint asTextRenderer() {
     return TextPaint(
       style: TextStyle(

--- a/packages/flame/test/text/text_paint_test.dart
+++ b/packages/flame/test/text/text_paint_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Color;
+
 import 'package:flame/text.dart';
 import 'package:flutter/rendering.dart' as flutter;
 import 'package:test/test.dart';
@@ -11,5 +13,34 @@ void main() {
       expect(tp.style.fontSize, 12);
       expect(tp.style.fontFamily, 'Helvetica');
     });
+
+    test(
+      'can convert back and forth between TextPaint and InlineTextStyle',
+      () {
+        const flutterStyle = flutter.TextStyle(
+          fontSize: 12,
+          fontFamily: 'Times',
+          fontStyle: flutter.FontStyle.italic,
+          fontWeight: flutter.FontWeight.bold,
+          color: Color(0xFF00FF00),
+          letterSpacing: 1.5,
+        );
+        final textPaint = TextPaint(style: flutterStyle);
+
+        final inlineTextStyle = textPaint.asInlineTextStyle();
+        expect(inlineTextStyle.fontSize, 12);
+        expect(inlineTextStyle.fontFamily, 'Times');
+        expect(inlineTextStyle.fontStyle, flutter.FontStyle.italic);
+        expect(inlineTextStyle.fontWeight, flutter.FontWeight.bold);
+        expect(inlineTextStyle.color, const Color(0xFF00FF00));
+
+        final newTextPaint = inlineTextStyle.asTextRenderer();
+        expect(newTextPaint.style.fontSize, 12);
+        expect(newTextPaint.style.fontFamily, 'Times');
+        expect(newTextPaint.style.fontStyle, flutter.FontStyle.italic);
+        expect(newTextPaint.style.fontWeight, flutter.FontWeight.bold);
+        expect(newTextPaint.style.color, const Color(0xFF00FF00));
+      },
+    );
   });
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Add ability to convert between `TextPaint` and `InlineTextStyle`.

The opposite is already possible with `asTextRenderer`, which this exposes.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
