### PR TITLE
ci: Update shebang on cspell scripts to be more env agnostic

### DIFF
--- a/scripts/cspell-run.sh
+++ b/scripts/cspell-run.sh
@@ -1,3 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash
+set -e
 
 cspell --no-progress -c .github/cspell.json "**/*.{md,dart}"

--- a/scripts/cspell-verify.sh
+++ b/scripts/cspell-verify.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -e
 
 fix=$([[ "$*" == *--fix* ]] && echo true || echo false)
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Update shebang on cspell scripts to be more env agnostic.

This follows standard practices as seen in the [ysap guide](https://style.ysap.sh/):

> Bash is not always located at /bin/bash, so use this line:
> `#!/usr/bin/env bash`

This is also in line with the other scripts on the repo.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->