### PR TITLE
docs: Add missing flame_console link to docs

### DIFF
--- a/doc/bridge_packages/bridge_packages.md
+++ b/doc/bridge_packages/bridge_packages.md
@@ -10,6 +10,12 @@ Play multiple audio files simultaneously (bridge package for [AudioPlayers]).
 A predictable state management library (bridge package for [Bloc]).
 :::
 
+:::{package} flame_console
+
+A terminal overlay for Flame games which allows developers to debug and interact
+with their games.
+:::
+
 :::{package} flame_fire_atlas
 
 Create texture atlases for games (bridge package for [FireAtlas]).


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
After having some trouble using flamw_console, I realize it actually has documentation, but it was just missing on the menu.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->