### PR TITLE
feat: Add `clampDouble` to `Vector2Extension` and its tests

### DIFF
--- a/packages/flame/lib/src/extensions/vector2.dart
+++ b/packages/flame/lib/src/extensions/vector2.dart
@@ -115,6 +115,13 @@ extension Vector2Extension on Vector2 {
     y = y.clamp(min.y, max.y);
   }
 
+  /// Clamps this vector so that it is within or equals to the bounds defined by
+  /// ([minX], [maxX]) and ([minY], [maxY]).
+  void clampDouble(double minX, double maxX, double minY, double maxY) {
+    x = x.clamp(minX, maxX);
+    y = y.clamp(minY, maxY);
+  }
+
   /// Sets both x and y to [value].
   void setAll(double value) => setValues(value, value);
 

--- a/packages/flame/test/extensions/vector2_test.dart
+++ b/packages/flame/test/extensions/vector2_test.dart
@@ -246,6 +246,34 @@ void main() {
       });
     });
 
+    group('clampDouble', () {
+      test('clamp x and y', () {
+        final v = Vector2(10.0, 10.0)..clampDouble(0.0, 5.0, 0.0, 5.0);
+        expect(v, Vector2(5.0, 5.0));
+      });
+
+      test('clamp x min and y max', () {
+        final v = Vector2(-10.0, 20.0)..clampDouble(0.0, 5.0, 0.0, 5.0);
+        expect(v, Vector2(0.0, 5.0));
+      });
+
+      test('no effect when in range', () {
+        final v = Vector2(2.5, 2.5)..clampDouble(0.0, 5.0, 0.0, 5.0);
+        expect(v, Vector2(2.5, 2.5));
+      });
+
+      testRandom('clampDouble clamps x and y', (Random r) {
+        final v = Vector2(r.nextDouble() * 100 - 50, r.nextDouble() * 100 - 50);
+        const minX = -10.0;
+        const maxX = 10.0;
+        const minY = -20.0;
+        const maxY = 20.0;
+        v.clampDouble(minX, maxX, minY, maxY);
+        expect(v.x >= minX && v.x <= maxX, true);
+        expect(v.y >= minY && v.y <= maxY, true);
+      });
+    });
+
     group('projection', () {
       test('Project onto longer vector', () {
         final u = Vector2(5, 2);


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
   - Implementation: Added void clampDouble(double minX, double maxX, double minY, double maxY) to Vector2Extension. This method allows for direct clamping of the x and y components using primitive double values, providing a more performant alternative
     to the existing clamp(Vector2 min, Vector2 max) method by avoiding the overhead of creating temporary Vector2 instances for the bounds.
   - Testing: Added a comprehensive test suite in packages/flame/test/extensions/vector2_test.dart that verifies:
       - Correct clamping behavior when coordinates exceed maximum bounds.
       - Correct clamping behavior when coordinates fall below minimum bounds.
       - Stability (no changes) when the vector is already within the specified range.
       - General robustness via a randomized test (testRandom) covering a wide variety of coordinate ranges.


<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
