### PR TITLE
feat: Expose vector classes on core file [flame_3d]

### DIFF
--- a/packages/flame_3d/example/lib/main.dart
+++ b/packages/flame_3d/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:example/crate.dart';
 import 'package:example/keyboard_controlled_camera.dart';

--- a/packages/flame_3d/lib/camera.dart
+++ b/packages/flame_3d/lib/camera.dart
@@ -1,4 +1,6 @@
 export 'package:flame/camera.dart';
 
+export 'package:vector_math/vector_math.dart' show Frustum;
+
 export 'src/camera/camera_component_3d.dart';
 export 'src/camera/world_3d.dart';

--- a/packages/flame_3d/lib/core.dart
+++ b/packages/flame_3d/lib/core.dart
@@ -1,3 +1,4 @@
-export 'package:vector_math/vector_math.dart' show Vector2, Vector3, Vector4, Matrix4;
+export 'package:vector_math/vector_math.dart'
+    show Vector2, Vector3, Vector4, Matrix3, Matrix4, Quaternion, Aabb3;
 
 export 'extensions.dart';

--- a/packages/flame_3d/lib/core.dart
+++ b/packages/flame_3d/lib/core.dart
@@ -1,0 +1,3 @@
+export 'package:vector_math/vector_math.dart' show Vector2, Vector3, Vector4, Matrix4;
+
+export 'extensions.dart';

--- a/packages/flame_3d/lib/extensions.dart
+++ b/packages/flame_3d/lib/extensions.dart
@@ -1,3 +1,5 @@
+export 'package:vector_math/vector_math.dart' hide Colors;
+
 export 'src/extensions/aabb3.dart';
 export 'src/extensions/color.dart';
 export 'src/extensions/matrix4.dart';

--- a/packages/flame_3d/lib/extensions.dart
+++ b/packages/flame_3d/lib/extensions.dart
@@ -1,5 +1,3 @@
-export 'package:vector_math/vector_math.dart' hide Colors;
-
 export 'src/extensions/aabb3.dart';
 export 'src/extensions/color.dart';
 export 'src/extensions/matrix4.dart';

--- a/packages/flame_3d/lib/game.dart
+++ b/packages/flame_3d/lib/game.dart
@@ -1,5 +1,4 @@
-export 'package:vector_math/vector_math.dart' hide Colors;
-
+export 'core.dart';
 export 'src/game/flame_game_3d.dart';
 export 'src/game/notifying_quaternion.dart';
 export 'src/game/notifying_vector3.dart';

--- a/packages/flame_3d/lib/src/camera/camera_component_3d.dart
+++ b/packages/flame_3d/lib/src/camera/camera_component_3d.dart
@@ -1,5 +1,4 @@
 import 'package:flame_3d/camera.dart';
-import 'package:flame_3d/extensions.dart';
 import 'package:flame_3d/game.dart';
 
 enum CameraProjection { perspective, orthographic }

--- a/packages/flame_3d/lib/src/components/component_3d.dart
+++ b/packages/flame_3d/lib/src/components/component_3d.dart
@@ -70,8 +70,9 @@ class Component3D extends Component with HasWorldReference<World3D> {
 
   /// The scale factor of this component. The scale can be different along
   /// the X, Y and Z dimensions. A scale greater than 1 makes the component
-  /// bigger along that axis, and less than 1 smaller. The scale can also be negative,
-  /// which results in a mirror reflection along the corresponding axis.
+  /// bigger along that axis, and less than 1 smaller. The scale can also be
+  /// negative, which results in a mirror reflection along the corresponding
+  /// axis.
   NotifyingVector3 get scale => transform.scale;
   set scale(Vector3 scale) => transform.scale = scale;
 

--- a/packages/flame_3d/lib/src/components/mesh_component.dart
+++ b/packages/flame_3d/lib/src/components/mesh_component.dart
@@ -2,7 +2,6 @@ import 'package:flame_3d/components.dart';
 import 'package:flame_3d/game.dart';
 import 'package:flame_3d/resources.dart';
 import 'package:flame_3d/src/camera/camera_component_3d.dart';
-import 'package:flame_3d/src/extensions/aabb3.dart';
 import 'package:flame_3d/src/graphics/graphics_device.dart';
 
 /// {@template mesh_component}

--- a/packages/flame_3d/lib/src/extensions/matrix4.dart
+++ b/packages/flame_3d/lib/src/extensions/matrix4.dart
@@ -1,3 +1,9 @@
+export 'package:vector_math/vector_math.dart'
+    show
+        degrees2Radians,
+        setViewMatrix,
+        setPerspectiveMatrix,
+        setOrthographicMatrix;
 import 'package:flame_3d/game.dart';
 
 extension Matrix4Extension on Matrix4 {

--- a/packages/flame_3d/lib/src/extensions/matrix4.dart
+++ b/packages/flame_3d/lib/src/extensions/matrix4.dart
@@ -1,10 +1,11 @@
+import 'package:flame_3d/game.dart';
+
 export 'package:vector_math/vector_math.dart'
     show
         degrees2Radians,
         setViewMatrix,
         setPerspectiveMatrix,
         setOrthographicMatrix;
-import 'package:flame_3d/game.dart';
 
 extension Matrix4Extension on Matrix4 {
   /// Set the matrix to be a view matrix.

--- a/packages/flame_3d/lib/src/resources/mesh/vertex.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/vertex.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 
-import 'package:flame_3d/extensions.dart';
 import 'package:flame_3d/game.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flame_3d/pubspec.yaml
+++ b/packages/flame_3d/pubspec.yaml
@@ -8,14 +8,15 @@ funding:
   - https://patreon.com/bluefireoss
 
 environment:
-  sdk: '>=3.3.0-279.2.beta <4.0.0'
-  flutter: ">=3.13.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flame: ^1.16.0
   flutter:
     sdk: flutter
   flutter_gpu:
+  vector_math: ^2.1.4
 
 dev_dependencies:
   flame_lint: ^1.1.2

--- a/packages/flame_3d/test/vector2_extensions_test.dart
+++ b/packages/flame_3d/test/vector2_extensions_test.dart
@@ -1,5 +1,4 @@
-import 'package:flame_3d/extensions.dart';
-import 'package:flame_3d/game.dart';
+import 'package:flame_3d/core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/flame_3d/test/vector3_extensions_test.dart
+++ b/packages/flame_3d/test/vector3_extensions_test.dart
@@ -1,4 +1,3 @@
-import 'package:flame_3d/extensions.dart';
 import 'package:flame_3d/game.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flame_3d/test/vector4_extensions_test.dart
+++ b/packages/flame_3d/test/vector4_extensions_test.dart
@@ -1,4 +1,3 @@
-import 'package:flame_3d/extensions.dart';
 import 'package:flame_3d/game.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Expose vector classes on extensions file.

It is very common that we want to work with vector and matrices even though I don't want to import anything else specific from Flame. This PR allows we to use the extensions file as a base import similar to how it is on normal flame.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->