### PR TITLE
feat: Add displace extension to Rect

### DIFF
--- a/packages/flame/lib/src/extensions/rect.dart
+++ b/packages/flame/lib/src/extensions/rect.dart
@@ -80,6 +80,12 @@ extension RectExtension on Rect {
     );
   }
 
+  /// Displaces this [Rect] by the given [delta] displacement vector,
+  /// returning a new [Rect] instance. Equivalent to [shift] or [translate].
+  Rect displace(Vector2 delta) {
+    return shift(delta.toOffset());
+  }
+
   /// Generates a random point within the bounds of this [Rect].
   Vector2 randomPoint([Random? random]) {
     final randomGenerator = random ?? randomFallback;

--- a/packages/flame/test/extensions/rect_test.dart
+++ b/packages/flame/test/extensions/rect_test.dart
@@ -181,6 +181,16 @@ void main() {
       expect(result.bottomRight.toVector2(), closeToVector(Vector2(20, 20)));
     });
 
+    test('test displace', () {
+      const input = Rect.fromLTWH(0, 1, 10, 10);
+      final delta = Vector2(10, 10);
+      final result = input.displace(delta);
+
+      expect(result.topLeft.toVector2(), closeToVector(Vector2(10, 11)));
+      expect(result.bottomRight.toVector2(), closeToVector(Vector2(20, 21)));
+      expect(result.size.toVector2(), closeToVector(input.size.toVector2()));
+    });
+
     testRandom('test bounding box', (Random r) {
       final points = List.generate(
         r.nextInt(15) + 2,


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add displace extension to Rect.
In line with existing extensions that facilitate existing methods by using `Vector2`.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->