### PR TITLE
docs: Flame Platforms should unify variable for NAME_OF_YOUR_REPOSITORY

### DIFF
--- a/doc/flame/platforms.md
+++ b/doc/flame/platforms.md
@@ -77,7 +77,7 @@ Now, whenever you push something to the `main` branch, the action will run and u
 deployed game.
 
 The game should be available at an URL like this:
-`https://YOUR_GITHUB_USERNAME.github.io/YOUR_REPO_NAME/`
+`https://YOUR_GITHUB_USERNAME.github.io/NAME_OF_YOUR_REPOSITORY/`
 
 
 ## Deploy your game to itch.io


### PR DESCRIPTION
Fixes https://github.com/flame-engine/flame/issues/3364


# Description
Merges two variables that mean the same thing into one. (NAME_OF_YOUR_REPOSITORY and YOUR_REPO_NAME)

<!-- Exclude from commit message -->
## Checklist
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
