### PR TITLE
chore(release): Publish flame 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,94 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-02-05
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`flame_fire_atlas` - `v1.8.0`](#flame_fire_atlas---v180)
+ - [`flame_3d` - `v0.1.0-dev.5`](#flame_3d---v010-dev5)
+ - [`flame_tiled` - `v2.0.0`](#flame_tiled---v200)
+
+Packages with other changes:
+
+ - [`flame` - `v1.24.0`](#flame---v1240)
+ - [`flame_test` - `v1.17.5`](#flame_test---v1175)
+ - [`flame_behavior_tree` - `v0.1.3+5`](#flame_behavior_tree---v0135)
+ - [`flame_oxygen` - `v0.2.3+5`](#flame_oxygen---v0235)
+ - [`flame_isolate` - `v0.6.2+5`](#flame_isolate---v0625)
+ - [`flame_texturepacker` - `v4.1.5`](#flame_texturepacker---v415)
+ - [`flame_sprite_fusion` - `v0.1.3+5`](#flame_sprite_fusion---v0135)
+ - [`flame_audio` - `v2.10.8`](#flame_audio---v2108)
+ - [`flame_spine` - `v0.2.2+5`](#flame_spine---v0225)
+ - [`flame_bloc` - `v1.12.6`](#flame_bloc---v1126)
+ - [`flame_kenney_xml` - `v0.1.1+5`](#flame_kenney_xml---v0115)
+ - [`flame_lottie` - `v0.4.2+5`](#flame_lottie---v0425)
+ - [`flame_markdown` - `v0.2.3+1`](#flame_markdown---v0231)
+ - [`flame_console` - `v0.1.2+1`](#flame_console---v0121)
+ - [`flame_rive` - `v1.10.8`](#flame_rive---v1108)
+ - [`flame_forge2d` - `v0.18.2+5`](#flame_forge2d---v01825)
+ - [`flame_noise` - `v0.3.2+5`](#flame_noise---v0325)
+ - [`flame_riverpod` - `v5.4.8`](#flame_riverpod---v548)
+ - [`flame_svg` - `v1.11.5`](#flame_svg---v1115)
+ - [`flame_network_assets` - `v0.3.3+5`](#flame_network_assets---v0335)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `flame_behavior_tree` - `v0.1.3+5`
+ - `flame_oxygen` - `v0.2.3+5`
+ - `flame_isolate` - `v0.6.2+5`
+ - `flame_texturepacker` - `v4.1.5`
+ - `flame_sprite_fusion` - `v0.1.3+5`
+ - `flame_audio` - `v2.10.8`
+ - `flame_spine` - `v0.2.2+5`
+ - `flame_bloc` - `v1.12.6`
+ - `flame_kenney_xml` - `v0.1.1+5`
+ - `flame_lottie` - `v0.4.2+5`
+ - `flame_markdown` - `v0.2.3+1`
+ - `flame_console` - `v0.1.2+1`
+ - `flame_rive` - `v1.10.8`
+ - `flame_forge2d` - `v0.18.2+5`
+ - `flame_noise` - `v0.3.2+5`
+ - `flame_riverpod` - `v5.4.8`
+ - `flame_svg` - `v1.11.5`
+ - `flame_network_assets` - `v0.3.3+5`
+
+---
+
+#### `flame_fire_atlas` - `v1.8.0`
+
+ - **BREAKING** **FIX**: Bump tiled to 0.11.0 and add ColorData extension (#3473).
+
+#### `flame_3d` - `v0.1.0-dev.5`
+
+ - **BREAKING** **FEAT**: Make resource creation be on demand to enable testing (#3411).
+
+#### `flame_tiled` - `v2.0.0`
+
+ - **BREAKING** **FIX**: Bump tiled to 0.11.0 and add ColorData extension (#3473).
+
+#### `flame` - `v1.24.0`
+
+ - **PERF**: Switch from forEach to regular for-loops for about 30% improvement in raw update performance (#3472).
+ - **FIX**: SpawnComponent.periodRange should change range each iteration (#3464).
+ - **FIX**: Don't use a future when assets for SpriteButton is already loaded (#3456).
+ - **FIX**: Darkness increases with higher values (#3448).
+ - **FEAT**: NineTileBoxComponent with HasPaint to enable effects (#3459).
+ - **FEAT**: Devtools overlay navigation (#3449).
+ - **FEAT**: Add direction and length getters and constructor to LineSegment (#3446).
+ - **FEAT**: Add multiFactory to SpawnComponent (#3440).
+
+#### `flame_test` - `v1.17.5`
+
+ - **FIX**: Don't use a future when assets for SpriteButton is already loaded (#3456).
+
+
 ## 2025-01-02
 
 ### Changes

--- a/doc/flame/examples/pubspec.yaml
+++ b/doc/flame/examples/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
-  flame_rive: ^1.10.7
+  flame: ^1.24.0
+  flame_rive: ^1.10.8
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/klondike/app/pubspec.yaml
+++ b/doc/tutorials/klondike/app/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/platformer/app/pubspec.yaml
+++ b/doc/tutorials/platformer/app/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 

--- a/doc/tutorials/space_shooter/app/pubspec.yaml
+++ b/doc/tutorials/space_shooter/app/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 

--- a/examples/games/padracing/pubspec.yaml
+++ b/examples/games/padracing/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.23.0
-  flame_forge2d: ^0.18.2+4
+  flame: ^1.24.0
+  flame_forge2d: ^0.18.2+5
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/examples/games/rogue_shooter/pubspec.yaml
+++ b/examples/games/rogue_shooter/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 

--- a/examples/games/trex/pubspec.yaml
+++ b/examples/games/trex/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -12,15 +12,15 @@ environment:
 
 dependencies:
   dashbook: ^0.1.16
-  flame: ^1.23.0
-  flame_audio: ^2.10.7
-  flame_forge2d: ^0.18.2+4
-  flame_isolate: ^0.6.2+4
-  flame_lottie: ^0.4.2+4
-  flame_noise: ^0.3.2+4
-  flame_spine: ^0.2.2+4
-  flame_svg: ^1.11.4
-  flame_tiled: ^1.21.2
+  flame: ^1.24.0
+  flame_audio: ^2.10.8
+  flame_forge2d: ^0.18.2+5
+  flame_isolate: ^0.6.2+5
+  flame_lottie: ^0.4.2+5
+  flame_noise: ^0.3.2+5
+  flame_spine: ^0.2.2+5
+  flame_svg: ^1.11.5
+  flame_tiled: ^2.0.0
   flutter:
     sdk: flutter
   google_fonts: ^4.0.4

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.24.0
+
+ - **PERF**: Switch from forEach to regular for-loops for about 30% improvement in raw update performance (#3472).
+ - **FIX**: SpawnComponent.periodRange should change range each iteration (#3464).
+ - **FIX**: Don't use a future when assets for SpriteButton is already loaded (#3456).
+ - **FIX**: Darkness increases with higher values (#3448).
+ - **FEAT**: NineTileBoxComponent with HasPaint to enable effects (#3459).
+ - **FEAT**: Devtools overlay navigation (#3449).
+ - **FEAT**: Add direction and length getters and constructor to LineSegment (#3446).
+ - **FEAT**: Add multiFactory to SpawnComponent (#3440).
+
 ## 1.23.0
 
  - **REFACTOR**: Fix lint issues from latest flutter release ([#3390](https://github.com/flame-engine/flame/issues/3390)). ([978ad31b](https://github.com/flame-engine/flame/commit/978ad31b429d1801097b0db385a600c85a157867))

--- a/packages/flame/example/pubspec.yaml
+++ b/packages/flame/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -30,7 +30,7 @@ dev_dependencies:
   canvas_test: ^0.2.0
   dartdoc: ^8.0.8
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/packages/flame_3d/CHANGELOG.md
+++ b/packages/flame_3d/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.0-dev.5
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **FEAT**: Make resource creation be on demand to enable testing (#3411).
+
 ## 0.1.0-dev.4
 
 > Note: This release has breaking changes.

--- a/packages/flame_3d/example/pubspec.yaml
+++ b/packages/flame_3d/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_3d: ^0.1.0-dev.4
+  flame: ^1.24.0
+  flame_3d: ^0.1.0-dev.5
   flutter:
     sdk: flutter
 

--- a/packages/flame_3d/pubspec.yaml
+++ b/packages/flame_3d/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   flutter_gpu:
@@ -24,7 +24,7 @@ dependencies:
 
 dev_dependencies:
   flame_lint: ^1.2.0
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter
 

--- a/packages/flame_audio/CHANGELOG.md
+++ b/packages/flame_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.10.8
+
+ - Update a dependency to the latest release.
+
 ## 2.10.7
 
  - Update a dependency to the latest release.

--- a/packages/flame_audio/example/pubspec.yaml
+++ b/packages/flame_audio/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_audio: ^2.10.7
+  flame: ^1.24.0
+  flame_audio: ^2.10.8
   flutter:
     sdk: flutter
 

--- a/packages/flame_audio/pubspec.yaml
+++ b/packages/flame_audio/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 
 dependencies:
   audioplayers: ^6.0.0
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   synchronized: ^3.1.0

--- a/packages/flame_behavior_tree/CHANGELOG.md
+++ b/packages/flame_behavior_tree/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+5
+
+ - Update a dependency to the latest release.
+
 ## 0.1.3+4
 
  - Update a dependency to the latest release.

--- a/packages/flame_behavior_tree/example/pubspec.yaml
+++ b/packages/flame_behavior_tree/example/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_behavior_tree: ^0.1.3+4
+  flame: ^1.24.0
+  flame_behavior_tree: ^0.1.3+5
   flutter:
     sdk: flutter
 

--- a/packages/flame_behavior_tree/pubspec.yaml
+++ b/packages/flame_behavior_tree/pubspec.yaml
@@ -16,13 +16,13 @@ environment:
 
 dependencies:
   behavior_tree: ^0.1.3
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/packages/flame_bloc/CHANGELOG.md
+++ b/packages/flame_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.6
+
+ - Update a dependency to the latest release.
+
 ## 1.12.5
 
  - Update a dependency to the latest release.

--- a/packages/flame_bloc/example/pubspec.yaml
+++ b/packages/flame_bloc/example/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  flame: ^1.23.0
-  flame_bloc: ^1.12.5
+  flame: ^1.24.0
+  flame_bloc: ^1.12.6
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.2

--- a/packages/flame_bloc/pubspec.yaml
+++ b/packages/flame_bloc/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   bloc: ">=8.1.1 <10.0.0"
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   flutter_bloc: ">=8.1.2 <10.0.0"
@@ -26,7 +26,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^8.0.8
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/packages/flame_console/CHANGELOG.md
+++ b/packages/flame_console/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+1
+
+ - Update a dependency to the latest release.
+
 ## 0.1.2
 
  - **REFACTOR**: Fix lint issues from latest flutter release ([#3390](https://github.com/flame-engine/flame/issues/3390)). ([978ad31b](https://github.com/flame-engine/flame/commit/978ad31b429d1801097b0db385a600c85a157867))

--- a/packages/flame_console/example/pubspec.yaml
+++ b/packages/flame_console/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_console: ^0.1.2
+  flame: ^1.24.0
+  flame_console: ^0.1.2+1
   flutter:
     sdk: flutter
 

--- a/packages/flame_console/pubspec.yaml
+++ b/packages/flame_console/pubspec.yaml
@@ -18,13 +18,13 @@ environment:
 
 dependencies:
   args: ^2.5.0
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   terminui: ^0.1.0
 
 dev_dependencies:
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter

--- a/packages/flame_devtools/pubspec.yaml
+++ b/packages/flame_devtools/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   animated_tree_view: ^2.2.0
   devtools_app_shared: ^0.3.0
   devtools_extensions: ^0.3.0
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.5.1

--- a/packages/flame_fire_atlas/CHANGELOG.md
+++ b/packages/flame_fire_atlas/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **FIX**: Bump tiled to 0.11.0 and add ColorData extension (#3473).
+
 ## 1.7.1
 
  - Update a dependency to the latest release.

--- a/packages/flame_fire_atlas/example/pubspec.yaml
+++ b/packages/flame_fire_atlas/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_fire_atlas: ^1.7.1
+  flame: ^1.24.0
+  flame_fire_atlas: ^1.8.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_fire_atlas/pubspec.yaml
+++ b/packages/flame_fire_atlas/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 
 dependencies:
   archive: ^4.0.2
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/CHANGELOG.md
+++ b/packages/flame_forge2d/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.2+5
+
+ - Update a dependency to the latest release.
+
 ## 0.18.2+4
 
  - **REFACTOR**: Fix lint issues from latest flutter release ([#3390](https://github.com/flame-engine/flame/issues/3390)). ([978ad31b](https://github.com/flame-engine/flame/commit/978ad31b429d1801097b0db385a600c85a157867))

--- a/packages/flame_forge2d/example/pubspec.yaml
+++ b/packages/flame_forge2d/example/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
-  flame_forge2d: ^0.18.2+4
+  flame: ^1.24.0
+  flame_forge2d: ^0.18.2+5
   flutter:
     sdk: flutter
 

--- a/packages/flame_forge2d/pubspec.yaml
+++ b/packages/flame_forge2d/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   forge2d: ^0.13.1
@@ -25,7 +25,7 @@ dependencies:
 dev_dependencies:
   dartdoc: ^8.0.8
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/packages/flame_isolate/CHANGELOG.md
+++ b/packages/flame_isolate/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2+5
+
+ - Update a dependency to the latest release.
+
 ## 0.6.2+4
 
  - **REFACTOR**: Fix lint issues from latest flutter release ([#3390](https://github.com/flame-engine/flame/issues/3390)). ([978ad31b](https://github.com/flame-engine/flame/commit/978ad31b429d1801097b0db385a600c85a157867))

--- a/packages/flame_isolate/example/pubspec.yaml
+++ b/packages/flame_isolate/example/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  flame: ^1.23.0
-  flame_isolate: ^0.6.2+4
+  flame: ^1.24.0
+  flame_isolate: ^0.6.2+5
   flutter:
     sdk: flutter
   quiver: ^3.2.1

--- a/packages/flame_isolate/pubspec.yaml
+++ b/packages/flame_isolate/pubspec.yaml
@@ -12,14 +12,14 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   integral_isolates: ^0.5.1
 
 dev_dependencies:
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_jenny/pubspec.yaml
+++ b/packages/flame_jenny/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   jenny: ^1.3.2

--- a/packages/flame_kenney_xml/CHANGELOG.md
+++ b/packages/flame_kenney_xml/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+5
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+4
 
  - Update a dependency to the latest release.

--- a/packages/flame_kenney_xml/example/pubspec.yaml
+++ b/packages/flame_kenney_xml/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_kenney_xml: ^0.1.1+4
+  flame: ^1.24.0
+  flame_kenney_xml: ^0.1.1+5
   flutter:
     sdk: flutter
 

--- a/packages/flame_kenney_xml/pubspec.yaml
+++ b/packages/flame_kenney_xml/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   xml: ^6.5.0

--- a/packages/flame_lottie/CHANGELOG.md
+++ b/packages/flame_lottie/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2+5
+
+ - Update a dependency to the latest release.
+
 ## 0.4.2+4
 
  - Update a dependency to the latest release.

--- a/packages/flame_lottie/example/pubspec.yaml
+++ b/packages/flame_lottie/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_lottie: ^0.4.2+4
+  flame: ^1.24.0
+  flame_lottie: ^0.4.2+5
   flutter:
     sdk: flutter
   lottie:

--- a/packages/flame_lottie/pubspec.yaml
+++ b/packages/flame_lottie/pubspec.yaml
@@ -17,13 +17,13 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   lottie: ^3.1.2
 
 dev_dependencies:
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter

--- a/packages/flame_markdown/CHANGELOG.md
+++ b/packages/flame_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3+1
+
+ - Update a dependency to the latest release.
+
 ## 0.2.3
 
  - **FIX**: Do not encode HTML by default when parsing markdown [flame_markdown] ([#3425](https://github.com/flame-engine/flame/issues/3425)). ([3067da94](https://github.com/flame-engine/flame/commit/3067da94fbc6df2da5197771cb9617588006a9b9))

--- a/packages/flame_markdown/example/pubspec.yaml
+++ b/packages/flame_markdown/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_markdown: ^0.2.3
+  flame: ^1.24.0
+  flame_markdown: ^0.2.3+1
   flutter:
     sdk: flutter
   markdown: ^7.1.1

--- a/packages/flame_markdown/pubspec.yaml
+++ b/packages/flame_markdown/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   markdown: ^7.1.1

--- a/packages/flame_network_assets/CHANGELOG.md
+++ b/packages/flame_network_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3+5
+
+ - Update a dependency to the latest release.
+
 ## 0.3.3+4
 
  - Update a dependency to the latest release.

--- a/packages/flame_network_assets/example/pubspec.yaml
+++ b/packages/flame_network_assets/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_network_assets: ^0.3.3+4
+  flame: ^1.24.0
+  flame_network_assets: ^0.3.3+5
   flutter:
     sdk: flutter
 

--- a/packages/flame_network_assets/pubspec.yaml
+++ b/packages/flame_network_assets/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 
 dependencies:
   dev: ^1.0.0
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   http: ^1.2.1

--- a/packages/flame_noise/CHANGELOG.md
+++ b/packages/flame_noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2+5
+
+ - Update a dependency to the latest release.
+
 ## 0.3.2+4
 
  - Update a dependency to the latest release.

--- a/packages/flame_noise/pubspec.yaml
+++ b/packages/flame_noise/pubspec.yaml
@@ -17,12 +17,12 @@ environment:
 
 dependencies:
   fast_noise: ^2.0.0
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   dartdoc: ^8.0.8
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   test: any

--- a/packages/flame_oxygen/CHANGELOG.md
+++ b/packages/flame_oxygen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3+5
+
+ - Update a dependency to the latest release.
+
 ## 0.2.3+4
 
  - **REFACTOR**: Fix lint issues from latest flutter release ([#3390](https://github.com/flame-engine/flame/issues/3390)). ([978ad31b](https://github.com/flame-engine/flame/commit/978ad31b429d1801097b0db385a600c85a157867))

--- a/packages/flame_oxygen/example/pubspec.yaml
+++ b/packages/flame_oxygen/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_oxygen: ^0.2.3+4
+  flame: ^1.24.0
+  flame_oxygen: ^0.2.3+5
   flutter:
     sdk: flutter
 

--- a/packages/flame_oxygen/pubspec.yaml
+++ b/packages/flame_oxygen/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   oxygen: ^0.3.1

--- a/packages/flame_rive/CHANGELOG.md
+++ b/packages/flame_rive/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.8
+
+ - Update a dependency to the latest release.
+
 ## 1.10.7
 
  - Update a dependency to the latest release.

--- a/packages/flame_rive/example/pubspec.yaml
+++ b/packages/flame_rive/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_rive: ^1.10.7
+  flame: ^1.24.0
+  flame_rive: ^1.10.8
   flutter:
     sdk: flutter
   rive: ^0.12.3

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   rive: ^0.12.3
@@ -25,6 +25,6 @@ dependencies:
 dev_dependencies:
   dartdoc: ^8.0.8
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter

--- a/packages/flame_riverpod/CHANGELOG.md
+++ b/packages/flame_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.8
+
+ - Update a dependency to the latest release.
+
 ## 5.4.7
 
  - Update a dependency to the latest release.

--- a/packages/flame_riverpod/example/pubspec.yaml
+++ b/packages/flame_riverpod/example/pubspec.yaml
@@ -6,8 +6,8 @@ version: 1.0.0+1
 environment:
   sdk: ">=3.6.0 <4.0.0"
 dependencies:
-  flame: ^1.23.0
-  flame_riverpod: ^5.4.7
+  flame: ^1.24.0
+  flame_riverpod: ^5.4.8
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.5.1

--- a/packages/flame_riverpod/pubspec.yaml
+++ b/packages/flame_riverpod/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.5.1

--- a/packages/flame_spine/CHANGELOG.md
+++ b/packages/flame_spine/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2+5
+
+ - Update a dependency to the latest release.
+
 ## 0.2.2+4
 
  - Update a dependency to the latest release.

--- a/packages/flame_spine/example/pubspec.yaml
+++ b/packages/flame_spine/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_spine: ^0.2.2+4
+  flame: ^1.24.0
+  flame_spine: ^0.2.2+5
   flutter:
     sdk: flutter
 

--- a/packages/flame_spine/pubspec.yaml
+++ b/packages/flame_spine/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   spine_flutter: ^4.2.29

--- a/packages/flame_sprite_fusion/CHANGELOG.md
+++ b/packages/flame_sprite_fusion/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+5
+
+ - Update a dependency to the latest release.
+
 ## 0.1.3+4
 
  - **REFACTOR**: Fix lint issues from latest flutter release ([#3390](https://github.com/flame-engine/flame/issues/3390)). ([978ad31b](https://github.com/flame-engine/flame/commit/978ad31b429d1801097b0db385a600c85a157867))

--- a/packages/flame_sprite_fusion/example/pubspec.yaml
+++ b/packages/flame_sprite_fusion/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_sprite_fusion: ^0.1.3+4
+  flame: ^1.24.0
+  flame_sprite_fusion: ^0.1.3+5
   flutter:
     sdk: flutter
 

--- a/packages/flame_sprite_fusion/pubspec.yaml
+++ b/packages/flame_sprite_fusion/pubspec.yaml
@@ -16,12 +16,12 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter

--- a/packages/flame_studio/pubspec.yaml
+++ b/packages/flame_studio/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.3.6

--- a/packages/flame_svg/CHANGELOG.md
+++ b/packages/flame_svg/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.5
+
+ - Update a dependency to the latest release.
+
 ## 1.11.4
 
  - **REFACTOR**: Fix lint issues from latest flutter release ([#3390](https://github.com/flame-engine/flame/issues/3390)). ([978ad31b](https://github.com/flame-engine/flame/commit/978ad31b429d1801097b0db385a600c85a157867))

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_svg: ^1.11.4
+  flame: ^1.24.0
+  flame_svg: ^1.11.5
   flutter:
     sdk: flutter
 

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.5

--- a/packages/flame_test/CHANGELOG.md
+++ b/packages/flame_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.5
+
+ - **FIX**: Don't use a future when assets for SpriteButton is already loaded (#3456).
+
 ## 1.17.4
 
  - **REFACTOR**: Fix lint issues from latest flutter release ([#3390](https://github.com/flame-engine/flame/issues/3390)). ([978ad31b](https://github.com/flame-engine/flame/commit/978ad31b429d1801097b0db385a600c85a157867))

--- a/packages/flame_test/example/pubspec.yaml
+++ b/packages/flame_test/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flame_lint: ^1.2.1
-  flame_test: ^1.17.4
+  flame_test: ^1.17.5
   flutter_test:
     sdk: flutter
   test: any

--- a/packages/flame_test/pubspec.yaml
+++ b/packages/flame_test/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/flame_texturepacker/CHANGELOG.md
+++ b/packages/flame_texturepacker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.5
+
+ - Update a dependency to the latest release.
+
 ## 4.1.4
 
  - Update a dependency to the latest release.

--- a/packages/flame_texturepacker/example/pubspec.yaml
+++ b/packages/flame_texturepacker/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
-  flame: ^1.23.0
-  flame_texturepacker: ^4.1.4
+  flame: ^1.24.0
+  flame_texturepacker: ^4.1.5
   flutter:
     sdk: flutter
 

--- a/packages/flame_texturepacker/pubspec.yaml
+++ b/packages/flame_texturepacker/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_tiled/CHANGELOG.md
+++ b/packages/flame_tiled/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **FIX**: Bump tiled to 0.11.0 and add ColorData extension (#3473).
+
 ## 1.21.2
 
  - **REFACTOR**: Fix lint issues from latest flutter release ([#3390](https://github.com/flame-engine/flame/issues/3390)). ([978ad31b](https://github.com/flame-engine/flame/commit/978ad31b429d1801097b0db385a600c85a157867))

--- a/packages/flame_tiled/example/pubspec.yaml
+++ b/packages/flame_tiled/example/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  flame: ^1.23.0
-  flame_tiled: ^1.21.2
+  flame: ^1.24.0
+  flame_tiled: ^2.0.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_tiled/pubspec.yaml
+++ b/packages/flame_tiled/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  flame: ^1.23.0
+  flame: ^1.24.0
   flutter:
     sdk: flutter
   meta: ^1.12.0


### PR DESCRIPTION
 - flame_fire_atlas@1.8.0
 - flame@1.24.0
 - flame_3d@0.1.0-dev.5
 - flame_test@1.17.5
 - flame_tiled@2.0.0
 - flame_behavior_tree@0.1.3+5
 - flame_oxygen@0.2.3+5
 - flame_isolate@0.6.2+5
 - flame_texturepacker@4.1.5
 - flame_sprite_fusion@0.1.3+5
 - flame_audio@2.10.8
 - flame_spine@0.2.2+5
 - flame_bloc@1.12.6
 - flame_kenney_xml@0.1.1+5
 - flame_lottie@0.4.2+5
 - flame_markdown@0.2.3+1
 - flame_console@0.1.2+1
 - flame_rive@1.10.8
 - flame_forge2d@0.18.2+5
 - flame_noise@0.3.2+5
 - flame_riverpod@5.4.8
 - flame_svg@1.11.5
 - flame_network_assets@0.3.3+5