### PR TITLE
feat: Add setup command to flame_3d example

### DIFF
--- a/packages/flame_3d/example/lib/commands/commands.dart
+++ b/packages/flame_3d/example/lib/commands/commands.dart
@@ -1,7 +1,9 @@
 import 'package:example/commands/destroy_command.dart';
 import 'package:example/commands/reset_command.dart';
+import 'package:example/commands/setup_command.dart';
 
 const customCommandProviders = [
   ResetCommand.new,
   DestroyCommand.new,
+  SetupCommand.new,
 ];

--- a/packages/flame_3d/example/lib/commands/destroy_command.dart
+++ b/packages/flame_3d/example/lib/commands/destroy_command.dart
@@ -21,13 +21,13 @@ class DestroyCommand extends FlameConsoleCommand<ExampleGame3D> {
     for (final arg in args.arguments) {
       switch (arg) {
         case '@all':
-          count += _destroyMatching(game, (e) => true);
+          count += destroyMatching(game, (e) => true);
         case '@crate':
-          count += _destroyMatching(game, (e) => e is Crate);
+          count += destroyMatching(game, (e) => e is Crate);
         case '@light':
-          count += _destroyMatching(game, (e) => e is RenderedPointLight);
+          count += destroyMatching(game, (e) => e is RenderedPointLight);
         case '@mesh':
-          count += _destroyMatching(game, (e) => e is MeshComponent);
+          count += destroyMatching(game, (e) => e is MeshComponent);
         default:
           return ('Invalid argument: $arg', '');
       }
@@ -35,7 +35,7 @@ class DestroyCommand extends FlameConsoleCommand<ExampleGame3D> {
     return (null, '$count objects were destroyed.');
   }
 
-  bool _ignoredComponents(Component component) {
+  static bool _ignoredComponents(Component component) {
     return switch (component) {
       Player() => true,
       CameraComponent3D() => true,
@@ -44,7 +44,10 @@ class DestroyCommand extends FlameConsoleCommand<ExampleGame3D> {
     };
   }
 
-  int _destroyMatching(ExampleGame3D game, bool Function(Component) predicate) {
+  static int destroyMatching(
+    ExampleGame3D game,
+    bool Function(Component) predicate,
+  ) {
     final toDestroy = game.world.children
         .where((element) => !_ignoredComponents(element))
         .where(predicate)

--- a/packages/flame_3d/example/lib/commands/setup_command.dart
+++ b/packages/flame_3d/example/lib/commands/setup_command.dart
@@ -17,7 +17,7 @@ class SetupCommand extends FlameConsoleCommand<ExampleGame3D> {
       return ('No scenario name provided.', '');
     }
 
-    final scenario = GameScenario.setups[scenarioName];
+    final scenario = GameScenario.scenarios[scenarioName];
     if (scenario == null) {
       return ('Unknown scenario: $scenarioName', '');
     }

--- a/packages/flame_3d/example/lib/commands/setup_command.dart
+++ b/packages/flame_3d/example/lib/commands/setup_command.dart
@@ -1,0 +1,29 @@
+import 'package:example/commands/destroy_command.dart';
+import 'package:example/example_game_3d.dart';
+import 'package:example/scenarios/game_setup.dart';
+import 'package:flame_console/flame_console.dart';
+
+class SetupCommand extends FlameConsoleCommand<ExampleGame3D> {
+  @override
+  String get name => 'setup';
+
+  @override
+  String get description => 'Sets up the game world';
+
+  @override
+  (String?, String) execute(ExampleGame3D game, ArgResults args) {
+    final scenarioName = args.arguments.firstOrNull;
+    if (scenarioName == null) {
+      return ('No scenario name provided.', '');
+    }
+
+    final scenario = GameScenario.setups[scenarioName];
+    if (scenario == null) {
+      return ('Unknown scenario: $scenarioName', '');
+    }
+
+    DestroyCommand.destroyMatching(game, (_) => true);
+    scenario.setup(game);
+    return (null, 'Scenario $scenarioName has been set up.');
+  }
+}

--- a/packages/flame_3d/example/lib/example_game_3d.dart
+++ b/packages/flame_3d/example/lib/example_game_3d.dart
@@ -1,18 +1,13 @@
 import 'dart:async';
-import 'dart:math';
 
-import 'package:example/components/crate.dart';
 import 'package:example/components/player.dart';
-import 'package:example/components/rendered_point_light.dart';
 import 'package:example/components/room_bounds.dart';
-import 'package:example/components/rotating_light.dart';
 import 'package:example/example_camera_3d.dart';
+import 'package:example/scenarios/boxes_setup.dart';
 import 'package:flame/events.dart';
-import 'package:flame/palette.dart';
 import 'package:flame_3d/camera.dart';
 import 'package:flame_3d/components.dart';
 import 'package:flame_3d/game.dart';
-import 'package:flame_3d/resources.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -60,65 +55,16 @@ class ExampleGame3D extends FlameGame3D<World3D, ExampleCamera3D>
   @override
   FutureOr<void> onLoad() async {
     world.addAll([
+      RoomBounds(),
       LightComponent.ambient(
         intensity: 1.0,
       ),
-      RotatingLight(),
-
-      RenderedPointLight(
-        position: Vector3(0, 0.1, 0),
-        color: const Color(0xFFFF00FF),
-      ),
-      RenderedPointLight(
-        position: Vector3(-2, 3, 2),
-        color: const Color(0xFFFF2255),
-      ),
-
-      // Add the player
       player = Player(
         position: Vector3(0, 1, 0),
       ),
-
-      // Floating crate
-      Crate(
-        position: Vector3(0, 5, 0),
-        size: Vector3.all(1),
-      ),
-
-      // Floating sphere
-      MeshComponent(
-        position: Vector3(5, 5, 5),
-        mesh: SphereMesh(
-          radius: 1,
-          material: SpatialMaterial(
-            albedoTexture: ColorTexture(
-              BasicPalette.green.color,
-            ),
-          ),
-        ),
-      ),
-
-      RoomBounds(),
     ]);
 
-    final rnd = Random();
-    for (var i = 0; i < 20; i++) {
-      final height = rnd.range(1, 12);
-
-      world.add(
-        MeshComponent(
-          position: Vector3(rnd.range(-15, 15), height / 2, rnd.range(-15, 15)),
-          mesh: CuboidMesh(
-            size: Vector3(1, height, 1),
-            material: SpatialMaterial(
-              albedoTexture: ColorTexture(
-                Color.fromRGBO(rnd.iRange(20, 255), rnd.iRange(10, 55), 30, 1),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
+    BoxesScenario.instance.setup(this);
   }
 
   @override
@@ -148,10 +94,4 @@ class ExampleGame3D extends FlameGame3D<World3D, ExampleCamera3D>
     camera.delta.setZero();
     super.onDragCancel(event);
   }
-}
-
-extension on Random {
-  double range(num min, num max) => nextDouble() * (max - min) + min;
-
-  int iRange(int min, int max) => range(min, max).toInt();
 }

--- a/packages/flame_3d/example/lib/example_game_3d.dart
+++ b/packages/flame_3d/example/lib/example_game_3d.dart
@@ -64,7 +64,7 @@ class ExampleGame3D extends FlameGame3D<World3D, ExampleCamera3D>
       ),
     ]);
 
-    BoxesScenario.instance.setup(this);
+    BoxesScenario().setup(this);
   }
 
   @override

--- a/packages/flame_3d/example/lib/scenarios/boxes_setup.dart
+++ b/packages/flame_3d/example/lib/scenarios/boxes_setup.dart
@@ -25,8 +25,6 @@ class BoxesScenario implements GameScenario {
         color: const Color(0xFFFF2255),
       ),
 
-      // Add the player
-
       // Floating crate
       Crate(
         position: Vector3(0, 5, 0),

--- a/packages/flame_3d/example/lib/scenarios/boxes_setup.dart
+++ b/packages/flame_3d/example/lib/scenarios/boxes_setup.dart
@@ -11,10 +11,6 @@ import 'package:flame_3d/components.dart';
 import 'package:flame_3d/resources.dart';
 
 class BoxesScenario implements GameScenario {
-  static final BoxesScenario instance = BoxesScenario._();
-
-  BoxesScenario._();
-
   @override
   void setup(ExampleGame3D game) {
     game.world.addAll([
@@ -53,16 +49,25 @@ class BoxesScenario implements GameScenario {
 
     final rnd = Random();
     for (var i = 0; i < 20; i++) {
-      final height = rnd.range(1, 12);
+      final height = rnd.nextDoubleBetween(1, 12);
 
       game.world.add(
         MeshComponent(
-          position: Vector3(rnd.range(-15, 15), height / 2, rnd.range(-15, 15)),
+          position: Vector3(
+            rnd.nextDoubleBetween(-15, 15),
+            height / 2,
+            rnd.nextDoubleBetween(-15, 15),
+          ),
           mesh: CuboidMesh(
             size: Vector3(1, height, 1),
             material: SpatialMaterial(
               albedoTexture: ColorTexture(
-                Color.fromRGBO(rnd.iRange(20, 255), rnd.iRange(10, 55), 30, 1),
+                Color.fromRGBO(
+                  rnd.nextIntBetween(20, 255),
+                  rnd.nextIntBetween(10, 55),
+                  30,
+                  1,
+                ),
               ),
             ),
           ),
@@ -70,10 +75,4 @@ class BoxesScenario implements GameScenario {
       );
     }
   }
-}
-
-extension on Random {
-  double range(num min, num max) => nextDouble() * (max - min) + min;
-
-  int iRange(int min, int max) => range(min, max).toInt();
 }

--- a/packages/flame_3d/example/lib/scenarios/boxes_setup.dart
+++ b/packages/flame_3d/example/lib/scenarios/boxes_setup.dart
@@ -1,0 +1,79 @@
+import 'dart:math';
+
+import 'package:example/components/crate.dart';
+import 'package:example/components/rendered_point_light.dart';
+import 'package:example/components/rotating_light.dart';
+import 'package:example/example_game_3d.dart';
+import 'package:example/scenarios/game_setup.dart';
+import 'package:flame/extensions.dart';
+import 'package:flame/palette.dart';
+import 'package:flame_3d/components.dart';
+import 'package:flame_3d/resources.dart';
+
+class BoxesScenario implements GameScenario {
+  static final BoxesScenario instance = BoxesScenario._();
+
+  BoxesScenario._();
+
+  @override
+  void setup(ExampleGame3D game) {
+    game.world.addAll([
+      RotatingLight(),
+
+      RenderedPointLight(
+        position: Vector3(0, 0.1, 0),
+        color: const Color(0xFFFF00FF),
+      ),
+      RenderedPointLight(
+        position: Vector3(-2, 3, 2),
+        color: const Color(0xFFFF2255),
+      ),
+
+      // Add the player
+
+      // Floating crate
+      Crate(
+        position: Vector3(0, 5, 0),
+        size: Vector3.all(1),
+      ),
+
+      // Floating sphere
+      MeshComponent(
+        position: Vector3(5, 5, 5),
+        mesh: SphereMesh(
+          radius: 1,
+          material: SpatialMaterial(
+            albedoTexture: ColorTexture(
+              BasicPalette.green.color,
+            ),
+          ),
+        ),
+      ),
+    ]);
+
+    final rnd = Random();
+    for (var i = 0; i < 20; i++) {
+      final height = rnd.range(1, 12);
+
+      game.world.add(
+        MeshComponent(
+          position: Vector3(rnd.range(-15, 15), height / 2, rnd.range(-15, 15)),
+          mesh: CuboidMesh(
+            size: Vector3(1, height, 1),
+            material: SpatialMaterial(
+              albedoTexture: ColorTexture(
+                Color.fromRGBO(rnd.iRange(20, 255), rnd.iRange(10, 55), 30, 1),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+  }
+}
+
+extension on Random {
+  double range(num min, num max) => nextDouble() * (max - min) + min;
+
+  int iRange(int min, int max) => range(min, max).toInt();
+}

--- a/packages/flame_3d/example/lib/scenarios/game_setup.dart
+++ b/packages/flame_3d/example/lib/scenarios/game_setup.dart
@@ -4,7 +4,7 @@ import 'package:example/scenarios/boxes_setup.dart';
 abstract class GameScenario {
   void setup(ExampleGame3D game);
 
-  static final Map<String, GameScenario> setups = {
-    'boxes': BoxesScenario.instance,
+  static final Map<String, GameScenario> scenarios = {
+    'boxes': BoxesScenario(),
   };
 }

--- a/packages/flame_3d/example/lib/scenarios/game_setup.dart
+++ b/packages/flame_3d/example/lib/scenarios/game_setup.dart
@@ -1,0 +1,10 @@
+import 'package:example/example_game_3d.dart';
+import 'package:example/scenarios/boxes_setup.dart';
+
+abstract class GameScenario {
+  void setup(ExampleGame3D game);
+
+  static final Map<String, GameScenario> setups = {
+    'boxes': BoxesScenario.instance,
+  };
+}


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
This creates a support structure on flame_3d example to allow for different testing scenarios, using commands to easily switch between different setups.

I will followup with other useful commands, such as `spawn` (similar to minecraft) and more. The example can be basically a sandbox to explore several 3d concepts and ideas.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->