### PR TITLE
test: Add customer_testing script for the flutter/tests registry

### DIFF
--- a/.github/.cspell/words_dictionary.txt
+++ b/.github/.cspell/words_dictionary.txt
@@ -17,6 +17,7 @@ preorder
 prerender
 prerendered
 pressable
+presubmit
 ptero # short for pterodactyl
 rasterizes
 refreshable

--- a/scripts/customer_testing.dart
+++ b/scripts/customer_testing.dart
@@ -1,0 +1,50 @@
+// This file is invoked by the flutter/tests registry entry for Flame
+// (https://github.com/flutter/tests/blob/main/registry/flame.test) to run
+// Flame's tests as a presubmit against flutter/flutter framework changes.
+// Changes here are only honored after the commit hash in that registry entry
+// is updated.
+
+import 'dart:io';
+
+Future<void> main() async {
+  await _run('flutter', ['analyze', '--no-fatal-infos']);
+
+  // Golden and rendering tests are platform-sensitive, so the full per-package
+  // test suites only run on Linux, where the golden files are generated.
+  if (!Platform.isLinux) {
+    return;
+  }
+
+  final packages =
+      Directory('packages')
+          .listSync()
+          .whereType<Directory>()
+          .where(
+            (directory) => Directory('${directory.path}/test').existsSync(),
+          )
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+  for (final package in packages) {
+    stdout.writeln('Running tests in ${package.path}');
+    await _run('flutter', ['test'], workingDirectory: package.path);
+  }
+}
+
+Future<void> _run(
+  String executable,
+  List<String> arguments, {
+  String? workingDirectory,
+}) async {
+  final process = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+    mode: ProcessStartMode.inheritStdio,
+    runInShell: true,
+  );
+  final exitCode = await process.exitCode;
+  if (exitCode != 0) {
+    exit(exitCode);
+  }
+}


### PR DESCRIPTION
## Description

Adds `scripts/customer_testing.dart` so that Flame can be registered in the [flutter/tests registry](https://github.com/flutter/tests/tree/main/registry).

The registry runs downstream packages' tests as a presubmit against `flutter/flutter` framework changes, so that breaking changes to the framework that would affect Flame are caught early (and Flame's code can be auto-migrated via `dart fix`).

A companion PR is open against `flutter/tests`: flutter/tests#489. It adds a `registry/flame.test` entry pinned to the commit of this PR that invokes the script via `dart run scripts/customer_testing.dart`.

## Why a single Dart script

The registry guarantees `dart` on the path, and a single Dart file is inherently cross-platform, so there's no need for the separate `.sh`/`.bat` pair the registry template otherwise expects. It also matches the existing `scripts/test_formatter.dart`.

## Behavior

- Flame is a pub workspace, so the registry's `update` step (`flutter pub get` at the repo root) resolves every member package.
- `flutter analyze --no-fatal-infos` runs over the whole workspace on **every platform**.
- The full per-package `flutter test` suites run on **Linux only**, since golden and rendering tests are platform-sensitive. This mirrors how `flutter/packages` handles its own registry entry.

Locally verified: root `flutter pub get` resolves the workspace, the script's analyze pass is clean over the whole tree, and per-package `flutter test` works.