### PR TITLE
chore: Use melos-action built-in GitHub release support

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
-      - uses: bluefireteam/melos-action@v2
+      - uses: bluefireteam/melos-action@v3
       - uses: bluefireteam/flutter-gh-pages@v9
         with:
           workingDir: examples

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,4 +21,5 @@ jobs:
       - uses: bluefireteam/melos-action@v3
         with:
           publish: true
+          create-release: true
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -19,27 +19,6 @@ jobs:
       - uses: bluefireteam/melos-action@v3
         with:
           tag: true
-      - name: Create v-tag and GitHub release for flame
-        run: |
-          # Get the flame version from its pubspec
-          FLAME_VERSION=$(grep '^version:' packages/flame/pubspec.yaml | awk '{print $2}')
-          TAG="v${FLAME_VERSION}"
-
-          # Create the short v-tag if it doesn't already exist
-          if ! git tag -l "$TAG" | grep -q .; then
-            git tag "$TAG"
-            git push origin "$TAG"
-          fi
-
-          # Extract changelog for this version (everything between first and second ## headings)
-          CHANGELOG=$(awk '/^## /{if(found) exit; found=1; next} found' packages/flame/CHANGELOG.md)
-
-          # Create GitHub release
-          gh release create "$TAG" \
-            --title "Flame $TAG" \
-            --notes "$CHANGELOG"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Trigger publish for unpublished packages
         run: |
           melos exec -c1 --no-published --no-private --order-dependents -- \


### PR DESCRIPTION
# Description

Replaces the manual shell script in `release-tag.yml` that created a short `v{VERSION}` tag and GitHub release for the `flame` package (using `awk` + `gh release create`) with the built-in `create-release: true` argument in `bluefireteam/melos-action`. Also updates `gh-pages.yml` from `melos-action@v2` to `@v3` to match the rest of the repo.

## Checklist

- [-] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md