### PR TITLE
feat: Add a "raw" field to access the underlying Flutter event in the new event system

### DIFF
--- a/packages/flame/lib/src/events/messages/displacement_event.dart
+++ b/packages/flame/lib/src/events/messages/displacement_event.dart
@@ -20,10 +20,11 @@ extension DisplacementContextDelta on DisplacementContext {
 /// This class includes properties that describe both positions where the event
 /// has occurred (start and end) and the delta (i.e. displacement) represented
 /// by the event.
-abstract class DisplacementEvent
-    extends LocationContextEvent<DisplacementContext> {
+abstract class DisplacementEvent<R>
+    extends LocationContextEvent<DisplacementContext, R> {
   DisplacementEvent(
     this._game, {
+    required super.raw,
     required this.deviceStartPosition,
     required this.deviceEndPosition,
   });

--- a/packages/flame/lib/src/events/messages/double_tap_cancel_event.dart
+++ b/packages/flame/lib/src/events/messages/double_tap_cancel_event.dart
@@ -1,3 +1,5 @@
 import 'package:flame/src/events/messages/event.dart';
 
-class DoubleTapCancelEvent extends Event {}
+class DoubleTapCancelEvent extends Event<void> {
+  DoubleTapCancelEvent() : super(raw: null);
+}

--- a/packages/flame/lib/src/events/messages/double_tap_down_event.dart
+++ b/packages/flame/lib/src/events/messages/double_tap_down_event.dart
@@ -2,12 +2,13 @@ import 'package:flame/extensions.dart';
 import 'package:flame/src/events/messages/position_event.dart';
 import 'package:flutter/gestures.dart';
 
-class DoubleTapDownEvent extends PositionEvent {
+class DoubleTapDownEvent extends PositionEvent<TapDownDetails> {
   final PointerDeviceKind deviceKind;
 
   DoubleTapDownEvent(super.game, TapDownDetails details)
     : deviceKind = details.kind ?? PointerDeviceKind.unknown,
       super(
+        raw: details,
         devicePosition: details.globalPosition.toVector2(),
       );
 }

--- a/packages/flame/lib/src/events/messages/double_tap_event.dart
+++ b/packages/flame/lib/src/events/messages/double_tap_event.dart
@@ -1,3 +1,5 @@
 import 'package:flame/src/events/messages/event.dart';
 
-class DoubleTapEvent extends Event {}
+class DoubleTapEvent extends Event<void> {
+  DoubleTapEvent() : super(raw: null);
+}

--- a/packages/flame/lib/src/events/messages/drag_cancel_event.dart
+++ b/packages/flame/lib/src/events/messages/drag_cancel_event.dart
@@ -3,8 +3,8 @@ import 'package:flame/src/events/messages/drag_start_event.dart';
 import 'package:flame/src/events/messages/event.dart';
 import 'package:flutter/gestures.dart';
 
-class DragCancelEvent extends Event {
-  DragCancelEvent(this.pointerId);
+class DragCancelEvent extends Event<void> {
+  DragCancelEvent(this.pointerId) : super(raw: null);
 
   /// The id of the event that has been cancelled. This id corresponds to the
   /// id of the previous [DragStartEvent].

--- a/packages/flame/lib/src/events/messages/drag_end_event.dart
+++ b/packages/flame/lib/src/events/messages/drag_end_event.dart
@@ -2,9 +2,10 @@ import 'package:flame/extensions.dart';
 import 'package:flame/src/events/messages/event.dart';
 import 'package:flutter/gestures.dart';
 
-class DragEndEvent extends Event {
+class DragEndEvent extends Event<DragEndDetails> {
   DragEndEvent(this.pointerId, DragEndDetails details)
-    : velocity = details.velocity.pixelsPerSecond.toVector2();
+    : velocity = details.velocity.pixelsPerSecond.toVector2(),
+      super(raw: details);
 
   final int pointerId;
 

--- a/packages/flame/lib/src/events/messages/drag_start_event.dart
+++ b/packages/flame/lib/src/events/messages/drag_start_event.dart
@@ -8,10 +8,11 @@ import 'package:flutter/gestures.dart';
 /// gesture on the game canvas.
 ///
 /// This is a [PositionEvent], where the position is the point of touch.
-class DragStartEvent extends PositionEvent {
+class DragStartEvent extends PositionEvent<DragStartDetails> {
   DragStartEvent(this.pointerId, super.game, DragStartDetails details)
     : deviceKind = details.kind ?? PointerDeviceKind.unknown,
       super(
+        raw: details,
         devicePosition: details.globalPosition.toVector2(),
       );
 

--- a/packages/flame/lib/src/events/messages/drag_update_event.dart
+++ b/packages/flame/lib/src/events/messages/drag_update_event.dart
@@ -2,10 +2,11 @@ import 'package:flame/extensions.dart';
 import 'package:flame/src/events/messages/displacement_event.dart';
 import 'package:flutter/gestures.dart';
 
-class DragUpdateEvent extends DisplacementEvent {
+class DragUpdateEvent extends DisplacementEvent<DragUpdateDetails> {
   DragUpdateEvent(this.pointerId, super.game, DragUpdateDetails details)
     : timestamp = details.sourceTimeStamp ?? Duration.zero,
       super(
+        raw: details,
         deviceStartPosition: details.globalPosition.toVector2(),
         deviceEndPosition:
             details.globalPosition.toVector2() + details.delta.toVector2(),

--- a/packages/flame/lib/src/events/messages/event.dart
+++ b/packages/flame/lib/src/events/messages/event.dart
@@ -7,7 +7,13 @@ import 'package:meta/meta.dart';
 /// This base class offers only simple common functionality; please see the
 /// concrete [Event] subclasses for the information about each individual event
 /// and the circumstances when they occur.
-abstract class Event {
+///
+/// The type parameter [R] represents the type of the original Flutter raw event
+/// that triggered this Flame event.
+abstract class Event<R> {
+  /// The original Flutter raw event that triggered this Flame event.
+  R raw;
+
   /// Flag that can be used to indicate that the event was handled by one of the
   /// components.
   ///
@@ -21,6 +27,8 @@ abstract class Event {
   /// the event will propagate further down the component tree to other eligible
   /// components.
   bool continuePropagation = false;
+
+  Event({required this.raw});
 
   @internal
   void deliverToComponents<T extends Component>(

--- a/packages/flame/lib/src/events/messages/location_context_event.dart
+++ b/packages/flame/lib/src/events/messages/location_context_event.dart
@@ -4,7 +4,10 @@ import 'package:meta/meta.dart';
 
 /// A base event that includes a location context, i.e. a position or set of
 /// positions in which the event happens.
-abstract class LocationContextEvent<C> extends Event {
+///
+/// The type parameter [C] is the generalization of the representation used to
+/// describe the location instance, such as a [Vector2].
+abstract class LocationContextEvent<C, R> extends Event<R> {
   /// The stacktrace of coordinates of the event within the components in their
   /// rendering order.
   ///
@@ -12,6 +15,8 @@ abstract class LocationContextEvent<C> extends Event {
   /// context -- which represents the event point -- but in the coordinate space
   /// of each parent component until the root.
   final List<C> renderingTrace = [];
+
+  LocationContextEvent({required super.raw});
 
   /// The context in the parent's coordinate space, containing start and end
   /// points.

--- a/packages/flame/lib/src/events/messages/pointer_move_event.dart
+++ b/packages/flame/lib/src/events/messages/pointer_move_event.dart
@@ -1,16 +1,17 @@
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
 import 'package:flame/src/events/messages/position_event.dart';
-import 'package:flutter/gestures.dart' as flutter;
+import 'package:flutter/services.dart';
 
-class PointerMoveEvent extends PositionEvent {
+class PointerMoveEvent extends PositionEvent<PointerHoverEvent> {
   PointerMoveEvent(
     this.pointerId,
     super.game,
-    flutter.PointerHoverEvent rawEvent,
+    PointerHoverEvent rawEvent,
   ) : timestamp = rawEvent.timeStamp,
       delta = rawEvent.delta.toVector2(),
       super(
+        raw: rawEvent,
         devicePosition: rawEvent.position.toVector2(),
       );
 
@@ -34,7 +35,7 @@ class PointerMoveEvent extends PositionEvent {
 
   factory PointerMoveEvent.fromPointerHoverEvent(
     Game game,
-    flutter.PointerHoverEvent event,
+    PointerHoverEvent event,
   ) {
     return PointerMoveEvent(
       event.pointer,

--- a/packages/flame/lib/src/events/messages/position_event.dart
+++ b/packages/flame/lib/src/events/messages/position_event.dart
@@ -7,8 +7,9 @@ import 'package:flame/src/game/game.dart';
 ///
 /// This class includes properties that describe the position where the event
 /// has occurred.
-abstract class PositionEvent extends LocationContextEvent<Vector2> {
-  PositionEvent(this._game, {required this.devicePosition});
+abstract class PositionEvent<R> extends LocationContextEvent<Vector2, R> {
+  PositionEvent(this._game, {required this.devicePosition, required super.raw});
+
   final Game _game;
 
   /// Event position in the coordinate space of the device -- either the phone,

--- a/packages/flame/lib/src/events/messages/tap_cancel_event.dart
+++ b/packages/flame/lib/src/events/messages/tap_cancel_event.dart
@@ -13,8 +13,8 @@ import 'package:flame/src/events/messages/tap_down_event.dart';
 ///    moved away from the point of contact.
 ///
 /// The [TapCancelEvent] will only occur if there was a previous [TapDownEvent].
-class TapCancelEvent extends Event {
-  TapCancelEvent(this.pointerId);
+class TapCancelEvent extends Event<void> {
+  TapCancelEvent(this.pointerId) : super(raw: null);
 
   /// The id of the event that has been cancelled. This id corresponds to the
   /// id of the previous [TapDownEvent].

--- a/packages/flame/lib/src/events/messages/tap_down_event.dart
+++ b/packages/flame/lib/src/events/messages/tap_down_event.dart
@@ -12,10 +12,11 @@ import 'package:flutter/gestures.dart';
 ///
 /// In order for a component to be eligible to receive this event, it must add
 /// the [TapCallbacks] mixin.
-class TapDownEvent extends PositionEvent {
+class TapDownEvent extends PositionEvent<TapDownDetails> {
   TapDownEvent(this.pointerId, super.game, TapDownDetails details)
     : deviceKind = details.kind ?? PointerDeviceKind.unknown,
       super(
+        raw: details,
         devicePosition: details.globalPosition.toVector2(),
       );
 

--- a/packages/flame/lib/src/events/messages/tap_up_event.dart
+++ b/packages/flame/lib/src/events/messages/tap_up_event.dart
@@ -10,10 +10,11 @@ import 'package:flutter/gestures.dart';
 /// has last occurred.
 ///
 /// The [TapUpEvent] will only occur if there was a previous [TapDownEvent].
-class TapUpEvent extends PositionEvent {
+class TapUpEvent extends PositionEvent<TapUpDetails> {
   TapUpEvent(this.pointerId, super.game, TapUpDetails details)
     : deviceKind = details.kind,
       super(
+        raw: details,
         devicePosition: details.globalPosition.toVector2(),
       );
 

--- a/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
@@ -406,6 +406,7 @@ mixin _DragCounter on DragCallbacks {
   @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
+    expect(event.raw, isNotNull);
     event.handled = true;
     dragStartEvent++;
     if (_wasDragged != isDragged) {
@@ -416,6 +417,7 @@ mixin _DragCounter on DragCallbacks {
 
   @override
   void onDragUpdate(DragUpdateEvent event) {
+    expect(event.raw, isNotNull);
     event.handled = true;
     dragUpdateEvent++;
   }
@@ -423,6 +425,7 @@ mixin _DragCounter on DragCallbacks {
   @override
   void onDragEnd(DragEndEvent event) {
     super.onDragEnd(event);
+    expect(event.raw, isNotNull);
     event.handled = true;
     dragEndEvent++;
     if (_wasDragged != isDragged) {

--- a/packages/flame/test/events/component_mixins/ignore_events_test.dart
+++ b/packages/flame/test/events/component_mixins/ignore_events_test.dart
@@ -119,12 +119,14 @@ mixin _TapCounter on TapCallbacks {
 
   @override
   void onTapDown(TapDownEvent event) {
+    expect(event.raw, isNotNull);
     event.continuePropagation = true;
     tapDownEvent++;
   }
 
   @override
   void onTapUp(TapUpEvent event) {
+    expect(event.raw, isNotNull);
     event.continuePropagation = true;
     tapUpEvent++;
   }

--- a/packages/flame/test/events/component_mixins/pointer_move_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/pointer_move_callbacks_test.dart
@@ -97,6 +97,7 @@ mixin _PointerMoveInspector on PointerMoveCallbacks {
 
   @override
   void onPointerMove(PointerMoveEvent event) {
+    expect(event.raw, isNotNull);
     receivedEventsAt.add(event.localPosition);
   }
 }

--- a/packages/flame/test/events/component_mixins/tap_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/tap_callbacks_test.dart
@@ -485,18 +485,21 @@ mixin _TapCounter on TapCallbacks {
 
   @override
   void onTapDown(TapDownEvent event) {
+    expect(event.raw, isNotNull);
     event.handled = true;
     tapDownEvent++;
   }
 
   @override
   void onLongTapDown(TapDownEvent event) {
+    expect(event.raw, isNotNull);
     event.handled = true;
     longTapDownEvent++;
   }
 
   @override
   void onTapUp(TapUpEvent event) {
+    expect(event.raw, isNotNull);
     event.handled = true;
     tapUpEvent++;
   }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add a "raw" field to access the underlying Flutter event in the new event system.

As per specified [in my event system proposal](https://docs.google.com/document/d/1nBUup9QCPioVwWL1zs79z1hWF882tAYfNywFMdye2Qc/edit?tab=t.0). This brings it in line with the old system.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->