### PR TITLE
fix: Remove extra `implements SizeProvider`s

### DIFF
--- a/packages/flame/lib/src/components/clip_component.dart
+++ b/packages/flame/lib/src/components/clip_component.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
-import 'package:flame/effects.dart';
 import 'package:flame/experimental.dart';
 
 /// A function that creates a shape based on a size represented by a [Vector2]
@@ -10,7 +9,7 @@ typedef ShapeBuilder = Shape Function(Vector2 size);
 /// {@template clip_component}
 /// A component that will clip its content.
 /// {@endtemplate}
-class ClipComponent extends PositionComponent implements SizeProvider {
+class ClipComponent extends PositionComponent {
   /// {@macro clip_component}
   ///
   /// Clips the canvas based its shape and size.

--- a/packages/flame/lib/src/components/custom_painter_component.dart
+++ b/packages/flame/lib/src/components/custom_painter_component.dart
@@ -1,5 +1,4 @@
 import 'package:flame/components.dart';
-import 'package:flame/effects.dart';
 import 'package:flutter/widgets.dart';
 
 /// A [PositionComponent] that renders a [CustomPainter] at the designated
@@ -11,7 +10,7 @@ import 'package:flutter/widgets.dart';
 ///
 /// Note that given the active rendering nature of a game, `shouldRepaint` is
 /// ignored by this component.
-class CustomPainterComponent extends PositionComponent implements SizeProvider {
+class CustomPainterComponent extends PositionComponent {
   /// The [CustomPainter] used to render this component
   CustomPainter? painter;
 

--- a/packages/flame/lib/src/components/nine_tile_box_component.dart
+++ b/packages/flame/lib/src/components/nine_tile_box_component.dart
@@ -1,13 +1,12 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
-import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:meta/meta.dart';
 
 export '../nine_tile_box.dart';
 
 /// This class is a thin wrapper on top of [NineTileBox] as a component.
-class NineTileBoxComponent extends PositionComponent implements SizeProvider {
+class NineTileBoxComponent extends PositionComponent {
   NineTileBox? nineTileBox;
 
   /// Takes the [NineTileBox] instance to render a box that can grow and shrink

--- a/packages/flame/lib/src/components/sprite_animation_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_component.dart
@@ -1,15 +1,12 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
-import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:flame/src/sprite_animation_ticker.dart';
 import 'package:meta/meta.dart';
 
 export '../sprite_animation.dart';
 
-class SpriteAnimationComponent extends PositionComponent
-    with HasPaint
-    implements SizeProvider {
+class SpriteAnimationComponent extends PositionComponent with HasPaint {
   /// The animation ticker used for updating [animation].
   SpriteAnimationTicker? _animationTicker;
 

--- a/packages/flame/lib/src/components/sprite_animation_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_animation_group_component.dart
@@ -1,15 +1,12 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
-import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:flame/src/sprite_animation_ticker.dart';
 import 'package:flutter/foundation.dart';
 
 export '../sprite_animation.dart';
 
-class SpriteAnimationGroupComponent<T> extends PositionComponent
-    with HasPaint
-    implements SizeProvider {
+class SpriteAnimationGroupComponent<T> extends PositionComponent with HasPaint {
   /// Key with the current playing animation
   T? _current;
 

--- a/packages/flame/lib/src/components/sprite_component.dart
+++ b/packages/flame/lib/src/components/sprite_component.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
-import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:meta/meta.dart';
 
 export '../sprite.dart';
@@ -11,9 +10,7 @@ export '../sprite.dart';
 /// angle.
 ///
 /// This a commonly used subclass of [Component].
-class SpriteComponent extends PositionComponent
-    with HasPaint
-    implements SizeProvider {
+class SpriteComponent extends PositionComponent with HasPaint {
   /// When set to true, the component is auto-resized to match the
   /// size of underlying sprite.
   bool _autoResize;

--- a/packages/flame/lib/src/components/sprite_group_component.dart
+++ b/packages/flame/lib/src/components/sprite_group_component.dart
@@ -1,16 +1,13 @@
 import 'dart:ui';
 
 import 'package:flame/components.dart';
-import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:flutter/foundation.dart';
 
 export '../sprite_animation.dart';
 
 /// A [PositionComponent] that can have multiple [Sprite]s and render
 /// the one mapped with the [current] key.
-class SpriteGroupComponent<T> extends PositionComponent
-    with HasPaint
-    implements SizeProvider {
+class SpriteGroupComponent<T> extends PositionComponent with HasPaint {
   /// Key for the current sprite.
   T? _current;
 

--- a/packages/flame/lib/src/geometry/circle_component.dart
+++ b/packages/flame/lib/src/geometry/circle_component.dart
@@ -3,11 +3,10 @@ import 'dart:math';
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/geometry.dart';
-import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:flame/src/math/solve_quadratic.dart';
 import 'package:meta/meta.dart';
 
-class CircleComponent extends ShapeComponent implements SizeProvider {
+class CircleComponent extends ShapeComponent {
   /// With this constructor you can create your [CircleComponent] from a radius
   /// and a position. It will also calculate the bounding rectangle [size] for
   /// the [CircleComponent].


### PR DESCRIPTION
I accidentally came across this. `PositionComponent` already implements `SizeProvider` but as it was added later it wasn't cleaned up everywhere.