### PR TITLE
fix: Fix albedo texture binding on shader

### DIFF
--- a/packages/flame_3d/lib/src/resources/texture/color_texture.dart
+++ b/packages/flame_3d/lib/src/resources/texture/color_texture.dart
@@ -14,10 +14,10 @@ class ColorTexture extends Texture {
             List.filled(
               width * height,
               // Convert to a 32 bit value representing this color.
-              (color.a ~/ 255) << 24 |
-                  (color.r ~/ 255) << 16 |
-                  (color.g ~/ 255) << 8 |
-                  (color.b ~/ 255),
+              (color.a * 255).round() << 24 |
+                  (color.r * 255).round() << 16 |
+                  (color.g * 255).round() << 8 |
+                  (color.b * 255).round(),
             ),
           ).buffer.asByteData(),
           width: width,


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Fix albedo texture binding on shader

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->