### PR TITLE
chore: Re-enable melos analyze on CICD following Dart 3.8 migration

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           flutter-version: ${{env.FLUTTER_MIN_VERSION}}
       - uses: bluefireteam/melos-action@v3
-      - run: melos exec --ignore=flame_3d dart analyze .
       - name: "Analyze with lowest supported version"
         uses: invertase/github-action-dart-analyzer@v3
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,10 +30,10 @@ jobs:
           flutter-version: ${{env.FLUTTER_MIN_VERSION}}
       - uses: bluefireteam/melos-action@v3
       - run: melos exec --ignore=flame_3d dart analyze .
-      #- name: "Analyze with lowest supported version"
-      #  uses: invertase/github-action-dart-analyzer@v3
-      #  with:
-      #    fatal-infos: true
+      - name: "Analyze with lowest supported version"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: true
 
   analyze-latest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Re-enable melos analyze on CICD following Dart 3.8 migration.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->