### PR TITLE
feat: Expand flame_lint to respect required pub.dev checks

### DIFF
--- a/doc/tutorials/platformer/app/lib/ember_quest.dart
+++ b/doc/tutorials/platformer/app/lib/ember_quest.dart
@@ -57,19 +57,19 @@ class EmberQuestGame extends FlameGame
   void loadGameSegments(int segmentIndex, double xPositionOffset) {
     for (final block in segments[segmentIndex]) {
       final component = switch (block.blockType) {
-        GroundBlock => GroundBlock(
+        GroundBlock _ => GroundBlock(
             gridPosition: block.gridPosition,
             xOffset: xPositionOffset,
           ),
-        PlatformBlock => PlatformBlock(
+        PlatformBlock _ => PlatformBlock(
             gridPosition: block.gridPosition,
             xOffset: xPositionOffset,
           ),
-        Star => Star(
+        Star _ => Star(
             gridPosition: block.gridPosition,
             xOffset: xPositionOffset,
           ),
-        WaterEnemy => WaterEnemy(
+        WaterEnemy _ => WaterEnemy(
             gridPosition: block.gridPosition,
             xOffset: xPositionOffset,
           ),

--- a/packages/flame/lib/src/widgets/base_future_builder.dart
+++ b/packages/flame/lib/src/widgets/base_future_builder.dart
@@ -28,11 +28,12 @@ class BaseFutureBuilder<T> extends StatelessWidget {
             case ConnectionState.active:
               return loadingBuilder?.call(context) ?? const SizedBox();
             case ConnectionState.done:
-              if (snapshot.hasData) {
-                return builder(context, snapshot.data!);
-              }
               if (snapshot.hasError) {
                 return errorBuilder?.call(context) ?? const SizedBox();
+              }
+              final data = snapshot.data;
+              if (data != null) {
+                return builder(context, data);
               }
               return loadingBuilder?.call(context) ?? const SizedBox();
           }

--- a/packages/flame/test/components/scroll_text_box_component_test.dart
+++ b/packages/flame/test/components/scroll_text_box_component_test.dart
@@ -10,18 +10,18 @@ void main() {
       (game) async {
         final onComplete = MockOnCompleteCallback();
 
-        when(onComplete).thenReturn(null);
+        when(onComplete.call).thenReturn(null);
 
         final component = ScrollTextBoxComponent(
           size: Vector2(200, 100),
           text: 'Short text',
-          onComplete: onComplete,
+          onComplete: onComplete.call,
         );
         await game.ensureAdd(component);
 
         game.update(0.1);
 
-        verify(onComplete).called(1);
+        verify(onComplete.call).called(1);
       },
     );
 
@@ -30,19 +30,19 @@ void main() {
       (game) async {
         final onComplete = MockOnCompleteCallback();
 
-        when(onComplete).thenReturn(null);
+        when(onComplete.call).thenReturn(null);
 
         final component = ScrollTextBoxComponent(
           size: Vector2(200, 100),
           text: '''Long text that will definitely require scrolling to be 
 fully visible in the given size of the ScrollTextBoxComponent.''',
-          onComplete: onComplete,
+          onComplete: onComplete.call,
         );
         await game.ensureAdd(component);
 
         game.update(0.1);
 
-        verify(onComplete).called(1);
+        verify(onComplete.call).called(1);
       },
     );
 

--- a/packages/flame/test/components/text_box_component_test.dart
+++ b/packages/flame/test/components/text_box_component_test.dart
@@ -129,18 +129,18 @@ void main() {
       (game) async {
         final onComplete = MockOnCompleteCallback();
 
-        when(onComplete).thenReturn(null);
+        when(onComplete.call).thenReturn(null);
 
         final component = ScrollTextBoxComponent(
           size: Vector2(200, 100),
           text: 'Short text',
-          onComplete: onComplete,
+          onComplete: onComplete.call,
         );
         await game.ensureAdd(component);
 
         game.update(0.1);
 
-        verify(onComplete).called(1);
+        verify(onComplete.call).called(1);
       },
     );
 

--- a/packages/flame/test/effects/controllers/effect_controller_test.dart
+++ b/packages/flame/test/effects/controllers/effect_controller_test.dart
@@ -323,8 +323,8 @@ void main() {
       final ec = EffectController(
         duration: 1,
         reverseDuration: 1,
-        onMax: mockOnMax,
-        onMin: mockOnMin,
+        onMax: mockOnMax.call,
+        onMin: mockOnMin.call,
         infinite: true,
       );
 

--- a/packages/flame/test/extensions/canvas_test.dart
+++ b/packages/flame/test/extensions/canvas_test.dart
@@ -35,7 +35,7 @@ void main() {
 
       final drawFunction = MocktailDrawFunction();
       when(() => drawFunction.call(canvas)).thenReturn(null);
-      canvas.renderAt(Vector2(1, 1), drawFunction);
+      canvas.renderAt(Vector2(1, 1), drawFunction.call);
       verify(canvas.save).called(1);
       verify(() => canvas.translateVector(Vector2(1, 1))).called(1);
       verify(() => drawFunction(canvas)).called(1);
@@ -54,7 +54,7 @@ void main() {
 
       final drawFunction = MocktailDrawFunction();
       when(() => drawFunction.call(canvas)).thenReturn(null);
-      canvas.renderRotated(0.5, Vector2(1, 1), drawFunction);
+      canvas.renderRotated(0.5, Vector2(1, 1), drawFunction.call);
       verify(canvas.save).called(1);
       verify(() => canvas.translateVector(Vector2(1, 1))).called(1);
       verify(() => canvas.rotate(.5)).called(1);

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -23,7 +23,6 @@ dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
   flame_test: ^1.16.1
-  flutter_lints: ^3.0.2
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.1

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   dartdoc: ^6.3.0
   flame_lint: ^1.1.2
   flame_test: ^1.16.1
-  flutter_lints: ^2.0.1
+  flutter_lints: ^3.0.2
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.1

--- a/packages/flame_lint/lib/analysis_options.yaml
+++ b/packages/flame_lint/lib/analysis_options.yaml
@@ -1,6 +1,8 @@
 # Source of linter options:
 # https://dart-lang.github.io/linter/lints/options/options.html
 
+include: package:lints/core.yaml
+
 analyzer:
   exclude:
     - "**/*.g.dart"

--- a/packages/flame_lint/pubspec.yaml
+++ b/packages/flame_lint/pubspec.yaml
@@ -10,5 +10,8 @@ funding:
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
+dependencies:
+  lints: ^3.0.0
+
 dev_dependencies:
   dartdoc: ^6.3.0


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Expand flame_lint to respect required pub.dev checks.

We are currently losing pub points due to lint violations:

![image](https://github.com/flame-engine/flame/assets/882703/b6a6cf0a-aea1-4e75-b1cb-611d5f8a154c)

Turns out `flame_lint` does not respect lints/core which is being enforced now by pub.

This adds that as a dependency on `flame_lint`, updates `flutter_lint` for the packages that use that, and fix all existing violations (luckily very few).

This change will ensure that us and everyone else who uses `flame_lint` get all the points they deserve on pub. We can consider expanding to `lints/recommended` in the future, but that is definitely not a requirement at this stage (and a much bigger change).
<!-- Exclude from commit message -->

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
