### PR TITLE
fix: Add missing export for CylinderMesh [flame_3d]

### DIFF
--- a/packages/flame_3d/lib/src/resources/mesh.dart
+++ b/packages/flame_3d/lib/src/resources/mesh.dart
@@ -1,4 +1,5 @@
 export 'mesh/cuboid_mesh.dart';
+export 'mesh/cylinder_mesh.dart';
 export 'mesh/mesh.dart';
 export 'mesh/plane_mesh.dart';
 export 'mesh/sphere_mesh.dart';


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add missing export for CylinderMesh

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->