### PR TITLE
docs: Add dartdocs to inline text node classes

### DIFF
--- a/packages/flame/lib/src/text/nodes/bold_text_node.dart
+++ b/packages/flame/lib/src/text/nodes/bold_text_node.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flame/src/text/nodes/inline_text_node.dart';
 import 'package:flame/text.dart';
 
+/// An [InlineTextNode] representing bold text.
 class BoldTextNode extends InlineTextNode {
   BoldTextNode(this.child);
 

--- a/packages/flame/lib/src/text/nodes/code_text_node.dart
+++ b/packages/flame/lib/src/text/nodes/code_text_node.dart
@@ -1,6 +1,7 @@
 import 'package:flame/src/text/nodes/inline_text_node.dart';
 import 'package:flame/text.dart';
 
+/// An [InlineTextNode] representing an inline code block string.
 class CodeTextNode extends InlineTextNode {
   CodeTextNode(this.child);
 

--- a/packages/flame/lib/src/text/nodes/group_text_node.dart
+++ b/packages/flame/lib/src/text/nodes/group_text_node.dart
@@ -2,6 +2,7 @@ import 'package:flame/src/text/elements/group_text_element.dart';
 import 'package:flame/src/text/nodes/inline_text_node.dart';
 import 'package:flame/text.dart';
 
+/// An [InlineTextNode] to group other [InlineTextNode]s.
 class GroupTextNode extends InlineTextNode {
   GroupTextNode(this.children);
 

--- a/packages/flame/lib/src/text/nodes/inline_text_node.dart
+++ b/packages/flame/lib/src/text/nodes/inline_text_node.dart
@@ -7,6 +7,7 @@ import 'package:flame/text.dart';
 /// * PlainTextNode - just a string of plain text, no special formatting.
 /// * BoldTextNode - bolded string
 /// * ItalicTextNode - italic string
+/// * CodeTextNode - inline code block
 /// * GroupTextNode - collection of multiple [InlineTextNode]'s to be joined one
 ///                   after the other.
 abstract class InlineTextNode extends TextNode<InlineTextStyle> {

--- a/packages/flame/lib/src/text/nodes/italic_text_node.dart
+++ b/packages/flame/lib/src/text/nodes/italic_text_node.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flame/src/text/nodes/inline_text_node.dart';
 import 'package:flame/text.dart';
 
+/// An [InlineTextNode] representing italic text.
 class ItalicTextNode extends InlineTextNode {
   ItalicTextNode(this.child);
 

--- a/packages/flame/lib/src/text/nodes/plain_text_node.dart
+++ b/packages/flame/lib/src/text/nodes/plain_text_node.dart
@@ -1,6 +1,7 @@
 import 'package:flame/src/text/nodes/inline_text_node.dart';
 import 'package:flame/text.dart';
 
+/// An [InlineTextNode] representing plain text.
 class PlainTextNode extends InlineTextNode {
   PlainTextNode(this.text);
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->

Add dartdocs to inline text node classes.

<!-- Exclude from commit message -->

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
