### PR TITLE
fix: Export TapConfig to make visible

### DIFF
--- a/packages/flame/lib/input.dart
+++ b/packages/flame/lib/input.dart
@@ -9,6 +9,7 @@ export 'src/components/input/joystick_component.dart';
 export 'src/components/input/sprite_button_component.dart';
 export 'src/events/game_mixins/multi_touch_drag_detector.dart';
 export 'src/events/game_mixins/multi_touch_tap_detector.dart';
+export 'src/events/tap_config.dart';
 export 'src/extensions/vector2.dart';
 export 'src/game/mixins/keyboard.dart';
 export 'src/gestures/detectors.dart';


### PR DESCRIPTION
# Description
A few time ago I added TapConfig class. It allows us to config the tap timing.
However, it's not exported. This PR fix this problem.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions
Not a breaking change.

## Related Issues
Related to https://github.com/flame-engine/flame/pull/3110.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
