### PR TITLE
fix: Clear removing state on the moved child instead of its new parent

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -704,7 +704,7 @@ class Component {
     } else if (child._parent != null) {
       if (child.isRemoving) {
         game.dequeueRemove(child);
-        _clearRemovingBit();
+        child._clearRemovingBit();
       }
       game.enqueueMove(child, this);
     } else if (isMounted && !child.isMounted) {

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -15,11 +15,15 @@ class ComponentTreeRoot extends Component {
     super.children,
     super.key,
   }) : queue = RecycledQueue(LifecycleEvent.new),
-       _blocked = <int>{};
+       _blocked = <Component>{};
 
   @internal
   final RecycledQueue<LifecycleEvent> queue;
-  final Set<int> _blocked;
+
+  /// Components whose events are blocked during the current
+  /// [processLifecycleEvents] pass. Compared by identity, since [Component]
+  /// does not override equality.
+  final Set<Component> _blocked;
   late final Map<ComponentKey, Component> _index = {};
   Completer<void>? _lifecycleEventsCompleter;
 
@@ -147,8 +151,7 @@ class ComponentTreeRoot extends Component {
       for (final event in queue) {
         final child = event.child!;
         final parent = event.parent!;
-        if (_blocked.contains(identityHashCode(child)) ||
-            _blocked.contains(identityHashCode(parent))) {
+        if (_blocked.contains(child) || _blocked.contains(parent)) {
           continue;
         }
 
@@ -165,8 +168,8 @@ class ComponentTreeRoot extends Component {
             queue.removeCurrent();
             repeatLoop = true;
           case LifecycleEventStatus.block:
-            _blocked.add(identityHashCode(child));
-            _blocked.add(identityHashCode(parent));
+            _blocked.add(child);
+            _blocked.add(parent);
           default:
         }
       }

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -1171,6 +1171,55 @@ void main() {
         expect(game.world.children.toList(), [parent, child]);
         expect(parent.children.toList(), isEmpty);
       });
+
+      testWithFlameGame(
+        'moving a component that is scheduled for removal cancels the removal',
+        (game) async {
+          final parentA = Component()..addToParent(game.world);
+          final parentB = Component()..addToParent(game.world);
+          final child = _LifecycleComponent('child')..addToParent(parentA);
+          await game.ready();
+
+          child.removeFromParent();
+          expect(child.isRemoving, true);
+          parentB.add(child);
+          expect(child.isRemoving, false);
+          await game.ready();
+
+          expect(child.isMounted, true);
+          expect(child.parent, parentB);
+          expect(parentA.hasChildren, false);
+          expect(child.countEvents('onRemove'), 1);
+          expect(child.countEvents('onMount'), 2);
+        },
+      );
+
+      testWithFlameGame(
+        'moving a removing child does not clear the removing state of the '
+        'new parent',
+        (game) async {
+          final parentA = Component()..addToParent(game.world);
+          final parentB = Component()..addToParent(game.world);
+          final child = Component()..addToParent(parentA);
+          await game.ready();
+
+          parentB.removeFromParent();
+          child.removeFromParent();
+          expect(parentB.isRemoving, true);
+          expect(child.isRemoving, true);
+
+          // Re-parenting the removing child must clear the child's removing
+          // state, not the new parent's.
+          parentB.add(child);
+          expect(child.isRemoving, false);
+          expect(parentB.isRemoving, true);
+          await game.ready();
+
+          expect(parentB.isRemoved, true);
+          expect(parentB.isMounted, false);
+          expect(child.parent, parentB);
+        },
+      );
     });
 
     group('Rebalancing components', () {
@@ -1553,6 +1602,38 @@ void main() {
           _Pair(world, [Vector2(664, 216)]),
         ]);
       });
+
+      testWithFlameGame(
+        'later siblings are hit first and can be removed during iteration',
+        (game) async {
+          final world = game.world;
+          final componentA = PositionComponent(size: Vector2.all(100))
+            ..addToParent(world);
+          final componentB = PositionComponent(size: Vector2.all(100))
+            ..addToParent(world);
+          final componentC = PositionComponent(size: Vector2.all(100))
+            ..addToParent(world);
+          await game.ready();
+
+          // Mimics an event handler that mutates the tree while the hit-test
+          // iterable is being consumed, like a tap handler removing the
+          // tapped component and one of its siblings.
+          final visited = <Component>[];
+          for (final component in world.componentsAtPoint(Vector2(50, 50))) {
+            if (component == componentC) {
+              componentC.removeFromParent();
+              componentB.removeFromParent();
+            }
+            visited.add(component);
+          }
+
+          // The removals are deferred, so the iteration still sees the tree
+          // as it was when the event was fired, in top-most-first order.
+          expect(visited, [componentC, componentB, componentA, world]);
+          await game.ready();
+          expect(world.children.toList(), [componentA]);
+        },
+      );
     });
 
     group('findRootGame()', () {

--- a/packages/flame/test/components/priority_test.dart
+++ b/packages/flame/test/components/priority_test.dart
@@ -26,6 +26,32 @@ void main() {
     );
 
     testWithFlameGame(
+      'components with equal priority keep insertion order',
+      (game) async {
+        final components = List.generate(5, (_) => _PriorityComponent(0));
+        await game.world.ensureAddAll(components);
+        expect(game.world.children.toList(), components);
+      },
+    );
+
+    testWithFlameGame(
+      'equal-priority components keep their relative order after a sibling '
+      'changes priority',
+      (game) async {
+        final a = _PriorityComponent(0);
+        final b = _PriorityComponent(0);
+        final c = _PriorityComponent(0);
+        final d = _PriorityComponent(1);
+        await game.world.ensureAddAll([a, b, c, d]);
+        expect(game.world.children.toList(), [a, b, c, d]);
+
+        d.priority = -1;
+        game.update(0);
+        expect(game.world.children.toList(), [d, a, b, c]);
+      },
+    );
+
+    testWithFlameGame(
       'changing priority with the priority setter should reorder the list',
       (game) async {
         final firstComponent = _PriorityComponent(-1);


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Two lifecycle fixes found while investigating #3957 (Phase 0), plus golden tests that pin behavior the later phases must preserve.

**Fixes**
- `Component._addChild` called `_clearRemovingBit()` on `this` (the new parent) instead of on the `child` being re-parented. Re-parenting a child that was scheduled for removal therefore corrupted the new parent's removing state (it could be silently taken out of its own pending removal), while the child kept its stale removing flag until the move was processed. The bit is now cleared on the child, right when its pending removal is dequeued.
- `ComponentTreeRoot._blocked` stored `identityHashCode` ints. Two distinct components can share an identity hash, in which case an unrelated component's lifecycle events would be spuriously blocked for a tick. The set now stores the components themselves (identity equality, same performance).

**New tests**
- Moving a component that is scheduled for removal cancels the removal (exactly one `onRemove`, two `onMount`s).
- Regression test for the removing-state corruption described above (fails without the fix).
- Equal-priority children keep insertion order, both initially and after a sibling's priority change.
- `componentsAtPoint` yields top-most first and tolerates tree mutations while the iterable is being consumed (removals are deferred).

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->
Related to #3957

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
