### PR TITLE
style: Simplify and unify syntax used for exports on flame_test

### DIFF
--- a/packages/flame_test/lib/flame_test.dart
+++ b/packages/flame_test/lib/flame_test.dart
@@ -1,7 +1,7 @@
-export 'src/close_to_aabb.dart' show closeToAabb;
+export 'src/close_to_aabb.dart';
 export 'src/close_to_vector.dart';
 export 'src/close_to_vector3.dart';
-export 'src/debug_text_renderer.dart' show DebugTextRenderer;
+export 'src/debug_text_renderer.dart';
 export 'src/expect_color.dart';
 export 'src/expect_double.dart';
 export 'src/fails_assert.dart';


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Simplify and unify syntax used for exports on flame_test.

The file in question only has one public class, which is exported.
This brings it in line with all other exports on the file - the only exception being `test_golden.dart` which does indeed declare other auxiliary public types.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->