### PR TITLE
chore: Upgrade to Melos 8.1.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,5 +80,5 @@ jobs:
           cache: true
       - uses: bluefireteam/melos-action@v3
       - name: Run tests
-        run: melos test
+        run: melos run test:select --no-select
   # END TESTING STAGE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ For a contribution to be accepted:
 
 - Follow the [Style Guide] when writing the code;
 - Format the code using `dart format .`;
-- Lint the code with `melos run analyze`;
-- Check that all tests pass: `melos run test`;
+- Lint the code with `melos analyze`;
+- Check that all tests pass: `melos test`;
 - Documentation should always be updated or added (if applicable);
 - Examples should always be updated or added (if applicable);
 - Tests should always be updated or added (if applicable) -- check the [Test writing guide] for

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,7 +76,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dev_dependencies:
-  melos: ^7.4.0
+  melos: ^8.1.0
 
 melos:
   command:
@@ -107,13 +107,9 @@ melos:
   scripts:
     lint:all:
       steps:
-        - analyze
+        - melos analyze
         - format
       description: Run all static analysis checks.
-
-    analyze:
-      run: melos exec dart analyze .
-      description: Run `dart analyze` for all packages.
 
     format-check:
       run: melos exec dart format . --set-exit-if-changed
@@ -160,10 +156,6 @@ melos:
       packageFilters:
         dirExists: test
       description: Run `flutter test` for selected packages.
-
-    test:
-      run: melos run test:select --no-select
-      description: Run all Flutter tests in this project.
 
     test:seeded:
       run: melos exec -c 1 -- flutter test --dart-define=RANDOM_SEED=$RANDOM_SEED


### PR DESCRIPTION
## Description

Upgrades the workspace to Melos 8.1.0 and adopts the new built-in commands where they fully replace custom scripts.

- Bump `melos` to `^8.1.0`.
- Drop the custom `analyze` script in favor of the built-in `melos analyze`.
- Drop the custom `test` wrapper. CI now runs `melos run test:select --no-select` so the `test_formatter.dart` aggregated output is preserved, while the built-in `melos test` stays available for a plain run.
- Update `lint:all` to call `melos analyze` explicitly (see notes).
- Update `CONTRIBUTING.md` to use `melos analyze` / `melos test`.

## Verification notes

- **Exec-scripts migration not needed.** The [exec-scripts migration](https://melos.invertase.dev/guides/migrations#configuring-exec-scripts) only affects the deprecated `run:` + sibling `exec:` map form, which this repo never used. All scripts use inline `melos exec ...` inside `run:`, which is still valid in v8. Confirmed the config parses, `melos bootstrap` succeeds, and `run:` + `packageFilters` still scopes correctly.
- **Built-in `analyze`** runs a single-pass `dart analyze` across packages and fully replaces the custom script. The CI `analyze` jobs already use `invertase/github-action-dart-analyzer`, so the custom script was only used by `lint:all`.
- **Built-in `test`** auto-detects `test/` dirs and picks `flutter test` vs `dart test` per package, but has no custom-formatter hook, so it can't reproduce `test_formatter.dart`. CI therefore stays on the formatter path via `test:select`.

Two v8 behaviors worth noting:
- In `steps:`, `format` resolves to the built-in but `analyze`/`test` do not (they fall through to shell), so built-in commands other than `format` must be spelled out as `melos analyze` in steps.
- A custom script named `test`/`analyze` shadows the built-in even for the bare `melos test`/`melos analyze` invocation.