### PR TITLE
refactor: Make GestureDetectorBuilder and detector/callback registering more resilient

### DIFF
--- a/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/double_tap_callbacks.dart
@@ -10,6 +10,8 @@ import 'package:flame/events.dart';
 /// At present, flutter detects only one double-tap events simultaneously.
 /// This means that if you're double-tapping two [DoubleTapCallbacks] located
 /// far away from each other, only one callback will be fired (or none).
+///
+/// This callback uses [DoubleTapDispatcher] to route events.
 mixin DoubleTapCallbacks on Component {
   /// This triggers when the pointer stops contacting the device after the
   /// second tap.
@@ -25,11 +27,6 @@ mixin DoubleTapCallbacks on Component {
   @override
   void onMount() {
     super.onMount();
-    final game = findRootGame()!;
-    if (game.findByKey(const DoubleTapDispatcherKey()) == null) {
-      final dispatcher = DoubleTapDispatcher();
-      game.registerKey(const DoubleTapDispatcherKey(), dispatcher);
-      game.add(dispatcher);
-    }
+    DoubleTapDispatcher.addDispatcher(this);
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/drag_callbacks.dart
@@ -10,6 +10,8 @@ import 'package:meta/meta.dart';
 /// the component.
 ///
 /// This mixin is the replacement of the Draggable mixin.
+///
+/// This callback uses [MultiDragDispatcher] to route events.
 mixin DragCallbacks on Component {
   bool _isDragged = false;
 
@@ -61,11 +63,6 @@ mixin DragCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    final game = findRootGame()!;
-    if (game.findByKey(const MultiDragDispatcherKey()) == null) {
-      final dispatcher = MultiDragDispatcher();
-      game.registerKey(const MultiDragDispatcherKey(), dispatcher);
-      game.add(dispatcher);
-    }
+    MultiDragDispatcher.addDispatcher(this);
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/hover_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/hover_callbacks.dart
@@ -11,6 +11,8 @@ import 'package:meta/meta.dart';
 /// component.
 ///
 /// This mixin is the replacement of the Hoverable mixin.
+///
+/// This callback uses [PointerMoveDispatcher] to route events.
 mixin HoverCallbacks on Component implements PointerMoveCallbacks {
   bool _isHovered = false;
 
@@ -56,6 +58,6 @@ mixin HoverCallbacks on Component implements PointerMoveCallbacks {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    PointerMoveCallbacks.onMountHandler(this);
+    PointerMoveDispatcher.addDispatcher(this);
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/long_press_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/long_press_callbacks.dart
@@ -19,6 +19,8 @@ import 'package:flutter/foundation.dart';
 ///   long press.
 /// - [onLongPressEnd]: called when the pointer is lifted after a long press.
 /// - [onLongPressCancel]: called if the gesture is cancelled before completion.
+///
+/// This callback uses [LongPressDispatcher] to route events.
 mixin LongPressCallbacks on Component {
   bool _isLongPressing = false;
 
@@ -46,11 +48,6 @@ mixin LongPressCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    final game = findRootGame()!;
-    if (game.findByKey(const LongPressDispatcherKey()) == null) {
-      final dispatcher = LongPressDispatcher();
-      game.registerKey(const LongPressDispatcherKey(), dispatcher);
-      game.add(dispatcher);
-    }
+    LongPressDispatcher.addDispatcher(this);
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/pointer_move_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/pointer_move_callbacks.dart
@@ -4,6 +4,8 @@ import 'package:meta/meta.dart';
 
 /// This mixin can be added to a [Component] allowing it to receive
 /// pointer movement events.
+///
+/// This callback uses [PointerMoveDispatcher] to route events.
 mixin PointerMoveCallbacks on Component {
   void onPointerMove(PointerMoveEvent event) {}
 
@@ -13,16 +15,6 @@ mixin PointerMoveCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    onMountHandler(this);
-  }
-
-  static void onMountHandler(PointerMoveCallbacks instance) {
-    final game = instance.findRootGame()!;
-    const key = MouseMoveDispatcherKey();
-    if (game.findByKey(key) == null) {
-      final dispatcher = PointerMoveDispatcher();
-      game.registerKey(key, dispatcher);
-      game.add(dispatcher);
-    }
+    PointerMoveDispatcher.addDispatcher(this);
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/scale_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/scale_callbacks.dart
@@ -3,6 +3,7 @@ import 'package:flame/events.dart';
 import 'package:flame/src/events/flame_game_mixins/scale_dispatcher.dart';
 import 'package:flutter/foundation.dart';
 
+/// This callback uses [ScaleDispatcher] to route events.
 mixin ScaleCallbacks on Component {
   bool _isScaling = false;
 
@@ -25,11 +26,6 @@ mixin ScaleCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    final game = findRootGame()!;
-    if (game.findByKey(const ScaleDispatcherKey()) == null) {
-      final dispatcher = ScaleDispatcher();
-      game.registerKey(const ScaleDispatcherKey(), dispatcher);
-      game.add(dispatcher);
-    }
+    ScaleDispatcher.addDispatcher(this);
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/scroll_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/scroll_callbacks.dart
@@ -5,6 +5,8 @@ import 'package:meta/meta.dart';
 
 /// This mixin can be added to a [Component] allowing it to receive
 /// pointer scroll (mouse wheel) events.
+///
+/// This callback uses [ScrollDispatcher] to route events.
 mixin ScrollCallbacks on Component {
   void onScroll(ScrollEvent event) {}
 
@@ -12,16 +14,6 @@ mixin ScrollCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    onMountHandler(this);
-  }
-
-  static void onMountHandler(ScrollCallbacks instance) {
-    final game = instance.findRootGame()!;
-    const key = ScrollDispatcherKey();
-    if (game.findByKey(key) == null) {
-      final dispatcher = ScrollDispatcher();
-      game.registerKey(key, dispatcher);
-      game.add(dispatcher);
-    }
+    ScrollDispatcher.addDispatcher(this);
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/secondary_tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/secondary_tap_callbacks.dart
@@ -11,6 +11,8 @@ import 'package:meta/meta.dart';
 ///
 /// Note that FlameGame _is_ a [Component] and does implement
 /// [containsLocalPoint]; so this can be used at the game level.
+///
+/// This callback uses [SecondaryTapDispatcher] to route events.
 mixin SecondaryTapCallbacks on Component {
   void onSecondaryTapDown(SecondaryTapDownEvent event) {}
   void onSecondaryTapUp(SecondaryTapUpEvent event) {}
@@ -20,11 +22,6 @@ mixin SecondaryTapCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    final game = findRootGame()!;
-    if (game.findByKey(const SecondaryTapDispatcherKey()) == null) {
-      final dispatcher = SecondaryTapDispatcher();
-      game.registerKey(const SecondaryTapDispatcherKey(), dispatcher);
-      game.add(dispatcher);
-    }
+    SecondaryTapDispatcher.addDispatcher(this);
   }
 }

--- a/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
+++ b/packages/flame/lib/src/events/component_mixins/tap_callbacks.dart
@@ -10,6 +10,8 @@ import 'package:meta/meta.dart';
 ///
 /// Note that FlameGame _is_ a [Component] and does implement
 /// [containsLocalPoint]; so this can be used at the game level.
+///
+/// This callback uses [MultiTapDispatcher] to route events.
 mixin TapCallbacks on Component {
   void onTapDown(TapDownEvent event) {}
   void onLongTapDown(TapDownEvent event) {}
@@ -20,11 +22,6 @@ mixin TapCallbacks on Component {
   @mustCallSuper
   void onMount() {
     super.onMount();
-    final game = findRootGame()!;
-    if (game.findByKey(const MultiTapDispatcherKey()) == null) {
-      final dispatcher = MultiTapDispatcher();
-      game.registerKey(const MultiTapDispatcherKey(), dispatcher);
-      game.add(dispatcher);
-    }
+    MultiTapDispatcher.addDispatcher(this);
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/dispatcher.dart
@@ -1,0 +1,29 @@
+import 'package:flame/components.dart';
+import 'package:flame/src/game/flame_game.dart';
+import 'package:flutter/foundation.dart';
+
+abstract class Dispatcher<G extends FlameGame> extends Component
+    with HasGameReference<G> {
+  static void addDispatcher<T extends Component>(
+    Component component,
+    ComponentKey key,
+    T Function() create,
+  ) {
+    final game = component.findRootGame()!;
+    if (game.findByKey(key) != null) {
+      return;
+    }
+    final dispatcher = create();
+    game.registerKey(key, dispatcher);
+    game.add(dispatcher);
+  }
+
+  static void removeDispatcher(
+    FlameGame game,
+    ComponentKey key, {
+    VoidCallback? unregister,
+  }) {
+    unregister?.call();
+    game.unregisterKey(key);
+  }
+}

--- a/packages/flame/lib/src/events/flame_game_mixins/dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/dispatcher.dart
@@ -1,6 +1,5 @@
 import 'package:flame/components.dart';
 import 'package:flame/src/game/flame_game.dart';
-import 'package:flutter/foundation.dart';
 
 abstract class Dispatcher<G extends FlameGame> extends Component
     with HasGameReference<G> {
@@ -18,12 +17,7 @@ abstract class Dispatcher<G extends FlameGame> extends Component
     game.add(dispatcher);
   }
 
-  static void removeDispatcher(
-    FlameGame game,
-    ComponentKey key, {
-    VoidCallback? unregister,
-  }) {
-    unregister?.call();
+  static void removeDispatcher(FlameGame game, ComponentKey key) {
     game.unregisterKey(key);
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
@@ -1,6 +1,7 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
+import 'package:flame/src/events/flame_game_mixins/dispatcher.dart';
 import 'package:flutter/gestures.dart';
 
 class DoubleTapDispatcherKey implements ComponentKey {
@@ -18,7 +19,7 @@ class DoubleTapDispatcherKey implements ComponentKey {
 /// the component tree that is mixed with [DoubleTapCallbacks]. This will be
 /// attached to the [FlameGame] instance automatically whenever any
 /// [DoubleTapCallbacks] are mounted into the component tree.
-class DoubleTapDispatcher extends Component with HasGameReference<FlameGame> {
+class DoubleTapDispatcher extends Dispatcher<FlameGame> {
   final _components = <DoubleTapCallbacks>{};
 
   void _onDoubleTapDown(DoubleTapDownEvent event) {
@@ -45,7 +46,8 @@ class DoubleTapDispatcher extends Component with HasGameReference<FlameGame> {
   }
 
   static void addDispatcher(Component component) {
-    component.findRootGame()!.addDispatcher(
+    Dispatcher.addDispatcher(
+      component,
       const DoubleTapDispatcherKey(),
       DoubleTapDispatcher.new,
     );
@@ -67,8 +69,12 @@ class DoubleTapDispatcher extends Component with HasGameReference<FlameGame> {
 
   @override
   void onRemove() {
-    game.removeDispatcher<DoubleTapGestureRecognizer>(
+    Dispatcher.removeDispatcher(
+      game,
       const DoubleTapDispatcherKey(),
+      unregister: () {
+        game.gestureDetectors.unregister<DoubleTapGestureRecognizer>();
+      },
     );
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
@@ -44,9 +44,16 @@ class DoubleTapDispatcher extends Component with HasGameReference<FlameGame> {
     _components.clear();
   }
 
+  static void addDispatcher(Component component) {
+    component.findRootGame()!.addDispatcher(
+      const DoubleTapDispatcherKey(),
+      DoubleTapDispatcher.new,
+    );
+  }
+
   @override
   void onMount() {
-    game.gestureDetectors.add(
+    game.gestureDetectors.register<DoubleTapGestureRecognizer>(
       DoubleTapGestureRecognizer.new,
       (DoubleTapGestureRecognizer instance) {
         instance.onDoubleTapDown = (details) =>
@@ -60,7 +67,8 @@ class DoubleTapDispatcher extends Component with HasGameReference<FlameGame> {
 
   @override
   void onRemove() {
-    game.gestureDetectors.remove<DoubleTapGestureRecognizer>();
-    game.unregisterKey(const DoubleTapDispatcherKey());
+    game.removeDispatcher<DoubleTapGestureRecognizer>(
+      const DoubleTapDispatcherKey(),
+    );
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/double_tap_dispatcher.dart
@@ -69,12 +69,7 @@ class DoubleTapDispatcher extends Dispatcher<FlameGame> {
 
   @override
   void onRemove() {
-    Dispatcher.removeDispatcher(
-      game,
-      const DoubleTapDispatcherKey(),
-      unregister: () {
-        game.gestureDetectors.unregister<DoubleTapGestureRecognizer>();
-      },
-    );
+    game.gestureDetectors.unregister<DoubleTapGestureRecognizer>();
+    Dispatcher.removeDispatcher(game, const DoubleTapDispatcherKey());
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/long_press_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/long_press_dispatcher.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/src/events/component_mixins/long_press_callbacks.dart';
+import 'package:flame/src/events/flame_game_mixins/dispatcher.dart';
 import 'package:flame/src/events/messages/long_press_cancel_event.dart';
 import 'package:flame/src/events/messages/long_press_end_event.dart';
 import 'package:flame/src/events/messages/long_press_move_update_event.dart';
@@ -13,11 +14,9 @@ import 'package:meta/meta.dart';
 /// that use the [LongPressCallbacks] mixin. It will be attached to the
 /// [FlameGame] instance automatically whenever any [LongPressCallbacks]
 /// components are mounted into the component tree.
-class LongPressDispatcher extends Component {
+class LongPressDispatcher extends Dispatcher<FlameGame> {
   /// Records all components currently being long-pressed, keyed by pointerId.
   final Set<TaggedComponent<LongPressCallbacks>> _records = {};
-
-  FlameGame get game => parent! as FlameGame;
 
   /// Monotonically increasing id assigned to each new long press gesture.
   int _nextPointerId = 0;
@@ -124,7 +123,8 @@ class LongPressDispatcher extends Component {
   //#endregion
 
   static void addDispatcher(Component component) {
-    component.findRootGame()!.addDispatcher(
+    Dispatcher.addDispatcher(
+      component,
       const LongPressDispatcherKey(),
       LongPressDispatcher.new,
     );
@@ -147,8 +147,12 @@ class LongPressDispatcher extends Component {
 
   @override
   void onRemove() {
-    game.removeDispatcher<LongPressGestureRecognizer>(
+    Dispatcher.removeDispatcher(
+      game,
       const LongPressDispatcherKey(),
+      unregister: () {
+        game.gestureDetectors.unregister<LongPressGestureRecognizer>();
+      },
     );
     super.onRemove();
   }

--- a/packages/flame/lib/src/events/flame_game_mixins/long_press_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/long_press_dispatcher.dart
@@ -147,14 +147,8 @@ class LongPressDispatcher extends Dispatcher<FlameGame> {
 
   @override
   void onRemove() {
-    Dispatcher.removeDispatcher(
-      game,
-      const LongPressDispatcherKey(),
-      unregister: () {
-        game.gestureDetectors.unregister<LongPressGestureRecognizer>();
-      },
-    );
-    super.onRemove();
+    game.gestureDetectors.unregister<LongPressGestureRecognizer>();
+    Dispatcher.removeDispatcher(game, const LongPressDispatcherKey());
   }
 }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/long_press_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/long_press_dispatcher.dart
@@ -123,9 +123,16 @@ class LongPressDispatcher extends Component {
 
   //#endregion
 
+  static void addDispatcher(Component component) {
+    component.findRootGame()!.addDispatcher(
+      const LongPressDispatcherKey(),
+      LongPressDispatcher.new,
+    );
+  }
+
   @override
   void onMount() {
-    game.gestureDetectors.add<LongPressGestureRecognizer>(
+    game.gestureDetectors.register<LongPressGestureRecognizer>(
       LongPressGestureRecognizer.new,
       (LongPressGestureRecognizer instance) {
         instance
@@ -140,8 +147,9 @@ class LongPressDispatcher extends Component {
 
   @override
   void onRemove() {
-    game.gestureDetectors.remove<LongPressGestureRecognizer>();
-    game.unregisterKey(const LongPressDispatcherKey());
+    game.removeDispatcher<LongPressGestureRecognizer>(
+      const LongPressDispatcherKey(),
+    );
     super.onRemove();
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
@@ -206,13 +206,8 @@ class MultiDragDispatcher extends Dispatcher<FlameGame>
 
   @override
   void onRemove() {
-    Dispatcher.removeDispatcher(
-      game,
-      const MultiDragDispatcherKey(),
-      unregister: () {
-        game.gestureDetectors.unregister<ImmediateMultiDragGestureRecognizer>();
-      },
-    );
+    game.gestureDetectors.unregister<ImmediateMultiDragGestureRecognizer>();
+    Dispatcher.removeDispatcher(game, const MultiDragDispatcherKey());
     _dragUpdateController.close();
     _dragCancelController.close();
     _dragStartController.close();

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/src/events/flame_drag_adapter.dart';
+import 'package:flame/src/events/flame_game_mixins/dispatcher.dart';
 import 'package:flame/src/events/tagged_component.dart';
 import 'package:flame/src/game/flame_game.dart';
 import 'package:flame/src/game/game_render_box.dart';
@@ -24,7 +25,8 @@ class MultiDragDispatcherKey implements ComponentKey {
 /// [DragCallbacks] components in the component tree. It will be attached to
 /// the [FlameGame] instance automatically whenever any [DragCallbacks]
 /// components are mounted into the component tree.
-class MultiDragDispatcher extends Component implements MultiDragListener {
+class MultiDragDispatcher extends Dispatcher<FlameGame>
+    implements MultiDragListener {
   /// The record of all components currently being touched.
   final Set<TaggedComponent<DragCallbacks>> _records = {};
 
@@ -51,8 +53,6 @@ class MultiDragDispatcher extends Component implements MultiDragListener {
   );
 
   Stream<DragCancelEvent> get onCancel => _dragCancelController.stream;
-
-  FlameGame get game => parent! as FlameGame;
 
   /// Called when the user initiates a drag gesture, for example by touching the
   /// screen and then moving the finger.
@@ -187,7 +187,8 @@ class MultiDragDispatcher extends Component implements MultiDragListener {
   //#endregion
 
   static void addDispatcher(Component component) {
-    component.findRootGame()!.addDispatcher(
+    Dispatcher.addDispatcher(
+      component,
       const MultiDragDispatcherKey(),
       MultiDragDispatcher.new,
     );
@@ -205,8 +206,12 @@ class MultiDragDispatcher extends Component implements MultiDragListener {
 
   @override
   void onRemove() {
-    game.removeDispatcher<ImmediateMultiDragGestureRecognizer>(
+    Dispatcher.removeDispatcher(
+      game,
       const MultiDragDispatcherKey(),
+      unregister: () {
+        game.gestureDetectors.unregister<ImmediateMultiDragGestureRecognizer>();
+      },
     );
     _dragUpdateController.close();
     _dragCancelController.close();

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_drag_dispatcher.dart
@@ -186,9 +186,16 @@ class MultiDragDispatcher extends Component implements MultiDragListener {
 
   //#endregion
 
+  static void addDispatcher(Component component) {
+    component.findRootGame()!.addDispatcher(
+      const MultiDragDispatcherKey(),
+      MultiDragDispatcher.new,
+    );
+  }
+
   @override
   void onMount() {
-    game.gestureDetectors.add<ImmediateMultiDragGestureRecognizer>(
+    game.gestureDetectors.register<ImmediateMultiDragGestureRecognizer>(
       ImmediateMultiDragGestureRecognizer.new,
       (ImmediateMultiDragGestureRecognizer instance) {
         instance.onStart = (Offset point) => FlameDragAdapter(this, point);
@@ -198,8 +205,9 @@ class MultiDragDispatcher extends Component implements MultiDragListener {
 
   @override
   void onRemove() {
-    game.gestureDetectors.remove<ImmediateMultiDragGestureRecognizer>();
-    game.unregisterKey(const MultiDragDispatcherKey());
+    game.removeDispatcher<ImmediateMultiDragGestureRecognizer>(
+      const MultiDragDispatcherKey(),
+    );
     _dragUpdateController.close();
     _dragCancelController.close();
     _dragStartController.close();

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
@@ -1,6 +1,7 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/input.dart';
+import 'package:flame/src/events/flame_game_mixins/dispatcher.dart';
 import 'package:flame/src/events/tagged_component.dart';
 import 'package:flame/src/game/flame_game.dart';
 import 'package:flame/src/game/game_render_box.dart';
@@ -18,11 +19,10 @@ class MultiTapDispatcherKey implements ComponentKey {
       other is MultiTapDispatcherKey && other.hashCode == hashCode;
 }
 
-class MultiTapDispatcher extends Component implements MultiTapListener {
+class MultiTapDispatcher extends Dispatcher<FlameGame>
+    implements MultiTapListener {
   /// The record of all components currently being touched.
   final Set<TaggedComponent<TapCallbacks>> _record = {};
-
-  FlameGame get game => parent! as FlameGame;
 
   /// Called when the user touches the device screen within the game canvas,
   /// either with a finger, a stylus, or a mouse.
@@ -150,7 +150,8 @@ class MultiTapDispatcher extends Component implements MultiTapListener {
   //#endregion
 
   static void addDispatcher(Component component) {
-    component.findRootGame()!.addDispatcher(
+    Dispatcher.addDispatcher(
+      component,
       const MultiTapDispatcherKey(),
       MultiTapDispatcher.new,
     );
@@ -177,8 +178,12 @@ class MultiTapDispatcher extends Component implements MultiTapListener {
 
   @override
   void onRemove() {
-    game.removeDispatcher<MultiTapGestureRecognizer>(
+    Dispatcher.removeDispatcher(
+      game,
       const MultiTapDispatcherKey(),
+      unregister: () {
+        game.gestureDetectors.unregister<MultiTapGestureRecognizer>();
+      },
     );
   }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
@@ -178,13 +178,8 @@ class MultiTapDispatcher extends Dispatcher<FlameGame>
 
   @override
   void onRemove() {
-    Dispatcher.removeDispatcher(
-      game,
-      const MultiTapDispatcherKey(),
-      unregister: () {
-        game.gestureDetectors.unregister<MultiTapGestureRecognizer>();
-      },
-    );
+    game.gestureDetectors.unregister<MultiTapGestureRecognizer>();
+    Dispatcher.removeDispatcher(game, const MultiTapDispatcherKey());
   }
 
   @override

--- a/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/multi_tap_dispatcher.dart
@@ -149,9 +149,16 @@ class MultiTapDispatcher extends Component implements MultiTapListener {
 
   //#endregion
 
+  static void addDispatcher(Component component) {
+    component.findRootGame()!.addDispatcher(
+      const MultiTapDispatcherKey(),
+      MultiTapDispatcher.new,
+    );
+  }
+
   @override
   void onMount() {
-    game.gestureDetectors.add<MultiTapGestureRecognizer>(
+    game.gestureDetectors.register<MultiTapGestureRecognizer>(
       () => MultiTapGestureRecognizer(
         allowedButtonsFilter: (buttons) => buttons == kPrimaryButton,
       ),
@@ -170,8 +177,9 @@ class MultiTapDispatcher extends Component implements MultiTapListener {
 
   @override
   void onRemove() {
-    game.gestureDetectors.remove<MultiTapGestureRecognizer>();
-    game.unregisterKey(const MultiTapDispatcherKey());
+    game.removeDispatcher<MultiTapGestureRecognizer>(
+      const MultiTapDispatcherKey(),
+    );
   }
 
   @override

--- a/packages/flame/lib/src/events/flame_game_mixins/pointer_move_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/pointer_move_dispatcher.dart
@@ -45,6 +45,13 @@ class PointerMoveDispatcher extends Component {
     onMouseMove(PointerMoveEvent.fromPointerHoverEvent(game, event));
   }
 
+  static void addDispatcher(Component component) {
+    component.findRootGame()!.addDispatcher(
+      const MouseMoveDispatcherKey(),
+      PointerMoveDispatcher.new,
+    );
+  }
+
   @override
   void onMount() {
     game.mouseDetector = _handlePointerMove;

--- a/packages/flame/lib/src/events/flame_game_mixins/pointer_move_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/pointer_move_dispatcher.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
+import 'package:flame/src/events/flame_game_mixins/dispatcher.dart';
 import 'package:flame/src/events/tagged_component.dart';
 import 'package:flame/src/game/flame_game.dart';
 import 'package:flutter/gestures.dart' as flutter;
@@ -9,11 +10,9 @@ import 'package:meta/meta.dart';
 /// [PointerMoveCallbacks] components in the component tree. It will be attached
 /// to the [FlameGame] instance automatically whenever any
 /// [PointerMoveCallbacks] components are mounted into the component tree.
-class PointerMoveDispatcher extends Component {
+class PointerMoveDispatcher extends Dispatcher<FlameGame> {
   /// The record of all components currently being hovered.
   final Set<TaggedComponent<PointerMoveCallbacks>> _records = {};
-
-  FlameGame get game => parent! as FlameGame;
 
   @mustCallSuper
   void onMouseMove(PointerMoveEvent event) {
@@ -46,7 +45,8 @@ class PointerMoveDispatcher extends Component {
   }
 
   static void addDispatcher(Component component) {
-    component.findRootGame()!.addDispatcher(
+    Dispatcher.addDispatcher(
+      component,
       const MouseMoveDispatcherKey(),
       PointerMoveDispatcher.new,
     );
@@ -60,7 +60,7 @@ class PointerMoveDispatcher extends Component {
   @override
   void onRemove() {
     game.mouseDetector = null;
-    game.unregisterKey(const MouseMoveDispatcherKey());
+    Dispatcher.removeDispatcher(game, const MouseMoveDispatcherKey());
   }
 }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/scale_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/scale_dispatcher.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
+import 'package:flame/src/events/flame_game_mixins/dispatcher.dart';
 import 'package:flame/src/events/interfaces/scale_listener.dart';
 import 'package:flame/src/events/tagged_component.dart';
 import 'package:flame/src/game/game_widget/gesture_detector_builder.dart';
@@ -46,11 +47,9 @@ class ScaleDispatcherKey implements ComponentKey {
 /// implementing [ScaleCallbacks]. It will be attached to
 /// the [FlameGame] instance automatically whenever any [ScaleCallbacks]
 /// components are mounted into the component tree.
-class ScaleDispatcher extends Component implements ScaleListener {
+class ScaleDispatcher extends Dispatcher<FlameGame> implements ScaleListener {
   /// Records all components currently being scaled, keyed by pointerId.
   final Set<TaggedComponent<ScaleCallbacks>> _records = {};
-
-  FlameGame get game => parent! as FlameGame;
 
   /// Store the last drag events
   DragStartDetails? lastDragStart;
@@ -295,7 +294,8 @@ class ScaleDispatcher extends Component implements ScaleListener {
   //#endregion
 
   static void addDispatcher(Component component) {
-    component.findRootGame()!.addDispatcher(
+    Dispatcher.addDispatcher(
+      component,
       const ScaleDispatcherKey(),
       ScaleDispatcher.new,
     );
@@ -341,7 +341,13 @@ class ScaleDispatcher extends Component implements ScaleListener {
 
   @override
   void onRemove() {
-    game.removeDispatcher<ScaleGestureRecognizer>(const ScaleDispatcherKey());
+    Dispatcher.removeDispatcher(
+      game,
+      const ScaleDispatcherKey(),
+      unregister: () {
+        game.gestureDetectors.unregister<ScaleGestureRecognizer>();
+      },
+    );
     super.onRemove();
   }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/scale_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/scale_dispatcher.dart
@@ -341,13 +341,8 @@ class ScaleDispatcher extends Dispatcher<FlameGame> implements ScaleListener {
 
   @override
   void onRemove() {
-    Dispatcher.removeDispatcher(
-      game,
-      const ScaleDispatcherKey(),
-      unregister: () {
-        game.gestureDetectors.unregister<ScaleGestureRecognizer>();
-      },
-    );
+    game.gestureDetectors.unregister<ScaleGestureRecognizer>();
+    Dispatcher.removeDispatcher(game, const ScaleDispatcherKey());
     super.onRemove();
   }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/scale_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/scale_dispatcher.dart
@@ -294,9 +294,16 @@ class ScaleDispatcher extends Component implements ScaleListener {
 
   //#endregion
 
+  static void addDispatcher(Component component) {
+    component.findRootGame()!.addDispatcher(
+      const ScaleDispatcherKey(),
+      ScaleDispatcher.new,
+    );
+  }
+
   @override
   void onMount() {
-    game.gestureDetectors.add<ScaleGestureRecognizer>(
+    game.gestureDetectors.register<ScaleGestureRecognizer>(
       ScaleGestureRecognizer.new,
       (ScaleGestureRecognizer instance) {
         instance
@@ -334,7 +341,7 @@ class ScaleDispatcher extends Component implements ScaleListener {
 
   @override
   void onRemove() {
-    game.gestureDetectors.remove<ScaleGestureRecognizer>();
+    game.removeDispatcher<ScaleGestureRecognizer>(const ScaleDispatcherKey());
     super.onRemove();
   }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/scroll_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/scroll_dispatcher.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/src/events/component_mixins/scroll_callbacks.dart';
+import 'package:flame/src/events/flame_game_mixins/dispatcher.dart';
 import 'package:flame/src/events/messages/scroll_event.dart';
 import 'package:flame/src/game/flame_game.dart';
 import 'package:flutter/gestures.dart' as flutter;
@@ -9,9 +10,7 @@ import 'package:meta/meta.dart';
 /// [ScrollCallbacks] components in the component tree. It will be attached
 /// to the [FlameGame] instance automatically whenever any
 /// [ScrollCallbacks] components are mounted into the component tree.
-class ScrollDispatcher extends Component {
-  FlameGame get game => parent! as FlameGame;
-
+class ScrollDispatcher extends Dispatcher<FlameGame> {
   @mustCallSuper
   void onPointerScroll(ScrollEvent event) {
     event.deliverAtPoint(
@@ -28,7 +27,8 @@ class ScrollDispatcher extends Component {
   }
 
   static void addDispatcher(Component component) {
-    component.findRootGame()!.addDispatcher(
+    Dispatcher.addDispatcher(
+      component,
       const ScrollDispatcherKey(),
       ScrollDispatcher.new,
     );
@@ -42,7 +42,7 @@ class ScrollDispatcher extends Component {
   @override
   void onRemove() {
     game.scrollDetector = null;
-    game.unregisterKey(const ScrollDispatcherKey());
+    Dispatcher.removeDispatcher(game, const ScrollDispatcherKey());
   }
 }
 

--- a/packages/flame/lib/src/events/flame_game_mixins/scroll_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/scroll_dispatcher.dart
@@ -27,6 +27,13 @@ class ScrollDispatcher extends Component {
     onPointerScroll(ScrollEvent.fromPointerScrollEvent(game, event));
   }
 
+  static void addDispatcher(Component component) {
+    component.findRootGame()!.addDispatcher(
+      const ScrollDispatcherKey(),
+      ScrollDispatcher.new,
+    );
+  }
+
   @override
   void onMount() {
     game.scrollDetector = _handlePointerScroll;

--- a/packages/flame/lib/src/events/flame_game_mixins/secondary_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/secondary_tap_dispatcher.dart
@@ -71,12 +71,7 @@ class SecondaryTapDispatcher extends Dispatcher<FlameGame> {
 
   @override
   void onRemove() {
-    Dispatcher.removeDispatcher(
-      game,
-      const SecondaryTapDispatcherKey(),
-      unregister: () {
-        game.gestureDetectors.unregister<TapGestureRecognizer>();
-      },
-    );
+    game.gestureDetectors.unregister<TapGestureRecognizer>();
+    Dispatcher.removeDispatcher(game, const SecondaryTapDispatcherKey());
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/secondary_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/secondary_tap_dispatcher.dart
@@ -1,6 +1,7 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
+import 'package:flame/src/events/flame_game_mixins/dispatcher.dart';
 import 'package:flutter/gestures.dart';
 
 class SecondaryTapDispatcherKey implements ComponentKey {
@@ -19,8 +20,7 @@ class SecondaryTapDispatcherKey implements ComponentKey {
 /// [SecondaryTapCallbacks]. This will be attached to the [FlameGame] instance
 /// automatically whenever any [SecondaryTapCallbacks] are mounted into the
 /// component tree.
-class SecondaryTapDispatcher extends Component
-    with HasGameReference<FlameGame> {
+class SecondaryTapDispatcher extends Dispatcher<FlameGame> {
   final _components = <SecondaryTapCallbacks>{};
 
   void _onSecondaryTapDown(SecondaryTapDownEvent event) {
@@ -47,7 +47,8 @@ class SecondaryTapDispatcher extends Component
   }
 
   static void addDispatcher(Component component) {
-    component.findRootGame()!.addDispatcher(
+    Dispatcher.addDispatcher(
+      component,
       const SecondaryTapDispatcherKey(),
       SecondaryTapDispatcher.new,
     );
@@ -70,8 +71,12 @@ class SecondaryTapDispatcher extends Component
 
   @override
   void onRemove() {
-    game.removeDispatcher<TapGestureRecognizer>(
+    Dispatcher.removeDispatcher(
+      game,
       const SecondaryTapDispatcherKey(),
+      unregister: () {
+        game.gestureDetectors.unregister<TapGestureRecognizer>();
+      },
     );
   }
 }

--- a/packages/flame/lib/src/events/flame_game_mixins/secondary_tap_dispatcher.dart
+++ b/packages/flame/lib/src/events/flame_game_mixins/secondary_tap_dispatcher.dart
@@ -46,9 +46,16 @@ class SecondaryTapDispatcher extends Component
     _components.clear();
   }
 
+  static void addDispatcher(Component component) {
+    component.findRootGame()!.addDispatcher(
+      const SecondaryTapDispatcherKey(),
+      SecondaryTapDispatcher.new,
+    );
+  }
+
   @override
   void onMount() {
-    game.gestureDetectors.add(
+    game.gestureDetectors.register(
       TapGestureRecognizer.new,
       (TapGestureRecognizer instance) {
         instance.onSecondaryTapDown = (details) =>
@@ -63,7 +70,8 @@ class SecondaryTapDispatcher extends Component
 
   @override
   void onRemove() {
-    game.gestureDetectors.remove<TapGestureRecognizer>();
-    game.unregisterKey(const SecondaryTapDispatcherKey());
+    game.removeDispatcher<TapGestureRecognizer>(
+      const SecondaryTapDispatcherKey(),
+    );
   }
 }

--- a/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
+++ b/packages/flame/lib/src/events/game_mixins/multi_touch_drag_detector.dart
@@ -44,7 +44,7 @@ mixin MultiTouchDragDetector on Game implements MultiDragListener {
 
   @override
   void mount() {
-    gestureDetectors.add<ImmediateMultiDragGestureRecognizer>(
+    gestureDetectors.register<ImmediateMultiDragGestureRecognizer>(
       ImmediateMultiDragGestureRecognizer.new,
       (ImmediateMultiDragGestureRecognizer instance) {
         instance.onStart = (Offset point) => FlameDragAdapter(this, point);

--- a/packages/flame/lib/src/events/game_mixins/multi_touch_tap_detector.dart
+++ b/packages/flame/lib/src/events/game_mixins/multi_touch_tap_detector.dart
@@ -47,13 +47,4 @@ mixin MultiTouchTapDetector on Game implements MultiTapListener {
   }
 
   //#endregion
-
-  @override
-  void mount() {
-    gestureDetectors.add<MultiTapGestureRecognizer>(
-      MultiTapGestureRecognizer.new,
-      (MultiTapGestureRecognizer instance) {},
-    );
-    super.mount();
-  }
 }

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -9,6 +9,7 @@ import 'package:flame/src/devtools/dev_tools_service.dart';
 import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:flame/src/game/game.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 // TODO(spydon): Remove this import when flutter version is updated to 3.35.0
 // ignore: unnecessary_import
 import 'package:meta/meta.dart';
@@ -64,6 +65,28 @@ class FlameGame<W extends World> extends ComponentTreeRoot
     _camera.world = _world;
     add(_camera);
     add(_world);
+  }
+
+  /// Registers a dispatcher component for the given [key] if one does not
+  /// already exist.
+  ///
+  /// If no component is registered under [key], creates one via [create],
+  /// registers it under [key], and adds it to the game.
+  void addDispatcher(ComponentKey key, Component Function() create) {
+    if (findByKey(key) == null) {
+      final dispatcher = create();
+      registerKey(key, dispatcher);
+      add(dispatcher);
+    }
+  }
+
+  /// Removes a gesture-based dispatcher registered under [key].
+  ///
+  /// Unregisters the gesture recognizer of type [R] from the gesture detector
+  /// builder and removes [key] from the component key registry.
+  void removeDispatcher<R extends GestureRecognizer>(ComponentKey key) {
+    gestureDetectors.unregister<R>();
+    unregisterKey(key);
   }
 
   /// The [World] that the [camera] is rendering.

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -9,7 +9,6 @@ import 'package:flame/src/devtools/dev_tools_service.dart';
 import 'package:flame/src/effects/provider_interfaces.dart';
 import 'package:flame/src/game/game.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/gestures.dart';
 // TODO(spydon): Remove this import when flutter version is updated to 3.35.0
 // ignore: unnecessary_import
 import 'package:meta/meta.dart';
@@ -65,28 +64,6 @@ class FlameGame<W extends World> extends ComponentTreeRoot
     _camera.world = _world;
     add(_camera);
     add(_world);
-  }
-
-  /// Registers a dispatcher component for the given [key] if one does not
-  /// already exist.
-  ///
-  /// If no component is registered under [key], creates one via [create],
-  /// registers it under [key], and adds it to the game.
-  void addDispatcher(ComponentKey key, Component Function() create) {
-    if (findByKey(key) == null) {
-      final dispatcher = create();
-      registerKey(key, dispatcher);
-      add(dispatcher);
-    }
-  }
-
-  /// Removes a gesture-based dispatcher registered under [key].
-  ///
-  /// Unregisters the gesture recognizer of type [R] from the gesture detector
-  /// builder and removes [key] from the component key registry.
-  void removeDispatcher<R extends GestureRecognizer>(ComponentKey key) {
-    gestureDetectors.unregister<R>();
-    unregisterKey(key);
   }
 
   /// The [World] that the [camera] is rendering.

--- a/packages/flame/lib/src/game/game_widget/gesture_detector_builder.dart
+++ b/packages/flame/lib/src/game/game_widget/gesture_detector_builder.dart
@@ -7,42 +7,38 @@ import 'package:flutter/widgets.dart';
 class GestureDetectorBuilder {
   GestureDetectorBuilder([this._onChange]);
 
-  final Map<Type, GestureRecognizerFactory> _gestures = {};
-  final Map<Type, int> _counters = {};
+  final Map<Type, GestureRecognizerFactory> _factories = {};
   final void Function()? _onChange;
 
-  void add<T extends GestureRecognizer>(
+  /// Registers a gesture recognizer of type [T].
+  ///
+  /// Throws a [StateError] if [T] is already registered.
+  void register<T extends GestureRecognizer>(
     T Function() constructor,
     void Function(T) initializer,
   ) {
-    final count = _counters[T];
-    if (count == null) {
-      _gestures[T] = GestureRecognizerFactoryWithHandlers<T>(
-        constructor,
-        initializer,
-      );
-      _onChange?.call();
+    if (_factories.containsKey(T)) {
+      throw StateError('Recognizer of type $T is already registered.');
     }
-    _counters[T] = (count ?? 0) + 1;
+    _factories[T] = GestureRecognizerFactoryWithHandlers<T>(
+      constructor,
+      initializer,
+    );
+    _onChange?.call();
   }
 
-  void remove<T extends GestureRecognizer>() {
-    final count = _counters[T]!;
-    if (count == 1) {
-      _counters.remove(T);
-      _gestures.remove(T);
-      _onChange?.call();
-    } else {
-      _counters[T] = count - 1;
-    }
+  /// Removes the registration for type [T].
+  void unregister<T extends GestureRecognizer>() {
+    _factories.remove(T);
+    _onChange?.call();
   }
 
   Widget build(Widget child) {
-    if (_gestures.isEmpty) {
+    if (_factories.isEmpty) {
       return child;
     }
     return RawGestureDetector(
-      gestures: _gestures,
+      gestures: _factories,
       behavior: HitTestBehavior.deferToChild,
       child: child,
     );
@@ -54,7 +50,7 @@ class GestureDetectorBuilder {
     if (game is TapDetector ||
         game is SecondaryTapDetector ||
         game is TertiaryTapDetector) {
-      add(
+      register(
         TapGestureRecognizer.new,
         (TapGestureRecognizer instance) {
           // support for deprecated detectors
@@ -79,7 +75,7 @@ class GestureDetectorBuilder {
       );
     }
     if (game is DoubleTapDetector) {
-      add(
+      register(
         DoubleTapGestureRecognizer.new,
         (DoubleTapGestureRecognizer instance) {
           instance.onDoubleTap = game.onDoubleTap;
@@ -89,7 +85,7 @@ class GestureDetectorBuilder {
       );
     }
     if (game is LongPressDetector) {
-      add(
+      register(
         LongPressGestureRecognizer.new,
         (LongPressGestureRecognizer instance) {
           instance.onLongPress = game.onLongPress;
@@ -102,7 +98,7 @@ class GestureDetectorBuilder {
       );
     }
     if (game is VerticalDragDetector) {
-      add(
+      register(
         VerticalDragGestureRecognizer.new,
         (VerticalDragGestureRecognizer instance) {
           instance.onDown = game.handleVerticalDragDown;
@@ -114,7 +110,7 @@ class GestureDetectorBuilder {
       );
     }
     if (game is HorizontalDragDetector) {
-      add(
+      register(
         HorizontalDragGestureRecognizer.new,
         (HorizontalDragGestureRecognizer instance) {
           instance.onDown = game.handleHorizontalDragDown;
@@ -126,7 +122,7 @@ class GestureDetectorBuilder {
       );
     }
     if (game is ForcePressDetector) {
-      add(
+      register(
         ForcePressGestureRecognizer.new,
         (ForcePressGestureRecognizer instance) {
           instance.onStart = game.handleForcePressStart;
@@ -137,7 +133,7 @@ class GestureDetectorBuilder {
       );
     }
     if (game is PanDetector) {
-      add(
+      register(
         PanGestureRecognizer.new,
         (PanGestureRecognizer instance) {
           instance.onDown = game.handlePanDown;
@@ -149,7 +145,7 @@ class GestureDetectorBuilder {
       );
     }
     if (game is ScaleDetector) {
-      add(
+      register(
         ScaleGestureRecognizer.new,
         (ScaleGestureRecognizer instance) {
           instance.onStart = game.handleScaleStart;
@@ -159,7 +155,7 @@ class GestureDetectorBuilder {
       );
     }
     if (game is MultiTapListener) {
-      add(
+      register(
         MultiTapGestureRecognizer.new,
         (MultiTapGestureRecognizer instance) {
           final g = game as MultiTapListener;

--- a/packages/flame/test/game/game_widget/gesture_detector_builder_test.dart
+++ b/packages/flame/test/game/game_widget/gesture_detector_builder_test.dart
@@ -1,0 +1,86 @@
+import 'package:flame/src/game/game_widget/gesture_detector_builder.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('GestureDetectorBuilder', () {
+    test('register adds a recognizer factory', () {
+      var onChange = 0;
+      final builder = GestureDetectorBuilder(() => onChange++);
+
+      builder.register<TapGestureRecognizer>(
+        TapGestureRecognizer.new,
+        (_) {},
+      );
+
+      expect(onChange, 1);
+    });
+
+    test('register throws on duplicate type', () {
+      final builder = GestureDetectorBuilder(() {});
+
+      builder.register<TapGestureRecognizer>(
+        TapGestureRecognizer.new,
+        (_) {},
+      );
+
+      expect(
+        () => builder.register<TapGestureRecognizer>(
+          TapGestureRecognizer.new,
+          (_) {},
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('unregister removes the recognizer factory', () {
+      var onChange = 0;
+      final builder = GestureDetectorBuilder(() => onChange++);
+
+      builder.register<TapGestureRecognizer>(
+        TapGestureRecognizer.new,
+        (_) {},
+      );
+      expect(onChange, 1);
+
+      builder.unregister<TapGestureRecognizer>();
+      expect(onChange, 2);
+    });
+
+    test('can re-register after unregister', () {
+      var onChange = 0;
+      final builder = GestureDetectorBuilder(() => onChange++);
+
+      builder.register<LongPressGestureRecognizer>(
+        LongPressGestureRecognizer.new,
+        (_) {},
+      );
+      expect(onChange, 1);
+
+      builder.unregister<LongPressGestureRecognizer>();
+      expect(onChange, 2);
+
+      builder.register<LongPressGestureRecognizer>(
+        LongPressGestureRecognizer.new,
+        (_) {},
+      );
+      expect(onChange, 3);
+    });
+
+    test('different recognizer types can coexist', () {
+      var onChange = 0;
+      final builder = GestureDetectorBuilder(() => onChange++);
+
+      builder.register<TapGestureRecognizer>(
+        TapGestureRecognizer.new,
+        (_) {},
+      );
+      builder.register<LongPressGestureRecognizer>(
+        LongPressGestureRecognizer.new,
+        (_) {},
+      );
+
+      expect(onChange, 2);
+    });
+  });
+}


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Make GestureDetectorBuilder and detector/callback registering more resilient wrt to multiple registrations (callbacks that use the same detector).

This extracts a base class to dispatchers to share code and remove reundancies.
It also makes the code on *Callbacks themselves trivial, and accounts for duplication.
Before different callbacks could duplicate dispatchers. Now we properly guarantee dispatchers are singleton while allowing callbacks to require and use the same dispatcher. This is important for tertiary callbacks which will use the same underlying dispatcher as secondary.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->