### PR TITLE
feat: Add flame_console to flame_3d example to enable more complex setups

### DIFF
--- a/packages/flame_3d/example/lib/commands/commands.dart
+++ b/packages/flame_3d/example/lib/commands/commands.dart
@@ -1,0 +1,5 @@
+import 'package:example/commands/reset_command.dart';
+
+const customCommandProviders = [
+  ResetCommand.new,
+];

--- a/packages/flame_3d/example/lib/commands/reset_command.dart
+++ b/packages/flame_3d/example/lib/commands/reset_command.dart
@@ -1,0 +1,17 @@
+import 'package:example/example_game_3d.dart';
+import 'package:flame_console/flame_console.dart';
+
+class ResetCommand extends FlameConsoleCommand<ExampleGame3D> {
+  @override
+  String get name => 'reset';
+
+  @override
+  String get description => 'Resets the camera and player';
+
+  @override
+  (String?, String) execute(ExampleGame3D game, ArgResults args) {
+    game.camera.reset();
+    game.player.reset();
+    return (null, 'Camera was reset.');
+  }
+}

--- a/packages/flame_3d/example/lib/components/player.dart
+++ b/packages/flame_3d/example/lib/components/player.dart
@@ -47,7 +47,7 @@ class Player extends MeshComponent
   }
 
   void reset() {
-    position.setFrom(Vector3(0, 0, 0));
+    position.setFrom(Vector3(0, 1, 0));
     lookAngle = 0.0;
     _input.setZero();
   }

--- a/packages/flame_3d/example/lib/example_game_3d.dart
+++ b/packages/flame_3d/example/lib/example_game_3d.dart
@@ -29,16 +29,26 @@ class ExampleGame3D extends FlameGame3D<World3D, ExampleCamera3D>
     KeyEvent event,
     Set<LogicalKeyboardKey> keysPressed,
   ) {
-    if (event is KeyDownEvent) {
-      if (event.logicalKey == LogicalKeyboardKey.keyR) {
-        camera.reset();
-        player.reset();
-        return KeyEventResult.handled;
-      } else if (event.logicalKey == LogicalKeyboardKey.keyM) {
-        camera.mode = camera.mode == CameraMode.drag
-            ? CameraMode.player
-            : CameraMode.drag;
-        return KeyEventResult.handled;
+    if (overlays.isActive('console')) {
+      if (event is KeyDownEvent &&
+          event.logicalKey == LogicalKeyboardKey.backquote) {
+        overlays.remove('console');
+      }
+    } else {
+      if (event is KeyDownEvent) {
+        if (event.logicalKey == LogicalKeyboardKey.backquote) {
+          overlays.add('console');
+          return KeyEventResult.handled;
+        } else if (event.logicalKey == LogicalKeyboardKey.keyR) {
+          camera.reset();
+          player.reset();
+          return KeyEventResult.handled;
+        } else if (event.logicalKey == LogicalKeyboardKey.keyM) {
+          camera.mode = camera.mode == CameraMode.drag
+              ? CameraMode.player
+              : CameraMode.drag;
+          return KeyEventResult.handled;
+        }
       }
     }
 

--- a/packages/flame_3d/example/lib/main.dart
+++ b/packages/flame_3d/example/lib/main.dart
@@ -1,11 +1,24 @@
+import 'package:example/commands/commands.dart';
 import 'package:example/example_game_3d.dart';
 import 'package:flame/game.dart';
+import 'package:flame_console/flame_console.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
   runApp(
-    const GameWidget.controlled(
+    GameWidget.controlled(
       gameFactory: ExampleGame3D.new,
+      overlayBuilderMap: {
+        'console': (BuildContext context, ExampleGame3D game) {
+          return FlameConsoleView(
+            game: game,
+            customCommands: customCommandProviders.map((it) => it()).toList(),
+            onClose: () {
+              game.overlays.remove('console');
+            },
+          );
+        },
+      },
     ),
   );
 }

--- a/packages/flame_3d/example/pubspec.yaml
+++ b/packages/flame_3d/example/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flame: ^1.28.0
   flame_3d: ^0.1.0-dev.10
+  flame_console: ^0.1.2+6
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add flame_console to flame_3d example to enable more complex setups later on.
For now I am only adding one command, reset (which is already bound to R) but this will allow me to add much more complex things without requiring summoning byzantine keybindings.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->