### PR TITLE
chore: Use new collection literals on flame_3d

### DIFF
--- a/packages/flame_3d/lib/src/model/model.dart
+++ b/packages/flame_3d/lib/src/model/model.dart
@@ -41,11 +41,11 @@ class Model {
   }
 
   Set<String> get animationNames {
-    return animations.map((e) => e.name).nonNulls.toSet();
+    return {for (final animation in animations) ?animation.name};
   }
 
   Set<String> get nodeNames {
-    return nodes.values.map((e) => e.name).nonNulls.toSet();
+    return {for (final node in nodes.values) ?node.name};
   }
 
   Map<int, ProcessedNode> processNodes(AnimationState animation) {
@@ -64,7 +64,10 @@ class Model {
     }
 
     final queue = Queue<int>.from(
-      nodes.values.map((e) => e.nodeIndex).where((e) => inDegree[e] == 0),
+      [
+        for (final node in nodes.values)
+          if (inDegree[node.nodeIndex] == 0) node.nodeIndex,
+      ],
     );
 
     while (queue.isNotEmpty) {

--- a/packages/flame_3d/lib/src/model/model_node.dart
+++ b/packages/flame_3d/lib/src/model/model_node.dart
@@ -23,8 +23,8 @@ class ModelNode {
   });
 
   List<int> get dependencies => [
-    if (parentNodeIndex != null) parentNodeIndex!,
-    ...joints.values.map((e) => e.nodeIndex),
+    ?parentNodeIndex,
+    for (final joint in joints.values) joint.nodeIndex,
   ];
 
   ModelNode.simple({


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Use new collection literals on flame_3d, now possible in Dart 3.8

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->