### PR TITLE
feat: Expose brighten and darken helpers on palette

### DIFF
--- a/doc/flame/rendering/palette.md
+++ b/doc/flame/rendering/palette.md
@@ -86,3 +86,6 @@ members:
 - `paint`: creates a new `Paint` with the color specified. `Paint` is a non-`const` class, so this
   method actually creates a brand new instance every time it's called. It's safe to cascade
   mutations to this.
+
+It also exposes helper methods to derive a new `PaletteEntry` by transforming the underlying color,
+such as `withRed` or `lighten`.

--- a/packages/flame/lib/src/palette.dart
+++ b/packages/flame/lib/src/palette.dart
@@ -1,5 +1,7 @@
 import 'dart:ui';
 
+import 'package:flame/extensions.dart';
+
 class PaletteEntry {
   final Color color;
 
@@ -21,6 +23,14 @@ class PaletteEntry {
 
   PaletteEntry withBlue(int blue) {
     return PaletteEntry(color.withBlue(blue));
+  }
+
+  PaletteEntry darken(double amount) {
+    return PaletteEntry(color.darken(amount));
+  }
+
+  PaletteEntry brighten(double amount) {
+    return PaletteEntry(color.brighten(amount));
   }
 }
 

--- a/packages/flame/test/palette_test.dart
+++ b/packages/flame/test/palette_test.dart
@@ -1,0 +1,22 @@
+import 'package:flame/palette.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Palette', () {
+    test('updates color', () {
+      const entry = BasicPalette.red;
+      expect(entry.color, const Color(0xFFFF0000));
+      expect(entry.withAlpha(100).color, const Color(0x64FF0000));
+      expect(entry.withRed(100).color, const Color(0xFF640000));
+      expect(entry.withGreen(100).color, const Color(0xFFFF6400));
+      expect(entry.withBlue(100).color, const Color(0xFFFF0064));
+    });
+
+    test('darkens and brightens color', () {
+      const entry = BasicPalette.red;
+      expect(entry.color, const Color(0xFFFF0000));
+      expect(entry.darken(0.5).color, const Color(0xFF800000));
+      expect(entry.brighten(0.5).color, const Color(0xFFFF8080));
+    });
+  });
+}


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Expose brighten and darken helpers from color directly on palette.

I considered adding a generic `transform` method but maybe that is overkill - open to it if we think it makes sense.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->