### PR TITLE
fix: Resolve `fontPackage` in `IconComponent` (`_rasterizeIcon`)

### DIFF
--- a/packages/flame/lib/src/components/icon_component.dart
+++ b/packages/flame/lib/src/components/icon_component.dart
@@ -155,18 +155,22 @@ class IconComponent extends PositionComponent with HasPaint {
   /// Rasterizes the current [icon] to a white [Image].
   Future<Image> _rasterizeIcon() {
     final iconData = _icon!;
+    final fontFamily =
+        iconData.fontFamily != null && iconData.fontPackage != null
+        ? 'packages/${iconData.fontPackage}/${iconData.fontFamily}'
+        : iconData.fontFamily;
     final paragraphBuilder =
         ParagraphBuilder(
             ParagraphStyle(
               fontSize: _iconSize,
-              fontFamily: iconData.fontFamily,
+              fontFamily: fontFamily,
             ),
           )
           ..pushStyle(
             TextStyle(
               color: const Color(0xFFFFFFFF),
               fontSize: _iconSize,
-              fontFamily: iconData.fontFamily,
+              fontFamily: fontFamily,
               fontFamilyFallback: iconData.fontFamilyFallback,
             ),
           )

--- a/packages/flame/test/components/icon_component_test.dart
+++ b/packages/flame/test/components/icon_component_test.dart
@@ -56,6 +56,21 @@ void main() {
       expect(component.iconSize, 128);
     });
 
+    testWithFlameGame('supports fontPackage', (game) async {
+      const iconWithPackage = IconData(
+        0x41,
+        fontFamily: 'MyFont',
+        fontPackage: 'my_package',
+      );
+      final component = IconComponent(
+        icon: iconWithPackage,
+        iconSize: 32,
+      );
+      await game.ensureAdd(component);
+
+      expect(component.image, isNotNull);
+    });
+
     testWithFlameGame('rasterizes icon on load', (game) async {
       final component = IconComponent(
         icon: _testIcon,


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Flame's IconComponent uses dart:ui's ParagraphBuilder for rasterization, which does not have a fontPackage parameter. This change manually prefixes the fontFamily with 'packages/$fontPackage/' if both are provided in the IconData, ensuring that the engine can correctly locate package-based font assets.

- Updated IconComponent._rasterizeIcon to resolve the package path.
- Added a test case in IconComponentTest to verify fontPackage support.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
Closes #3837

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
