### PR TITLE
refactor: Re-organize internal event imports

### DIFF
--- a/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
@@ -1,8 +1,5 @@
-import 'package:flame/src/components/core/component.dart';
-import 'package:flame/src/events/flame_game_mixins/double_tap_dispatcher.dart';
-import 'package:flame/src/events/messages/double_tap_cancel_event.dart';
-import 'package:flame/src/events/messages/double_tap_down_event.dart';
-import 'package:flame/src/events/messages/double_tap_event.dart';
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
 
 /// [DoubleTapCallbacks] adds the ability to receive double-tap events in a
 /// component.

--- a/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
@@ -1,9 +1,5 @@
-import 'package:flame/src/components/core/component.dart';
-import 'package:flame/src/events/flame_game_mixins/multi_drag_dispatcher.dart';
-import 'package:flame/src/events/messages/drag_cancel_event.dart';
-import 'package:flame/src/events/messages/drag_end_event.dart';
-import 'package:flame/src/events/messages/drag_start_event.dart';
-import 'package:flame/src/events/messages/drag_update_event.dart';
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
 import 'package:meta/meta.dart';
 
 /// This mixin can be added to a [Component] allowing it to receive drag events.

--- a/packages/flame/lib/src/events/component_mixins/hover_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/hover_callbacks.dart
@@ -1,5 +1,5 @@
+import 'package:flame/components.dart';
 import 'package:flame/events.dart';
-import 'package:flame/src/components/core/component.dart';
 import 'package:meta/meta.dart';
 
 /// This mixin can be added to a [Component] allowing it to receive hover

--- a/packages/flame/lib/src/events/component_mixins/pointer_move_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/pointer_move_callbacks.dart
@@ -1,5 +1,5 @@
+import 'package:flame/components.dart';
 import 'package:flame/events.dart';
-import 'package:flame/src/components/core/component.dart';
 import 'package:meta/meta.dart';
 
 /// This mixin can be added to a [Component] allowing it to receive

--- a/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
@@ -1,8 +1,5 @@
-import 'package:flame/src/components/core/component.dart';
-import 'package:flame/src/events/flame_game_mixins/multi_tap_dispatcher.dart';
-import 'package:flame/src/events/messages/tap_cancel_event.dart';
-import 'package:flame/src/events/messages/tap_down_event.dart';
-import 'package:flame/src/events/messages/tap_up_event.dart';
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
 import 'package:meta/meta.dart';
 
 /// This mixin can be added to a [Component] allowing it to receive tap events.

--- a/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
@@ -1,9 +1,6 @@
 import 'package:flame/components.dart';
+import 'package:flame/events.dart';
 import 'package:flame/game.dart';
-import 'package:flame/src/events/component_mixins/double_tap_callbacks.dart';
-import 'package:flame/src/events/messages/double_tap_cancel_event.dart';
-import 'package:flame/src/events/messages/double_tap_down_event.dart';
-import 'package:flame/src/events/messages/double_tap_event.dart';
 import 'package:flutter/gestures.dart';
 
 class DoubleTapDispatcherKey implements ComponentKey {

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
@@ -1,12 +1,6 @@
-import 'package:flame/src/components/core/component.dart';
-import 'package:flame/src/components/core/component_key.dart';
-import 'package:flame/src/events/component_mixins/drag_callbacks.dart';
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
 import 'package:flame/src/events/flame_drag_adapter.dart';
-import 'package:flame/src/events/interfaces/multi_drag_listener.dart';
-import 'package:flame/src/events/messages/drag_cancel_event.dart';
-import 'package:flame/src/events/messages/drag_end_event.dart';
-import 'package:flame/src/events/messages/drag_start_event.dart';
-import 'package:flame/src/events/messages/drag_update_event.dart';
 import 'package:flame/src/events/tagged_component.dart';
 import 'package:flame/src/game/flame_game.dart';
 import 'package:flame/src/game/game_render_box.dart';

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
@@ -1,11 +1,7 @@
 import 'package:flame/components.dart';
-import 'package:flame/src/events/component_mixins/tap_callbacks.dart';
-import 'package:flame/src/events/interfaces/multi_tap_listener.dart';
-import 'package:flame/src/events/messages/tap_cancel_event.dart';
-import 'package:flame/src/events/messages/tap_down_event.dart';
-import 'package:flame/src/events/messages/tap_up_event.dart';
+import 'package:flame/events.dart';
+import 'package:flame/input.dart';
 import 'package:flame/src/events/tagged_component.dart';
-import 'package:flame/src/events/tap_config.dart';
 import 'package:flame/src/game/flame_game.dart';
 import 'package:flame/src/game/game_render_box.dart';
 import 'package:flutter/gestures.dart';

--- a/packages/flame/lib/src/events/flame_game_mixins/pointer_move_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/pointer_move_dispatcher.dart
@@ -1,6 +1,5 @@
+import 'package:flame/components.dart';
 import 'package:flame/events.dart';
-import 'package:flame/src/components/core/component.dart';
-import 'package:flame/src/components/core/component_key.dart';
 import 'package:flame/src/events/tagged_component.dart';
 import 'package:flame/src/game/flame_game.dart';
 import 'package:flutter/gestures.dart' as flutter;

--- a/packages/flame/lib/src/events/interfaces/multi_drag_listener.dart
+++ b/packages/flame/lib/src/events/interfaces/multi_drag_listener.dart
@@ -1,5 +1,4 @@
-import 'package:flame/src/events/game_mixins/multi_touch_drag_detector.dart';
-import 'package:flame/src/events/interfaces/multi_tap_listener.dart';
+import 'package:flame/events.dart';
 import 'package:flame/src/game/game_render_box.dart';
 import 'package:flutter/gestures.dart';
 

--- a/packages/flame/lib/src/events/interfaces/multi_tap_listener.dart
+++ b/packages/flame/lib/src/events/interfaces/multi_tap_listener.dart
@@ -1,4 +1,4 @@
-import 'package:flame/src/events/game_mixins/multi_touch_tap_detector.dart';
+import 'package:flame/events.dart';
 import 'package:flame/src/game/game_render_box.dart';
 import 'package:flutter/gestures.dart';
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Re-organize internal event files using the `events.dart` export.

This changes the imports on all files to use the exposed `events.dart` export - this will vastly help us to catch issues of forgetting to expose things. If anything is imported from `src/`, we know it is not exposed by Flame.

This should be absolutely no-op whatsoever - just organizational.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->