### PR TITLE
fix: Fix color to byte conversion for shaders

### DIFF
--- a/packages/flame_3d/lib/src/resources/material/spatial_material.dart
+++ b/packages/flame_3d/lib/src/resources/material/spatial_material.dart
@@ -6,8 +6,8 @@ import 'package:flame_3d/resources.dart';
 
 class SpatialMaterial extends Material {
   SpatialMaterial({
+    this.albedoColor = const Color(0xFFFFFFFF),
     Texture? albedoTexture,
-    Color albedoColor = const Color(0xFFFFFFFF),
     this.metallic = 0.8,
     this.roughness = 0.6,
   }) : albedoTexture = albedoTexture ?? Texture.standard,
@@ -41,19 +41,10 @@ class SpatialMaterial extends Material {
              UniformSlot.value('Camera', {'position'}),
            ],
          ),
-       ) {
-    this.albedoColor = albedoColor;
-  }
+       );
 
   /// The material's base color.
-  Color get albedoColor => _albedoColor;
-  set albedoColor(Color color) {
-    _albedoColor = color;
-    _albedoCache.copyFromArray(color.storage);
-  }
-
-  late Color _albedoColor;
-  final Vector3 _albedoCache = Vector3.zero();
+  Color albedoColor;
 
   /// The texture that will be multiplied by [albedoColor].
   Texture albedoTexture;
@@ -94,7 +85,7 @@ class SpatialMaterial extends Material {
     _applyLights(device);
     fragmentShader
       ..setTexture('albedoTexture', albedoTexture)
-      ..setVector3('Material.albedoColor', _albedoCache)
+      ..setColor('Material.albedoColor', albedoColor)
       ..setFloat('Material.metallic', metallic)
       ..setFloat('Material.roughness', roughness);
   }

--- a/packages/flame_3d/lib/src/resources/shader/shader.dart
+++ b/packages/flame_3d/lib/src/resources/shader/shader.dart
@@ -6,6 +6,8 @@ import 'package:flame_3d/graphics.dart';
 import 'package:flame_3d/resources.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 
+Map<Color, Float32List> _colorBytesCache = {};
+
 /// {@template shader_resource}
 ///
 /// {@endtemplate}
@@ -89,7 +91,8 @@ class Shader {
   /// Set a [Matrix4] at the given [key] on the buffer.
   void setMatrix4(String key, Matrix4 matrix) => _setValue(key, matrix.storage);
 
-  void setColor(String key, Color color) => _setValue(key, color.storage);
+  void setColor(String key, Color color) =>
+      _setValue(key, _colorBytesCache.putIfAbsent(color, () => color.storage));
 
   void bind(GraphicsDevice device) {
     for (final slot in slots) {


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Fix color to byte conversion for shaders.

Why hadn't we noticed this before?
Everything in the example uses the `ColorTexture` to create an in-memory texture with a solid color. That uses a different method to create texture data using one byte per pixel:

```
        Uint32List.fromList(
          List.filled(
            width * height,
            // Convert to a 32 bit value representing this color.
            (color.a * 255).round() << 24 |
                (color.r * 255).round() << 16 |
                (color.g * 255).round() << 8 |
                (color.b * 255).round(),
          ),
        ).buffer.asByteData(),
```
As for the lights, they already used `setColor`, which works. But when setting an albedo color instead of albedo texture, it would have its own method that included an ad-hoc cache. That method was not wiring the bytes in the correct order, causing the issue. I changed it to use `setColor`, which is much nicer, and replaced the cache with a global-level cache for mapping the immutable Colors onto bytes. That way we get the benefit of the cache for lights too.

Before:
<img width="1686" height="1498" alt="image" src="https://github.com/user-attachments/assets/58cb9872-ba8e-49dc-9fa0-5fb685925ebc" />

After:
<img width="1666" height="1470" alt="image" src="https://github.com/user-attachments/assets/70ba73d5-2e74-4780-ad21-1d6869441b5c" />

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->