### PR TITLE
perf: Optimize `TexturePackerSprite` when sprites do not need to be rotated

### DIFF
--- a/packages/flame_texturepacker/lib/src/texture_packer_sprite.dart
+++ b/packages/flame_texturepacker/lib/src/texture_packer_sprite.dart
@@ -31,8 +31,9 @@ class TexturePackerSprite extends Sprite {
             useOriginalSize ? region.originalHeight : region.height,
           ),
         ) {
-    _decorator = Transform2DDecorator(_transform);
     if (region.rotate) {
+      final _transform = Transform2D();
+      _decorator = Transform2DDecorator(_transform);
       _transform.angle = math.pi / 2;
     }
   }
@@ -132,8 +133,7 @@ class TexturePackerSprite extends Sprite {
     src = (position ?? Vector2.zero()).toPositionedRect(_srcSize);
   }
 
-  late final Decorator _decorator;
-  final Transform2D _transform = Transform2D();
+  Decorator? _decorator;
 
   // Used to avoid the creation of new Vector2 objects in render.
   static final _tmpRenderPosition = Vector2.zero();
@@ -206,7 +206,7 @@ class TexturePackerSprite extends Sprite {
       -_tmpRenderOffset.x - _tmpRenderImageSize.x,
     );
 
-    _decorator.applyChain(
+    _decorator?.applyChain(
       (applyCanvas) => super.render(
         applyCanvas,
         position: _tmpRenderPosition,

--- a/packages/flame_texturepacker/lib/src/texture_packer_sprite.dart
+++ b/packages/flame_texturepacker/lib/src/texture_packer_sprite.dart
@@ -32,9 +32,8 @@ class TexturePackerSprite extends Sprite {
           ),
         ) {
     if (region.rotate) {
-      final _transform = Transform2D();
-      _decorator = Transform2DDecorator(_transform);
-      _transform.angle = math.pi / 2;
+      final transform = Transform2D()..angle = math.pi / 2;
+      _decorator = Transform2DDecorator(transform);
     }
   }
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
TexturePackerSprite creates unnecessary Transform2D and Transform2DDecorator objects when region rotation is set to false. This bloats the TexturePackerSprite object size and causes severe performance issues when using thousands of TexturePackerSprites. This PR wraps the creation of these objects in a region rotation check.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
