### PR TITLE
fix: Add fallback default material to avoid crashes

### DIFF
--- a/packages/flame_3d/lib/src/graphics/graphics_device.dart
+++ b/packages/flame_3d/lib/src/graphics/graphics_device.dart
@@ -118,9 +118,7 @@ class GraphicsDevice {
   /// Bind a [surface].
   void bindSurface(Surface surface) {
     _renderPass.clearBindings();
-    if (surface.material != null) {
-      bindMaterial(surface.material!);
-    }
+    bindMaterial(surface.material);
 
     _renderPass.bindVertexBuffer(
       gpu.BufferView(

--- a/packages/flame_3d/lib/src/resources/material/material.dart
+++ b/packages/flame_3d/lib/src/resources/material/material.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flame_3d/graphics.dart';
 import 'package:flame_3d/resources.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
@@ -13,6 +15,9 @@ abstract class Material extends Resource<gpu.RenderPipeline> {
     required Shader fragmentShader,
   }) : _vertexShader = vertexShader,
        _fragmentShader = fragmentShader;
+
+  static Material defaultMaterial = SpatialMaterial()
+    ..albedoColor = const Color(0xFFFF00FF);
 
   @override
   gpu.RenderPipeline createResource() {

--- a/packages/flame_3d/lib/src/resources/mesh/surface.dart
+++ b/packages/flame_3d/lib/src/resources/mesh/surface.dart
@@ -18,13 +18,13 @@ class Surface extends Resource<gpu.DeviceBuffer?> {
   Surface({
     required List<Vertex> vertices,
     required List<int> indices,
-    this.material,
+    Material? material,
     this.jointMap,
     /**
      * If `true`, the normals will be calculated if they are not provided.
      */
     bool calculateNormals = true,
-  }) {
+  }) : material = material ?? Material.defaultMaterial {
     final normalizedVertices = _normalize(
       vertices: vertices,
       indices: indices,
@@ -44,7 +44,7 @@ class Surface extends Resource<gpu.DeviceBuffer?> {
     _calculateAabb(normalizedVertices);
   }
 
-  Material? material;
+  Material material;
   Map<int, int>? jointMap;
 
   Aabb3 get aabb => _aabb;


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add fallback default material to avoid crashes.

Currently if you don't specify a material on a mesh it will cause a cryptic crash.
Since the parameter is not required, we should add a fallback.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->