### PR TITLE
chore: Bring back GitHub CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,11 +7,20 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+
 env:
   FLUTTER_MIN_VERSION: '3.41.0'
 
 jobs:
   # BEGIN LINTING STAGE
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+      - uses: bluefireteam/melos-action@v3
+      - run: melos run format-check
+
   analyze:
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +30,17 @@ jobs:
           flutter-version: ${{env.FLUTTER_MIN_VERSION}}
       - uses: bluefireteam/melos-action@v3
       - name: "Analyze with lowest supported version"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: true
+
+  analyze-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+      - uses: bluefireteam/melos-action@v3
+      - name: "Analyze with latest stable"
         uses: invertase/github-action-dart-analyzer@v3
         with:
           fatal-infos: true
@@ -49,3 +69,16 @@ jobs:
       - name: Run DCM
         run: dcm analyze .
   # END LINTING STAGE
+
+  # BEGIN TESTING STAGE
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          cache: true
+      - uses: bluefireteam/melos-action@v3
+      - name: Run tests
+        run: melos test
+  # END TESTING STAGE

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ A Flutter-based game engine.
 
 <p align="center">
   <a title="Pub" href="https://pub.dev/packages/flame"><img src="https://img.shields.io/pub/v/flame.svg?style=popout"/></a>
-  <a title="Shorebird CI" href="https://console.shorebird.dev/ci"><img src="https://api.shorebird.dev/api/v1/github/flame-engine/flame/badge.svg"/></a>
   <a title="Test" href="https://github.com/flame-engine/flame/actions?query=workflow%3Acicd+branch%3Amain"><img src="https://github.com/flame-engine/flame/actions/workflows/cicd.yml/badge.svg?branch=main&event=push"/></a>
   <a title="Discord" href="https://discord.gg/pxrBmy4"><img src="https://img.shields.io/discord/509714518008528896.svg"/></a>
   <a title="Melos" href="https://github.com/invertase/melos"><img src="https://img.shields.io/badge/maintained%20with-melos-f700ff.svg"/></a>


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Since we can't see the results clearly of shorebird CI, I propose we bring back the GitHub one.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->