### PR TITLE
chore: Bump rive on flame_rive to fix CI

### DIFF
--- a/packages/flame_rive/lib/flame_rive.dart
+++ b/packages/flame_rive/lib/flame_rive.dart
@@ -1,3 +1,3 @@
-export 'package:rive/rive.dart';
+export 'package:rive/rive.dart' hide RiveSemanticsMixin, RiveSemanticsWidget;
 
 export 'src/rive_component.dart';

--- a/packages/flame_rive/pubspec.yaml
+++ b/packages/flame_rive/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flame: ^1.37.0
   flutter:
     sdk: flutter
-  rive: ^0.14.0
+  rive: ^0.14.6
 
 dev_dependencies:
   dartdoc: ^9.0.0


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
A new rive patch version causes an analysis issue due to re-exporting internal components.
In order to fix we have to bump the version on pubspec as these classes didn't exist before so could not be hidden.

<!-- Exclude from commit message -->

On CI:

```
Dart Analyzer - Warnings
  /home/runner/work/flame/flame/packages/flame_rive/lib/flame_rive.dart:1:1 The member 'RiveSemanticsMixin' can't be exported as a part of a package's public API.
  Warning: Try using a hide clause to hide 'RiveSemanticsMixin'.
  See https://dart.dev/diagnostics/invalid_export_of_internal_element to learn more about this problem.
  
  /home/runner/work/flame/flame/packages/flame_rive/lib/flame_rive.dart:1:1 The member 'RiveSemanticsWidget' can't be exported as a part of a package's public API.
  Warning: Try using a hide clause to hide 'RiveSemanticsWidget'.
  See https://dart.dev/diagnostics/invalid_export_of_internal_element to learn more about this problem.
```

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->