### PR TITLE
fix!: Add APIs to get TileData by layer index

### DIFF
--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:flame/cache.dart';
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
@@ -89,7 +90,7 @@ class RenderableTiledMap {
     return map.layers[layerId].visible;
   }
 
-  /// Changes the Gid of the corresponding layer at the given position,
+  /// Changes the Gid of the corresponding layer at the given layerId,
   /// if different
   void setTileData({
     required int layerId,
@@ -97,7 +98,7 @@ class RenderableTiledMap {
     required int y,
     required Gid gid,
   }) {
-    final layer = map.layers[layerId];
+    final layer = map.layers.firstWhereOrNull((layer) => layer.id == layerId);
     if (layer is TileLayer) {
       final td = layer.tileData;
       if (td != null) {
@@ -112,13 +113,49 @@ class RenderableTiledMap {
     }
   }
 
-  /// Gets the Gid  of the corresponding layer at the given position
+  /// Changes the Gid of the corresponding layer at the given position,
+  /// if different
+  void setTileDataByLayerIndex({
+    required int layerIndex,
+    required int x,
+    required int y,
+    required Gid gid,
+  }) {
+    final layer = map.layers[layerIndex];
+    if (layer is TileLayer) {
+      final td = layer.tileData;
+      if (td != null) {
+        if (td[y][x].tile != gid.tile ||
+            td[y][x].flips.horizontally != gid.flips.horizontally ||
+            td[y][x].flips.vertically != gid.flips.vertically ||
+            td[y][x].flips.diagonally != gid.flips.diagonally) {
+          td[y][x] = gid;
+          _refreshCache();
+        }
+      }
+    }
+  }
+
+  /// Gets the Gid  of the corresponding layer at the given layerId
   Gid? getTileData({
     required int layerId,
     required int x,
     required int y,
   }) {
-    final layer = map.layers[layerId];
+    final layer = map.layers.firstWhereOrNull((layer) => layer.id == layerId);
+    if (layer is TileLayer) {
+      return layer.tileData?[y][x];
+    }
+    return null;
+  }
+
+  /// Gets the Gid  of the corresponding layer at the given position
+  Gid? getTileDataByLayerIndex({
+    required int layerIndex,
+    required int x,
+    required int y,
+  }) {
+    final layer = map.layers[layerIndex];
     if (layer is TileLayer) {
       return layer.tileData?[y][x];
     }

--- a/packages/flame_tiled/test/assets/deleted_layer_map.tmx
+++ b/packages/flame_tiled/test/assets/deleted_layer_map.tmx
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" renderorder="right-down" width="10" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="1">
+ <tileset firstgid="1" name="4_color_sprite" tilewidth="16" tileheight="16" tilecount="4" columns="2">
+  <image source="4_color_sprite.png" width="32" height="32"/>
+ </tileset>
+ <layer id="1" name="FirstLayer" width="10" height="5">
+  <data encoding="csv">
+1,0,0,0,0,0,0,0,0,0,
+0,0,1,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+ <objectgroup id="2" name="SecondLayer"/>
+ <layer id="7" name="ThirdLayer" width="10" height="5">
+  <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+ <objectgroup id="4" name="FourthLayer"/>
+ <layer id="6" name="SixthLayer" width="10" height="5">
+  <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,1,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+</map>

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -1076,14 +1076,15 @@ void main() {
     late RenderableTiledMap renderableTiledMap;
 
     setUp(() async {
-      Flame.bundle = TestAssetBundle(
+      final bundle = TestAssetBundle(
         imageNames: ['4_color_sprite.png'],
         stringNames: ['deleted_layer_map.tmx'],
       );
       renderableTiledMap = await RenderableTiledMap.fromFile(
         'deleted_layer_map.tmx',
         Vector2.all(16),
-        bundle: Flame.bundle,
+        bundle: bundle,
+        images: Images(bundle: bundle),
       );
     });
 

--- a/packages/flame_tiled/test/tiled_test.dart
+++ b/packages/flame_tiled/test/tiled_test.dart
@@ -1071,4 +1071,34 @@ void main() {
       });
     }
   });
+
+  group('RenderableTiledMap.TileData', () {
+    late RenderableTiledMap renderableTiledMap;
+
+    setUp(() async {
+      Flame.bundle = TestAssetBundle(
+        imageNames: ['4_color_sprite.png'],
+        stringNames: ['deleted_layer_map.tmx'],
+      );
+      renderableTiledMap = await RenderableTiledMap.fromFile(
+        'deleted_layer_map.tmx',
+        Vector2.all(16),
+        bundle: Flame.bundle,
+      );
+    });
+
+    test('same TileData is found by layerId and layerIndex', () {
+      final tileData1 = renderableTiledMap.getTileData(layerId: 6, x: 5, y: 3);
+      final tileData2 =
+          renderableTiledMap.getTileDataByLayerIndex(layerIndex: 4, x: 5, y: 3);
+      expect(tileData1, isNotNull);
+      expect(tileData2, isNotNull);
+      expect(tileData1, equals(tileData2));
+    });
+
+    test('returns null for non-existent layer', () {
+      expect(renderableTiledMap.getTileData(layerId: 3, x: 1, y: 1), isNull);
+      expect(renderableTiledMap.getTileData(layerId: 5, x: 1, y: 1), isNull);
+    });
+  });
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->

This PR makes sure that `TileData` can be found using `layerIndex` as well as `layerId`.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

Use `getTileDataByLayerIndex` instead of `getTileData` to get the `TileData` using layer index.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #3536

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
