### PR TITLE
fix: Fix melos/workspace scripts to be able to lint monorepo locally

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,10 +103,6 @@ melos:
       run: melos exec dart analyze .
       description: Run `dart analyze` for all packages.
 
-    format:
-      run: melos exec dart format .
-      description: Run `dart format` resolution for all packages.
-
     format-check:
       run: melos exec dart format . --set-exit-if-changed
       description: Run `dart format` checks for all packages.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,6 +99,14 @@ melos:
         - format
       description: Run all static analysis checks.
 
+    analyze:
+      run: melos exec dart analyze .
+      description: Run `dart analyze` for all packages.
+
+    format:
+      run: melos exec dart format .
+      description: Run `dart format` resolution for all packages.
+
     format-check:
       run: melos exec dart format . --set-exit-if-changed
       description: Run `dart format` checks for all packages.


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Fix melos/workspace scripts to be able to lint monorepo locally

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->