### PR TITLE
feat: Add direction and length getters and constructor to LineSegment

### DIFF
--- a/packages/flame/lib/src/geometry/line_segment.dart
+++ b/packages/flame/lib/src/geometry/line_segment.dart
@@ -9,7 +9,19 @@ class LineSegment {
 
   LineSegment(this.from, this.to);
 
+  /// Creates a [LineSegment] starting at a given a [start] point and following
+  /// a certain [direction] for a given [length].
+  LineSegment.withLength({
+    required Vector2 start,
+    required Vector2 direction,
+    required double length,
+  }) : this(start, start + direction.normalized() * length);
+
   factory LineSegment.zero() => LineSegment(Vector2.zero(), Vector2.zero());
+
+  Vector2 get direction => (to - from)..normalize();
+
+  double get length => (to - from).length;
 
   Vector2 get midpoint => (from + to)..scale(0.5);
 

--- a/packages/flame/test/geometry/line_segment_test.dart
+++ b/packages/flame/test/geometry/line_segment_test.dart
@@ -11,5 +11,25 @@ void main() {
       final lineSegment2 = LineSegment(Vector2.all(0), Vector2(0, 2));
       expect(lineSegment2.midpoint, Vector2(0, 1));
     });
+
+    test('(to, from) and (direction, length) are equivalent', () {
+      final lineSegment1 = LineSegment(Vector2(1, 1), Vector2(2, 1));
+      expect(lineSegment1.from, Vector2(1, 1));
+      expect(lineSegment1.to, Vector2(2, 1));
+
+      expect(lineSegment1.length, 1);
+      expect(lineSegment1.direction, Vector2(1, 0));
+
+      final lineSegment2 = LineSegment.withLength(
+        start: Vector2(1, 1),
+        direction: Vector2(1, 0),
+        length: 1,
+      );
+      expect(lineSegment2.from, Vector2(1, 1));
+      expect(lineSegment2.to, Vector2(2, 1));
+
+      expect(lineSegment2.length, 1);
+      expect(lineSegment2.direction, Vector2(1, 0));
+    });
   });
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
feat: Add direction and length getters and constructor to LineSegment

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->