### PR TITLE
fix: Don't recompile Flutter apps that already failed to compile

### DIFF
--- a/doc/_sphinx/extensions/flutter_app.py
+++ b/doc/_sphinx/extensions/flutter_app.py
@@ -75,6 +75,10 @@ class FlutterAppDirective(SphinxDirective):
     }
     # Static list of targets that were already compiled during the build
     COMPILED = []
+    # Static map of targets whose compilation failed, to the error it failed
+    # with. Compiling is expensive and deterministic within a single build, so
+    # a target that failed once is not attempted again.
+    FAILED = {}
 
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
@@ -172,13 +176,24 @@ class FlutterAppDirective(SphinxDirective):
         )
         if not need_compiling:
             return
+        # A target that already failed to compile would fail again in exactly
+        # the same way, so report the original error instead of paying for
+        # another full `flutter build web`.
+        previous_error = FlutterAppDirective.FAILED.get(self.source_dir)
+        if previous_error is not None:
+            raise self.error(previous_error)
         self.logger.info('Compiling Flutter app [%s]' % self.app_name)
-        self._compile_source()
-        self._copy_compiled()
-        self._create_index_html()
+        try:
+            self._compile_source()
+            self._copy_compiled()
+            self._create_index_html()
+            assert os.path.isfile(self.target_dir + '/main.dart.js')
+            assert os.path.isfile(self.target_dir + '/index.html')
+        except Exception as e:
+            error = getattr(e, 'msg', str(e))
+            FlutterAppDirective.FAILED[self.source_dir] = error
+            raise
         self.logger.info('  + copied into ' + self.target_dir)
-        assert os.path.isfile(self.target_dir + '/main.dart.js')
-        assert os.path.isfile(self.target_dir + '/index.html')
         FlutterAppDirective.COMPILED.append(self.source_dir)
 
     def _compile_source(self):


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
`_ensure_compiled` dedupes compilation through the static `COMPILED` list, but
`COMPILED.append(...)` is the last statement of the function. If the compile, the copy or one
of the asserts raises, the target is never recorded, so the next page referencing that app
compiles it all over again, even though the result is guaranteed to be identical.

The effect is quadratic in the worst case. The v1.35.1 docs reference `../flame/examples` from
36 pages, so a single broken app produced 36 identical failing web builds of ~62s each:

```
20:30:54 Compiling Flutter app [examples]
20:31:55 Compiling Flutter app [examples]   <- same app, 62s later
20:32:58 Compiling Flutter app [examples]   <- ...11 times, no success in between
```

Failures are now recorded in a `FAILED` map alongside their error. A target that already
failed re-raises the stored error instead of paying for another `flutter build web`. Error
reporting is unchanged: every page referencing a broken app still reports it, so nothing is
silently swallowed.

## Context

This was found while investigating why the docs build on [flame-docs-site] takes 4h17m. The
reason those compiles were failing in the first place turned out to be a separate bug in that
repo's build script, fixed in flame-engine/flame-docs-site#22: the versions are built
sequentially in one clone, and `git checkout -f` leaves ignored files alone, so a generated
web plugin registrant importing `package:rive_native` survived from a version using
rive `^0.14` into versions using rive `^0.13`, which do not depend on it.

So that PR, not this one, is the actual fix for the failing builds. This PR is worth having
regardless: retrying a deterministic failure once per referencing page is wrong on its own
terms, and it is what turned a handful of broken apps into 590 failed compiles and ~3.3 hours
of wasted CI time. With this change, a genuinely broken app costs one compile instead of 36.

To be explicit about the numbers: on [run 29694895994] this change alone would have cut the
build from 4h17m to ~58m. Once the state leak is fixed the compiles succeed, so the saving
from this PR in normal operation is small. Its value is bounding the cost of future breakage
rather than speeding up the healthy path.

## Testing instructions

The behaviour only differs when an app fails to compile, so the failure has to be forced:

1. `melos run doc-setup`
2. Break one of the apps that many pages reference, for example add `int x = 'oops';` to
   `examples/lib/main.dart`.
3. `melos run doc-build`

Before this change, `Compiling Flutter app [flame-examples]` is logged once per referencing
page (36 times, each a full failing web build). After it, the app is compiled once and every
referencing page still reports the error.

Reverting step 2 and running `melos run doc-build` again should behave exactly as before,
since nothing changes on the success path.

[flame-docs-site]: https://github.com/flame-engine/flame-docs-site
[run 29694895994]: https://github.com/flame-engine/flame-docs-site/actions/runs/29694895994

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
