### PR TITLE
docs: Fix missing reference on documentation for InlineTextNode

### DIFF
--- a/packages/flame/lib/src/text/nodes/inline_text_node.dart
+++ b/packages/flame/lib/src/text/nodes/inline_text_node.dart
@@ -7,7 +7,8 @@ import 'package:flame/text.dart';
 /// * PlainTextNode - just a string of plain text, no special formatting.
 /// * BoldTextNode - bolded string
 /// * ItalicTextNode - italic string
-/// * CodeTextNode - inline code block
+/// * CodeTextNode - inline code string
+/// * StrikethroughTextNode - strikethrough string
 /// * GroupTextNode - collection of multiple [InlineTextNode]'s to be joined one
 ///                   after the other.
 abstract class InlineTextNode extends TextNode<InlineTextStyle> {


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Fix missing reference on documentation for InlineTextNode

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->