### PR TITLE
refactor: Add collections library to flame_3d

### DIFF
--- a/packages/flame_3d/lib/src/model/model_node.dart
+++ b/packages/flame_3d/lib/src/model/model_node.dart
@@ -1,7 +1,7 @@
+import 'package:collection/collection.dart';
 import 'package:flame_3d/game.dart';
 import 'package:flame_3d/resources.dart';
 import 'package:flame_3d/src/model/animation_state.dart';
-import 'package:ordered_set/comparing.dart';
 
 /// A node wraps over a mesh as part of a 3D model, including its joints and
 /// local transformations.
@@ -72,8 +72,7 @@ class ModelNode {
       }
 
       final jointTransforms =
-          (globalToLocalJointMap.entries.toList()
-                ..sort(Comparing.on((a) => a.value)))
+          (globalToLocalJointMap.entries..sortedBy((e) => e.value))
               .map((e) => e.key)
               .map((jointIndex) {
                 final joint = joints[jointIndex];

--- a/packages/flame_3d/lib/src/resources/shader/uniform_value.dart
+++ b/packages/flame_3d/lib/src/resources/shader/uniform_value.dart
@@ -1,9 +1,9 @@
 import 'dart:collection';
 import 'dart:typed_data';
 
+import 'package:collection/collection.dart';
 import 'package:flame_3d/graphics.dart';
 import 'package:flame_3d/resources.dart';
-import 'package:ordered_set/comparing.dart';
 
 /// {@template uniform_value}
 /// Instance of a uniform value. Represented by a [ByteBuffer].
@@ -21,7 +21,7 @@ class UniformValue extends UniformInstance<String, ByteBuffer> {
   ByteBuffer createResource() {
     var previousIndex = -1;
 
-    final entries = _storage.entries.toList()..sort(Comparing.on((c) => c.key));
+    final entries = _storage.entries.sortedBy((c) => c.key);
     final data = entries.fold<List<double>>([], (p, e) {
       if (previousIndex + 1 != e.key) {
         final field = slot.fields.indexed.firstWhere(

--- a/packages/flame_3d/pubspec.yaml
+++ b/packages/flame_3d/pubspec.yaml
@@ -13,6 +13,7 @@ environment:
   flutter: ">=3.27.1"
 
 dependencies:
+  collection: ^1.19.1
   flame: ^1.30.1
   flutter:
     sdk: flutter


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add collections library to flame_3d to use the `sortBy` method instead of using `Comparing` from `ordered_set`.

Note: I noticed that while collections is used in a few other packages, versions are not consistent. If this proposal holds, I can followup with version unification.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->