### PR TITLE
fix: Add missing export of GroupElement to text.dart

### DIFF
--- a/packages/flame/lib/src/text/common/utils.dart
+++ b/packages/flame/lib/src/text/common/utils.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 
-import 'package:flame/src/text/elements/group_element.dart';
 import 'package:flame/text.dart';
 import 'package:meta/meta.dart';
 

--- a/packages/flame/lib/src/text/nodes/column_node.dart
+++ b/packages/flame/lib/src/text/nodes/column_node.dart
@@ -1,5 +1,4 @@
 import 'package:flame/src/text/common/utils.dart';
-import 'package:flame/src/text/elements/group_element.dart';
 import 'package:flame/text.dart';
 import 'package:meta/meta.dart';
 

--- a/packages/flame/lib/src/text/nodes/document_root.dart
+++ b/packages/flame/lib/src/text/nodes/document_root.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:flame/src/text/common/utils.dart';
-import 'package:flame/src/text/elements/group_element.dart';
 import 'package:flame/text.dart';
 import 'package:flutter/painting.dart';
 

--- a/packages/flame/lib/src/text/nodes/text_block_node.dart
+++ b/packages/flame/lib/src/text/nodes/text_block_node.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:flame/src/text/common/utils.dart';
-import 'package:flame/src/text/elements/group_element.dart';
 import 'package:flame/text.dart';
 import 'package:meta/meta.dart';
 

--- a/packages/flame/lib/text.dart
+++ b/packages/flame/lib/text.dart
@@ -4,6 +4,7 @@ export 'src/text/common/glyph.dart' show Glyph;
 export 'src/text/common/line_metrics.dart' show LineMetrics;
 export 'src/text/common/sprite_font.dart' show SpriteFont;
 export 'src/text/elements/block_element.dart' show BlockElement;
+export 'src/text/elements/group_element.dart' show GroupElement;
 export 'src/text/elements/inline_text_element.dart' show InlineTextElement;
 export 'src/text/elements/rect_element.dart' show RectElement;
 export 'src/text/elements/rrect_element.dart' show RRectElement;

--- a/packages/flame/test/text/text_element_test.dart
+++ b/packages/flame/test/text/text_element_test.dart
@@ -1,4 +1,3 @@
-import 'package:flame/src/text/elements/group_element.dart';
 import 'package:flame/text.dart';
 import 'package:flutter/rendering.dart';
 import 'package:test/test.dart';

--- a/packages/flame/test/text/text_style_test.dart
+++ b/packages/flame/test/text/text_style_test.dart
@@ -1,4 +1,3 @@
-import 'package:flame/src/text/elements/group_element.dart';
 import 'package:flame/src/text/elements/group_text_element.dart';
 import 'package:flame/text.dart';
 import 'package:flutter/rendering.dart';


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add missing export of GroupElement to text.dart

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->