### PR TITLE
fix: Wire in background and foreground colors in TextPaint

### DIFF
--- a/packages/flame/lib/src/text/renderers/text_paint.dart
+++ b/packages/flame/lib/src/text/renderers/text_paint.dart
@@ -82,6 +82,18 @@ class TextPaint extends TextRenderer {
       decorationColor: style.decorationColor,
       decorationStyle: style.decorationStyle,
       decorationThickness: style.decorationThickness,
+      background: _extractBackground(style),
+      foreground: style.foreground,
     );
+  }
+
+  Paint? _extractBackground(TextStyle style) {
+    if (style.background != null) {
+      return style.background;
+    }
+    if (style.backgroundColor != null) {
+      return Paint()..color = style.backgroundColor!;
+    }
+    return null;
   }
 }

--- a/packages/flame/test/text/text_paint_test.dart
+++ b/packages/flame/test/text/text_paint_test.dart
@@ -44,6 +44,7 @@ void main() {
           decorationColor: Color(0xFF0000FF),
           decorationStyle: TextDecorationStyle.dashed,
           decorationThickness: 1.5,
+          backgroundColor: Color(0xFFFF00FF),
         );
         final textPaint = TextPaint(style: flutterStyle);
 
@@ -77,6 +78,7 @@ void main() {
         expect(inlineTextStyle.decorationColor, const Color(0xFF0000FF));
         expect(inlineTextStyle.decorationStyle, TextDecorationStyle.dashed);
         expect(inlineTextStyle.decorationThickness, 1.5);
+        expect(inlineTextStyle.background!.color, const Color(0xFFFF00FF));
 
         final newTextPaint = inlineTextStyle.asTextRenderer();
         expect(newTextPaint.style.fontSize, 12);
@@ -108,7 +110,33 @@ void main() {
         expect(newTextPaint.style.decorationColor, const Color(0xFF0000FF));
         expect(newTextPaint.style.decorationStyle, TextDecorationStyle.dashed);
         expect(newTextPaint.style.decorationThickness, 1.5);
+        expect(newTextPaint.style.background!.color, const Color(0xFFFF00FF));
       },
     );
   });
+
+  test(
+    'TextPaint and InlineTextStyle can receive Paint instead of Color',
+    () {
+      final flutterStyle = flutter.TextStyle(
+        fontSize: 12,
+        fontFamily: 'Times',
+        foreground: Paint()..color = const Color(0xFF0000FF),
+        background: Paint()..color = const Color(0xFFFF00FF),
+      );
+      final textPaint = TextPaint(style: flutterStyle);
+
+      final inlineTextStyle = textPaint.asInlineTextStyle();
+      expect(inlineTextStyle.fontSize, 12);
+      expect(inlineTextStyle.fontFamily, 'Times');
+      expect(inlineTextStyle.foreground!.color, const Color(0xFF0000FF));
+      expect(inlineTextStyle.background!.color, const Color(0xFFFF00FF));
+
+      final newTextPaint = inlineTextStyle.asTextRenderer();
+      expect(newTextPaint.style.fontSize, 12);
+      expect(newTextPaint.style.fontFamily, 'Times');
+      expect(newTextPaint.style.foreground!.color, const Color(0xFF0000FF));
+      expect(newTextPaint.style.background!.color, const Color(0xFFFF00FF));
+    },
+  );
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->

Wire in background and foreground colors in TextPaint.

<!-- Exclude from commit message -->

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
