### PR TITLE
docs: Fix incorrect class name on flame_console docs

### DIFF
--- a/doc/bridge_packages/flame_console/flame_console.md
+++ b/doc/bridge_packages/flame_console/flame_console.md
@@ -56,11 +56,11 @@ Widget build(BuildContext context) {
 
 ## Custom commands
 
- Custom commands can be created by extending the `ConsoleCommand` class and adding them to the
+ Custom commands can be created by extending the `FlameConsoleCommand` class and adding them to the
  the `customCommands` list in the `ConsoleView` widget.
 
  ```dart
-class MyCustomCommand extends ConsoleCommand<MyGame> {
+class MyCustomCommand extends FlameConsoleCommand<MyGame> {
   MyCustomCommand();
 
   @override


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Fix incorrect class name on flame_console docs.
As far as I can tell, there is no such thing as `ConsoleCommand` at all. At least I could not find it.
As per my testing, I believe this should be `FlameConsoleCommand`.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->