### PR TITLE
fix: Workaround for the TextBoxComponent entering an endless loop

### DIFF
--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -208,7 +208,23 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
     var offset = 0;
 
     while (offset < text.length) {
-      final range = textPainter.getLineBoundary(TextPosition(offset: offset));
+      var range = textPainter.getLineBoundary(TextPosition(offset: offset));
+      // Flutter web sometimes report the range on the previous page instead of
+      // the following. This is probably a bug cause by the
+      // JS floating number inaccuracies.
+      //
+      // We have an issue tracking that down on Flutter itself:
+      // https://github.com/flutter/flutter/issues/188874
+      //
+      // This code is a workaround, that captures when such we fall
+      // in that issue and tries to get the next page.
+      if (range.start < offset) {
+        range = textPainter.getLineBoundary(
+          TextPosition(
+            offset: offset + 1,
+          ),
+        );
+      }
       var lineText = text.substring(range.start, range.end);
 
       // Don't include the trailing newline character in the line text


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
This PR adds an workaround for and issue that was cause the `TextBoxComponent` enter a never ending loop when rendering some texts.

This is being cause due the result `TextRange` from the `TextPainter` sometimes reporting an incorrect result, very mostly likely because of the floating number innacuracy in javascript.

An issue was open in the Flutter repository to track this issue: https://github.com/flutter/flutter/issues/188874

This workaround could be removed/revisited depending on the outcome of such issue.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues

Closes #3938

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
