### PR TITLE
fix: Replace CurvedParticle inheritance with Particle in ScaledParticle

### DIFF
--- a/packages/flame/lib/src/particles/scaled_particle.dart
+++ b/packages/flame/lib/src/particles/scaled_particle.dart
@@ -1,14 +1,13 @@
 import 'dart:ui';
 
 import 'package:flame/src/components/mixins/single_child_particle.dart';
-import 'package:flame/src/particles/curved_particle.dart';
 import 'package:flame/src/particles/particle.dart';
 import 'package:flame/src/particles/scaling_particle.dart';
 
 /// Statically scales the given child [Particle] by given [scale].
 ///
 /// If you're looking to scale the child over time, consider [ScalingParticle].
-class ScaledParticle extends CurvedParticle with SingleChildParticle {
+class ScaledParticle extends Particle with SingleChildParticle {
   @override
   Particle child;
 


### PR DESCRIPTION
# feat: Replace CurvedParticle inheritance with Paricle in ScaledParticle

This PR removed the CurvedParticle inheritance from the ScaledParticle, as the scale did not change over time which also ensures backwardwards compatibility as the Curve essentially did nothing.

## Checklist
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.