### PR TITLE
fix: Add missing export of GroupTextElement to text.dart

### DIFF
--- a/packages/flame/lib/src/text/nodes/group_text_node.dart
+++ b/packages/flame/lib/src/text/nodes/group_text_node.dart
@@ -1,4 +1,3 @@
-import 'package:flame/src/text/elements/group_text_element.dart';
 import 'package:flame/src/text/nodes/inline_text_node.dart';
 import 'package:flame/text.dart';
 

--- a/packages/flame/lib/text.dart
+++ b/packages/flame/lib/text.dart
@@ -5,6 +5,7 @@ export 'src/text/common/line_metrics.dart' show LineMetrics;
 export 'src/text/common/sprite_font.dart' show SpriteFont;
 export 'src/text/elements/block_element.dart' show BlockElement;
 export 'src/text/elements/group_element.dart' show GroupElement;
+export 'src/text/elements/group_text_element.dart' show GroupTextElement;
 export 'src/text/elements/inline_text_element.dart' show InlineTextElement;
 export 'src/text/elements/rect_element.dart' show RectElement;
 export 'src/text/elements/rrect_element.dart' show RRectElement;

--- a/packages/flame/test/text/text_style_test.dart
+++ b/packages/flame/test/text/text_style_test.dart
@@ -1,4 +1,3 @@
-import 'package:flame/src/text/elements/group_text_element.dart';
 import 'package:flame/text.dart';
 import 'package:flutter/rendering.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add missing export of GroupTextElement to text.dart

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->