### PR TITLE
fix: Make `removeAll(children)` work in `onRemove`

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -743,6 +743,13 @@ class Component {
       } else if (!child.isRemoved) {
         root.dequeueAdd(child, this);
         child._parent = null;
+      } else if (isRemoving) {
+        // This parent is being removed from the tree, and the child was
+        // already marked as removed during ancestor removal propagation.
+        // The child is now being explicitly removed by user code (e.g.
+        // via removeAll(children) in onRemove), so detach it.
+        _internalChildren.remove(child);
+        child._parent = null;
       }
     } else {
       _children?.remove(child);

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -1007,9 +1007,27 @@ void main() {
       );
 
       testWithFlameGame(
-        'A removed child should be able to be removed from onRemove',
+        'removeAll(children) in onRemove detaches children',
         (game) async {
           final parent = _RemoveAllChildrenComponent();
+          final child = _LifecycleComponent('child')..addToParent(parent);
+          await game.world.add(parent);
+          await game.ready();
+          parent.removeFromParent();
+          game.update(0);
+          expect(parent.isMounted, false);
+          expect(child.isMounted, false);
+          expect(child.parent, isNull);
+          expect(parent.children.length, 0);
+          expect(parent.parent, isNull);
+        },
+      );
+
+      testWithFlameGame(
+        'children retain parent when ancestor is removed without explicit '
+        'child removal',
+        (game) async {
+          final parent = Component();
           final child = _LifecycleComponent('child')..addToParent(parent);
           await game.world.add(parent);
           await game.ready();
@@ -2000,7 +2018,7 @@ class _ComponentWithChildrenRemoveAll extends Component {
 class _RemoveAllChildrenComponent extends Component {
   @override
   void onRemove() {
-    super.onMount();
+    super.onRemove();
     removeAll(children);
   }
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
When a component's onRemove called removeAll(children), the children were already marked as removed by the ancestor removal propagation, causing _removeChild to silently skip them. This adds handling for already-removed children so they are properly detached when explicitly removed.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
Closes #2743

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
