### PR TITLE
fix: Only expose `ReadOnlyOrderedset` from `component.children`

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -287,7 +287,15 @@ class Component {
     }
   }
 
+  /// This field should be used internally for functionality when you don't need
+  /// to create a component set for the children if one doesn't already exist.
+  ///
+  /// This makes it possible to have lighter components that don't have any
+  /// children.
   OrderedSet<Component>? _children;
+
+  /// This field should be used internally for functionality when you need to
+  /// make sure that the component set is created if it doesn't already exist.
   OrderedSet<Component> get _internalChildren =>
       _children ??= createComponentSet();
 

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -12,7 +12,7 @@ import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:flutter/painting.dart';
 import 'package:meta/meta.dart';
 import 'package:ordered_set/ordered_set.dart';
-import 'package:ordered_set/queryable_ordered_set.dart';
+import 'package:ordered_set/read_only_ordered_set.dart';
 
 /// [Component]s are the basic building blocks for a [FlameGame].
 ///
@@ -287,14 +287,22 @@ class Component {
     }
   }
 
-  QueryableOrderedSet<Component>? _children;
+  OrderedSet<Component>? _children;
+  OrderedSet<Component> get _internalChildren =>
+      _children ??= createComponentSet();
+
+  void rebalanceChildren() {
+    if (_children != null) {
+      _children!.rebalanceAll();
+    }
+  }
 
   /// The children components of this component.
   ///
   /// This getter will automatically create the [OrderedSet] container within
   /// the current object if it didn't exist before. Check the [hasChildren]
   /// property in order to avoid instantiating the children container.
-  QueryableOrderedSet<Component> get children =>
+  ReadOnlyOrderedSet<Component> get children =>
       _children ??= createComponentSet();
 
   /// Whether this component has any children.
@@ -304,21 +312,25 @@ class Component {
   /// `Component.childrenFactory` is the default method for creating children
   /// containers within all components. Replace this method if you want to have
   /// customized (non-default) [OrderedSet] instances in your project.
-  static ComponentSetFactory childrenFactory = () {
-    return OrderedSet.queryable(
-      OrderedSet.mapping<num, Component>(_componentPriorityMapper),
-      strictMode: false,
+  static OrderedSet<Component> Function() childrenFactory = () {
+    return OrderedSet.mapping(
+      _componentPriorityMapper,
+      strictMode: strictQueryMode,
     );
   };
 
-  static int _componentPriorityMapper(Component component) {
+  /// Whether OrderedSet's strict mode mode should be enabled for all children
+  /// sets.
+  static bool strictQueryMode = false;
+
+  static num _componentPriorityMapper(Component component) {
     return component.priority;
   }
 
   /// This method creates the children container for the current component.
   /// Override this method if you need to have a custom [OrderedSet] within
   /// a particular class.
-  QueryableOrderedSet<Component> createComponentSet() => childrenFactory();
+  OrderedSet<Component> createComponentSet() => childrenFactory();
 
   /// Returns the closest parent further up the hierarchy that satisfies type=T,
   /// or null if no such parent can be found.
@@ -654,9 +666,9 @@ class Component {
   FutureOr<void> _addChild(Component child) {
     final game = findGame() ?? child.findGame();
     if ((!isMounted && !child.isMounted) || game == null) {
-      child._parent?.children.remove(child);
+      child._parent?._internalChildren.remove(child);
       child._parent = this;
-      children.add(child);
+      _internalChildren.add(child);
     } else if (child._parent != null) {
       if (child.isRemoving) {
         game.dequeueRemove(child);
@@ -669,7 +681,7 @@ class Component {
     } else {
       child._parent = this;
       // This will be reconciled during the mounting stage
-      children.add(child);
+      _internalChildren.add(child);
     }
     if (!child.isLoaded && !child.isLoading && (game?.hasLayout ?? false)) {
       return child._startLoading();
@@ -883,7 +895,7 @@ class Component {
         // This case happens when the child is added to a parent that is being
         // removed in the same tick.
         _parent = parent;
-        parent.children.add(this);
+        parent._internalChildren.add(this);
         return LifecycleEventStatus.done;
       }
       return LifecycleEventStatus.block;
@@ -975,7 +987,7 @@ class Component {
     _setMountedBit();
     _mountCompleter?.complete();
     _mountCompleter = null;
-    _parent!.children.add(this);
+    _parent!._internalChildren.add(this);
     _reAddChildren();
     _parent!.onChildrenChanged(this, ChildrenChangeType.added);
     _clearMountingBit();
@@ -1042,7 +1054,7 @@ class Component {
   void _remove() {
     assert(_parent != null, 'Trying to remove a component with no parent');
 
-    _parent!.children.remove(this);
+    _parent!._internalChildren.remove(this);
     propagateToChildren(
       (Component component) {
         component
@@ -1155,7 +1167,5 @@ class Component {
 
   //#endregion
 }
-
-typedef ComponentSetFactory = QueryableOrderedSet<Component> Function();
 
 enum ChildrenChangeType { added, removed }

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -153,7 +153,7 @@ class ComponentTreeRoot extends Component {
     }
 
     for (final parent in reorderParents) {
-      parent.children.rebalanceAll();
+      parent.rebalanceChildren();
     }
 
     if (!hasLifecycleEvents && _lifecycleEventsCompleter != null) {

--- a/packages/flame/pubspec.yaml
+++ b/packages/flame/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.12.0
-  ordered_set: ^7.0.0
+  ordered_set: ^8.0.0
   vector_math: ^2.1.4
 
 dev_dependencies:

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -6,9 +6,8 @@ import 'package:flame/src/components/core/component_tree_root.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ordered_set/comparing.dart';
+import 'package:ordered_set/mapping_ordered_set.dart';
 import 'package:ordered_set/ordered_set.dart';
-import 'package:ordered_set/queryable_ordered_set.dart';
 
 import '../custom_component.dart';
 
@@ -1474,18 +1473,19 @@ void main() {
         final component0 = Component();
         expect(component0.children.strictMode, false);
 
-        Component.childrenFactory = () => QueryableOrderedSet(
-              OrderedSet.comparing(Comparing.on((e) => e.priority)),
-              strictMode: false,
+        Component.childrenFactory = () => OrderedSet.mapping<num, Component>(
+              (e) => e.priority,
+              // ignore: avoid_redundant_argument_values
+              strictMode: true,
             );
         final component1 = Component();
         final component2 = Component();
         component1.add(component2);
         component2.add(Component());
-        expect(component1.children, isInstanceOf<QueryableOrderedSet>());
-        expect(component1.children.strictMode, false);
-        expect(component2.children, isInstanceOf<QueryableOrderedSet>());
-        expect(component2.children.strictMode, false);
+        expect(component1.children, isInstanceOf<MappingOrderedSet>());
+        expect(component1.children.strictMode, isTrue);
+        expect(component2.children, isInstanceOf<MappingOrderedSet>());
+        expect(component2.children.strictMode, isTrue);
       });
 
       testWithFlameGame('initially same debugMode as parent', (game) async {

--- a/packages/flame/test/components/priority_test.dart
+++ b/packages/flame/test/components/priority_test.dart
@@ -2,8 +2,8 @@ import 'dart:ui';
 
 import 'package:flame/components.dart';
 import 'package:flame_test/flame_test.dart';
+import 'package:ordered_set/mapping_ordered_set.dart';
 import 'package:ordered_set/ordered_set.dart';
-import 'package:ordered_set/queryable_ordered_set.dart';
 import 'package:test/test.dart';
 
 import '../custom_component.dart';
@@ -235,13 +235,10 @@ void main() {
   });
 }
 
-class _SpyComponentSet extends QueryableOrderedSet<Component> {
+class _SpyComponentSet extends MappingOrderedSet<num, Component> {
   int callCount = 0;
 
-  _SpyComponentSet()
-      : super(
-          OrderedSet.mapping<num, Component>((e) => e.priority),
-        );
+  _SpyComponentSet() : super((e) => e.priority);
 
   @override
   void rebalanceAll() {
@@ -258,7 +255,7 @@ class _ParentWithReorderSpy extends Component {
   _ParentWithReorderSpy(int priority) : super(priority: priority);
 
   @override
-  QueryableOrderedSet<Component> createComponentSet() => _SpyComponentSet();
+  OrderedSet<Component> createComponentSet() => _SpyComponentSet();
 
   void assertCalled(int n) {
     final componentSet = children as _SpyComponentSet;

--- a/packages/flame_3d/pubspec.yaml
+++ b/packages/flame_3d/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   flutter_gpu:
     sdk: flutter
   meta: ^1.12.0
-  ordered_set: ^7.0.0
+  ordered_set: ^8.0.0
   vector_math: ^2.1.4
 
 dev_dependencies:


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
This PR updates to ordered_set 8.0.0 and makes sure that `children` are of the `ReadOnlyOrderedSet` type, so that `children.add/remove` isn't directly exposed to the user, since they skip the component lifecycle.

Since we previously had the `ComponentSet` to hide `add/remove` we now had to introduce a new internal getter in the component to make sure that the set only is initialized when it is needed. This was a previous optimization to keep components without children more lightweight.

It also introduces the static `Component.strictQueryMode` variable so that the user can set the `ComponentSetFactory` to only create components sets with strict mode turned on (this functionality also previously lived in the `ComponentSet` class).

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
