### PR TITLE
test: Exclude flame_3d from the flutter/tests customer_testing run

### DIFF
--- a/scripts/customer_testing.dart
+++ b/scripts/customer_testing.dart
@@ -6,8 +6,29 @@
 
 import 'dart:io';
 
+// flame_3d builds on the experimental flutter_gpu library, whose API changes
+// frequently in flutter/flutter's presubmit. Analyzing it here would block
+// framework changes on an unstable dependency that is not representative of
+// Flame, so it is excluded from this run.
+const _excludedPackages = {'flame_3d'};
+
 Future<void> main() async {
-  await _run('flutter', ['analyze', '--no-fatal-infos']);
+  final packages =
+      Directory('packages')
+          .listSync()
+          .whereType<Directory>()
+          .where(
+            (directory) => !_excludedPackages.contains(_packageName(directory)),
+          )
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+  await _run('flutter', [
+    'analyze',
+    '--no-fatal-infos',
+    'doc',
+    ...packages.map((directory) => directory.path),
+  ]);
 
   // Golden and rendering tests are platform-sensitive, so the full per-package
   // test suites only run on Linux, where the golden files are generated.
@@ -15,21 +36,16 @@ Future<void> main() async {
     return;
   }
 
-  final packages =
-      Directory('packages')
-          .listSync()
-          .whereType<Directory>()
-          .where(
-            (directory) => Directory('${directory.path}/test').existsSync(),
-          )
-          .toList()
-        ..sort((a, b) => a.path.compareTo(b.path));
-
-  for (final package in packages) {
+  for (final package in packages.where(
+    (directory) => Directory('${directory.path}/test').existsSync(),
+  )) {
     stdout.writeln('Running tests in ${package.path}');
     await _run('flutter', ['test'], workingDirectory: package.path);
   }
 }
+
+String _packageName(Directory directory) =>
+    directory.path.split(Platform.pathSeparator).last;
 
 Future<void> _run(
   String executable,


### PR DESCRIPTION
## Description

Follow-up to #3941. `flame_3d` builds on the experimental `flutter_gpu` library, whose API changes frequently in flutter/flutter's presubmit. Because the customer_testing script runs `flutter analyze` over the whole workspace, those upstream changes break the analyze step and would block flutter/flutter framework PRs on an unstable dependency that is not representative of Flame.

This excludes `flame_3d` from the customer_testing run (both analyze and tests) while every other package is still analyzed and tested. Analyze now targets `doc` plus each package directory except `flame_3d`, preserving the previous coverage.

`flame_3d` still compiles and tests cleanly against the stable Flutter that Flame targets; it simply cannot track the experimental engine API on flutter/flutter master.

## Checklist

- [x] I have followed the [Contributor Guide](https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md) when preparing my PR.
- [x] I have run `melos format` and `melos analyze` (or an equivalent) and it passes.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.