### PR TITLE
fix: Expose Line3D on components.dart

### DIFF
--- a/packages/flame_3d/lib/components.dart
+++ b/packages/flame_3d/lib/components.dart
@@ -1,4 +1,5 @@
 export 'src/components/component_3d.dart';
 export 'src/components/light_component.dart';
+export 'src/components/line_3d.dart';
 export 'src/components/mesh_component.dart';
 export 'src/components/object_3d.dart';

--- a/packages/flame_3d/test/components/line_3d_test.dart
+++ b/packages/flame_3d/test/components/line_3d_test.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
+import 'package:flame_3d/components.dart';
 import 'package:flame_3d/core.dart';
-import 'package:flame_3d/src/components/line_3d.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Expose `Line3D` on `components.dart`

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->