### PR TITLE
feat: Use new random extensions to simplify the t-rex example game

### DIFF
--- a/examples/games/trex/lib/background/cloud.dart
+++ b/examples/games/trex/lib/background/cloud.dart
@@ -1,16 +1,12 @@
 import 'package:flame/components.dart';
+import 'package:flame/extensions.dart';
 import 'package:trex_game/background/cloud_manager.dart';
-import 'package:trex_game/random_extension.dart';
 import 'package:trex_game/trex_game.dart';
 
 class Cloud extends SpriteComponent
     with ParentIsA<CloudManager>, HasGameReference<TRexGame> {
   Cloud({required Vector2 position})
-      : cloudGap = random.fromRange(
-          minCloudGap,
-          maxCloudGap,
-        ),
-        super(
+      : super(
           position: position,
           size: initialSize,
         );
@@ -23,7 +19,10 @@ class Cloud extends SpriteComponent
   static const double maxSkyLevel = 71.0;
   static const double minSkyLevel = 30.0;
 
-  final double cloudGap;
+  late final double cloudGap = game.random.nextDoubleBetween(
+    minCloudGap,
+    maxCloudGap,
+  );
 
   @override
   Future<void> onLoad() async {
@@ -55,7 +54,7 @@ class Cloud extends SpriteComponent
   void onGameResize(Vector2 size) {
     super.onGameResize(size);
     y = ((absolutePosition.y / 2 - (maxSkyLevel - minSkyLevel)) +
-            random.fromRange(minSkyLevel, maxSkyLevel)) -
+            game.random.nextDoubleBetween(minSkyLevel, maxSkyLevel)) -
         absolutePositionOf(absoluteTopLeftPosition).y;
   }
 }

--- a/examples/games/trex/lib/background/cloud_manager.dart
+++ b/examples/games/trex/lib/background/cloud_manager.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
+import 'package:flame/extensions.dart';
 import 'package:trex_game/background/cloud.dart';
-import 'package:trex_game/random_extension.dart';
 import 'package:trex_game/trex_game.dart';
 
 class CloudManager extends PositionComponent with HasGameReference<TRexGame> {
@@ -11,8 +11,8 @@ class CloudManager extends PositionComponent with HasGameReference<TRexGame> {
   void addCloud() {
     final cloudPosition = Vector2(
       game.size.x + Cloud.initialSize.x + 10,
-      ((absolutePosition.y / 2 - (Cloud.maxSkyLevel - Cloud.minSkyLevel)) +
-              random.fromRange(Cloud.minSkyLevel, Cloud.maxSkyLevel)) -
+      (absolutePosition.y / 2 - (Cloud.maxSkyLevel - Cloud.minSkyLevel)) +
+          game.random.nextDoubleBetween(Cloud.minSkyLevel, Cloud.maxSkyLevel) -
           absolutePosition.y,
     );
     add(Cloud(position: cloudPosition));

--- a/examples/games/trex/lib/obstacle/obstacle.dart
+++ b/examples/games/trex/lib/obstacle/obstacle.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
+import 'package:flame/extensions.dart';
 import 'package:trex_game/obstacle/obstacle_type.dart';
-import 'package:trex_game/random_extension.dart';
 import 'package:trex_game/trex_game.dart';
 
 class Obstacle extends SpriteComponent with HasGameReference<TRexGame> {
@@ -32,7 +32,7 @@ class Obstacle extends SpriteComponent with HasGameReference<TRexGame> {
     final minGap =
         (width * speed * settings.minGap * gapCoefficient).roundToDouble();
     final maxGap = (minGap * _maxGapCoefficient).roundToDouble();
-    return random.fromRange(minGap, maxGap);
+    return game.random.nextDoubleBetween(minGap, maxGap);
   }
 
   @override

--- a/examples/games/trex/lib/obstacle/obstacle_manager.dart
+++ b/examples/games/trex/lib/obstacle/obstacle_manager.dart
@@ -1,9 +1,9 @@
 import 'dart:collection';
 
 import 'package:flame/components.dart';
+import 'package:flame/extensions.dart';
 import 'package:trex_game/obstacle/obstacle.dart';
 import 'package:trex_game/obstacle/obstacle_type.dart';
-import 'package:trex_game/random_extension.dart';
 import 'package:trex_game/trex_game.dart';
 
 class ObstacleManager extends Component with HasGameReference<TRexGame> {
@@ -37,7 +37,7 @@ class ObstacleManager extends Component with HasGameReference<TRexGame> {
     if (speed == 0) {
       return;
     }
-    var settings = random.nextBool()
+    var settings = game.random.nextBool()
         ? ObstacleTypeSettings.cactusSmall
         : ObstacleTypeSettings.cactusLarge;
     if (duplicateObstacleCheck(settings.type) || speed < settings.allowedAt) {
@@ -72,7 +72,9 @@ class ObstacleManager extends Component with HasGameReference<TRexGame> {
 
   int _groupSize(ObstacleTypeSettings settings) {
     if (game.currentSpeed > settings.multipleAt) {
-      return random.fromRange(1.0, ObstacleTypeSettings.maxGroupSize).floor();
+      return game.random
+          .nextDoubleBetween(1.0, ObstacleTypeSettings.maxGroupSize)
+          .floor();
     } else {
       return 1;
     }

--- a/examples/games/trex/lib/player.dart
+++ b/examples/games/trex/lib/player.dart
@@ -8,9 +8,9 @@ class Player extends SpriteAnimationGroupComponent<PlayerState>
     with HasGameReference<TRexGame>, CollisionCallbacks {
   Player() : super(size: Vector2(90, 88));
 
-  final double gravity = 1;
+  final double gravity = 0.85;
 
-  final double initialJumpVelocity = -15.0;
+  final double initialJumpVelocity = -16;
   final double introDuration = 1500.0;
   final double startXPosition = 50;
 

--- a/examples/games/trex/lib/random_extension.dart
+++ b/examples/games/trex/lib/random_extension.dart
@@ -1,8 +1,0 @@
-import 'dart:math';
-
-final random = Random();
-
-extension RandomExtension on Random {
-  double fromRange(double min, double max) =>
-      (nextDouble() * (max - min + 1)).floor() + min;
-}

--- a/examples/games/trex/lib/trex_game.dart
+++ b/examples/games/trex/lib/trex_game.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:flame/components.dart';
@@ -22,6 +23,7 @@ class TRexGame extends FlameGame
     to survive, the more points you get.
   ''';
 
+  final Random random = Random();
   late final Image spriteImage;
 
   @override


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Use new random extensions to simplify the t-rex example game.
Also make the jump a bit more forgiving to better mimic the chrome version.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->