### PR TITLE
chore: Deprecate old detectors fully replaced with callbacks

### DIFF
--- a/examples/lib/stories/rendering/nine_tile_box_custom_grid_example.dart
+++ b/examples/lib/stories/rendering/nine_tile_box_custom_grid_example.dart
@@ -1,10 +1,9 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 
 class NineTileBoxCustomGridExample extends FlameGame
-    with TapCallbacks, DoubleTapDetector {
+    with TapCallbacks, DoubleTapCallbacks {
   static const String description = '''
     If you want to create a background for something that can stretch you can
     use the `NineTileBox` which is showcased here. In this example a custom
@@ -41,7 +40,7 @@ class NineTileBoxCustomGridExample extends FlameGame
   }
 
   @override
-  void onDoubleTap() {
+  void onDoubleTapDown(_) {
     nineTileBoxComponent.scale.scale(0.8);
   }
 }

--- a/examples/lib/stories/rendering/nine_tile_box_example.dart
+++ b/examples/lib/stories/rendering/nine_tile_box_example.dart
@@ -3,7 +3,7 @@ import 'package:flame/events.dart';
 import 'package:flame/game.dart';
 
 class NineTileBoxExample extends FlameGame
-    with TapCallbacks, DoubleTapDetector {
+    with TapCallbacks, DoubleTapCallbacks {
   static const String description = '''
     If you want to create a background for something that can stretch you can
     use the `NineTileBox` which is showcased here.\n\n
@@ -33,7 +33,7 @@ class NineTileBoxExample extends FlameGame
   }
 
   @override
-  void onDoubleTap() {
+  void onDoubleTapDown(_) {
     nineTileBoxComponent.scale.scale(0.8);
   }
 }

--- a/examples/lib/stories/system/pause_resume_example.dart
+++ b/examples/lib/stories/system/pause_resume_example.dart
@@ -1,10 +1,9 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 
 class PauseResumeExample extends FlameGame
-    with TapCallbacks, DoubleTapDetector {
+    with TapCallbacks, DoubleTapCallbacks {
   static const description = '''
     Demonstrate how to use the pause and resume engine methods and paused
     attribute.
@@ -47,7 +46,7 @@ class PauseResumeExample extends FlameGame
   }
 
   @override
-  void onDoubleTap() {
+  void onDoubleTapDown(_) {
     paused = !paused;
   }
 }

--- a/examples/lib/stories/utils/timer_component_example.dart
+++ b/examples/lib/stories/utils/timer_component_example.dart
@@ -4,7 +4,7 @@ import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 
 class TimerComponentExample extends FlameGame
-    with TapCallbacks, DoubleTapDetector {
+    with TapCallbacks, DoubleTapCallbacks {
   static const String description = '''
     This examples showcases the `TimerComponent`.\n\n
     Tap to start a timer that lives for one second and double tap to start
@@ -22,7 +22,7 @@ class TimerComponentExample extends FlameGame
   }
 
   @override
-  void onDoubleTap() {
+  void onDoubleTapDown(_) {
     doubleTapComponent?.removeFromParent();
     doubleTapComponent = RenderedTimeComponent(5, yOffset: 180);
     add(doubleTapComponent!);

--- a/packages/flame/lib/src/gestures/detectors.dart
+++ b/packages/flame/lib/src/gestures/detectors.dart
@@ -18,6 +18,7 @@ mixin TapDetector on Game {
   }
 }
 
+@Deprecated('Use SecondaryTapCallbacks instead')
 mixin SecondaryTapDetector on Game {
   void onSecondaryTapDown(TapDownInfo info) {}
   void onSecondaryTapUp(TapUpInfo info) {}
@@ -32,6 +33,7 @@ mixin SecondaryTapDetector on Game {
   }
 }
 
+@Deprecated('Use TertiaryTapCallbacks instead')
 mixin TertiaryTapDetector on Game {
   void onTertiaryTapDown(TapDownInfo info) {}
   void onTertiaryTapUp(TapUpInfo info) {}
@@ -46,6 +48,7 @@ mixin TertiaryTapDetector on Game {
   }
 }
 
+@Deprecated('Use DoubleTapCallbacks instead')
 mixin DoubleTapDetector on Game {
   void onDoubleTap() {}
   void onDoubleTapCancel() {}
@@ -56,6 +59,7 @@ mixin DoubleTapDetector on Game {
   }
 }
 
+@Deprecated('Use LongPressCallbacks instead')
 mixin LongPressDetector on Game {
   void onLongPress() {}
   void onLongPressStart(LongPressStartInfo info) {}


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Deprecate old detectors fully replaced with callbacks. These all have 1:1 callback equivalents.

Part of our event system design doc proposal.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->