### PR TITLE
chore: Update imports within flame_3d to not bring in flutter widgets unnecessarily [flame_3d]

### DIFF
--- a/packages/flame_3d/lib/src/camera/world_3d.dart
+++ b/packages/flame_3d/lib/src/camera/world_3d.dart
@@ -1,9 +1,11 @@
+import 'dart:ui';
+
 import 'package:flame/components.dart' as flame;
 import 'package:flame_3d/camera.dart';
 import 'package:flame_3d/components.dart';
 import 'package:flame_3d/graphics.dart';
 import 'package:flame_3d/resources.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' show MediaQuery;
 import 'package:meta/meta.dart';
 
 /// {@template world_3d}

--- a/packages/flame_3d/lib/src/game/notifying_quaternion.dart
+++ b/packages/flame_3d/lib/src/game/notifying_quaternion.dart
@@ -1,8 +1,7 @@
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:flame_3d/game.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
 
 /// {@template notifying_quaternion}
 /// Extension of the standard [Quaternion] class, implementing the

--- a/packages/flame_3d/lib/src/game/notifying_vector3.dart
+++ b/packages/flame_3d/lib/src/game/notifying_vector3.dart
@@ -1,7 +1,5 @@
-import 'dart:typed_data';
-
 import 'package:flame_3d/game.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
 
 /// {@template notifying_vector_3}
 /// Extension of the standard [Vector3] class, implementing the [ChangeNotifier]

--- a/packages/flame_3d/lib/src/game/transform_3d.dart
+++ b/packages/flame_3d/lib/src/game/transform_3d.dart
@@ -1,5 +1,5 @@
 import 'package:flame_3d/game.dart';
-import 'package:flutter/widgets.dart' show ChangeNotifier;
+import 'package:flutter/foundation.dart' show ChangeNotifier;
 
 /// {@template transform_3d}
 /// This class describes a generic 3D transform, which is a combination of

--- a/packages/flame_3d/lib/src/resources/mesh/vertex.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/vertex.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
+import 'dart:ui' show Color;
 
 import 'package:flame_3d/game.dart';
-import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
 
 /// {@template vertex}
 /// Represents a vertex in 3D space.

--- a/packages/flame_3d/lib/src/resources/resource.dart
+++ b/packages/flame_3d/lib/src/resources/resource.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 // TODO(wolfenrain): in the long run it would be nice of we can make it
 // automatically refer to same type of objects to prevent memory leaks


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Update imports within flame_3d to not bring in flutter widgets unnecessarily.

I think it is prefer to import things directly when possible, for example:

* import meta instead of flutter
* import Color, Paint, etc from dart:ui
* import flutter foundations instead of widgets

Unless other things from a higher level are already used anyway (like a class that actually uses flutter widgets can keep those imports).

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->