### PR TITLE
fix: Use `virtualSize` when calling `onParentResize` on children of `Viewport`

### DIFF
--- a/packages/flame/lib/src/camera/viewport.dart
+++ b/packages/flame/lib/src/camera/viewport.dart
@@ -92,7 +92,7 @@ abstract class Viewport extends Component
     onViewportResize();
     if (hasChildren) {
       for (final child in children) {
-        child.onParentResize(_size);
+        child.onParentResize(virtualSize);
       }
     }
   }

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame/src/cache/value_cache.dart';
+import 'package:flame/src/camera/viewport.dart';
 import 'package:flame/src/components/core/component_render_context.dart';
 import 'package:flame/src/components/core/component_tree_root.dart';
 import 'package:flame/src/effects/provider_interfaces.dart';
@@ -955,7 +956,11 @@ class Component {
     _setMountingBit();
     onGameResize(_parent!.findGame()!.canvasSize);
     if (_parent is ReadOnlySizeProvider) {
-      onParentResize((_parent! as ReadOnlySizeProvider).size);
+      if (_parent is Viewport) {
+        onParentResize((_parent! as Viewport).virtualSize);
+      } else {
+        onParentResize((_parent! as ReadOnlySizeProvider).size);
+      }
     }
     if (isRemoved) {
       _clearRemovedBit();

--- a/packages/flame/test/camera/viewports/fixed_resolution_viewport_test.dart
+++ b/packages/flame/test/camera/viewports/fixed_resolution_viewport_test.dart
@@ -1,0 +1,52 @@
+import 'package:flame/camera.dart';
+import 'package:flame/game.dart';
+import 'package:flame/src/components/position_component.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FixedResolutionViewport.virtualSize', () {
+    testWithFlameGame('remains the same after resize', (game) async {
+      final fixedResolution = Vector2(800, 600);
+      final viewport = FixedResolutionViewport(resolution: fixedResolution);
+      game.camera.viewport = viewport;
+
+      await game.ready();
+
+      final resize = Vector2(400, 300);
+      game.onGameResize(resize);
+
+      expect(viewport.size, resize);
+      expect(viewport.virtualSize, fixedResolution);
+    });
+
+    testWithFlameGame(
+        'children components receive virtualSize in onParentResize',
+        (game) async {
+      final fixedResolution = Vector2(800, 600);
+      final viewport = FixedResolutionViewport(resolution: fixedResolution);
+      game.camera.viewport = viewport;
+
+      final child = _OnParentResizeTesterComponent();
+      await child.addToParent(viewport);
+
+      await game.ready();
+
+      expect(child._parentSize, fixedResolution);
+
+      game.onGameResize(Vector2(400, 300));
+      expect(child._parentSize, fixedResolution);
+    });
+  });
+}
+
+class _OnParentResizeTesterComponent extends PositionComponent {
+  _OnParentResizeTesterComponent();
+
+  Vector2? _parentSize;
+
+  @override
+  void onParentResize(Vector2 size) {
+    _parentSize = size;
+  }
+}


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->

Children of `Viewport` were receiving the actual `size` of viewport as input on the `onParentResize` method. In most cases this is fine, but for viewports like `FixedResolutionViewport`, we should be using the `virtualSize`. This PR makes that change.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #3529 

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
