### PR TITLE
feat: Make it easier work with the Mesh class [flame_3d]

### DIFF
--- a/packages/flame_3d/example/lib/crate.dart
+++ b/packages/flame_3d/example/lib/crate.dart
@@ -14,7 +14,11 @@ class Crate extends MeshComponent {
   @override
   FutureOr<void> onLoad() async {
     final crateTexture = await Flame.images.loadTexture('crate.jpg');
-    mesh.addMaterialToSurface(0, StandardMaterial(albedoTexture: crateTexture));
+    mesh.updateSurfaces((surfaces) {
+      surfaces[0].material = StandardMaterial(
+        albedoTexture: crateTexture,
+      );
+    });
   }
 
   double direction = 0.1;

--- a/packages/flame_3d/lib/src/resources/mesh/cuboid_mesh.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/cuboid_mesh.dart
@@ -59,6 +59,12 @@ class CuboidMesh extends Mesh {
       20, 21, 22, 22, 23, 20, // Face 6
     ];
 
-    addSurface(vertices, indices, material: material);
+    addSurface(
+      Surface(
+        vertices: vertices,
+        indices: indices,
+        material: material,
+      ),
+    );
   }
 }

--- a/packages/flame_3d/lib/src/resources/mesh/mesh.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/mesh.dart
@@ -46,22 +46,43 @@ class Mesh extends Resource<void> {
     }
   }
 
-  /// Add a new surface represented by [vertices], [indices] and a material.
+  /// Add a new surface represented by [vertices], [indices] and a [material].
   void addSurface(
     List<Vertex> vertices,
     List<int> indices, {
     Material? material,
   }) {
-    _surfaces.add(Surface(vertices, indices, material));
+    add(Surface(vertices, indices, material));
   }
 
-  /// Add a material to the surface at [index].
-  void addMaterialToSurface(int index, Material material) {
-    _surfaces[index].material = material;
+  /// Must be called when the mesh has been modified.
+  void updateBounds() {
+    _aabb = null;
   }
 
-  /// Get a material from the surface at [index].
-  Material? getMaterialToSurface(int index) {
-    return _surfaces[index].material;
+  /// Add a new [surface] to the mesh.
+  void add(Surface surface) {
+    _surfaces.add(surface);
+    updateBounds();
+  }
+
+  /// An unmodifiable view over the list of the surfaces.
+  /// 
+  /// Note: if you modify the geometry of any [Surface] within this list,
+  /// you will need to call [updateBounds] to update the mesh's bounds.
+  List<Surface> get surfaces {
+    return List.unmodifiable(_surfaces);
+  }
+
+  /// Replace the surface at [index] with [surface].
+  void updateSurface(int index, Surface surface) {
+    _surfaces[index] = surface;
+    updateBounds();
+  }
+
+  /// Remove the surface at [index].
+  void removeSurface(int index) {
+    _surfaces.removeAt(index);
+    updateBounds();
   }
 }

--- a/packages/flame_3d/lib/src/resources/mesh/plane_mesh.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/plane_mesh.dart
@@ -18,6 +18,12 @@ class PlaneMesh extends Mesh {
       Vertex(position: Vector3(x, 0, y), texCoord: Vector2(1, 1)),
       Vertex(position: Vector3(-x, 0, y), texCoord: Vector2(0, 1)),
     ];
-    addSurface(vertices, [0, 1, 2, 2, 3, 0], material: material);
+    addSurface(
+      Surface(
+        vertices: vertices,
+        indices: [0, 1, 2, 2, 3, 0],
+        material: material,
+      ),
+    );
   }
 }

--- a/packages/flame_3d/lib/src/resources/mesh/sphere_mesh.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/sphere_mesh.dart
@@ -48,6 +48,12 @@ class SphereMesh extends Mesh {
       }
     }
 
-    addSurface(vertices, indices, material: material);
+    addSurface(
+      Surface(
+        vertices: vertices,
+        indices: indices,
+        material: material,
+      ),
+    );
   }
 }

--- a/packages/flame_3d/lib/src/resources/mesh/surface.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/surface.dart
@@ -14,11 +14,11 @@ enum PrimitiveType {
 /// {@endtemplate}
 class Surface extends Resource<gpu.DeviceBuffer?> {
   /// {@macro surface}
-  Surface(
-    List<Vertex> vertices,
-    List<int> indices, [
+  Surface({
+    required List<Vertex> vertices,
+    required List<int> indices,
     this.material,
-  ]) : super(null) {
+  }) : super(null) {
     // `TODO`(bdero): This should have an attribute map instead and be fully SoA
     // but vertex attributes in Impeller aren't flexible enough yet.
     // See also https://github.com/flutter/flutter/issues/116168.


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Currently it is quite hard to operate with the `Mesh` class, because the list of surfaces is kept private.

I understand the concern with immutability, and the fact that the `aabb` must be recalculated when anything change.
Sadly I don't think Dart provides us with patterns to fully automate updating the `aabb`.
We need a way to update the meshes, so this is a compromise:

* add a getter to an unmodifiable list
* if the user updates the surfaces within, they are responsible for calling `updateBounds`
* add methods to update or remove elements from the list, which automatically call `updateBounds`
* this allow us to remove the silly "updateMaterial" methods that are used by Defend the Donut

This also adds an `add` method that takes a `Surface` object witch is extremely handy (even though it allows for post-modifications).

If we prefer to go a truly fully immutable route, we instead need helper methods to copy and recreate meshes with given set of changes. I am happy to take a stab at that option too.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->