### PR TITLE
chore: Expunge codebase of unholy abbreviations (idx)

### DIFF
--- a/examples/lib/stories/components/look_at_example.dart
+++ b/examples/lib/stories/components/look_at_example.dart
@@ -74,7 +74,7 @@ class _TapWorld extends World
     paint: BasicPalette.black.paint(),
   );
 
-  int _currentFlipIdx = 0;
+  int _currentFlipIndex = 0;
   final _flips = [
     (Vector2(1, 1), Vector2(1, 1)),
     (Vector2(1, 1), Vector2(1, -1)),
@@ -111,8 +111,8 @@ class _TapWorld extends World
   }
 
   void _cycleFlips() {
-    _currentFlipIdx = (_currentFlipIdx + 1) % _flips.length;
-    final nextFlip = _flips[_currentFlipIdx];
+    _currentFlipIndex = (_currentFlipIndex + 1) % _flips.length;
+    final nextFlip = _flips[_currentFlipIndex];
     for (final parent in game._choppers) {
       parent.scale = nextFlip.$1;
       parent.chopper.scale = nextFlip.$2;

--- a/packages/flame/benchmark/update_components_benchmark.dart
+++ b/packages/flame/benchmark/update_components_benchmark.dart
@@ -47,8 +47,8 @@ class UpdateComponentsBenchmark extends AsyncBenchmarkBase {
 
   @override
   Future<void> run() async {
-    for (final (idx, dt) in _dts.indexed) {
-      if (_inputTicks.contains(idx)) {
+    for (final (index, dt) in _dts.indexed) {
+      if (_inputTicks.contains(index)) {
         _components[random.nextInt(_amountComponents)].input(
           xDirection: random.nextInt(3) - 1,
           doJump: random.nextBool(),

--- a/packages/flame/lib/src/components/core/component_key.dart
+++ b/packages/flame/lib/src/components/core/component_key.dart
@@ -1,7 +1,7 @@
 import 'package:flame/game.dart';
 import 'package:meta/meta.dart';
 
-var _idx = 0;
+var _index = 0;
 
 /// A key that can be used to identify a component and later
 /// retrieve it from its [FlameGame] ancestor.
@@ -12,7 +12,7 @@ class ComponentKey {
 
   /// Creates a key that is unique, each instance will only
   /// be equal to itself.
-  ComponentKey.unique() : _internalHash = _idx++;
+  ComponentKey.unique() : _internalHash = _index++;
 
   final int _internalHash;
 

--- a/packages/flame/test/components/position_component_test.dart
+++ b/packages/flame/test/components/position_component_test.dart
@@ -1079,7 +1079,7 @@ void main() {
           -4, -3, -2, -1, 0, 1, 2, 3, //
           0, 1, 2, 3, 4, -3, -2, -1, //
         ];
-        var idx = 0;
+        var index = 0;
         for (final flip in flips) {
           wrapper.scale = flip.$1;
           child.scale = flip.$2;
@@ -1088,7 +1088,7 @@ void main() {
             final target = Vector2(0, -1)..rotate(angle);
             expectDouble(
               child.angleTo(target),
-              expectedResults[idx++] * tau / 8,
+              expectedResults[index++] * tau / 8,
               epsilon: 1e-10,
               reason: 'angleTo with flip $flip, angle $angle, target $target',
             );

--- a/packages/flame/test/widgets/sprite_animation_widget_test.dart
+++ b/packages/flame/test/widgets/sprite_animation_widget_test.dart
@@ -90,7 +90,7 @@ Future<void> main() async {
         animationTicker1.onStart = () => animation1Started = true;
         animationTicker2.onStart = () => animation2Started = true;
 
-        for (var idx = 0; idx < executionCount; idx++) {
+        for (var index = 0; index < executionCount; index++) {
           animation1Started = false;
           animation2Started = false;
 

--- a/packages/flame_3d/lib/src/graphics/joints_info.dart
+++ b/packages/flame_3d/lib/src/graphics/joints_info.dart
@@ -7,7 +7,7 @@ class JointsInfo {
   /// Joints for the current surface
   List<Matrix4> jointTransforms = [];
 
-  void setSurface(int surfaceIdx) {
-    jointTransforms = jointTransformsPerSurface[surfaceIdx] ?? [];
+  void setSurface(int surfaceIndex) {
+    jointTransforms = jointTransformsPerSurface[surfaceIndex] ?? [];
   }
 }

--- a/packages/flame_3d/lib/src/parser/gltf/animation.dart
+++ b/packages/flame_3d/lib/src/parser/gltf/animation.dart
@@ -78,8 +78,8 @@ class Animation extends GltfNode {
               }
               as AnimationSpline;
 
-      final nodeIdx = channel.target.node.index;
-      (controllers[nodeIdx] ??= []).add(
+      final nodeIndex = channel.target.node.index;
+      (controllers[nodeIndex] ??= []).add(
         AnimationController(
           animation: spline,
         ),

--- a/packages/flame_3d/lib/src/resources/shader/uniform_array.dart
+++ b/packages/flame_3d/lib/src/resources/shader/uniform_array.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 import 'package:flame_3d/graphics.dart';
 import 'package:flame_3d/resources.dart';
 
-typedef UniformArrayKey = ({int idx, String field});
+typedef UniformArrayKey = ({int index, String field});
 
 /// {@template uniform_value}
 /// Instance of a uniform array. Represented by a [ByteBuffer].
@@ -36,18 +36,20 @@ class UniformArray extends UniformInstance<UniformArrayKey, ByteBuffer> {
     return Float32List.fromList(data).buffer;
   }
 
-  Map<int, ({int hash, List<double> data})> _get(int idx) {
-    while (idx >= _storage.length) {
+  Map<int, ({int hash, List<double> data})> _get(int index) {
+    while (index >= _storage.length) {
       _storage.add(HashMap());
     }
-    return _storage[idx];
+    return _storage[index];
   }
 
-  List<double>? get(int idx, String key) => _get(idx)[slot.indexOf(key)]?.data;
+  List<double>? get(int index, String key) {
+    return _get(index)[slot.indexOf(key)]?.data;
+  }
 
   @override
   void set(UniformArrayKey key, ByteBuffer buffer) {
-    final storage = _get(key.idx);
+    final storage = _get(key.index);
     final index = slot.indexOf(key.field);
 
     // Ensure that we are only setting new data if the hash has changed.
@@ -65,15 +67,15 @@ class UniformArray extends UniformInstance<UniformArrayKey, ByteBuffer> {
   }
 
   @override
-  UniformArrayKey makeKey(int? idx, String? field) {
-    if (idx == null) {
-      throw StateError('idx is required for ${slot.name}');
+  UniformArrayKey makeKey(int? index, String? field) {
+    if (index == null) {
+      throw StateError('index is required for ${slot.name}');
     }
     if (field == null) {
       throw StateError('field is required for ${slot.name}');
     }
 
-    return (idx: idx, field: field);
+    return (index: index, field: field);
   }
 
   @override

--- a/packages/flame_3d/lib/src/resources/shader/uniform_instance.dart
+++ b/packages/flame_3d/lib/src/resources/shader/uniform_instance.dart
@@ -16,5 +16,5 @@ abstract class UniformInstance<K, T> extends Resource<T?> {
 
   void set(K key, T value);
 
-  K makeKey(int? idx, String? field);
+  K makeKey(int? index, String? field);
 }

--- a/packages/flame_3d/lib/src/resources/shader/uniform_sampler.dart
+++ b/packages/flame_3d/lib/src/resources/shader/uniform_sampler.dart
@@ -25,5 +25,5 @@ class UniformSampler extends UniformInstance<void, Texture> {
   Texture createResource() => texture!;
 
   @override
-  void makeKey(int? idx, String? field) {}
+  void makeKey(int? index, String? field) {}
 }

--- a/packages/flame_3d/lib/src/resources/shader/uniform_value.dart
+++ b/packages/flame_3d/lib/src/resources/shader/uniform_value.dart
@@ -55,9 +55,9 @@ class UniformValue extends UniformInstance<String, ByteBuffer> {
   }
 
   @override
-  String makeKey(int? idx, String? field) {
-    if (idx != null) {
-      throw StateError('idx is not supported for ${slot.name}');
+  String makeKey(int? index, String? field) {
+    if (index != null) {
+      throw StateError('index is not supported for ${slot.name}');
     }
     if (field == null) {
       throw StateError('field is required for ${slot.name}');

--- a/packages/flame_markdown/test/flame_markdown_test.dart
+++ b/packages/flame_markdown/test/flame_markdown_test.dart
@@ -514,8 +514,8 @@ void _expectGroup(
   expect(node, isA<GroupTextNode>());
   final group = node as GroupTextNode;
   expect(group.children, hasLength(expectChildren.length));
-  for (final (idx, expectChild) in expectChildren.indexed) {
-    expectChild(group.children[idx]);
+  for (final (index, expectChild) in expectChildren.indexed) {
+    expectChild(group.children[index]);
   }
 }
 
@@ -524,8 +524,8 @@ void _expectDocument(
   List<void Function(BlockNode)> expectChildren,
 ) {
   expect(root.children, hasLength(expectChildren.length));
-  for (final (idx, expectChild) in expectChildren.indexed) {
-    expectChild(root.children[idx]);
+  for (final (index, expectChild) in expectChildren.indexed) {
+    expectChild(root.children[index]);
   }
 }
 
@@ -538,8 +538,8 @@ void _expectElementGroup(
   expect(element, isA<GroupElement>());
   final group = element as GroupElement;
   expect(group.children, hasLength(expectChildren.length));
-  for (final (idx, expectChild) in expectChildren.indexed) {
-    expectChild(group.children[idx]);
+  for (final (index, expectChild) in expectChildren.indexed) {
+    expectChild(group.children[index]);
   }
 }
 
@@ -550,8 +550,8 @@ void _expectElementGroupText(
   expect(element, isA<GroupTextElement>());
   final group = element as GroupTextElement;
   expect(group.children, hasLength(expectChildren.length));
-  for (final (idx, expectChild) in expectChildren.indexed) {
-    expectChild(group.children[idx]);
+  for (final (index, expectChild) in expectChildren.indexed) {
+    expectChild(group.children[index]);
   }
 }
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Expunge codebase of unholy abbreviations (idx). This prevents further misery to be latched upon @spydon 

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->