### PR TITLE
docs(example): DraggableBox does not follow the cursor smoothly

### DIFF
--- a/examples/lib/stories/bridge_libraries/flame_forge2d/utils/boxes.dart
+++ b/examples/lib/stories/bridge_libraries/flame_forge2d/utils/boxes.dart
@@ -31,8 +31,12 @@ class Box extends BodyComponent {
   Body createBody() {
     final shape = PolygonShape()
       ..setAsBox(width / 2, height / 2, Vector2.zero(), 0);
-    final fixtureDef =
-        FixtureDef(shape, friction: 0.3, restitution: 0.2, density: 10);
+    final fixtureDef = FixtureDef(
+      shape,
+      friction: 0.3,
+      restitution: 0.2,
+      density: 10,
+    );
     final bodyDef = BodyDef(
       userData: this, // To be able to determine object in collision
       position: startPosition,

--- a/examples/lib/stories/bridge_libraries/flame_forge2d/utils/boxes.dart
+++ b/examples/lib/stories/bridge_libraries/flame_forge2d/utils/boxes.dart
@@ -9,14 +9,12 @@ class Box extends BodyComponent {
   final Vector2 startPosition;
   final double width;
   final double height;
-  final double density;
   final BodyType bodyType;
 
   Box({
     required this.startPosition,
     required this.width,
     required this.height,
-    this.density = 10,
     this.bodyType = BodyType.dynamic,
     Color? color,
   }) {
@@ -33,12 +31,8 @@ class Box extends BodyComponent {
   Body createBody() {
     final shape = PolygonShape()
       ..setAsBox(width / 2, height / 2, Vector2.zero(), 0);
-    final fixtureDef = FixtureDef(
-      shape,
-      friction: 0.3,
-      restitution: 0.2,
-      density: density,
-    );
+    final fixtureDef =
+        FixtureDef(shape, friction: 0.3, restitution: 0.2, density: 10);
     final bodyDef = BodyDef(
       userData: this, // To be able to determine object in collision
       position: startPosition,
@@ -58,7 +52,6 @@ class DraggableBox extends Box with DragCallbacks {
     required super.startPosition,
     required super.width,
     required super.height,
-    super.density = 1000,
   });
 
   @override
@@ -77,7 +70,7 @@ class DraggableBox extends Box with DragCallbacks {
     final target = game.screenToWorld(event.devicePosition);
 
     final mouseJointDef = MouseJointDef()
-      ..maxForce = 2000 * body.mass
+      ..maxForce = 5000 * body.mass
       ..dampingRatio = 0.1
       ..frequencyHz = 50
       ..target.setFrom(target)


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
This PR makes the `DraggableBox` movement more smooth and predictable by:
1) adjusting `FixtureDef` and `MouseJointDef` parameters
2) setting the `MouseJoint` target to `game.screenToWorld(event.deviceEndPosition)` rather than `event.localEndPosition`

Fixes https://github.com/flame-engine/flame/issues/3203

The comparison recordings are presented below:

<details closed><summary>GearJointExample</summary>

  | BEFORE | AFTER |
  |----------|----------|
  | <video src="https://github.com/flame-engine/flame/assets/30288967/8188ed18-e0aa-4c0f-a6c4-092015ba471c"> | <video src="https://github.com/flame-engine/flame/assets/30288967/2388bf23-ab32-43a8-af88-a974687b6901"> |

</details>

<details closed><summary>PrismaticJointExample</summary>

  | BEFORE | AFTER |
  |----------|----------|
  | <video src="https://github.com/flame-engine/flame/assets/30288967/80ca56cd-7b7c-4a12-a551-37f268011bb0"> | <video src="https://github.com/flame-engine/flame/assets/30288967/aaae0f7d-230b-47db-a1c2-cc39cace74e7"> |

</details>

<details closed><summary>PulleyJointExample</summary>

  | BEFORE | AFTER |
  |----------|----------|
  | <video src="https://github.com/flame-engine/flame/assets/30288967/1d40b0a0-57d2-444e-a324-63112548f9e3"> | <video src="https://github.com/flame-engine/flame/assets/30288967/6deb1226-0f96-440f-ba72-14806612bd32"> |

</details>

<details closed><summary>RopeJointExample</summary>

  | BEFORE | AFTER |
  |----------|----------|
  | <video src="https://github.com/flame-engine/flame/assets/30288967/60b2ceee-4a41-4443-a2db-de5515270f18"> | <video src="https://github.com/flame-engine/flame/assets/30288967/c06e35ff-2c59-4a02-b6bb-7611817a76c0"> |

</details>

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [X] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
