### PR TITLE
feat: Support text align on new text rendering pipeline

### DIFF
--- a/examples/lib/stories/rendering/rendering.dart
+++ b/examples/lib/stories/rendering/rendering.dart
@@ -67,7 +67,15 @@ void addRenderingStories(Dashbook dashbook) {
     )
     ..add(
       'Rich Text',
-      (_) => GameWidget(game: RichTextExample()),
+      (context) => GameWidget(
+        game: RichTextExample(
+          textAlign: context.listProperty(
+            'Text align',
+            TextAlign.left,
+            TextAlign.values,
+          ),
+        ),
+      ),
       codeLink: baseLink('rendering/rich_text_example.dart'),
       info: RichTextExample.description,
     );

--- a/examples/lib/stories/rendering/rich_text_example.dart
+++ b/examples/lib/stories/rendering/rich_text_example.dart
@@ -4,6 +4,10 @@ import 'package:flame/text.dart';
 import 'package:flutter/painting.dart';
 
 class RichTextExample extends FlameGame {
+  final TextAlign textAlign;
+
+  RichTextExample({this.textAlign = TextAlign.left});
+
   static const String description =
       'A non-interactive example of how to render rich text in Flame.';
 
@@ -23,10 +27,14 @@ class RichTextExample extends FlameGame {
       ),
       paragraph: BlockStyle(
         padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+        textAlign: textAlign,
         background: BackgroundStyle(
           color: const Color(0xFF004D40),
           borderColor: const Color(0xFFAAAAAA),
         ),
+      ),
+      header1: BlockStyle(
+        textAlign: textAlign,
       ),
     );
     final document = DocumentRoot([

--- a/packages/flame/lib/src/text/styles/block_style.dart
+++ b/packages/flame/lib/src/text/styles/block_style.dart
@@ -11,6 +11,7 @@ class BlockStyle extends FlameTextStyle {
     EdgeInsets? padding,
     this.background,
     this.text,
+    this.textAlign,
   })  : _margin = margin,
         _padding = padding;
 
@@ -18,6 +19,7 @@ class BlockStyle extends FlameTextStyle {
   final EdgeInsets? _padding;
   final BackgroundStyle? background;
   final InlineTextStyle? text;
+  final TextAlign? textAlign;
 
   EdgeInsets get margin => _margin ?? EdgeInsets.zero;
   EdgeInsets get padding => _padding ?? EdgeInsets.zero;
@@ -29,6 +31,7 @@ class BlockStyle extends FlameTextStyle {
       padding: other._padding ?? _padding,
       background: other.background ?? background,
       text: FlameTextStyle.merge(text, other.text),
+      textAlign: other.textAlign ?? textAlign,
     );
   }
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Support text align on new text rendering pipeline.

<!-- Exclude from commit message -->
### Notes

I am re-using Flutter's `TextAlign` enum for simplicity; however, it has extra constants we don't quite need. It has `start` and `end` that for us are synonyms of `left` and `right` because the text rendering pipeline does not support rtl text directions. It also has `justify` which this PR does not support as it is much more involved (though we could support later).

The other options were to either make a new enum, use a double from 0 to 1, or use the anchor class (but only take the horizontal component - vertically it doesn't make sense as it is always exactly line height). Of those options, I believe re-using the enum is cleaner.

That being said, this does touch on a crucial point that I am noticing: it seems we are rebuilding a lot of what Flutter already gives us for free. There is a whole `TextPainter` based rendering pipeline available in Flutter is decomposed from flutter components and could be leverage more directly leverage by Flame. It includes layouting, line breaking, text metrics, handles rtl text, etc etc. I have some doubts about our current structure, even though it was vastly simplified [with this series of PRs](https://github.com/flame-engine/flame/pull/2663), we still have two minorly overlapping systems that both also have varying degrees of overlap with inherited Flutter abstractions, with often less powerful features.

### Results
<!-- End of exclude from commit message -->

![image](https://github.com/flame-engine/flame/assets/882703/62f91c8e-f38f-48b0-8c59-06efb10acdf3)

![image](https://github.com/flame-engine/flame/assets/882703/b00afb90-6051-4a2c-aac6-ac36ea1bcba2)

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->