### PR TITLE
fix: Fix warnings on flame_fire_atlas.dart

### DIFF
--- a/packages/flame_fire_atlas/lib/flame_fire_atlas.dart
+++ b/packages/flame_fire_atlas/lib/flame_fire_atlas.dart
@@ -144,7 +144,6 @@ class SpriteSelection extends BaseSelection {
   }) : super(info);
 
   /// Creates a [SpriteSelection] from [json].
-  @override
   factory SpriteSelection.fromJson(Map<String, dynamic> json) {
     final info = Selection.fromJson(json);
     final group = json['group'] as String?;
@@ -193,7 +192,6 @@ class AnimationSelection extends BaseSelection {
   }) : super(info);
 
   /// Creates a [AnimationSelection] from [json].
-  @override
   factory AnimationSelection.fromJson(Map<String, dynamic> json) {
     final info = Selection.fromJson(json);
     final group = json['group'] as String?;


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Error message:

> The annotation 'override' can only be used on fields, getters, methods, or setters.

Which makes sense - factory is a static method so override doesn't apply.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->