### PR TITLE
ci: Fix cspell verify script to use the run script

### DIFF
--- a/.github/.cspell/words_dictionary.txt
+++ b/.github/.cspell/words_dictionary.txt
@@ -2,7 +2,6 @@
 bloodlust
 collidable
 collidables
-draggables
 endianness
 focusable
 gamepad
@@ -10,7 +9,6 @@ gamepads
 gapless
 grayscale
 hoverable
-hoverables
 inactives
 layouting
 microtask
@@ -30,6 +28,5 @@ renderable
 rescan
 strikethrough # of a text with a horizontal line across
 tappable
-tappables
 toolset
 underutilize

--- a/scripts/cspell-run.sh
+++ b/scripts/cspell-run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-cspell --no-progress -c .github/cspell.json "**/*.{md,dart}"
+cspell "$@" --no-progress -c .github/cspell.json "**/*.{md,dart}"

--- a/scripts/cspell-verify.sh
+++ b/scripts/cspell-verify.sh
@@ -43,7 +43,8 @@ for file in "$tmp_dir"/*; do
         touch "$dictionary_dir/$(basename "$file")"
     fi
 done
-cspell --dot --no-progress --unique --words-only "**/*.{md,dart}" | lowercase | sort -f > $word_list  || exit 1
+
+./scripts/cspell-run.sh --dot --unique --words-only | lowercase | sort -f > $word_list  || exit 1
 rm -r "$dictionary_dir"
 mv "$tmp_dir" "$dictionary_dir"
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Fix cspell verify script to use the run script.

As part of investigating why the newest cspell version [causes issues](https://github.com/flame-engine/flame/pull/3727) with the verify script, I first notice that we don't run cspell with the correct flags inside the verify script (notably not applying our own config file).

This fixes that by re-using the run script in the verify script, which avoid repetition and future drift.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->