### PR TITLE
fix: Fix bug preventing removeAll(children) from be called before mount

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -643,7 +643,8 @@ class Component {
 
   /// Removes all the children in the list and calls [onRemove] for all of them
   /// and their children.
-  void removeAll(Iterable<Component> components) => components.forEach(remove);
+  void removeAll(Iterable<Component> components) =>
+      components.toList(growable: false).forEach(_removeChild);
 
   /// Removes all the children for which the [test] function returns true.
   void removeWhere(bool Function(Component component) test) {

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -643,12 +643,13 @@ class Component {
 
   /// Removes all the children in the list and calls [onRemove] for all of them
   /// and their children.
-  void removeAll(Iterable<Component> components) =>
-      components.toList(growable: false).forEach(_removeChild);
+  void removeAll(Iterable<Component> components) {
+    components.toList(growable: false).forEach(_removeChild);
+  }
 
   /// Removes all the children for which the [test] function returns true.
   void removeWhere(bool Function(Component component) test) {
-    removeAll([...children.where(test)]);
+    children.where(test).toList(growable: false).forEach(_removeChild);
   }
 
   void _removeChild(Component child) {

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -653,6 +653,16 @@ void main() {
         await game.ready();
         expect(child.isMounted, true);
       });
+
+      testWithFlameGame(
+        "can remove component's children before adding the parent",
+        (game) async {
+          final c = _ComponentWithChildrenRemoveAll();
+          game.add(c);
+
+          await game.ready();
+        },
+      );
     });
 
     group('Removing components', () {
@@ -1803,4 +1813,14 @@ FlameTester<_DetachableFlameGame> _myDetachableGame({required bool open}) {
       await tester.pumpWidget(_Wrapper(open: open, child: gameWidget));
     },
   );
+}
+
+class _ComponentWithChildrenRemoveAll extends Component {
+  @override
+  void onMount() {
+    super.onMount();
+
+    add(Component());
+    removeAll(children);
+  }
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Fix bug preventing removeAll(children) from be called before mount.

Fixes https://github.com/flame-engine/flame/issues/2933

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->