### PR TITLE
fix: Do not encode HTML by default when parsing markdown [flame_markdown]

### DIFF
--- a/packages/flame_markdown/example/assets/fire_and_ice.md
+++ b/packages/flame_markdown/example/assets/fire_and_ice.md
@@ -1,9 +1,9 @@
-# Fire and Ice
+# Fire & Ice
 
 Some say the world will end in **fire**,
 
 Some say in *ice*.
 
-From what I've tasted of desire
+From what I've tasted of >desire<,
 
 I hold with those who favor **fire**.

--- a/packages/flame_markdown/lib/flame_markdown.dart
+++ b/packages/flame_markdown/lib/flame_markdown.dart
@@ -26,7 +26,13 @@ class FlameMarkdown {
   }
 
   static List<Node> _parse(String markdown, {Document? document}) {
-    return (document ?? Document()).parse(markdown);
+    return (document ?? _defaultDocument()).parse(markdown);
+  }
+
+  static Document _defaultDocument() {
+    return Document(
+      encodeHtml: false,
+    );
   }
 
   static TextNode _convertNode(Node node) {

--- a/packages/flame_markdown/test/flame_markdown_test.dart
+++ b/packages/flame_markdown/test/flame_markdown_test.dart
@@ -68,7 +68,7 @@ void main() {
       final doc = FlameMarkdown.toDocument(markdown);
 
       _expectDocument(doc, [
-        (node) => _expectHeader(node, 1, 'Fire and Ice'),
+        (node) => _expectHeader(node, 1, 'Fire & Ice'),
         (node) => _expectParagraph(node, (p) {
               _expectGroup(p, [
                 (node) => _expectPlain(node, 'Some say the world will end in '),
@@ -86,7 +86,7 @@ void main() {
             ),
         (node) => _expectSimpleParagraph(
               node,
-              "From what I've tasted of desire",
+              "From what I've tasted of >desire<,",
             ),
         (node) => _expectParagraph(node, (p) {
               _expectGroup(p, [


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Do not encode HTML by default when parsing markdown [flame_markdown].

The Flame text rendering pipeline is not configured to accept HTML encoded sequences, therefore the default behaviour of Flame Markdown doesn't lead to a good result:

![image](https://github.com/user-attachments/assets/b8463c88-1b2c-475e-ab23-9eb56864d518)

With this change:

![image](https://github.com/user-attachments/assets/85c94c0c-019f-4b55-b713-a995ccef1361)

Of the user can still override it as before.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->