### PR TITLE
fix: Improve quaternion slerp logic to avoid NaN edge cases

### DIFF
--- a/packages/flame_3d/test/quaternion_extensions_test.dart
+++ b/packages/flame_3d/test/quaternion_extensions_test.dart
@@ -40,6 +40,22 @@ void main() {
       final slerp3 = QuaternionUtils.slerp(quaternion2, quaternion2, 0.5);
       expect(angle2, closeTo(slerp3.radians, _epsilon));
     });
+
+    test('slerp edge cases', () {
+      const angle1 = 1.2;
+      const angle2 = angle1 + _epsilon;
+
+      final axis = Vector3(1, 0, 0);
+
+      final quaternion1 = Quaternion.axisAngle(axis, angle1);
+      final quaternion2 = Quaternion.axisAngle(axis, angle2);
+
+      final slerp1 = QuaternionUtils.slerp(quaternion1, quaternion2, 0);
+      expect(angle1, closeTo(slerp1.radians, _epsilon));
+
+      final slerp2 = QuaternionUtils.slerp(quaternion1, quaternion2, 1);
+      expect(angle2, closeTo(slerp2.radians, _epsilon));
+    });
   });
 }
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Improve quaternion slerp logic to avoid NaN edge cases

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->