### PR TITLE
feat: Add ComponentTreeRoot.lifecycleEventsProcessed future

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -259,7 +259,20 @@ class Component {
   /// This can be null if the component hasn't been added to the component tree
   /// yet, or if it is the root of component tree.
   ///
-  /// Setting this property to null is equivalent to [removeFromParent].
+  /// Setting this property to `null` is equivalent to [removeFromParent].
+  /// Setting it to a new parent component is equivalent to calling
+  /// [addToParent] and will properly remove this component from its current
+  /// parent, if any.
+  ///
+  /// Note that the [parent] setter, like [add] and similar methods,
+  /// merely enqueues the move from one parent to another. For example:
+  ///
+  /// ```dart
+  /// coin.parent = inventory;
+  /// // The inventory.children set does not include coin yet.
+  /// await game.lifecycleEventsProcessed;
+  /// // The inventory.children set now includes coin.
+  /// ```
   Component? get parent => _parent;
   Component? _parent;
   set parent(Component? newParent) {
@@ -543,6 +556,13 @@ class Component {
   /// The cost of this flexibility is that the component won't be added right
   /// away. Instead, it will be placed into a queue, and then added later, after
   /// it has finished loading, but no sooner than on the next game tick.
+  /// You can await [FlameGame.lifecycleEventsProcessed] like so:
+  ///
+  /// ```dart
+  /// world.add(coin);
+  /// await game.lifecycleEventsProcessed;
+  /// // The coin is now guaranteed to be added.
+  /// ```
   ///
   /// When multiple children are scheduled to be added to the same parent, we
   /// start loading all of them as soon as possible. Nevertheless, the children

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -140,7 +140,7 @@ class ComponentTreeRoot extends Component {
       _blocked.clear();
     }
 
-    if (_lifecycleEventsCompleter != null) {
+    if (!hasLifecycleEvents && _lifecycleEventsCompleter != null) {
       _lifecycleEventsCompleter!.complete();
       _lifecycleEventsCompleter = null;
     }

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flame/components.dart';
 import 'package:flame/src/components/core/recycled_queue.dart';
 import 'package:meta/meta.dart';
@@ -20,6 +22,7 @@ class ComponentTreeRoot extends Component {
   final Set<int> _blocked;
   final Set<Component> _componentsToRebalance;
   late final Map<ComponentKey, Component> _index = {};
+  Completer<void>? _lifecycleEventsCompleter;
 
   @internal
   void enqueueAdd(Component child, Component parent) {
@@ -76,6 +79,33 @@ class ComponentTreeRoot extends Component {
 
   bool get hasLifecycleEvents => _queue.isNotEmpty;
 
+  /// A future that will complete once all lifecycle events have been
+  /// processed.
+  ///
+  /// If there are no lifecycle events to be processed ([hasLifecycleEvents]
+  /// is `false`), then this future returns immediately.
+  ///
+  /// This is useful when you modify the component tree
+  /// (by adding, moving or removing a component) and you want to make sure
+  /// you react to the changed state, not the current one.
+  /// Remember, methods like [Component.add] don't act immediately and instead
+  /// enqueue their action. This action also cannot be awaited
+  /// with something like `await world.add(something)` since that future
+  /// completes _before_ the lifecycle events are processed.
+  ///
+  /// Example usage:
+  ///
+  /// ```dart
+  /// player.inventory.addAll(enemy.inventory.children);
+  /// await game.lifecycleEventsProcessed;
+  /// updateUi(player.inventory);
+  /// ```
+  Future<void> get lifecycleEventsProcessed {
+    return !hasLifecycleEvents
+        ? Future.value()
+        : (_lifecycleEventsCompleter ??= Completer<void>()).future;
+  }
+
   void processLifecycleEvents() {
     assert(_blocked.isEmpty);
     var repeatLoop = true;
@@ -108,6 +138,11 @@ class ComponentTreeRoot extends Component {
         }
       }
       _blocked.clear();
+    }
+
+    if (_lifecycleEventsCompleter != null) {
+      _lifecycleEventsCompleter!.complete();
+      _lifecycleEventsCompleter = null;
     }
   }
 

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -381,9 +381,10 @@ void main() {
 
           await Future.delayed(Duration.zero).then((_) => game.update(0));
           assert(
-              game.hasLifecycleEvents,
-              'One update should not have been enough '
-              'to add the heavy component');
+            game.hasLifecycleEvents,
+            'One update should not have been enough '
+            'to add the heavy component',
+          );
 
           // Trigger dequeue.
           component.parent = parent2;

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -327,6 +327,38 @@ void main() {
           expect(child.isMounted, true);
         },
       );
+
+      group('lifecycleEventsProcessed', () {
+        testWithFlameGame('waits for unprocessed events', (game) async {
+          await game.ready();
+          final component = _LifecycleComponent();
+          await game.world.add(component);
+          expect(game.hasLifecycleEvents, isTrue);
+
+          Future.delayed(Duration.zero).then((_) => game.update(0));
+          await game.lifecycleEventsProcessed;
+          expect(game.hasLifecycleEvents, isFalse);
+        });
+
+        testWithFlameGame("doesn't block when there are no events",
+            (game) async {
+          await game.ready();
+          expect(game.hasLifecycleEvents, isFalse);
+          await game.lifecycleEventsProcessed;
+          expect(game.hasLifecycleEvents, isFalse);
+        });
+      });
+
+      testWithFlameGame('Can wait for lifecycleEventsProcessed', (game) async {
+        await game.ready();
+        final component = _LifecycleComponent();
+        await game.world.add(component);
+        expect(game.hasLifecycleEvents, isTrue);
+
+        Future.delayed(Duration.zero).then((_) => game.update(0));
+        await game.lifecycleEventsProcessed;
+        expect(game.hasLifecycleEvents, isFalse);
+      });
     });
 
     group('onGameResize', () {

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -347,6 +347,22 @@ void main() {
           await game.lifecycleEventsProcessed;
           expect(game.hasLifecycleEvents, isFalse);
         });
+
+        testWithFlameGame('guarantees addition even with heavy onLoad',
+            (game) async {
+          await game.ready();
+          final component = _SlowComponent('heavy', 1);
+          await game.world.add(component);
+          expect(game.world.children, isNot(contains(component)));
+
+          game.lifecycleEventsProcessed.then(
+            expectAsync1((_) {
+              expect(game.world.children, contains(component));
+            }),
+          );
+
+          await game.ready();
+        });
       });
 
       testWithFlameGame('Can wait for lifecycleEventsProcessed', (game) async {


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->

Adds a future that will complete once all lifecycle events have been processed.

If there are no lifecycle events to be processed (`hasLifecycleEvents` is `false`), then this future returns immediately.

This is useful when you modify the component tree (by adding, moving or removing a component) and you want to make sure you react to the changed state, not the current one.

Remember, methods like `Component.add` don't act immediately and instead enqueue their action. This action also cannot be awaited with something like `await world.add(something)` since that future completes _before_ the lifecycle events are processed.

Example usage:

```dart
player.inventory.addAll(enemy.inventory.children);
await game.lifecycleEventsProcessed;
updateUi(player.inventory);
```

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Discussed here: https://discord.com/channels/509714518008528896/1285583996842934348

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
