### PR TITLE
feat: Add validation against passing both color and foreground to InlineTextStyle

### DIFF
--- a/packages/flame/lib/src/text/styles/inline_text_style.dart
+++ b/packages/flame/lib/src/text/styles/inline_text_style.dart
@@ -28,7 +28,10 @@ class InlineTextStyle extends FlameTextStyle {
     this.decorationThickness,
     this.background,
     this.foreground,
-  });
+  }) : assert(
+          color == null || foreground == null,
+          'Cannot provide both color and foreground',
+        );
 
   final Color? color;
   final String? fontFamily;
@@ -84,10 +87,15 @@ class InlineTextStyle extends FlameTextStyle {
   }
 
   TextStyle asTextStyle() {
+    final fontSize = this.fontSize;
+    if (fontSize == null) {
+      throw Exception('fontSize must be set');
+    }
+
     return TextStyle(
       color: color,
       fontFamily: fontFamily,
-      fontSize: fontSize! * (fontScale ?? 1.0),
+      fontSize: fontSize * (fontScale ?? 1.0),
       fontWeight: fontWeight,
       fontStyle: fontStyle,
       letterSpacing: letterSpacing,

--- a/packages/flame/test/text/text_style_test.dart
+++ b/packages/flame/test/text/text_style_test.dart
@@ -1,5 +1,6 @@
 import 'package:flame/text.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart' show throwsAssertionError;
 import 'package:test/test.dart';
 
 void main() {
@@ -139,6 +140,37 @@ void main() {
       expect(styles[3].fontWeight, isNull);
       expect(styles[3].fontStyle, FontStyle.italic);
       expect(styles[3].fontFamily, 'Arial');
+    });
+
+    test("inline text style can be converted to Flutter's text style", () {
+      final withColor = InlineTextStyle(
+        color: const Color(0xFF00FF00),
+        fontSize: 12,
+      );
+      final withColorTextStyle = withColor.asTextStyle();
+      expect(withColorTextStyle.color, const Color(0xFF00FF00));
+      expect(withColorTextStyle.foreground, isNull);
+
+      final paint = Paint()..color = const Color(0xFF00FF00);
+      final withForeground = InlineTextStyle(
+        foreground: paint,
+        fontSize: 12,
+      );
+      final withForegroundTextStyle = withForeground.asTextStyle();
+      expect(withForegroundTextStyle.foreground, paint);
+      expect(withForegroundTextStyle.color, isNull);
+
+      // try setting both options will throw an error
+      expect(
+        () {
+          InlineTextStyle(
+            color: const Color(0xFF00FF00),
+            foreground: paint,
+            fontSize: 12,
+          ).asTextStyle();
+        },
+        throwsAssertionError,
+      );
     });
   });
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add validation against passing both color and foreground to InlineTextStyle.

Note: I plan on working on standardizing asserts, exceptions and tests thereof on a followup, so I am not focusing on this particular issue here.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->