### PR TITLE
feat: Add missing parameters to InlineTextStyle

### DIFF
--- a/packages/flame/lib/src/text/renderers/text_paint.dart
+++ b/packages/flame/lib/src/text/renderers/text_paint.dart
@@ -72,6 +72,16 @@ class TextPaint extends TextRenderer {
       fontWeight: style.fontWeight,
       fontStyle: style.fontStyle,
       letterSpacing: style.letterSpacing,
+      wordSpacing: style.wordSpacing,
+      height: style.height,
+      leadingDistribution: style.leadingDistribution,
+      shadows: style.shadows,
+      fontFeatures: style.fontFeatures,
+      fontVariations: style.fontVariations,
+      decoration: style.decoration,
+      decorationColor: style.decorationColor,
+      decorationStyle: style.decorationStyle,
+      decorationThickness: style.decorationThickness,
     );
   }
 }

--- a/packages/flame/lib/src/text/styles/inline_text_style.dart
+++ b/packages/flame/lib/src/text/styles/inline_text_style.dart
@@ -2,6 +2,10 @@ import 'package:flame/text.dart';
 import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
+/// A [FlameTextStyle] used to style an inline text element.
+///
+/// Note: the fields on this class are equivalent to the fields on Flutter's
+/// [TextStyle] class; check its documentation for more details.
 @immutable
 class InlineTextStyle extends FlameTextStyle {
   InlineTextStyle({
@@ -12,6 +16,16 @@ class InlineTextStyle extends FlameTextStyle {
     this.fontWeight,
     this.fontStyle,
     this.letterSpacing,
+    this.wordSpacing,
+    this.height,
+    this.leadingDistribution,
+    this.shadows,
+    this.fontFeatures,
+    this.fontVariations,
+    this.decoration,
+    this.decorationColor,
+    this.decorationStyle,
+    this.decorationThickness,
   });
 
   final Color? color;
@@ -21,6 +35,16 @@ class InlineTextStyle extends FlameTextStyle {
   final FontWeight? fontWeight;
   final FontStyle? fontStyle;
   final double? letterSpacing;
+  final double? wordSpacing;
+  final double? height;
+  final TextLeadingDistribution? leadingDistribution;
+  final List<Shadow>? shadows;
+  final List<FontFeature>? fontFeatures;
+  final List<FontVariation>? fontVariations;
+  final TextDecoration? decoration;
+  final Color? decorationColor;
+  final TextDecorationStyle? decorationStyle;
+  final double? decorationThickness;
 
   late final TextRenderer renderer = asTextRenderer();
 
@@ -34,19 +58,43 @@ class InlineTextStyle extends FlameTextStyle {
       fontWeight: other.fontWeight ?? fontWeight,
       fontStyle: other.fontStyle ?? fontStyle,
       letterSpacing: other.letterSpacing ?? letterSpacing,
+      wordSpacing: other.wordSpacing ?? wordSpacing,
+      height: other.height ?? height,
+      leadingDistribution: other.leadingDistribution ?? leadingDistribution,
+      shadows: other.shadows ?? shadows,
+      fontFeatures: other.fontFeatures ?? fontFeatures,
+      fontVariations: other.fontVariations ?? fontVariations,
+      decoration: other.decoration ?? decoration,
+      decorationColor: other.decorationColor ?? decorationColor,
+      decorationStyle: other.decorationStyle ?? decorationStyle,
+      decorationThickness: other.decorationThickness ?? decorationThickness,
     );
   }
 
   TextPaint asTextRenderer() {
     return TextPaint(
-      style: TextStyle(
-        color: color,
-        fontFamily: fontFamily,
-        fontSize: fontSize! * (fontScale ?? 1.0),
-        fontWeight: fontWeight,
-        fontStyle: fontStyle,
-        letterSpacing: letterSpacing,
-      ),
+      style: asTextStyle(),
+    );
+  }
+
+  TextStyle asTextStyle() {
+    return TextStyle(
+      color: color,
+      fontFamily: fontFamily,
+      fontSize: fontSize! * (fontScale ?? 1.0),
+      fontWeight: fontWeight,
+      fontStyle: fontStyle,
+      letterSpacing: letterSpacing,
+      wordSpacing: wordSpacing,
+      height: height,
+      leadingDistribution: leadingDistribution,
+      shadows: shadows,
+      fontFeatures: fontFeatures,
+      fontVariations: fontVariations,
+      decoration: decoration,
+      decorationColor: decorationColor,
+      decorationStyle: decorationStyle,
+      decorationThickness: decorationThickness,
     );
   }
 }

--- a/packages/flame/test/text/text_paint_test.dart
+++ b/packages/flame/test/text/text_paint_test.dart
@@ -1,4 +1,4 @@
-import 'dart:ui' show Color;
+import 'dart:ui';
 
 import 'package:flame/text.dart';
 import 'package:flutter/rendering.dart' as flutter;
@@ -24,6 +24,26 @@ void main() {
           fontWeight: flutter.FontWeight.bold,
           color: Color(0xFF00FF00),
           letterSpacing: 1.5,
+          wordSpacing: 2.5,
+          height: 3.5,
+          leadingDistribution: TextLeadingDistribution.even,
+          shadows: [
+            Shadow(
+              color: Color(0xFFFF0000),
+              offset: Offset(1, 1),
+              blurRadius: 1,
+            ),
+          ],
+          fontFeatures: [
+            flutter.FontFeature.alternativeFractions(),
+          ],
+          fontVariations: [
+            flutter.FontVariation.slant(0.3),
+          ],
+          decoration: TextDecoration.lineThrough,
+          decorationColor: Color(0xFF0000FF),
+          decorationStyle: TextDecorationStyle.dashed,
+          decorationThickness: 1.5,
         );
         final textPaint = TextPaint(style: flutterStyle);
 
@@ -33,6 +53,30 @@ void main() {
         expect(inlineTextStyle.fontStyle, flutter.FontStyle.italic);
         expect(inlineTextStyle.fontWeight, flutter.FontWeight.bold);
         expect(inlineTextStyle.color, const Color(0xFF00FF00));
+        expect(inlineTextStyle.letterSpacing, 1.5);
+        expect(inlineTextStyle.wordSpacing, 2.5);
+        expect(inlineTextStyle.height, 3.5);
+        expect(
+          inlineTextStyle.leadingDistribution,
+          TextLeadingDistribution.even,
+        );
+        expect(inlineTextStyle.shadows, [
+          const Shadow(
+            color: Color(0xFFFF0000),
+            offset: Offset(1, 1),
+            blurRadius: 1,
+          ),
+        ]);
+        expect(inlineTextStyle.fontFeatures, [
+          const flutter.FontFeature.alternativeFractions(),
+        ]);
+        expect(inlineTextStyle.fontVariations, [
+          const FontVariation.slant(0.3),
+        ]);
+        expect(inlineTextStyle.decoration, TextDecoration.lineThrough);
+        expect(inlineTextStyle.decorationColor, const Color(0xFF0000FF));
+        expect(inlineTextStyle.decorationStyle, TextDecorationStyle.dashed);
+        expect(inlineTextStyle.decorationThickness, 1.5);
 
         final newTextPaint = inlineTextStyle.asTextRenderer();
         expect(newTextPaint.style.fontSize, 12);
@@ -40,6 +84,30 @@ void main() {
         expect(newTextPaint.style.fontStyle, flutter.FontStyle.italic);
         expect(newTextPaint.style.fontWeight, flutter.FontWeight.bold);
         expect(newTextPaint.style.color, const Color(0xFF00FF00));
+        expect(newTextPaint.style.letterSpacing, 1.5);
+        expect(newTextPaint.style.wordSpacing, 2.5);
+        expect(newTextPaint.style.height, 3.5);
+        expect(
+          newTextPaint.style.leadingDistribution,
+          TextLeadingDistribution.even,
+        );
+        expect(newTextPaint.style.shadows, [
+          const Shadow(
+            color: Color(0xFFFF0000),
+            offset: Offset(1, 1),
+            blurRadius: 1,
+          ),
+        ]);
+        expect(newTextPaint.style.fontFeatures, [
+          const flutter.FontFeature.alternativeFractions(),
+        ]);
+        expect(newTextPaint.style.fontVariations, [
+          const FontVariation.slant(0.3),
+        ]);
+        expect(newTextPaint.style.decoration, TextDecoration.lineThrough);
+        expect(newTextPaint.style.decorationColor, const Color(0xFF0000FF));
+        expect(newTextPaint.style.decorationStyle, TextDecorationStyle.dashed);
+        expect(newTextPaint.style.decorationThickness, 1.5);
       },
     );
   });


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add missing parameters to `InlineTextStyle`, such as `height` and `shadows`.

Without this, it is not possible to configure such parameters in the new text rendering pipeline. Since the other parameters are 1:1 to Flutter's `TextStyle`, these missing fields seem to have been just an oversight.

However, it does make me question why are we copying the values from Flutter's class. I don't see why we could not just replace all these fields with a single `TextStyle` field. In fact, we could just make `TextPaint` extend `FlameTextStyle` and get rid of `InlineTextStyle` altogether. Either way, these can be followups.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->