### PR TITLE
docs: Fix two code snippets that do not compile

### DIFF
--- a/doc/flame/rendering/decorators.md
+++ b/doc/flame/rendering/decorators.md
@@ -115,7 +115,7 @@ colored glass. It is recommended that the `color` used by this decorator was sem
 that you can see the details of the image below.
 
 ```dart
-final decorator = PaintDecorator.tint(const Color(0xAAFF0000);
+final decorator = PaintDecorator.tint(const Color(0xAAFF0000));
 ```
 
 Possible uses:

--- a/packages/flame_kenney_xml/README.md
+++ b/packages/flame_kenney_xml/README.md
@@ -28,14 +28,14 @@ To get started, first add `flame_kenney_xml` as a dependency in your flutter pro
 flutter pub add flame_kenney_xml
 ```
 
-Then place the `spritesheet.json` in `assets/` and `spritesheet.png` in `assets/images/`
+Then place the `spritesheet.xml` in `assets/` and `spritesheet.png` in `assets/images/`
 (or whatever the names of the files are).
 
 Then load the image and the spritesheet using:
 
 ```dart
 final spritesheet = await XmlSpriteSheet.load(
-  image: 'spritesheet.png',
-  xml: 'spritesheet.xml`,
+  imagePath: 'spritesheet.png',
+  xmlPath: 'spritesheet.xml',
 );
 ```


### PR DESCRIPTION
Fixes #3954

Two documentation snippets did not parse. Both are verified against the declarations in `lib/`, and I confirmed with `dart format --output=none` that each block fails to parse before the change and parses after it.

### `packages/flame_kenney_xml/README.md`

```diff
-Then place the `spritesheet.json` in `assets/` and `spritesheet.png` in `assets/images/`
+Then place the `spritesheet.xml` in `assets/` and `spritesheet.png` in `assets/images/`

 final spritesheet = await XmlSpriteSheet.load(
-  image: 'spritesheet.png',
-  xml: 'spritesheet.xml`,
+  imagePath: 'spritesheet.png',
+  xmlPath: 'spritesheet.xml',
 );
```

- `image:`/`xml:` are not parameters of `XmlSpriteSheet.load`. `lib/flame_kenney_xml.dart:34` declares `imagePath:`/`xmlPath:`, and the package's own `example/lib/main.dart:26-27` and `test/flame_kenney_xml_test.dart:60-61` use those names — so the README was the only place with the old spelling.
- The closing quote on `'spritesheet.xml`` was a backtick, leaving an unterminated string literal.
- The prose said `spritesheet.json`, but `load` reads the file as XML via `assetsCache.readFile`.

### `doc/flame/rendering/decorators.md`

```diff
-final decorator = PaintDecorator.tint(const Color(0xAAFF0000);
+final decorator = PaintDecorator.tint(const Color(0xAAFF0000));
```

`PaintDecorator.tint(Color color)` is declared at `packages/flame/lib/src/rendering/paint_decorator.dart:19`.

Docs only — no code or test changes. There is a third unbalanced snippet at `packages/flame/CHANGELOG.md:523`, which I left alone since changelog entries are historical.
