### PR TITLE
feat: Add normals to surfaces when not specified

### DIFF
--- a/packages/flame_3d/example/lib/main.dart
+++ b/packages/flame_3d/example/lib/main.dart
@@ -87,6 +87,7 @@ class ExampleGame3D extends FlameGame<World3D>
         mesh: CuboidMesh(
           size: Vector3(32, 5, 1),
           material: SpatialMaterial(albedoTexture: ColorTexture(Colors.lime)),
+          useFaceNormals: false,
         ),
       ),
     ]);

--- a/packages/flame_3d/lib/src/resources/mesh/cuboid_mesh.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/cuboid_mesh.dart
@@ -9,137 +9,150 @@ class CuboidMesh extends Mesh {
   CuboidMesh({
     required Vector3 size,
     Material? material,
+    bool useFaceNormals = true,
   }) {
     final Vector3(:x, :y, :z) = size / 2;
 
+    Vertex vertex({
+      required Vector3 position,
+      required Vector2 texCoord,
+      required Vector3 normal,
+    }) {
+      return Vertex(
+        position: position,
+        texCoord: texCoord,
+        normal: useFaceNormals ? normal : null,
+      );
+    }
+
     final vertices = [
       // Face 1 (front)
-      Vertex(
+      vertex(
         position: Vector3(-x, -y, -z),
         texCoord: Vector2(0, 0),
         normal: Vector3(0, 0, -1),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, -y, -z),
         texCoord: Vector2(1, 0),
         normal: Vector3(0, 0, -1),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, y, -z),
         texCoord: Vector2(1, 1),
         normal: Vector3(0, 0, -1),
       ),
-      Vertex(
+      vertex(
         position: Vector3(-x, y, -z),
         texCoord: Vector2(0, 1),
         normal: Vector3(0, 0, -1),
       ),
 
       // Face 2 (back)
-      Vertex(
+      vertex(
         position: Vector3(-x, -y, z),
         texCoord: Vector2(0, 0),
         normal: Vector3(0, 0, 1),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, -y, z),
         texCoord: Vector2(1, 0),
         normal: Vector3(0, 0, 1),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, y, z),
         texCoord: Vector2(1, 1),
         normal: Vector3(0, 0, 1),
       ),
-      Vertex(
+      vertex(
         position: Vector3(-x, y, z),
         texCoord: Vector2(0, 1),
         normal: Vector3(0, 0, 1),
       ),
 
       // Face 3 (left)
-      Vertex(
+      vertex(
         position: Vector3(-x, -y, z),
         texCoord: Vector2(0, 0),
         normal: Vector3(-1, 0, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(-x, -y, -z),
         texCoord: Vector2(1, 0),
         normal: Vector3(-1, 0, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(-x, y, -z),
         texCoord: Vector2(1, 1),
         normal: Vector3(-1, 0, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(-x, y, z),
         texCoord: Vector2(0, 1),
         normal: Vector3(-1, 0, 0),
       ),
 
       // Face 4 (right)
-      Vertex(
+      vertex(
         position: Vector3(x, -y, -z),
         texCoord: Vector2(0, 0),
         normal: Vector3(1, 0, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, -y, z),
         texCoord: Vector2(1, 0),
         normal: Vector3(1, 0, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, y, z),
         texCoord: Vector2(1, 1),
         normal: Vector3(1, 0, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, y, -z),
         texCoord: Vector2(0, 1),
         normal: Vector3(1, 0, 0),
       ),
 
       // Face 5 (top)
-      Vertex(
+      vertex(
         position: Vector3(-x, y, -z),
         texCoord: Vector2(0, 0),
         normal: Vector3(0, 1, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, y, -z),
         texCoord: Vector2(1, 0),
         normal: Vector3(0, 1, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, y, z),
         texCoord: Vector2(1, 1),
         normal: Vector3(0, 1, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(-x, y, z),
         texCoord: Vector2(0, 1),
         normal: Vector3(0, 1, 0),
       ),
 
       // Face 6 (bottom)
-      Vertex(
+      vertex(
         position: Vector3(-x, -y, z),
         texCoord: Vector2(0, 0),
         normal: Vector3(0, -1, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, -y, z),
         texCoord: Vector2(1, 0),
         normal: Vector3(0, -1, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(x, -y, -z),
         texCoord: Vector2(1, 1),
         normal: Vector3(0, -1, 0),
       ),
-      Vertex(
+      vertex(
         position: Vector3(-x, -y, -z),
         texCoord: Vector2(0, 1),
         normal: Vector3(0, -1, 0),

--- a/packages/flame_3d/lib/src/resources/mesh/vertex.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/vertex.dart
@@ -97,5 +97,4 @@ class Vertex {
     }
     return normals;
   }
-
 }

--- a/packages/flame_3d/lib/src/resources/mesh/vertex.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/vertex.dart
@@ -20,7 +20,7 @@ class Vertex {
     Vector3? normal,
   })  : position = position.immutable,
         texCoord = texCoord.immutable,
-        normal = (normal ?? Vector3.zero()).immutable,
+        normal = normal?.immutable,
         _storage = Float32List.fromList([
           ...position.storage, // 1, 2, 3
           ...texCoord.storage, // 4, 5
@@ -39,7 +39,7 @@ class Vertex {
   final ImmutableVector2 texCoord;
 
   /// The normal vector of the vertex.
-  final ImmutableVector3 normal;
+  final ImmutableVector3? normal;
 
   /// The color on the vertex.
   final Color color;
@@ -65,8 +65,37 @@ class Vertex {
     return Vertex(
       position: position ?? this.position.mutable,
       texCoord: texCoord ?? this.texCoord.mutable,
-      normal: normal ?? this.normal.mutable,
+      normal: normal ?? this.normal?.mutable,
       color: color ?? this.color,
     );
   }
+
+  static List<Vector3> calculateVertexNormals(
+    List<Vector3> vertices,
+    List<int> indices,
+  ) {
+    final normals = List.filled(vertices.length, Vector3.zero());
+    for (var i = 0; i < indices.length; i += 3) {
+      final i0 = indices[i];
+      final i1 = indices[i + 1];
+      final i2 = indices[i + 2];
+
+      final v0 = vertices[i0];
+      final v1 = vertices[i1];
+      final v2 = vertices[i2];
+
+      final edge1 = v1 - v0;
+      final edge2 = v2 - v0;
+      final faceNormal = edge1.cross(edge2)..normalize();
+
+      normals[i0] += faceNormal;
+      normals[i1] += faceNormal;
+      normals[i2] += faceNormal;
+    }
+    for (final normal in normals) {
+      normal.normalize();
+    }
+    return normals;
+  }
+
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add normals to surfaces when not specified.

Not all meshes come with normals.
For example, the provided `SphereMesh` has no normals.
Similarly, some GLTF files come without normals.
Note that this still allows the user to specify their own normals. For example, the `CuboidMesh` uses face normals by default.
However, if the user sets `useFaceNormals` to false, the vertex normals are computed instead.

All objects need normals for lighting purposes. The choice of using face or vertex normal is up to the user, as that will have different consequences.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->