### PR TITLE
chore: Enable DCM rule avoid-unrelated-type-assertions

### DIFF
--- a/packages/flame_lint/lib/analysis_options_with_dcm.yaml
+++ b/packages/flame_lint/lib/analysis_options_with_dcm.yaml
@@ -11,5 +11,7 @@ dart_code_metrics:
     - avoid-top-level-members-in-tests:
         include:
           - 'test/**/*_test.dart'
+    - avoid-unrelated-type-assertions:
+      ignore-mixins: true
   # flutter rules
     - prefer-define-hero-tag


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Enable DCM rule avoid-unrelated-type-assertions.

More details [here](https://dcm.dev/docs/rules/common/avoid-unrelated-type-assertions/). Note that we have to ignore mixins otherwise the rule has false positives.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->