### PR TITLE
feat: Add missing background and foreground properties to InlineTextStyle

### DIFF
--- a/packages/flame/lib/src/text/styles/inline_text_style.dart
+++ b/packages/flame/lib/src/text/styles/inline_text_style.dart
@@ -26,6 +26,8 @@ class InlineTextStyle extends FlameTextStyle {
     this.decorationColor,
     this.decorationStyle,
     this.decorationThickness,
+    this.background,
+    this.foreground,
   });
 
   final Color? color;
@@ -45,6 +47,8 @@ class InlineTextStyle extends FlameTextStyle {
   final Color? decorationColor;
   final TextDecorationStyle? decorationStyle;
   final double? decorationThickness;
+  final Paint? background;
+  final Paint? foreground;
 
   late final TextRenderer renderer = asTextRenderer();
 
@@ -68,6 +72,8 @@ class InlineTextStyle extends FlameTextStyle {
       decorationColor: other.decorationColor ?? decorationColor,
       decorationStyle: other.decorationStyle ?? decorationStyle,
       decorationThickness: other.decorationThickness ?? decorationThickness,
+      background: other.background ?? background,
+      foreground: other.foreground ?? foreground,
     );
   }
 
@@ -95,6 +101,8 @@ class InlineTextStyle extends FlameTextStyle {
       decorationColor: decorationColor,
       decorationStyle: decorationStyle,
       decorationThickness: decorationThickness,
+      background: background,
+      foreground: foreground,
     );
   }
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->

Add missing background and foreground properties to `InlineTextStyle`.

Note that Flutter also exposes `backgroundColor` and `foregroundColor` as redundant helpers. I think for the sake of keeping things simpler on our end, in particular the merge logic, we can do away with those.
<!-- Exclude from commit message -->

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
