### PR TITLE
fix: Reset srcPosition to zero on rasterized Sprite

### DIFF
--- a/packages/flame/lib/src/sprite.dart
+++ b/packages/flame/lib/src/sprite.dart
@@ -84,6 +84,7 @@ class Sprite {
       final cachedImage = imagesCache.fromCache(key);
       return Sprite(
         cachedImage,
+        srcPosition: Vector2.zero(),
         srcSize: srcSize,
       );
     }
@@ -93,6 +94,7 @@ class Sprite {
 
     return Sprite(
       rasterizedImage,
+      srcPosition: Vector2.zero(),
       srcSize: srcSize,
     );
   }

--- a/packages/flame/test/raster_sprite_test.dart
+++ b/packages/flame/test/raster_sprite_test.dart
@@ -44,6 +44,34 @@ void main() {
       expect(images.keys, hasLength(2));
     });
 
+    test(
+      'resets srcPosition to zero on the rasterized sprite (regression #3902)',
+      () async {
+        final images = Images();
+        final image = await loadImage('flame.png');
+        images.add('flame.png', image);
+
+        final atlasSprite = await Sprite.load(
+          'flame.png',
+          srcPosition: Vector2(10, 10),
+          srcSize: Vector2(20, 20),
+          images: images,
+        );
+
+        final rasterized = await atlasSprite.rasterize(images: images);
+
+        expect(rasterized.srcPosition, Vector2.zero());
+        expect(rasterized.srcSize, Vector2(20, 20));
+        expect(rasterized.src, const Rect.fromLTWH(0, 0, 20, 20));
+
+        // The cached branch must also produce a sprite with srcPosition (0,0)
+        // — the cached image is already cropped to srcSize.
+        final rasterizedAgain = await atlasSprite.rasterize(images: images);
+        expect(rasterizedAgain.srcPosition, Vector2.zero());
+        expect(rasterizedAgain.src, const Rect.fromLTWH(0, 0, 20, 20));
+      },
+    );
+
     group('when using a custom cache key', () {
       test('adds the image to the cache with the custom key', () async {
         final images = Images();


### PR DESCRIPTION
## Description

`Sprite.rasterize()` previously forwarded only `srcSize` to the new `Sprite`, leaving the original `srcPosition` in place. When rasterizing a sub-region of an atlas, the resulting `Sprite` is backed by an image already cropped to `srcSize`, but the atlas-relative `srcPosition` was retained — producing an out-of-bounds `src` `Rect` and triggering a `drawImageRect` assertion failure.

This passes `srcPosition: Vector2.zero()` in both the cached and the freshly rasterized branches so the new `src` `Rect` always lies within the rasterized image.

## Checklist

- [x] Bug fix
- [x] Regression test added (covers both cached and uncached branches)
- [x] `flutter analyze` clean on touched files
- [x] All `raster_sprite_test.dart` tests pass

Fixes #3902