### PR TITLE
feat!: Children should retain `parent` after parent is remove from tree

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -718,7 +718,7 @@ class Component {
           root.enqueueRemove(child, this);
           child._setRemovingBit();
         }
-      } else {
+      } else if (!child.isRemoved) {
         root.dequeueAdd(child, this);
         child._parent = null;
       }
@@ -1053,12 +1053,12 @@ class Component {
           .._setRemovedBit()
           .._removeCompleter?.complete()
           .._removeCompleter = null
-          .._parent!.onChildrenChanged(component, ChildrenChangeType.removed)
-          .._parent = null;
+          .._parent!.onChildrenChanged(component, ChildrenChangeType.removed);
         return true;
       },
       includeSelf: true,
     );
+    _parent = null;
   }
 
   void _unregisterKey() {


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Currently children are not retaining their `parent` while they aren't mounted, even though they haven't been removed from their subtree, but their parent has. This is problematic since the `parent` of the child might need to be accessed in `onRemove` (directly or indirectly). See https://github.com/gnarhard/component_removal_mre for an MRE.

This PR makes sure that the `parent` is always set until the child is itself explicitly removed from its parent.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

This is technically a breaking change, but I very much doubt anyone will be affected by it (except that it might solve some people's bugs).

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
