### PR TITLE
chore: Fix deprecated color methods [flame_3d]

### DIFF
--- a/packages/flame_3d/lib/src/extensions/color.dart
+++ b/packages/flame_3d/lib/src/extensions/color.dart
@@ -3,10 +3,5 @@ import 'dart:ui';
 
 extension ColorExtension on Color {
   /// Returns a Float32List that represents the color as a vector.
-  Float32List get storage => Float32List.fromList([
-        opacity,
-        red.toDouble() / 255,
-        green.toDouble() / 255,
-        blue.toDouble() / 255,
-      ]);
+  Float32List get storage => Float32List.fromList([a, r, g, b]);
 }

--- a/packages/flame_3d/lib/src/resources/texture/color_texture.dart
+++ b/packages/flame_3d/lib/src/resources/texture/color_texture.dart
@@ -11,6 +11,7 @@ class ColorTexture extends Texture {
   ColorTexture(Color color, {int width = 1, int height = 1})
       : super(
           Uint32List.fromList(
+            // ignore: deprecated_member_use
             List.filled(width * height, color.value),
           ).buffer.asByteData(),
           width: width,


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Fix deprecated color methods

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->