### PR TITLE
docs: Fix capitalization of the Dart programming language on pubspec description field

### DIFF
--- a/packages/flame_behavior_tree/behavior_tree/pubspec.yaml
+++ b/packages/flame_behavior_tree/behavior_tree/pubspec.yaml
@@ -1,5 +1,5 @@
 name: behavior_tree
-description: A behavior tree implementation written in dart. This package is designed to be used for implementing AI in games.
+description: A behavior tree implementation written in Dart. This package is designed to be used for implementing AI in games.
 version: 0.1.2
 repository: https://github.com/flame-engine/flame/tree/main/packages/flame_behavior_tree/behavior_tree
 funding:


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Fix capitalization of the Dart programming language on pubspec description field

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->