### PR TITLE
docs: Link contributing doc into the relevant homepage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Do you want to contribute with a PR? PRs are always welcome, just make sure to c
 correct branch (main) and follow the [checklist](.github/pull_request_template.md) which will
 appear when you open the PR.
 
+Also, before you start, make sure to read our [Contributing Guide](CONTRIBUTING.md).
+
 For bigger changes, or if in doubt, make sure to talk about your contribution to the team. Either
 via an issue, GitHub discussion, or reach out to the team either using the
 [Discord server](https://discord.gg/pxrBmy4).


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->

Link contributing doc into the relevant homepage section.

I noticed that we don't actually link our [contributing guide](https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md) anywhere on our readme, so I propose we include it on the relevant section.

<!-- Exclude from commit message -->

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
