### PR TITLE
chore: Enable DCM rule double-literal-format

### DIFF
--- a/doc/flame/examples/lib/sequence_effect.dart
+++ b/doc/flame/examples/lib/sequence_effect.dart
@@ -24,7 +24,7 @@ class SequenceEffectGame extends FlameGame {
               EffectController(duration: 0.5),
             ),
             ScaleEffect.by(
-              Vector2.all(.75),
+              Vector2.all(0.75),
               EffectController(duration: 0.2, alternate: true),
             ),
           ]),

--- a/doc/tutorials/klondike/app/lib/step4/components/tableau_pile.dart
+++ b/doc/tutorials/klondike/app/lib/step4/components/tableau_pile.dart
@@ -12,7 +12,7 @@ class TableauPile extends PositionComponent implements Pile {
   /// Which cards are currently placed onto this pile.
   final List<Card> _cards = [];
   final Vector2 _fanOffset1 = Vector2(0, KlondikeGame.cardHeight * 0.05);
-  final Vector2 _fanOffset2 = Vector2(0, KlondikeGame.cardHeight * 0.20);
+  final Vector2 _fanOffset2 = Vector2(0, KlondikeGame.cardHeight * 0.2);
 
   //#region Pile API
 

--- a/doc/tutorials/klondike/app/lib/step5/components/tableau_pile.dart
+++ b/doc/tutorials/klondike/app/lib/step5/components/tableau_pile.dart
@@ -12,7 +12,7 @@ class TableauPile extends PositionComponent implements Pile {
   /// Which cards are currently placed onto this pile.
   final List<Card> _cards = [];
   final Vector2 _fanOffset1 = Vector2(0, KlondikeGame.cardHeight * 0.05);
-  final Vector2 _fanOffset2 = Vector2(0, KlondikeGame.cardHeight * 0.20);
+  final Vector2 _fanOffset2 = Vector2(0, KlondikeGame.cardHeight * 0.2);
 
   //#region Pile API
 

--- a/doc/tutorials/platformer/app/lib/actors/water_enemy.dart
+++ b/doc/tutorials/platformer/app/lib/actors/water_enemy.dart
@@ -23,7 +23,7 @@ class WaterEnemy extends SpriteAnimationComponent
       SpriteAnimationData.sequenced(
         amount: 2,
         textureSize: Vector2.all(16),
-        stepTime: 0.70,
+        stepTime: 0.7,
       ),
     );
     position = Vector2(

--- a/doc/tutorials/platformer/app/lib/objects/star.dart
+++ b/doc/tutorials/platformer/app/lib/objects/star.dart
@@ -27,10 +27,10 @@ class Star extends SpriteComponent with HasGameReference<EmberQuestGame> {
     add(RectangleHitbox(collisionType: CollisionType.passive));
     add(
       SizeEffect.by(
-        Vector2(-24, -24),
+        Vector2.all(-24),
         EffectController(
-          duration: .75,
-          reverseDuration: .5,
+          duration: 0.75,
+          reverseDuration: 0.5,
           infinite: true,
           curve: Curves.easeOut,
         ),

--- a/doc/tutorials/space_shooter/app/lib/step3/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step3/main.dart
@@ -52,7 +52,7 @@ class Player extends SpriteAnimationComponent
       'player.png',
       SpriteAnimationData.sequenced(
         amount: 4,
-        stepTime: .2,
+        stepTime: 0.2,
         textureSize: Vector2(32, 48),
       ),
     );

--- a/doc/tutorials/space_shooter/app/lib/step4/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step4/main.dart
@@ -64,7 +64,7 @@ class Player extends SpriteAnimationComponent
       'player.png',
       SpriteAnimationData.sequenced(
         amount: 4,
-        stepTime: .2,
+        stepTime: 0.2,
         textureSize: Vector2(32, 48),
       ),
     );
@@ -72,7 +72,7 @@ class Player extends SpriteAnimationComponent
     position = game.size / 2;
 
     _bulletSpawner = SpawnComponent(
-      period: .2,
+      period: 0.2,
       selfPositioning: true,
       factory: (index) {
         return Bullet(
@@ -119,7 +119,7 @@ class Bullet extends SpriteAnimationComponent
       'bullet.png',
       SpriteAnimationData.sequenced(
         amount: 4,
-        stepTime: .2,
+        stepTime: 0.2,
         textureSize: Vector2(8, 16),
       ),
     );

--- a/doc/tutorials/space_shooter/app/lib/step5/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step5/main.dart
@@ -75,7 +75,7 @@ class Player extends SpriteAnimationComponent
       'player.png',
       SpriteAnimationData.sequenced(
         amount: 4,
-        stepTime: .2,
+        stepTime: 0.2,
         textureSize: Vector2(32, 48),
       ),
     );
@@ -83,7 +83,7 @@ class Player extends SpriteAnimationComponent
     position = game.size / 2;
 
     _bulletSpawner = SpawnComponent(
-      period: .2,
+      period: 0.2,
       selfPositioning: true,
       factory: (index) {
         return Bullet(
@@ -130,7 +130,7 @@ class Bullet extends SpriteAnimationComponent
       'bullet.png',
       SpriteAnimationData.sequenced(
         amount: 4,
-        stepTime: .2,
+        stepTime: 0.2,
         textureSize: Vector2(8, 16),
       ),
     );
@@ -167,7 +167,7 @@ class Enemy extends SpriteAnimationComponent
       'enemy.png',
       SpriteAnimationData.sequenced(
         amount: 4,
-        stepTime: .2,
+        stepTime: 0.2,
         textureSize: Vector2.all(16),
       ),
     );

--- a/doc/tutorials/space_shooter/app/lib/step6/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step6/main.dart
@@ -77,7 +77,7 @@ class Player extends SpriteAnimationComponent
       'player.png',
       SpriteAnimationData.sequenced(
         amount: 4,
-        stepTime: .2,
+        stepTime: 0.2,
         textureSize: Vector2(32, 48),
       ),
     );
@@ -85,7 +85,7 @@ class Player extends SpriteAnimationComponent
     position = game.size / 2;
 
     _bulletSpawner = SpawnComponent(
-      period: .2,
+      period: 0.2,
       selfPositioning: true,
       factory: (index) {
         return Bullet(
@@ -132,7 +132,7 @@ class Bullet extends SpriteAnimationComponent
       'bullet.png',
       SpriteAnimationData.sequenced(
         amount: 4,
-        stepTime: .2,
+        stepTime: 0.2,
         textureSize: Vector2(8, 16),
       ),
     );
@@ -175,7 +175,7 @@ class Enemy extends SpriteAnimationComponent
       'enemy.png',
       SpriteAnimationData.sequenced(
         amount: 4,
-        stepTime: .2,
+        stepTime: 0.2,
         textureSize: Vector2.all(16),
       ),
     );
@@ -227,7 +227,7 @@ class Explosion extends SpriteAnimationComponent
       'explosion.png',
       SpriteAnimationData.sequenced(
         amount: 6,
-        stepTime: .1,
+        stepTime: 0.1,
         textureSize: Vector2.all(32),
         loop: false,
       ),

--- a/examples/games/trex/lib/game_over.dart
+++ b/examples/games/trex/lib/game_over.dart
@@ -36,7 +36,7 @@ class GameOverText extends SpriteComponent with HasGameReference<TRexGame> {
   void onGameResize(Vector2 size) {
     super.onGameResize(size);
     x = size.x / 2;
-    y = size.y * .25;
+    y = size.y * 0.25;
   }
 }
 
@@ -56,6 +56,6 @@ class GameOverRestart extends SpriteComponent with HasGameReference<TRexGame> {
   void onGameResize(Vector2 size) {
     super.onGameResize(size);
     x = size.x / 2;
-    y = size.y * .75;
+    y = size.y * 0.75;
   }
 }

--- a/examples/lib/stories/bridge_libraries/flame_forge2d/revolute_joint_with_motor_example.dart
+++ b/examples/lib/stories/bridge_libraries/flame_forge2d/revolute_joint_with_motor_example.dart
@@ -71,8 +71,8 @@ class CircleShuffler extends BodyComponent {
       final fixtureDef = FixtureDef(
         shape,
         density: 50.0,
-        friction: .1,
-        restitution: .9,
+        friction: 0.1,
+        restitution: 0.9,
       );
 
       body.createFixture(fixtureDef);

--- a/examples/lib/stories/camera_and_viewport/camera_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_component_example.dart
@@ -173,7 +173,7 @@ class AntWorld extends World {
       add(
         Ant()
           ..color = baseColor.withHue(random.nextDouble() * 360).toColor()
-          ..scale = Vector2.all(.4)
+          ..scale = Vector2.all(0.4)
           ..setTravelPath(curve.path),
       );
     }

--- a/examples/lib/stories/collision_detection/multiple_shapes_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes_example.dart
@@ -263,7 +263,7 @@ class CollidableSnowman extends MyCollidable {
     );
     final middle = SnowmanPart(
       size.x * 0.4,
-      Vector2(size.x / 2, size.y * 0.40),
+      Vector2(size.x / 2, size.y * 0.4),
       Colors.yellow,
     );
     final bottom = SnowmanPart(

--- a/examples/lib/stories/components/clip_component_example.dart
+++ b/examples/lib/stories/components/clip_component_example.dart
@@ -22,7 +22,7 @@ class _Rectangle extends RectangleComponent {
           children: [
             RotateEffect.by(
               pi * 2,
-              EffectController(duration: .4, infinite: true),
+              EffectController(duration: 0.4, infinite: true),
             ),
           ],
         );

--- a/examples/lib/stories/rendering/particles_example.dart
+++ b/examples/lib/stories/rendering/particles_example.dart
@@ -169,7 +169,7 @@ class ParticlesExample extends FlameGame {
     return Particle.generate(
       count: 5,
       generator: (i) => MovingParticle(
-        to: randomCellVector2()..scale(.5),
+        to: randomCellVector2()..scale(0.5),
         child: CircleParticle(
           radius: 5 + rnd.nextDouble() * 5,
           paint: Paint()..color = Colors.deepOrange,
@@ -185,7 +185,7 @@ class ParticlesExample extends FlameGame {
       count: 5,
       generator: (i) => MovingParticle(
         curve: Curves.easeOutQuad,
-        to: randomCellVector2()..scale(.5),
+        to: randomCellVector2()..scale(0.5),
         child: CircleParticle(
           radius: 5 + rnd.nextDouble() * 5,
           paint: Paint()..color = Colors.deepPurple,
@@ -203,8 +203,8 @@ class ParticlesExample extends FlameGame {
     return Particle.generate(
       count: 5,
       generator: (i) => MovingParticle(
-        curve: const Interval(.2, .6, curve: Curves.easeInOutCubic),
-        to: randomCellVector2()..scale(.5),
+        curve: const Interval(0.2, 0.6, curve: Curves.easeInOutCubic),
+        to: randomCellVector2()..scale(0.5),
         child: CircleParticle(
           radius: 5 + rnd.nextDouble() * 5,
           paint: Paint()..color = Colors.greenAccent,
@@ -269,8 +269,8 @@ class ParticlesExample extends FlameGame {
 
     return Particle.generate(
       generator: (i) => MovingParticle(
-        curve: Interval(rnd.nextDouble() * .1, rnd.nextDouble() * .8 + .1),
-        to: randomCellVector2()..scale(.5),
+        curve: Interval(rnd.nextDouble() * 0.1, rnd.nextDouble() * 0.8 + 0.1),
+        to: randomCellVector2()..scale(0.5),
         child: reusableParticle!,
       ),
     );
@@ -327,8 +327,11 @@ class ParticlesExample extends FlameGame {
   Particle acceleratedParticles() {
     return Particle.generate(
       generator: (i) => AcceleratedParticle(
-        speed:
-            Vector2(rnd.nextDouble() * 600 - 300, -rnd.nextDouble() * 600) * .2,
+        speed: Vector2(
+              rnd.nextDouble() * 600 - 300,
+              -rnd.nextDouble() * 600,
+            ) *
+            0.2,
         acceleration: Vector2(0, 200),
         child: rotatingImage(initialAngle: rnd.nextDouble() * pi),
       ),
@@ -373,7 +376,7 @@ class ParticlesExample extends FlameGame {
   Particle spriteParticle() {
     return SpriteParticle(
       sprite: Sprite(images.fromCache('zap.png')),
-      size: cellSize * .5,
+      size: cellSize * 0.5,
     );
   }
 
@@ -392,8 +395,8 @@ class ParticlesExample extends FlameGame {
   /// which is independent from the parent [Particle].
   Particle componentParticle() {
     return MovingParticle(
-      from: -halfCellSize * .2,
-      to: halfCellSize * .2,
+      from: -halfCellSize * 0.2,
+      to: halfCellSize * 0.2,
       curve: SineCurve(),
       child: ComponentParticle(component: trafficLight),
     );
@@ -435,7 +438,7 @@ class ParticlesExample extends FlameGame {
                 Offset.zero,
                 // Closer to the end of lifespan particles
                 // will turn into larger glaring circles
-                rnd.nextDouble() * particle.progress > .6
+                rnd.nextDouble() * particle.progress > 0.6
                     ? rnd.nextDouble() * (50 * particle.progress)
                     : 2 + (3 * particle.progress),
                 paint,

--- a/packages/flame/lib/src/events/tap_config.dart
+++ b/packages/flame/lib/src/events/tap_config.dart
@@ -20,7 +20,7 @@ final class TapConfig {
   /// Min delay to long tap delay is defined below.
   /// Values too low don't make sense because they
   /// would be basically a regular tap.
-  static const double _minLongTapDelay = 0.150;
+  static const double _minLongTapDelay = 0.15;
 
   /// Default long tap delay is 0.3 seconds.
   static const double _defaultLongTapDelay = 0.3;

--- a/packages/flame/lib/src/particles/particle.dart
+++ b/packages/flame/lib/src/particles/particle.dart
@@ -57,7 +57,7 @@ abstract class Particle {
   Particle({
     double? lifespan,
   }) {
-    setLifespan(lifespan ?? .5);
+    setLifespan(lifespan ?? 0.5);
   }
 
   /// Getter for the current lifespan of this [Particle].

--- a/packages/flame/test/events/tap_config_test.dart
+++ b/packages/flame/test/events/tap_config_test.dart
@@ -14,7 +14,7 @@ void main() {
 
     test('longTapDelay cannot be set to a value lower than 0.150', () {
       TapConfig.longTapDelay = 0.1;
-      expect(TapConfig.longTapDelay, 0.150);
+      expect(TapConfig.longTapDelay, 0.15);
     });
   });
 }

--- a/packages/flame/test/extensions/canvas_test.dart
+++ b/packages/flame/test/extensions/canvas_test.dart
@@ -47,7 +47,7 @@ void main() {
         ' and then restores', () {
       final canvas = _MocktailCanvas();
       when(canvas.save).thenReturn(null);
-      when(() => canvas.rotate(.5)).thenReturn(null);
+      when(() => canvas.rotate(0.5)).thenReturn(null);
       when(() => canvas.translateVector(Vector2(1, 1))).thenReturn(null);
       when(() => canvas.translateVector(Vector2(-1, -1))).thenReturn(null);
       when(canvas.restore).thenReturn(null);
@@ -57,7 +57,7 @@ void main() {
       canvas.renderRotated(0.5, Vector2(1, 1), drawFunction.call);
       verify(canvas.save).called(1);
       verify(() => canvas.translateVector(Vector2(1, 1))).called(1);
-      verify(() => canvas.rotate(.5)).called(1);
+      verify(() => canvas.rotate(0.5)).called(1);
       verify(() => drawFunction(canvas)).called(1);
       verify(() => canvas.translateVector(Vector2(-1, -1))).called(1);
       verify(canvas.restore).called(1);

--- a/packages/flame/test/extensions/rect_test.dart
+++ b/packages/flame/test/extensions/rect_test.dart
@@ -81,9 +81,9 @@ void main() {
       // create points left, above, right and under
 
       // y position [0, 1] but left to rect's left
-      final left = Vector2(-.5, r.nextDouble() * 1);
+      final left = Vector2(-0.5, r.nextDouble() * 1);
       // x position [0, 1] but above rect's top
-      final above = Vector2(r.nextDouble() * 1, -.5);
+      final above = Vector2(r.nextDouble() * 1, -0.5);
       // y position [0, 1] but right to rect's right
       final right = Vector2(1.5, r.nextDouble() * 1);
       // x position [0, 1] but under rect's bottom
@@ -96,22 +96,22 @@ void main() {
       expect(rect.intersectsSegment(under, above), true);
 
       // above the rect and left to rect's left
-      final aboveLeft = Vector2(-.5, r.nextDouble() * 1 - 1);
+      final aboveLeft = Vector2(-0.5, r.nextDouble() * 1 - 1);
       // above the rect and left to rect's left
       final aboveRight = Vector2(1.5, r.nextDouble() * 1 - 1);
       // under the rect and right to rect's right
       final underRight = Vector2(1.5, r.nextDouble() * 1 + 1);
       // under the rect and left to rect's left
-      final underLeft = Vector2(-.5, r.nextDouble() * 1 + 1);
+      final underLeft = Vector2(-0.5, r.nextDouble() * 1 + 1);
       expect(rect.intersectsSegment(aboveLeft, aboveRight), false);
       expect(rect.intersectsSegment(aboveLeft, underLeft), false);
       expect(rect.intersectsSegment(underLeft, underRight), false);
       expect(rect.intersectsSegment(underRight, aboveRight), false);
 
       // any y position but left to rect's left
-      final nearLeft = Vector2(-.25, r.nextDouble() * 256);
+      final nearLeft = Vector2(-0.25, r.nextDouble() * 256);
       // any x position but above rect's top
-      final nearAbove = Vector2(r.nextDouble() * 256, -.25);
+      final nearAbove = Vector2(r.nextDouble() * 256, -0.25);
       // any y position but right to rect's right
       final nearRight = Vector2(1.25, r.nextDouble() * 256);
       // any x position but under rect's bottom

--- a/packages/flame/test/game/flame_game_test.dart
+++ b/packages/flame/test/game/flame_game_test.dart
@@ -17,8 +17,8 @@ void main() {
       'default viewport does not change size',
       (game) async {
         game.onGameResize(Vector2(100.0, 200.0));
-        expect(game.canvasSize, Vector2(100.0, 200.00));
-        expect(game.size, Vector2(100.0, 200.00));
+        expect(game.canvasSize, Vector2(100.0, 200.0));
+        expect(game.size, Vector2(100.0, 200.0));
       },
     );
 

--- a/packages/flame/test/gestures/detectors_test.dart
+++ b/packages/flame/test/gestures/detectors_test.dart
@@ -556,7 +556,7 @@ void main() {
         game.handleForcePressStart(
           ForcePressDetails(
             globalPosition: const Offset(10, 10),
-            pressure: .4,
+            pressure: 0.4,
           ),
         );
 
@@ -573,7 +573,7 @@ void main() {
         game.handleForcePressUpdate(
           ForcePressDetails(
             globalPosition: const Offset(10, 10),
-            pressure: .7,
+            pressure: 0.7,
           ),
         );
 
@@ -590,7 +590,7 @@ void main() {
         game.handleForcePressPeak(
           ForcePressDetails(
             globalPosition: const Offset(10, 10),
-            pressure: .9,
+            pressure: 0.9,
           ),
         );
 
@@ -607,7 +607,7 @@ void main() {
         game.handleForcePressEnd(
           ForcePressDetails(
             globalPosition: const Offset(10, 10),
-            pressure: .2,
+            pressure: 0.2,
           ),
         );
         expect(game.forcePressEnded, equals(1));

--- a/packages/flame/test/particles/scaling_particle_test.dart
+++ b/packages/flame/test/particles/scaling_particle_test.dart
@@ -18,7 +18,7 @@ void main() {
         ),
       );
 
-      final particle = rect.scaling(to: .5, curve: Curves.easeIn);
+      final particle = rect.scaling(to: 0.5, curve: Curves.easeIn);
 
       final component = ParticleSystemComponent(
         particle: particle,
@@ -28,7 +28,7 @@ void main() {
       await game.ready();
       game.update(1);
 
-      expect(particle.scale, .841796875);
+      expect(particle.scale, 0.841796875);
       expect(particle.curve, Curves.easeIn);
       expect(particle.progress, 0.31640625);
       expect(particle.child, isInstanceOf<ComputedParticle>());

--- a/packages/flame_fire_atlas/test/flame_fire_atlas_test.dart
+++ b/packages/flame_fire_atlas/test/flame_fire_atlas_test.dart
@@ -238,7 +238,7 @@ void main() {
         final animation = AnimationSelection.fromJson({
           'id': 'bomb_ptero',
           'frameCount': 1,
-          'stepTime': .2,
+          'stepTime': 0.2,
           'loop': true,
           'x': 0,
           'y': 0,
@@ -249,7 +249,7 @@ void main() {
 
         expect(animation.id, 'bomb_ptero');
         expect(animation.frameCount, 1);
-        expect(animation.stepTime, .2);
+        expect(animation.stepTime, 0.2);
         expect(animation.loop, isTrue);
         expect(animation.x, 0);
         expect(animation.y, 0);
@@ -268,14 +268,14 @@ void main() {
             h: 16,
           ),
           frameCount: 1,
-          stepTime: .2,
+          stepTime: 0.2,
           loop: true,
           group: 'enemies',
         );
         final json = animation.toJson();
         expect(json['id'], 'bomb_ptero');
         expect(json['frameCount'], 1);
-        expect(json['stepTime'], .2);
+        expect(json['stepTime'], 0.2);
         expect(json['loop'], isTrue);
         expect(json['x'], 0);
         expect(json['y'], 0);
@@ -295,7 +295,7 @@ void main() {
               h: 16,
             ),
             frameCount: 1,
-            stepTime: .2,
+            stepTime: 0.2,
             loop: true,
             group: 'enemies',
           );
@@ -304,7 +304,7 @@ void main() {
           expect(copy.group, 'new_group');
           expect(copy.id, 'bomb_ptero');
           expect(copy.frameCount, 1);
-          expect(copy.stepTime, .2);
+          expect(copy.stepTime, 0.2);
           expect(copy.loop, isTrue);
           expect(copy.x, 0);
           expect(copy.y, 0);

--- a/packages/flame_isolate/example/lib/terrain/grass.dart
+++ b/packages/flame_isolate/example/lib/terrain/grass.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 
 class Grass extends PositionComponent with Terrain {
   static final _color = Paint()..color = const Color(0xff567d46);
-  static final _debugColor = Paint()..color = Colors.black.withOpacity(.5);
+  static final _debugColor = Paint()..color = Colors.black.withOpacity(0.5);
 
   late final _rect = size.toRect();
   late final _rect2 = Rect.fromCenter(

--- a/packages/flame_lint/lib/analysis_options_with_dcm.yaml
+++ b/packages/flame_lint/lib/analysis_options_with_dcm.yaml
@@ -11,5 +11,6 @@ dart_code_metrics:
     - avoid-top-level-members-in-tests:
         include:
           - 'test/**/*_test.dart'
+    - double-literal-format
   # flutter rules
     - prefer-define-hero-tag

--- a/packages/flame_network_assets/example/lib/main.dart
+++ b/packages/flame_network_assets/example/lib/main.dart
@@ -31,7 +31,7 @@ class MyGame extends FlameGame with TapDetector {
         SpriteAnimationData.sequenced(
           textureSize: Vector2(48, 32),
           amount: 4,
-          stepTime: .2,
+          stepTime: 0.2,
         ),
         size: Vector2(100, 50),
         anchor: Anchor.center,

--- a/packages/flame_studio/lib/src/widgets/toolbar/flame_studio_toolbar.dart
+++ b/packages/flame_studio/lib/src/widgets/toolbar/flame_studio_toolbar.dart
@@ -19,7 +19,7 @@ class FlameStudioToolbar extends ConsumerWidget {
     ];
 
     final height = ref.watch(toolbarHeightProvider);
-    final gap = height * 0.10;
+    final gap = height * 0.1;
 
     return Container(
       constraints: BoxConstraints.tightFor(height: height),

--- a/packages/flame_tiled/example/lib/main.dart
+++ b/packages/flame_tiled/example/lib/main.dart
@@ -54,7 +54,7 @@ class TiledGame extends FlameGame {
             coins,
             SpriteAnimationData.sequenced(
               amount: 8,
-              stepTime: .15,
+              stepTime: 0.15,
               textureSize: Vector2.all(20),
             ),
           ),

--- a/packages/flame_tiled/lib/src/renderable_layers/tile_layers/orthogonal_tile_layer.dart
+++ b/packages/flame_tiled/lib/src/renderable_layers/tile_layers/orthogonal_tile_layer.dart
@@ -67,8 +67,8 @@ class OrthogonalTileLayer extends FlameTileLayer {
 
         late double offsetX;
         late double offsetY;
-        offsetX = (tx + .5) * size.x;
-        offsetY = (ty + .5) * size.y;
+        offsetX = (tx + 0.5) * size.x;
+        offsetY = (ty + 0.5) * size.y;
 
         offsetX += tileset.tileOffset?.x ?? 0;
         offsetY += tileset.tileOffset?.y ?? 0;

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -969,27 +969,27 @@ void main() {
 
           final waterAnimation = layer.animations.first;
           final spikeAnimation = layer.animations.last;
-          expect(waterAnimation.frames.durations, [.18, .17, .15]);
-          expect(spikeAnimation.frames.durations, [.176, .176, .176, .176]);
+          expect(waterAnimation.frames.durations, [0.18, 0.17, 0.15]);
+          expect(spikeAnimation.frames.durations, [0.176, 0.176, 0.176, 0.176]);
 
-          map.update(.177);
+          map.update(0.177);
           expect(waterAnimation.frame, 0);
-          expect(waterAnimation.frames.frameTime, .177);
+          expect(waterAnimation.frames.frameTime, 0.177);
           expect(
             waterAnimation.batchedSource.toRect(),
             waterAnimation.frames.sources[0],
           );
 
           expect(spikeAnimation.frame, 1);
-          expect(spikeAnimation.frames.frameTime, moreOrLessEquals(.001));
+          expect(spikeAnimation.frames.frameTime, moreOrLessEquals(0.001));
           expect(
             spikeAnimation.batchedSource.toRect(),
             spikeAnimation.frames.sources[1],
           );
 
-          map.update(.003);
+          map.update(0.003);
           expect(waterAnimation.frame, 1);
-          expect(waterAnimation.frames.frameTime, moreOrLessEquals(.0));
+          expect(waterAnimation.frames.frameTime, moreOrLessEquals(0.0));
           expect(spikeAnimation.frame, 1);
           expect(spikeAnimation.frames.frameTime, moreOrLessEquals(0.004));
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Enable DCM rule double-literal-format.

More details [here](https://dcm.dev/docs/rules/common/double-literal-format/). This both forbids trailing zeroes and mandates leading zeroes.

If we would prefer a different style (e.g. prefer no leading zero instead), just lmk :)

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->