### PR TITLE
fix(flame_3d): Fix alpha blend factors for transparent background compositing

### DIFF
--- a/packages/flame_3d/lib/src/graphics/graphics_device.dart
+++ b/packages/flame_3d/lib/src/graphics/graphics_device.dart
@@ -84,7 +84,6 @@ class GraphicsDevice {
       ..setColorBlendEnable(true)
       ..setColorBlendEquation(
         gpu.ColorBlendEquation(
-          sourceAlphaBlendFactor: gpu.BlendFactor.one,
           destinationAlphaBlendFactor: blendState == BlendState.alphaBlend
               ? gpu.BlendFactor.oneMinusSourceAlpha
               : gpu.BlendFactor.zero,


### PR DESCRIPTION
# Description

Fixes #3811

The `alphaBlend` path in `GraphicsDevice.begin()` sets `sourceAlphaBlendFactor: oneMinusSourceAlpha`, which zeroes the alpha channel for opaque fragments:

```
result_alpha = src_alpha * (1 - src_alpha) = 1.0 * 0.0 = 0
```

The GPU texture has valid RGB but zero alpha, so it becomes invisible when composited onto the Flutter canvas via `srcOver`.

This swaps the factors to match the standard premultiplied "over" operator:

- `sourceAlphaBlendFactor: one` — preserves source alpha
- `destinationAlphaBlendFactor: oneMinusSourceAlpha` — blends with destination

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

The blend equation change is purely in the GPU pipeline — not feasible to unit test without a real GPU context. Verified manually by rendering models with `clearColor: 0x00000000` and compositing over Flutter widgets.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md