### PR TITLE
perf: `addAll` shouldn't create unnecessary growing lists

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -661,14 +661,14 @@ class Component {
 
   /// A convenience method to [add] multiple children at once.
   Future<void> addAll(Iterable<Component> components) {
-    final futures = <Future<void>>[];
+    late final List<Future<void>>? futures;
     for (final component in components) {
       final future = add(component);
       if (future is Future) {
-        futures.add(future);
+        (futures ??= []).add(future);
       }
     }
-    return Future.wait(futures);
+    return futures == null ? Future.value() : Future.wait(futures);
   }
 
   FutureOr<void> _addChild(Component child) {

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -661,7 +661,7 @@ class Component {
 
   /// A convenience method to [add] multiple children at once.
   Future<void> addAll(Iterable<Component> components) {
-    late final List<Future<void>>? futures;
+    List<Future<void>>? futures;
     for (final component in components) {
       final future = add(component);
       if (future is Future) {

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -660,7 +660,7 @@ class Component {
   FutureOr<void> addToParent(Component parent) => parent._addChild(this);
 
   /// A convenience method to [add] multiple children at once.
-  Future<void> addAll(Iterable<Component> components) {
+  Future<void> addAll(Iterable<Component> components) async {
     List<Future<void>>? futures;
     for (final component in components) {
       final future = add(component);
@@ -668,7 +668,9 @@ class Component {
         (futures ??= []).add(future);
       }
     }
-    return futures == null ? Future.value() : Future.wait(futures);
+    if (futures != null) {
+      await Future.wait(futures);
+    }
   }
 
   FutureOr<void> _addChild(Component child) {


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
This PR removes the sometimes unnecessary creation of a growing list from `addAll`.

> "I'm adding hundreds to thousands of components onto the screen in a short period of time. Switching to .add from .addAll cut down on these CPU-consuming functions:
> 
> _GrowableList.add, _allocateData, _growToNextCapacity, length=
> 
> Even if you're not adding components that need async onLoads, the engine is always instantiating a future list and > adding to it."

Later on we should experiment with list comprehensions and see if they create a statically sized list.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
