### PR TITLE
fix: Update version of lints to comply with new pub requirements

### DIFF
--- a/examples/lib/stories/components/time_scale_example.dart
+++ b/examples/lib/stories/components/time_scale_example.dart
@@ -108,11 +108,14 @@ class _Chopper extends SpriteAnimationComponent
   }
 
   @override
-  void onCollisionStart(Set<Vector2> _, PositionComponent other) {
+  void onCollisionStart(
+    Set<Vector2> intersectionPoints,
+    PositionComponent other,
+  ) {
     if (other is _Chopper) {
       game.timeScale = 0.25;
     }
-    super.onCollisionStart(_, other);
+    super.onCollisionStart(intersectionPoints, other);
   }
 
   @override

--- a/examples/lib/stories/system/step_engine_example.dart
+++ b/examples/lib/stories/system/step_engine_example.dart
@@ -59,7 +59,10 @@ class StepEngineExample extends FlameGame
   }
 
   @override
-  KeyEventResult onKeyEvent(_, Set<LogicalKeyboardKey> keysPressed) {
+  KeyEventResult onKeyEvent(
+    KeyEvent event,
+    Set<LogicalKeyboardKey> keysPressed,
+  ) {
     if (keysPressed.contains(LogicalKeyboardKey.keyP)) {
       paused = !paused;
     } else if (keysPressed.contains(LogicalKeyboardKey.keyS)) {
@@ -71,7 +74,7 @@ class StepEngineExample extends FlameGame
       _stepTimeMultiplier -= 1;
       _controlsText.text = _text;
     }
-    return super.onKeyEvent(_, keysPressed);
+    return super.onKeyEvent(event, keysPressed);
   }
 
   // Creates the circle detectors.
@@ -128,14 +131,17 @@ class _DetectorComponents extends CircleComponent with CollisionCallbacks {
   });
 
   @override
-  void onCollisionStart(_, __) {
+  void onCollisionStart(
+    Set<Vector2> intersectionPoints,
+    PositionComponent other,
+  ) {
     paint.color = BasicPalette.black.color;
-    super.onCollisionStart(_, __);
+    super.onCollisionStart(intersectionPoints, other);
   }
 
   @override
-  void onCollisionEnd(__) {
+  void onCollisionEnd(PositionComponent other) {
     paint.color = BasicPalette.white.color;
-    super.onCollisionEnd(__);
+    super.onCollisionEnd(other);
   }
 }

--- a/packages/flame/lib/src/components/input/joystick_component.dart
+++ b/packages/flame/lib/src/components/input/joystick_component.dart
@@ -119,15 +119,15 @@ class JoystickComponent extends PositionComponent
   }
 
   @override
-  bool onDragEnd(_) {
-    super.onDragEnd(_);
+  bool onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
     onDragStop();
     return false;
   }
 
   @override
-  bool onDragCancel(_) {
-    super.onDragCancel(_);
+  bool onDragCancel(DragCancelEvent event) {
+    super.onDragCancel(event);
     onDragStop();
     return false;
   }

--- a/packages/flame_behavior_tree/behavior_tree/pubspec.yaml
+++ b/packages/flame_behavior_tree/behavior_tree/pubspec.yaml
@@ -15,6 +15,5 @@ dependencies:
 
 dev_dependencies:
   flame_lint: ^1.2.0
-  lints: ^3.0.0
   mocktail: ^1.0.3
   test: any

--- a/packages/flame_lint/pubspec.yaml
+++ b/packages/flame_lint/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
-  lints: ^3.0.0
+  lints: ^4.0.0
 
 dev_dependencies:
   dartdoc: ^8.0.8


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Update version of lints to comply with new pub requirements.

<!-- Exclude from commit message -->
Turns out we are losing significant pub points due to lint violations:

![image](https://github.com/user-attachments/assets/38eb0717-5b0f-4756-8302-9e42a8dd4a5f)

The root cause was our severely outdated version of core lints used on `flame_lint`.
This updates it and fixes the new rule which forbids accessing parameters that are wildcards.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->