### PR TITLE
feat: Add renderLine helper to canvas extensions

### DIFF
--- a/packages/flame/lib/src/extensions/canvas.dart
+++ b/packages/flame/lib/src/extensions/canvas.dart
@@ -30,6 +30,13 @@ extension CanvasExtension on Canvas {
     drawRect(rect, paint ?? BasicPalette.magenta.paint());
   }
 
+  /// Renders a line between [p1] and [p2] using the provided [paint].
+  ///
+  /// Equivalent to [drawLine] but using [Vector2] instead of [Offset].
+  void renderLine(Vector2 p1, Vector2 p2, Paint paint) {
+    drawLine(p1.toOffset(), p2.toOffset(), paint);
+  }
+
   /// Utility method to render stuff on a specific place in an isolated way.
   ///
   /// Some render methods don't allow to pass a vector.

--- a/packages/flame/test/extensions/canvas_test.dart
+++ b/packages/flame/test/extensions/canvas_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:canvas_test/canvas_test.dart';
 import 'package:flame/extensions.dart';
 import 'package:mocktail/mocktail.dart';
@@ -18,12 +20,23 @@ void main() {
       canvas.translateVector(Vector2(1, 2));
       verify(() => canvas.translate(1, 2)).called(1);
     });
+
     test('renderPoint', () {
       final canvas = MockCanvas();
       canvas.renderPoint(Vector2.all(10.0), size: 2);
       expect(
         canvas,
         MockCanvas()..drawRect(const Rect.fromLTWH(9, 9, 2, 2)),
+      );
+    });
+
+    test('renderLine', () {
+      final canvas = MockCanvas();
+      final paint = Paint()..color = const Color(0xFFFF00FF);
+      canvas.renderLine(Vector2.all(1), Vector2(3, 0), paint);
+      expect(
+        canvas,
+        MockCanvas()..drawLine(const Offset(1, 1), const Offset(3, 0), paint),
       );
     });
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add renderLine helper to canvas extensions.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->