### PR TITLE
feat: Add canPop to RouterComponent

### DIFF
--- a/packages/flame/lib/src/components/router/router_component.dart
+++ b/packages/flame/lib/src/components/router/router_component.dart
@@ -81,6 +81,16 @@ class RouterComponent extends Component {
     return _routeStack.length >= 2 ? _routeStack[_routeStack.length - 2] : null;
   }
 
+  /// Returns whether the current route can be popped.
+  ///
+  /// Returns `true` if there are at least 2 routes in the stack, meaning the
+  /// current route can be popped without removing the last remaining route.
+  /// Returns `false` if there is only one route left, as the router must
+  /// maintain at least one route on the stack.
+  bool canPop() {
+    return _routeStack.length > 1;
+  }
+
   /// Puts the route [name] on top of the navigation stack.
   ///
   /// If the route is already in the stack, it will be simply moved to the top.

--- a/packages/flame/test/components/router_component_test.dart
+++ b/packages/flame/test/components/router_component_test.dart
@@ -316,6 +316,33 @@ void main() {
       );
     });
 
+    testWithFlameGame('canPop returns correct value', (game) async {
+      final router = RouterComponent(
+        routes: {
+          'A': Route(_ComponentA.new),
+          'B': Route(_ComponentB.new),
+        },
+        initialRoute: 'A',
+      )..addToParent(game);
+      await game.ready();
+
+      // Should return false when only one route is on the stack
+      expect(router.canPop(), false);
+      expect(router.stack.length, 1);
+
+      // Should return true when multiple routes are on the stack
+      router.pushNamed('B');
+      await game.ready();
+      expect(router.canPop(), true);
+      expect(router.stack.length, 2);
+
+      // Should return false again after popping back to one route
+      router.pop();
+      await game.ready();
+      expect(router.canPop(), false);
+      expect(router.stack.length, 1);
+    });
+
     testWithFlameGame('popUntilNamed', (game) async {
       final router = RouterComponent(
         routes: {


### PR DESCRIPTION
feat: add canPop method to RouterComponent

<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Adds a new `canPop()` method to the `RouterComponent` class that allows developers to check whether the current route can be safely popped from the navigation stack.

**What this PR adds:**
- `canPop()` method that returns `true` when there are multiple routes in the stack (safe to pop)

**Motivation:**
This method provides a safe way to check if a route can be popped before attempting to pop it, similar to Flutter's `Navigator.canPop()`. This prevents assertion errors that would occur when trying to pop the last remaining route from the router stack.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->