### PR TITLE
ci: Fix alphabetization check in cspell verify script

### DIFF
--- a/.github/.cspell/flame_dictionary.txt
+++ b/.github/.cspell/flame_dictionary.txt
@@ -20,10 +20,10 @@ spineboy # Name of a famous character used as an example for Spine https://en.es
 spineboys # Plural of spineboy
 Spritecow # A handy tool for locating sprites within a spritesheet http://www.spritecow.com/
 Supabase # Supabase, one of our sponsors https://supabase.com/
+terminui # A terminal UI library for Flutter
 texturepacker # a packed spritesheet format
 Tilemap # What tile maps are called within Tiled
 vantablack # brand name for a famous super-black ink known as the darkest ever made
 Weasley # Ron Weasley, a character from the book Harry Potter
 Wyrmsun # An open-source real-time strategy game https://www.indiedb.com/games/wyrmsun
 yarnspinner # A tool for building branching narrative and dialogue in games # https://yarnspinner.dev/
-terminui # A terminal UI library for Flutter

--- a/.github/.cspell/gamedev_dictionary.txt
+++ b/.github/.cspell/gamedev_dictionary.txt
@@ -11,6 +11,7 @@ backgrounded # moving the app to the background
 backgrounding # moving the app to the background
 backpressure # strategy to deal with excess flow of data
 backquote # another word for backtick
+BGRA # blue green red alpha
 bimedian # line segment joining the midpoints of opposite sides of a shape
 bitfield # data structure consisting of adjacent bits
 broadphase # common division of collision detection between broad and narrow phases
@@ -25,10 +26,10 @@ highp # high float precission setting on glsl fragment shaders
 hitbox # the collision box around objects for the purposes of collision detection
 hitboxes # plural of hitbox
 IDAT # PNG data chunk
-IHDR # PNG header chunk
 IEND # PNG end chunk
-ints # short for integers
+IHDR # PNG header chunk
 impellerc # Flutter's impeller compiler
+ints # short for integers
 jank # stutter or inconsistent gap or timing
 lerp # short for linear interpolation
 LTRB # left top right bottom
@@ -53,24 +54,23 @@ raycasts # plural of raycast
 raytrace # act of raytracing
 raytracing # rendering techniques that calculates light rays as straight lines
 rects # plural of rect
-respawned # past tense of respawn
 respawn # when the player character dies and is brought back after some time and penalties
+respawned # past tense of respawn
 retarget # to direct (something) toward a different target
 RGBA # red green blue alpha
 RGBO # red green blue opacity
-BGRA # blue green red alpha
 rrect # rounded rect
 scos # cosine of a rotation multiplied by the scale factor
 shaderbundle # a file extension used to bundle shaders for GLSL
 slerp # short for spherical linear interpolation, a method to interpolate quaternions
 spritesheet # a single image packing multiple sprites, normally in a grid
 ssin # sine of a rotation multiplied by the scale factor
+struct # a type of data model in programming that aggregates fields
 stylesheet # name of a CSS style file
 subfolders # plural of subfolders
 sublist # any sub-set of elements of a given list
 sublists # plural of sublist
 subrange # a range entirely contained on a given range
-struct # a type of data model in programming that aggregates fields
 SVGs # plural of SVG
 texel # equivalent of pixel for a texture image, a normalized coordinate system for ease of mapping
 texels # plural of texel

--- a/.github/.cspell/people_usernames.txt
+++ b/.github/.cspell/people_usernames.txt
@@ -9,16 +9,16 @@ fröber # github.com/Brixto
 gnarhard # github.com/gnarhard
 kenney # kenney.nl
 Klingsbo # github.com/spydon
+luan # github.com/luanpotter
 luanpotter # github.com/luanpotter
 Lukas # github.com/spydon
 pgainullin # github.com/pgainullin 
 Schnurber # github.com/schnurber 
-subosito # github.com/subosito
 spydon # github.com/spydon
 stpasha # github.com/stpasha
+subosito # github.com/subosito
 tavian # tavianator.com
 Tellinghuisen # Author of Statistical Error Propagation (2001)
 videon # github.com/markvideon
 wolfenrain # github.com/wolfenrain
 xaha # github.com/xvrh
-luan # github.com/luanpotter

--- a/.github/.cspell/words_dictionary.txt
+++ b/.github/.cspell/words_dictionary.txt
@@ -3,6 +3,7 @@ bloodlust
 collidable
 collidables
 draggables
+endianness
 focusable
 gamepad
 gamepads
@@ -32,4 +33,3 @@ tappable
 tappables
 toolset
 underutilize
-endianness

--- a/scripts/cspell-verify.sh
+++ b/scripts/cspell-verify.sh
@@ -2,8 +2,12 @@
 
 fix=$([[ "$*" == *--fix* ]] && echo true || echo false)
 
-function sort_fn() {
-    sort --ignore-case -C
+function sort_check_fn() {
+    sort -f -c
+}
+
+function sort_run_fn() {
+    sort -f
 }
 
 function sort_dictionary() {
@@ -11,7 +15,7 @@ function sort_dictionary() {
     local tmp_file=$(mktemp)
 
     head -n 1 "$file" > "$tmp_file"
-    tail -n +2 "$file" | sort_fn >> "$tmp_file"
+    tail -n +2 "$file" | sort_run_fn >> "$tmp_file"
     mv "$tmp_file" "$file"
 }
 
@@ -46,9 +50,11 @@ error=0
 for file in .github/.cspell/*.txt; do
     echo "Processing dictionary '$file'..."
 
-    violation=$(awk '!/^#/' "$file" | sort_fn 2>&1 || true)
+    violation=$(awk '!/^\s*(#|$)/' "$file" | sort_check_fn 2>&1 || true)
     if [ -n "$violation" ]; then
-        echo "Error: The dictionary '$file' is not in alphabetical order. First violation: '$violation'" >&2
+        # Extract only the line content after the last ': '
+        violation_line=$(echo "$violation" | sed 's/.*: //')
+        echo "Error: The dictionary '$file' is not in alphabetical order. First violation: '$violation_line'" >&2
         error=1
         if $fix; then
             echo "Fixing the dictionary '$file'"


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Fix alphabetization check in cspell verify script; it was using non-bash-compliant code that would not actually work on certain systems; in fact, it was not working on CI, which has caused some drift. This also fixes the dictionaries.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->