### PR TITLE
feat: Take in super.curve in ScalingParticle

### DIFF
--- a/doc/flame/rendering/particles.md
+++ b/doc/flame/rendering/particles.md
@@ -309,6 +309,7 @@ game.add(
     particle: ScalingParticle(
       lifespan: 2,
       to: 0,
+      curve: Curves.easeIn,
       child: CircleParticle(
         radius: 2.0,
         paint: Paint()..color = Colors.red,

--- a/packages/flame/lib/src/particles/particle.dart
+++ b/packages/flame/lib/src/particles/particle.dart
@@ -181,7 +181,12 @@ abstract class Particle {
   /// Wraps this particle with a [ScalingParticle].
   ///
   /// Allows for changing the size of this particle and/or its children.
-  ScalingParticle scaling({double to = 0}) {
-    return ScalingParticle(to: to, child: this, lifespan: _lifespan);
+  ScalingParticle scaling({double to = 0, Curve curve = Curves.linear}) {
+    return ScalingParticle(
+      to: to,
+      child: this,
+      lifespan: _lifespan,
+      curve: curve,
+    );
   }
 }

--- a/packages/flame/lib/src/particles/scaling_particle.dart
+++ b/packages/flame/lib/src/particles/scaling_particle.dart
@@ -16,6 +16,7 @@ class ScalingParticle extends CurvedParticle with SingleChildParticle {
     required this.child,
     this.to = 0,
     super.lifespan,
+    super.curve,
   });
 
   double get scale => lerpDouble(1, to, progress) ?? 0;

--- a/packages/flame/test/particles/scaling_particle_test.dart
+++ b/packages/flame/test/particles/scaling_particle_test.dart
@@ -18,7 +18,7 @@ void main() {
         ),
       );
 
-      final particle = rect.scaling(to: .5);
+      final particle = rect.scaling(to: .5, curve: Curves.easeIn);
 
       final component = ParticleSystemComponent(
         particle: particle,
@@ -28,7 +28,9 @@ void main() {
       await game.ready();
       game.update(1);
 
-      expect(particle.scale, .75);
+      expect(particle.scale, .841796875);
+      expect(particle.curve, Curves.easeIn);
+      expect(particle.progress, 0.31640625);
       expect(particle.child, isInstanceOf<ComputedParticle>());
       expect(particle.child.progress, 0.5);
     });


### PR DESCRIPTION
# feat: Take in curve parameter in ScalingParticle

This PR introduces a `curve` parameter to the `ScalingParticle` class. This allows for more flexible and customizable scaling by specifying different curves for scaling transformations. The default curve is set to `Curves.linear`, ensuring backward compatibility.

## Checklist
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.
