### PR TITLE
feat: Implement LongPressCallbacks on new event system

### DIFF
--- a/doc/flame/inputs/inputs.md
+++ b/doc/flame/inputs/inputs.md
@@ -10,6 +10,7 @@ works, but adapted for Flame's component tree.
 
 - [Tap Events](tap_events.md)
 - [Drag Events](drag_events.md)
+- [Long Press Events](long_press_events.md)
 - [Gesture Input](gesture_input.md)
 - [Keyboard Input](keyboard_input.md)
 - [Other Inputs and Helpers](other_inputs.md)
@@ -21,6 +22,7 @@ works, but adapted for Flame's component tree.
 
 Tap Events                <tap_events.md>
 Drag Events               <drag_events.md>
+Long Press Events         <long_press_events.md>
 Gesture Input             <gesture_input.md>
 Keyboard Input            <keyboard_input.md>
 Other Inputs              <other_inputs.md>

--- a/doc/flame/inputs/long_press_events.md
+++ b/doc/flame/inputs/long_press_events.md
@@ -1,0 +1,119 @@
+# Long Press Events
+
+**Long press events** occur when the user presses and holds a pointer (finger or mouse) on a
+component for a sustained period. This gesture is commonly used for context menus, drag-to-move
+behaviors, or any action that requires a deliberate, sustained touch.
+
+For components that should respond to long press events, add the `LongPressCallbacks` mixin.
+
+- This mixin adds four overridable methods to your component: `onLongPressStart`,
+  `onLongPressMoveUpdate`, `onLongPressEnd`, and `onLongPressCancel`.
+- By default, `isLongPressing` is tracked automatically and can be accessed by your component.
+- The component must implement `containsLocalPoint()` (already implemented in `PositionComponent`,
+  so most of the time you don't need to do anything here). This method allows Flame to know whether
+  the event occurred within the component or not. You can override it to `true` to receive all
+  long press events regardless of position.
+
+```dart
+class MyComponent extends PositionComponent with LongPressCallbacks {
+  MyComponent() : super(size: Vector2.all(32));
+
+  @override
+  void onLongPressStart(LongPressStartEvent event) {
+    super.onLongPressStart(event); // handles internal updating of isLongPressing
+    // Do something when the long press is recognized
+  }
+
+  @override
+  void onLongPressEnd(LongPressEndEvent event) {
+    super.onLongPressEnd(event); // handles internal updating of isLongPressing
+    // Do something when the long press finishes
+  }
+}
+```
+
+
+## Long press anatomy
+
+
+### onLongPressStart
+
+The first event in a long press sequence. It fires once the pointer has been held down long enough
+to be recognized as a long press. By default, Flutter's `LongPressGestureRecognizer` uses
+`kLongPressTimeout` (500ms) as a long press definition.
+
+The `LongPressStartEvent` provides the position of the contact point in multiple coordinate
+systems: `devicePosition` (device coordinates), `canvasPosition` (game widget coordinates), and
+`localPosition` (component-local coordinates).
+
+Any component that receives `onLongPressStart` will later receive either `onLongPressEnd` (on
+success) or `onLongPressCancel` (if cancelled). Move updates may also be delivered in between.
+
+Calling `super.onLongPressStart(event)` sets `isLongPressing` to `true`.
+
+
+### onLongPressMoveUpdate
+
+Fires continuously as the user moves their finger during an active long press. This event is only
+delivered to components that received the initial `onLongPressStart`.
+
+The `LongPressMoveUpdateEvent` is a `DisplacementEvent` that provides a frame-to-frame delta,
+just like `DragUpdateEvent`. That means you can use `localDelta` to move a component following
+the pointer (it correctly accounts for camera zoom and component transforms).
+The event also carries `offsetFromOrigin` for the total displacement since the gesture started.
+
+
+### onLongPressEnd
+
+Fires when the user lifts their pointer after a long press. The `LongPressEndEvent` includes the
+final position and the `velocity` of the pointer at the moment of release.
+
+Calling `super.onLongPressEnd(event)` sets `isLongPressing` to `false`.
+
+
+### onLongPressCancel
+
+Fires if the gesture is interrupted before completing (e.g. by a competing gesture recognizer).
+
+Calling `super.onLongPressCancel(event)` sets `isLongPressing` to `false`.
+
+
+## Mixins
+
+
+### LongPressCallbacks
+
+The `LongPressCallbacks` mixin can be added to any `Component` for that component to start
+receiving long press events.
+
+This mixin adds methods `onLongPressStart`, `onLongPressMoveUpdate`, `onLongPressEnd`, and
+`onLongPressCancel` to the component. Override them to implement behavior.
+
+A component will only receive long press events that originate *within* that component, as judged
+by the `containsLocalPoint()` function. The commonly-used `PositionComponent` class provides such
+an implementation based on its `size` property.
+
+The mixin also provides an `isLongPressing` property that tracks whether a long press gesture
+is currently active on the component. This is managed automatically when you call `super` in
+`onLongPressStart`, `onLongPressEnd`, and `onLongPressCancel`.
+
+```dart
+class LongPressSquare extends RectangleComponent with LongPressCallbacks {
+  @override
+  void onLongPressStart(LongPressStartEvent event) {
+    super.onLongPressStart(event);
+    paint.color = Colors.red;
+  }
+
+  @override
+  void onLongPressMoveUpdate(LongPressMoveUpdateEvent event) {
+    position += event.localDelta;
+  }
+
+  @override
+  void onLongPressEnd(LongPressEndEvent event) {
+    super.onLongPressEnd(event);
+    paint.color = Colors.blue;
+  }
+}
+```

--- a/examples/lib/stories/input/input.dart
+++ b/examples/lib/stories/input/input.dart
@@ -10,6 +10,7 @@ import 'package:examples/stories/input/joystick_advanced_example.dart';
 import 'package:examples/stories/input/joystick_example.dart';
 import 'package:examples/stories/input/keyboard_example.dart';
 import 'package:examples/stories/input/keyboard_listener_component_example.dart';
+import 'package:examples/stories/input/long_press_example.dart';
 import 'package:examples/stories/input/mouse_cursor_example.dart';
 import 'package:examples/stories/input/mouse_movement_example.dart';
 import 'package:examples/stories/input/multitap_advanced_example.dart';
@@ -95,6 +96,12 @@ void addInputStories(Dashbook dashbook) {
       ),
       codeLink: baseLink('input/mouse_cursor_example.dart'),
       info: MouseCursorExample.description,
+    )
+    ..add(
+      'Long Press',
+      (_) => GameWidget(game: LongPressExample()),
+      codeLink: baseLink('input/long_press_example.dart'),
+      info: LongPressExample.description,
     )
     ..add(
       'Scroll',

--- a/examples/lib/stories/input/long_press_example.dart
+++ b/examples/lib/stories/input/long_press_example.dart
@@ -1,0 +1,65 @@
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
+import 'package:flame/game.dart';
+import 'package:flame/palette.dart';
+import 'package:flutter/material.dart';
+
+class LongPressExample extends FlameGame {
+  static const String description = '''
+    In this example we show how to use `LongPressCallbacks`.\n\n
+    The colored squares will turn red when a long press is recognized,
+    follow the pointer while held, and turn back to green when released.
+  ''';
+
+  @override
+  Future<void> onLoad() async {
+    world.add(
+      LongPressSquare(
+        paint: BasicPalette.blue.paint(),
+        position: Vector2(-100, 0),
+      ),
+    );
+    world.add(
+      LongPressSquare(
+        paint: BasicPalette.green.paint(),
+        position: Vector2(100, 0),
+      ),
+    );
+  }
+}
+
+class LongPressSquare extends RectangleComponent with LongPressCallbacks {
+  LongPressSquare({required Paint paint, required Vector2 position})
+    : _originalPaint = paint,
+      super(
+        position: position,
+        size: Vector2.all(100),
+        paint: paint,
+        anchor: Anchor.center,
+      );
+
+  final Paint _originalPaint;
+
+  @override
+  void onLongPressStart(LongPressStartEvent event) {
+    super.onLongPressStart(event);
+    paint = BasicPalette.red.paint();
+  }
+
+  @override
+  void onLongPressMoveUpdate(LongPressMoveUpdateEvent event) {
+    position += event.localDelta;
+  }
+
+  @override
+  void onLongPressEnd(LongPressEndEvent event) {
+    super.onLongPressEnd(event);
+    paint = Paint()..color = const Color(0xFF00FF00);
+  }
+
+  @override
+  void onLongPressCancel(LongPressCancelEvent event) {
+    super.onLongPressCancel(event);
+    paint = _originalPaint;
+  }
+}

--- a/packages/flame/lib/events.dart
+++ b/packages/flame/lib/events.dart
@@ -2,6 +2,8 @@ export 'src/events/component_mixins/double_tap_callbacks.dart'
     show DoubleTapCallbacks;
 export 'src/events/component_mixins/drag_callbacks.dart' show DragCallbacks;
 export 'src/events/component_mixins/hover_callbacks.dart' show HoverCallbacks;
+export 'src/events/component_mixins/long_press_callbacks.dart'
+    show LongPressCallbacks;
 export 'src/events/component_mixins/pointer_move_callbacks.dart'
     show PointerMoveCallbacks;
 export 'src/events/component_mixins/scale_callbacks.dart' show ScaleCallbacks;
@@ -11,6 +13,8 @@ export 'src/events/component_mixins/secondary_tap_callbacks.dart'
 export 'src/events/component_mixins/tap_callbacks.dart' show TapCallbacks;
 export 'src/events/flame_game_mixins/double_tap_dispatcher.dart'
     show DoubleTapDispatcher, DoubleTapDispatcherKey;
+export 'src/events/flame_game_mixins/long_press_dispatcher.dart'
+    show LongPressDispatcher, LongPressDispatcherKey;
 export 'src/events/flame_game_mixins/multi_drag_dispatcher.dart'
     show MultiDragDispatcher, MultiDragDispatcherKey;
 export 'src/events/flame_game_mixins/multi_tap_dispatcher.dart'
@@ -37,6 +41,13 @@ export 'src/events/messages/drag_cancel_event.dart' show DragCancelEvent;
 export 'src/events/messages/drag_end_event.dart' show DragEndEvent;
 export 'src/events/messages/drag_start_event.dart' show DragStartEvent;
 export 'src/events/messages/drag_update_event.dart' show DragUpdateEvent;
+export 'src/events/messages/long_press_cancel_event.dart'
+    show LongPressCancelEvent;
+export 'src/events/messages/long_press_end_event.dart' show LongPressEndEvent;
+export 'src/events/messages/long_press_move_update_event.dart'
+    show LongPressMoveUpdateEvent;
+export 'src/events/messages/long_press_start_event.dart'
+    show LongPressStartEvent;
 export 'src/events/messages/pointer_move_event.dart' show PointerMoveEvent;
 export 'src/events/messages/scale_end_event.dart' show ScaleEndEvent;
 export 'src/events/messages/scale_start_event.dart' show ScaleStartEvent;

--- a/packages/flame/lib/src/events/component_mixins/long_press_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/long_press_callbacks.dart
@@ -1,0 +1,56 @@
+import 'package:flame/components.dart';
+import 'package:flame/src/events/flame_game_mixins/long_press_dispatcher.dart';
+import 'package:flame/src/events/messages/long_press_cancel_event.dart';
+import 'package:flame/src/events/messages/long_press_end_event.dart';
+import 'package:flame/src/events/messages/long_press_move_update_event.dart';
+import 'package:flame/src/events/messages/long_press_start_event.dart';
+import 'package:flutter/foundation.dart';
+
+/// This mixin can be added to a [Component] allowing it to receive
+/// long-press events.
+///
+/// In addition to adding this mixin, the component must also implement the
+/// [containsLocalPoint] method — only events that occur on top of the
+/// component will be delivered.
+///
+/// The following callbacks are available:
+/// - [onLongPressStart]: called when the long press gesture is recognized.
+/// - [onLongPressMoveUpdate]: called when the pointer moves during an active
+///   long press.
+/// - [onLongPressEnd]: called when the pointer is lifted after a long press.
+/// - [onLongPressCancel]: called if the gesture is cancelled before completion.
+mixin LongPressCallbacks on Component {
+  bool _isLongPressing = false;
+
+  /// Returns true while a long press gesture is active on this component.
+  bool get isLongPressing => _isLongPressing;
+
+  @mustCallSuper
+  void onLongPressStart(LongPressStartEvent event) {
+    _isLongPressing = true;
+  }
+
+  void onLongPressMoveUpdate(LongPressMoveUpdateEvent event) {}
+
+  @mustCallSuper
+  void onLongPressEnd(LongPressEndEvent event) {
+    _isLongPressing = false;
+  }
+
+  @mustCallSuper
+  void onLongPressCancel(LongPressCancelEvent event) {
+    _isLongPressing = false;
+  }
+
+  @override
+  @mustCallSuper
+  void onMount() {
+    super.onMount();
+    final game = findRootGame()!;
+    if (game.findByKey(const LongPressDispatcherKey()) == null) {
+      final dispatcher = LongPressDispatcher();
+      game.registerKey(const LongPressDispatcherKey(), dispatcher);
+      game.add(dispatcher);
+    }
+  }
+}

--- a/packages/flame/lib/src/events/flame_game_mixins/long_press_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/long_press_dispatcher.dart
@@ -1,0 +1,159 @@
+import 'package:flame/components.dart';
+import 'package:flame/src/events/component_mixins/long_press_callbacks.dart';
+import 'package:flame/src/events/messages/long_press_cancel_event.dart';
+import 'package:flame/src/events/messages/long_press_end_event.dart';
+import 'package:flame/src/events/messages/long_press_move_update_event.dart';
+import 'package:flame/src/events/messages/long_press_start_event.dart';
+import 'package:flame/src/events/tagged_component.dart';
+import 'package:flame/src/game/flame_game.dart';
+import 'package:flutter/gestures.dart';
+import 'package:meta/meta.dart';
+
+/// A component that dispatches long-press gesture events to components
+/// that use the [LongPressCallbacks] mixin. It will be attached to the
+/// [FlameGame] instance automatically whenever any [LongPressCallbacks]
+/// components are mounted into the component tree.
+class LongPressDispatcher extends Component {
+  /// Records all components currently being long-pressed, keyed by pointerId.
+  final Set<TaggedComponent<LongPressCallbacks>> _records = {};
+
+  FlameGame get game => parent! as FlameGame;
+
+  /// Monotonically increasing id assigned to each new long press gesture.
+  int _nextPointerId = 0;
+
+  /// The pointer id of the current (or most recent) long press gesture.
+  int _currentPointerId = 0;
+
+  /// Tracks the previous global position so we can compute frame-to-frame
+  /// deltas (Flutter's LongPressMoveUpdateDetails does not provide a delta).
+  Offset _previousGlobalPosition = Offset.zero;
+
+  @mustCallSuper
+  void onLongPressStart(LongPressStartEvent event) {
+    event.deliverAtPoint(
+      rootComponent: game,
+      eventHandler: (LongPressCallbacks component) {
+        _records.add(TaggedComponent(event.pointerId, component));
+        component.onLongPressStart(event);
+      },
+    );
+  }
+
+  @mustCallSuper
+  void onLongPressMoveUpdate(LongPressMoveUpdateEvent event) {
+    final delivered = <TaggedComponent<LongPressCallbacks>>{};
+    event.deliverAtPoint(
+      rootComponent: game,
+      deliverToAll: true,
+      eventHandler: (LongPressCallbacks component) {
+        final record = TaggedComponent(event.pointerId, component);
+        if (_records.contains(record)) {
+          component.onLongPressMoveUpdate(event);
+          delivered.add(record);
+        }
+      },
+    );
+    for (final record in _records) {
+      if (record.pointerId == event.pointerId && !delivered.contains(record)) {
+        record.component.onLongPressMoveUpdate(event);
+      }
+    }
+  }
+
+  @mustCallSuper
+  void onLongPressEnd(LongPressEndEvent event) {
+    _records.removeWhere((record) {
+      if (record.pointerId == event.pointerId) {
+        record.component.onLongPressEnd(event);
+        return true;
+      }
+      return false;
+    });
+  }
+
+  @mustCallSuper
+  void onLongPressCancel(LongPressCancelEvent event) {
+    _records.removeWhere((record) {
+      if (record.pointerId == event.pointerId) {
+        record.component.onLongPressCancel(event);
+        return true;
+      }
+      return false;
+    });
+  }
+
+  //#region Gesture recognizer handlers
+
+  @internal
+  void handleLongPressStart(LongPressStartDetails details) {
+    _currentPointerId = _nextPointerId++;
+    _previousGlobalPosition = details.globalPosition;
+    onLongPressStart(
+      LongPressStartEvent(_currentPointerId, game, details),
+    );
+  }
+
+  @internal
+  void handleLongPressMoveUpdate(LongPressMoveUpdateDetails details) {
+    onLongPressMoveUpdate(
+      LongPressMoveUpdateEvent(
+        _currentPointerId,
+        game,
+        details,
+        previousGlobalPosition: _previousGlobalPosition,
+      ),
+    );
+    _previousGlobalPosition = details.globalPosition;
+  }
+
+  @internal
+  void handleLongPressEnd(LongPressEndDetails details) {
+    onLongPressEnd(
+      LongPressEndEvent(_currentPointerId, game, details),
+    );
+  }
+
+  @internal
+  void handleLongPressCancel() {
+    onLongPressCancel(
+      LongPressCancelEvent(_currentPointerId),
+    );
+  }
+
+  //#endregion
+
+  @override
+  void onMount() {
+    game.gestureDetectors.add<LongPressGestureRecognizer>(
+      LongPressGestureRecognizer.new,
+      (LongPressGestureRecognizer instance) {
+        instance
+          ..onLongPressStart = handleLongPressStart
+          ..onLongPressMoveUpdate = handleLongPressMoveUpdate
+          ..onLongPressEnd = handleLongPressEnd
+          ..onLongPressCancel = handleLongPressCancel;
+      },
+    );
+    super.onMount();
+  }
+
+  @override
+  void onRemove() {
+    game.gestureDetectors.remove<LongPressGestureRecognizer>();
+    game.unregisterKey(const LongPressDispatcherKey());
+    super.onRemove();
+  }
+}
+
+/// Unique key for the [LongPressDispatcher] so the game can identify it.
+class LongPressDispatcherKey implements ComponentKey {
+  const LongPressDispatcherKey();
+
+  @override
+  int get hashCode => 71825634; // arbitrary unique number
+
+  @override
+  bool operator ==(Object other) =>
+      other is LongPressDispatcherKey && other.hashCode == hashCode;
+}

--- a/packages/flame/lib/src/events/messages/long_press_cancel_event.dart
+++ b/packages/flame/lib/src/events/messages/long_press_cancel_event.dart
@@ -1,0 +1,16 @@
+import 'package:flame/src/events/messages/event.dart';
+
+/// The event propagated through the Flame engine when a long press gesture
+/// is cancelled before completing.
+///
+/// This may happen if the pointer moves too far before the long press
+/// duration elapses, or if the gesture is otherwise interrupted.
+class LongPressCancelEvent extends Event<void> {
+  LongPressCancelEvent(this.pointerId) : super(raw: null);
+
+  /// The id of the gesture that was cancelled.
+  final int pointerId;
+
+  @override
+  String toString() => 'LongPressCancelEvent(pointerId: $pointerId)';
+}

--- a/packages/flame/lib/src/events/messages/long_press_end_event.dart
+++ b/packages/flame/lib/src/events/messages/long_press_end_event.dart
@@ -1,0 +1,29 @@
+import 'package:flame/extensions.dart';
+import 'package:flame/src/events/messages/position_event.dart';
+import 'package:flutter/gestures.dart';
+
+/// The event propagated through the Flame engine when a long press gesture
+/// ends (the user lifts their pointer after a long press).
+///
+/// This is a [PositionEvent], where the position is the point where the
+/// pointer was lifted.
+class LongPressEndEvent extends PositionEvent<LongPressEndDetails> {
+  LongPressEndEvent(this.pointerId, super.game, LongPressEndDetails details)
+    : velocity = details.velocity.pixelsPerSecond.toVector2(),
+      super(
+        raw: details,
+        devicePosition: details.globalPosition.toVector2(),
+      );
+
+  /// The unique identifier for this long press gesture.
+  final int pointerId;
+
+  /// The velocity of the pointer at the time the long press ended.
+  final Vector2 velocity;
+
+  @override
+  String toString() =>
+      'LongPressEndEvent(canvasPosition: $canvasPosition, '
+      'devicePosition: $devicePosition, '
+      'pointerId: $pointerId, velocity: $velocity)';
+}

--- a/packages/flame/lib/src/events/messages/long_press_move_update_event.dart
+++ b/packages/flame/lib/src/events/messages/long_press_move_update_event.dart
@@ -1,0 +1,41 @@
+import 'package:flame/extensions.dart';
+import 'package:flame/src/events/messages/displacement_event.dart';
+import 'package:flutter/gestures.dart';
+
+/// The event propagated through the Flame engine when the user moves their
+/// pointer during an active long press gesture.
+///
+/// This is a [DisplacementEvent] whose start/end positions represent a
+/// frame-to-frame delta, matching the semantics of `DragUpdateEvent`.
+/// Use [localDelta] to move a component to follow the pointer.
+class LongPressMoveUpdateEvent
+    extends DisplacementEvent<LongPressMoveUpdateDetails> {
+  /// Creates a [LongPressMoveUpdateEvent].
+  ///
+  /// [previousGlobalPosition] is the global position from the previous
+  /// move-update (or the start position for the first update). This is used
+  /// to compute the frame-to-frame delta.
+  LongPressMoveUpdateEvent(
+    this.pointerId,
+    super.game,
+    LongPressMoveUpdateDetails details, {
+    required Offset previousGlobalPosition,
+  }) : offsetFromOrigin = details.offsetFromOrigin.toVector2(),
+       super(
+         raw: details,
+         deviceStartPosition: previousGlobalPosition.toVector2(),
+         deviceEndPosition: details.globalPosition.toVector2(),
+       );
+
+  /// The unique identifier for this long press gesture.
+  final int pointerId;
+
+  /// The offset from the initial long press contact point.
+  final Vector2 offsetFromOrigin;
+
+  @override
+  String toString() =>
+      'LongPressMoveUpdateEvent(canvasEndPosition: $canvasEndPosition, '
+      'delta: $localDelta, '
+      'pointerId: $pointerId)';
+}

--- a/packages/flame/lib/src/events/messages/long_press_start_event.dart
+++ b/packages/flame/lib/src/events/messages/long_press_start_event.dart
@@ -1,0 +1,28 @@
+import 'package:flame/extensions.dart';
+import 'package:flame/src/events/messages/position_event.dart';
+import 'package:flutter/gestures.dart';
+
+/// The event propagated through the Flame engine when the user completes
+/// a long press gesture (i.e. the pointer has been held down long enough
+/// to be recognized as a long press).
+///
+/// This is a [PositionEvent], where the position is the point of contact.
+class LongPressStartEvent extends PositionEvent<LongPressStartDetails> {
+  LongPressStartEvent(this.pointerId, super.game, LongPressStartDetails details)
+    : super(
+        raw: details,
+        devicePosition: details.globalPosition.toVector2(),
+      );
+
+  /// The unique identifier for this long press gesture.
+  ///
+  /// Subsequent move update, end, or cancel events will carry the same
+  /// pointer id.
+  final int pointerId;
+
+  @override
+  String toString() =>
+      'LongPressStartEvent(canvasPosition: $canvasPosition, '
+      'devicePosition: $devicePosition, '
+      'pointerId: $pointerId)';
+}

--- a/packages/flame/test/events/component_mixins/long_press_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/long_press_callbacks_test.dart
@@ -1,0 +1,274 @@
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
+import 'package:flame/game.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LongPressCallbacks', () {
+    testWithFlameGame(
+      'can be added to a FlameGame',
+      (game) async {
+        await game.ensureAdd(_LongPressComponent());
+        await game.ready();
+
+        _hasDispatcher(game);
+      },
+    );
+
+    testWithFlameGame(
+      'receives long press start on component',
+      (game) async {
+        final component = _LongPressComponent(
+          position: Vector2.all(10),
+          size: Vector2.all(10),
+        );
+        await game.ensureAdd(component);
+
+        _hasDispatcher(game);
+
+        _longPressStart(game, const Offset(15, 15));
+        expect(component.startCount, 1);
+        expect(component.isLongPressing, isTrue);
+      },
+    );
+
+    testWithFlameGame(
+      'does not receive events outside bounds',
+      (game) async {
+        final component = _LongPressComponent(
+          position: Vector2.all(10),
+          size: Vector2.all(10),
+        );
+        await game.ensureAdd(component);
+
+        _longPressStart(game, const Offset(5, 5));
+        expect(component.startCount, 0);
+        expect(component.isLongPressing, isFalse);
+      },
+    );
+
+    testWithFlameGame(
+      'full lifecycle: start, move, end',
+      (game) async {
+        final component = _LongPressComponent(
+          position: Vector2.all(10),
+          size: Vector2.all(10),
+        );
+        await game.ensureAdd(component);
+        final dispatcher = game.firstChild<LongPressDispatcher>()!;
+
+        dispatcher.onLongPressStart(
+          createLongPressStartEvent(
+            game: game,
+            globalPosition: const Offset(15, 15),
+          ),
+        );
+        expect(component.startCount, 1);
+        expect(component.isLongPressing, isTrue);
+
+        dispatcher.onLongPressMoveUpdate(
+          createLongPressMoveUpdateEvent(
+            game: game,
+            globalPosition: const Offset(16, 16),
+            offsetFromOrigin: const Offset(1, 1),
+          ),
+        );
+        expect(component.moveUpdateCount, 1);
+
+        dispatcher.onLongPressEnd(
+          createLongPressEndEvent(
+            game: game,
+            globalPosition: const Offset(16, 16),
+          ),
+        );
+        expect(component.endCount, 1);
+        expect(component.isLongPressing, isFalse);
+      },
+    );
+
+    testWithFlameGame(
+      'cancel resets isLongPressing',
+      (game) async {
+        final component = _LongPressComponent(
+          position: Vector2.all(10),
+          size: Vector2.all(10),
+        );
+        await game.ensureAdd(component);
+        final dispatcher = game.firstChild<LongPressDispatcher>()!;
+
+        // Use handleLongPressStart to get the internally-assigned pointerId
+        dispatcher.handleLongPressStart(
+          const LongPressStartDetails(
+            globalPosition: Offset(15, 15),
+            localPosition: Offset(15, 15),
+          ),
+        );
+        expect(component.isLongPressing, isTrue);
+
+        dispatcher.handleLongPressCancel();
+        expect(component.cancelCount, 1);
+        expect(component.isLongPressing, isFalse);
+      },
+    );
+
+    testWithFlameGame(
+      'move update not delivered without start',
+      (game) async {
+        final component = _LongPressComponent(
+          position: Vector2.all(10),
+          size: Vector2.all(10),
+        );
+        await game.ensureAdd(component);
+        final dispatcher = game.firstChild<LongPressDispatcher>()!;
+
+        dispatcher.onLongPressMoveUpdate(
+          createLongPressMoveUpdateEvent(
+            game: game,
+            globalPosition: const Offset(15, 15),
+          ),
+        );
+        expect(component.moveUpdateCount, 0);
+      },
+    );
+
+    testWithFlameGame(
+      'overlapping components both receive start events',
+      (game) async {
+        final c1 = _LongPressComponent(
+          position: Vector2.all(10),
+          size: Vector2.all(20),
+        );
+        final c2 = _LongPressComponent(
+          position: Vector2.all(10),
+          size: Vector2.all(20),
+        );
+        game.add(c1);
+        game.add(c2);
+        await game.ready();
+
+        _longPressStart(game, const Offset(15, 15));
+        // deliverAtPoint only delivers to the topmost component by default
+        // (deliverToAll defaults to false for non-scroll events)
+        expect(c1.startCount + c2.startCount, 1);
+      },
+    );
+
+    testWithGame(
+      'FlameGame with LongPressCallbacks receives events',
+      _LongPressGame.new,
+      (game) async {
+        _hasDispatcher(game);
+
+        _longPressStart(game, const Offset(15, 15));
+        expect(game.startCount, 1);
+        expect(game.isLongPressing, isTrue);
+      },
+    );
+
+    testWithFlameGame(
+      'dispatcher is removed when last component unmounts',
+      (game) async {
+        final component = _LongPressComponent(
+          position: Vector2.all(10),
+          size: Vector2.all(10),
+        );
+        await game.ensureAdd(component);
+        _hasDispatcher(game);
+
+        component.removeFromParent();
+        await game.ready();
+
+        // Dispatcher stays as it is managed by the game, not by unmounting
+        _hasDispatcher(game);
+      },
+    );
+
+    testWidgets(
+      'long press via gesture recognizer',
+      (tester) async {
+        final component = _LongPressComponent(
+          position: Vector2.zero(),
+          size: Vector2.all(800),
+        );
+        final game = FlameGame(children: [component]);
+        await tester.pumpWidget(GameWidget(game: game));
+        await tester.pump();
+        await tester.pump();
+
+        expect(component.isMounted, isTrue);
+        _hasDispatcher(game);
+
+        // Simulate a long press gesture through the widget
+        final center = tester.getCenter(find.byType(GameWidget<FlameGame>));
+        final gesture = await tester.startGesture(center);
+        // Wait for long press to be recognized
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+        await gesture.up();
+        await tester.pump();
+
+        expect(component.startCount, 1);
+        expect(component.endCount, 1);
+      },
+    );
+  });
+}
+
+void _longPressStart(FlameGame game, Offset position) {
+  game.firstChild<LongPressDispatcher>()!.handleLongPressStart(
+    LongPressStartDetails(
+      globalPosition: position,
+      localPosition: position,
+    ),
+  );
+}
+
+void _hasDispatcher(FlameGame game) {
+  expect(
+    game.children.whereType<LongPressDispatcher>(),
+    hasLength(1),
+  );
+}
+
+class _LongPressComponent extends PositionComponent with LongPressCallbacks {
+  _LongPressComponent({super.position, super.size});
+
+  int startCount = 0;
+  int moveUpdateCount = 0;
+  int endCount = 0;
+  int cancelCount = 0;
+
+  @override
+  void onLongPressStart(LongPressStartEvent event) {
+    super.onLongPressStart(event);
+    startCount++;
+  }
+
+  @override
+  void onLongPressMoveUpdate(LongPressMoveUpdateEvent event) {
+    moveUpdateCount++;
+  }
+
+  @override
+  void onLongPressEnd(LongPressEndEvent event) {
+    super.onLongPressEnd(event);
+    endCount++;
+  }
+
+  @override
+  void onLongPressCancel(LongPressCancelEvent event) {
+    super.onLongPressCancel(event);
+    cancelCount++;
+  }
+}
+
+class _LongPressGame extends FlameGame with LongPressCallbacks {
+  int startCount = 0;
+
+  @override
+  void onLongPressStart(LongPressStartEvent event) {
+    super.onLongPressStart(event);
+    startCount++;
+  }
+}

--- a/packages/flame_test/lib/flame_test.dart
+++ b/packages/flame_test/lib/flame_test.dart
@@ -12,6 +12,7 @@ export 'src/fails_assert.dart';
 export 'src/flame_test.dart';
 export 'src/mock_gesture_events.dart';
 export 'src/mock_image.dart';
+export 'src/mock_long_press_events.dart';
 export 'src/mock_pointer_move_event.dart';
 export 'src/mock_scroll_event.dart';
 export 'src/mock_tap_drag_events.dart';

--- a/packages/flame_test/lib/src/mock_long_press_events.dart
+++ b/packages/flame_test/lib/src/mock_long_press_events.dart
@@ -1,0 +1,65 @@
+import 'package:flame/events.dart';
+import 'package:flame/game.dart';
+import 'package:flutter/gestures.dart';
+
+LongPressStartEvent createLongPressStartEvent({
+  required Game game,
+  int? pointerId,
+  Offset? globalPosition,
+  Offset? localPosition,
+}) {
+  return LongPressStartEvent(
+    pointerId ?? 1,
+    game,
+    LongPressStartDetails(
+      localPosition: localPosition ?? Offset.zero,
+      globalPosition: globalPosition ?? Offset.zero,
+    ),
+  );
+}
+
+LongPressMoveUpdateEvent createLongPressMoveUpdateEvent({
+  required Game game,
+  int? pointerId,
+  Offset? globalPosition,
+  Offset? localPosition,
+  Offset? offsetFromOrigin,
+  Offset? localOffsetFromOrigin,
+  Offset? previousGlobalPosition,
+}) {
+  return LongPressMoveUpdateEvent(
+    pointerId ?? 1,
+    game,
+    LongPressMoveUpdateDetails(
+      localPosition: localPosition ?? Offset.zero,
+      globalPosition: globalPosition ?? Offset.zero,
+      offsetFromOrigin: offsetFromOrigin ?? Offset.zero,
+      localOffsetFromOrigin: localOffsetFromOrigin ?? Offset.zero,
+    ),
+    previousGlobalPosition: previousGlobalPosition ?? Offset.zero,
+  );
+}
+
+LongPressEndEvent createLongPressEndEvent({
+  required Game game,
+  int? pointerId,
+  Offset? globalPosition,
+  Offset? localPosition,
+  Velocity? velocity,
+}) {
+  return LongPressEndEvent(
+    pointerId ?? 1,
+    game,
+    LongPressEndDetails(
+      localPosition: localPosition ?? Offset.zero,
+      globalPosition: globalPosition ?? Offset.zero,
+      velocity: velocity ?? Velocity.zero,
+    ),
+  );
+}
+
+LongPressCancelEvent createLongPressCancelEvent({
+  int? pointerId,
+}) {
+  return LongPressCancelEvent(pointerId ?? 1);
+}


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description

<!-- End of exclude from commit message -->
Following up on [our events master plan](https://docs.google.com/document/d/1nBUup9QCPioVwWL1zs79z1hWF882tAYfNywFMdye2Qc).

This adds `LongPressCallbacks` and necessary infrastructure to make it work.

This adds an alternative to the old `LongPressDetector` (which we can deprecate later), e.g.:

```dart
class MyGame extends FlameGame with LongPressDetector {
  @override
  void onLongPressStart(LongPressStartInfo info) {
    // game-level handling
  }
}
```

In `LongPressCallbacks` following the newer event system:

```dart
class LongPressableSquare extends RectangleComponent with LongPressCallbacks {
  @override
  void onLongPressStart(LongPressStartEvent event) {
    // component-level handling, with hit detection
  }

  @override
  void onLongPressMoveUpdate(LongPressMoveUpdateEvent event) {
    position += event.localDelta;
  }

  @override
  void onLongPressEnd(LongPressEndEvent event) {
    // long press finished
  }
}
```

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
