### PR TITLE
fix: Make `buildContext` available during `onLoad` and `onMount`

### DIFF
--- a/packages/flame/lib/src/game/game.dart
+++ b/packages/flame/lib/src/game/game.dart
@@ -58,11 +58,18 @@ abstract mixin class Game {
   GameRenderBox get renderBox => _gameRenderBox!;
   GameRenderBox? _gameRenderBox;
 
+  /// Build context set by [GameWidgetState] before the game is fully
+  /// attached to the render tree. This allows components to access the
+  /// build context during [onLoad] and [onMount].
+  @internal
+  BuildContext? widgetBuildContext;
+
   /// Currently attached build context. Can be null if not attached.
-  BuildContext? get buildContext => _gameRenderBox?.buildContext;
+  BuildContext? get buildContext =>
+      _gameRenderBox?.buildContext ?? widgetBuildContext;
 
   /// Whether the game widget was attached to the Flutter tree.
-  bool get isAttached => buildContext != null;
+  bool get isAttached => _gameRenderBox != null;
 
   /// Current size of the game as provided by the framework; it will be null if
   /// layout has not been computed yet.

--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -291,6 +291,7 @@ class GameWidgetState<T extends Game> extends State<GameWidget<T>> {
     currentGame.removeGameStateListener(_onGameStateChange);
     currentGame.lifecycleStateChange(AppLifecycleState.paused);
     currentGame.finalizeRemoval();
+    currentGame.widgetBuildContext = null;
     if (callGameOnDispose) {
       currentGame.onDispose();
     }
@@ -399,7 +400,7 @@ class GameWidgetState<T extends Game> extends State<GameWidget<T>> {
                   color: currentGame.backgroundColor(),
                 ),
                 child: LayoutBuilder(
-                  builder: (_, BoxConstraints constraints) {
+                  builder: (layoutContext, BoxConstraints constraints) {
                     return _protectedBuild(() {
                       final size = constraints.biggest.toVector2();
                       if (size.isZero()) {
@@ -407,6 +408,7 @@ class GameWidgetState<T extends Game> extends State<GameWidget<T>> {
                             Container();
                       }
                       currentGame.onGameResize(size);
+                      currentGame.widgetBuildContext = layoutContext;
                       // This should only be called if the game has already been
                       // loaded (in the case of resizing for example), since
                       // update otherwise should be called after onMount.

--- a/packages/flame/test/game/game_widget/game_widget_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_test.dart
@@ -1,3 +1,4 @@
+import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
@@ -429,4 +430,66 @@ void main() {
       expect(overlayKeyEvents, [LogicalKeyboardKey.keyA]);
     });
   });
+
+  group('buildContext availability', () {
+    testWidgets(
+      'buildContext is available during onLoad',
+      (tester) async {
+        final game = _GameWithBuildContextCheck();
+        await tester.pumpWidget(GameWidget(game: game));
+        await game.toBeLoaded();
+        await tester.pump();
+
+        expect(
+          game.buildContextDuringOnLoad,
+          isNotNull,
+          reason: 'buildContext should be available during onLoad',
+        );
+      },
+    );
+
+    testWidgets(
+      'buildContext is available for child components during onLoad',
+      (tester) async {
+        final game = _GameWithComponentBuildContextCheck();
+        await tester.pumpWidget(GameWidget(game: game));
+        await game.toBeLoaded();
+        await tester.pump();
+
+        expect(
+          game.component.buildContextDuringOnLoad,
+          isNotNull,
+          reason:
+              'buildContext should be available to components during onLoad',
+        );
+      },
+    );
+  });
+}
+
+class _GameWithBuildContextCheck extends FlameGame {
+  BuildContext? buildContextDuringOnLoad;
+
+  @override
+  Future<void> onLoad() async {
+    buildContextDuringOnLoad = buildContext;
+  }
+}
+
+class _ComponentWithBuildContextCheck extends Component {
+  BuildContext? buildContextDuringOnLoad;
+
+  @override
+  void onLoad() {
+    buildContextDuringOnLoad = findGame()!.buildContext;
+  }
+}
+
+class _GameWithComponentBuildContextCheck extends FlameGame {
+  final component = _ComponentWithBuildContextCheck();
+
+  @override
+  Future<void> onLoad() async {
+    add(component);
+  }
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
The `RenderGameWidget` (which provides `buildContext` via `GameRenderBox`) was only rendered inside a `FutureBuilder` after `loaderFuture` completed. Components mounting during `loaderFuture` (in `game.load()`, `game.mount()`, `game.update(0)`) would find `buildContext` to be null.

Add `widgetBuildContext` to `Game` set early by `GameWidgetState` from the `LayoutBuilder` context, so `buildContext` is available before the render box is attached. Update `isAttached` to check `_gameRenderBox` directly to avoid breaking coordinate conversion methods.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
