### PR TITLE
feat!: Remove integralSize property from class Svg, enforcing 'always true' behaviour

### DIFF
--- a/packages/flame_svg/lib/svg.dart
+++ b/packages/flame_svg/lib/svg.dart
@@ -12,7 +12,8 @@ import 'package:flutter_svg/flutter_svg.dart';
 class Svg {
   /// Creates an [Svg] with the received [pictureInfo].
   /// Default [pixelRatio] is the device pixel ratio.
-  /// Setting [fixedRatio] to `true` ensures the cache uses a single entry.
+  /// Setting [fixedRatio] to `true` ensures the cache uses one entry
+  /// per rendered size/scale.
   /// Default [cacheSize] is [defaultCacheSize], which is 10 as previously;
   /// specifying [unlimitedCacheSize] is the same as using a [Map] instead
   /// of a [MemoryCache].

--- a/packages/flame_svg/lib/svg.dart
+++ b/packages/flame_svg/lib/svg.dart
@@ -12,7 +12,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 class Svg {
   /// Creates an [Svg] with the received [pictureInfo].
   /// Default [pixelRatio] is the device pixel ratio.
-  /// Setting [integralSize] to `true` uses integer dimensions for cache keys.
   /// Setting [fixedRatio] to `true` ensures the cache uses a single entry.
   /// Default [cacheSize] is [defaultCacheSize], which is 10 as previously;
   /// specifying [unlimitedCacheSize] is the same as using a [Map] instead
@@ -20,7 +19,6 @@ class Svg {
   Svg(
     this.pictureInfo, {
     double? pixelRatio,
-    bool integralSize = false,
     bool fixedRatio = false,
     int cacheSize = defaultCacheSize,
   }) : pixelRatio =
@@ -31,7 +29,6 @@ class Svg {
                .views
                .first
                .devicePixelRatio {
-    _integralSize = integralSize;
     _fixedRatio = fixedRatio;
     _cacheSize = cacheSize;
     assert(_cacheSize >= 1, 'The cache size must support at least one slot.');
@@ -45,15 +42,6 @@ class Svg {
 
   /// The pixel ratio that this [Svg] is rendered based on.
   final double pixelRatio;
-
-  /// Whether we're using integral sizes for the cache keys (default: false).
-  bool get integralSize => _integralSize;
-  set integralSize(bool integral) {
-    _emptyCache();
-    _integralSize = integral;
-  }
-
-  late bool _integralSize;
 
   /// Whether we're using a fixed ratio for the cache keys (default: false).
   bool get fixedRatio => _fixedRatio;
@@ -90,7 +78,6 @@ class Svg {
     String fileName, {
     AssetsCache? cache,
     double? pixelRatio,
-    bool integralSize = false,
     bool fixedRatio = false,
     int cacheSize = defaultCacheSize,
     String? package,
@@ -100,7 +87,6 @@ class Svg {
     return Svg.loadFromString(
       svgString,
       pixelRatio: pixelRatio,
-      integralSize: integralSize,
       fixedRatio: fixedRatio,
       cacheSize: cacheSize,
     );
@@ -110,7 +96,6 @@ class Svg {
   static Future<Svg> loadFromString(
     String svgString, {
     double? pixelRatio,
-    bool integralSize = false,
     bool fixedRatio = false,
     int cacheSize = defaultCacheSize,
   }) async {
@@ -118,7 +103,6 @@ class Svg {
     return Svg(
       pictureInfo,
       pixelRatio: pixelRatio,
-      integralSize: integralSize,
       fixedRatio: fixedRatio,
       cacheSize: cacheSize,
     );
@@ -177,12 +161,7 @@ class Svg {
   Image _getImage(Size size, double widthRatio, double heightRatio) {
     final width = size.width * widthRatio;
     final height = size.height * heightRatio;
-    Size cacheKey;
-    if (fixedRatio || integralSize) {
-      cacheKey = Size(width.ceilToDouble(), height.ceilToDouble());
-    } else {
-      cacheKey = Size(width, height);
-    }
+    final cacheKey = Size(width.ceilToDouble(), height.ceilToDouble());
     final image = _imageCache.getValue(cacheKey);
 
     if (image == null) {
@@ -239,14 +218,12 @@ extension SvgLoader on Game {
   Future<Svg> loadSvg(
     String fileName, {
     String? package,
-    bool integralSize = false,
     bool fixedRatio = false,
     int cacheSize = Svg.defaultCacheSize,
   }) => Svg.load(
     fileName,
     cache: assets,
     package: package,
-    integralSize: integralSize,
     fixedRatio: fixedRatio,
     cacheSize: cacheSize,
   );


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
The `Svg.integralSize` property was added in PR #3956: when `true`, it ensures that the keys for `Svg._imageCache` are always integer-sized. The property, however, would _never_ be useful with its current default of `false`, since this would re-introduce floating-point rounding errors in the image cache keys.

# Resolution

[Remove](https://github.com/flame-engine/flame/pull/3956#issuecomment-5045164564) the `integralSize` property, always following its `true` [codepath](https://github.com/flame-engine/flame/pull/3956/changes#diff-ff717ec0f113030b284a5874321c9f93b1bca6b9e3542ec3b3b6ea5307d2f6f9R181).

# Testing

An updated testbed for the changes is [available](https://github.com/adario/flame_extended_svg) — this displays 200+1 SvgComponent objects, all with different rotation/scale values; it now features the **Svg** button, which cycles through a few SVG assets.
For comparison purposes, the testbed starts with the default implementation; the **Mode** and **Size** buttons cycle through several combinations of the `fixedRatio` and `cacheSize` properties..

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions
<!--
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->

This PR **does** change the internal caching behaviour in class `Svg`, for **all** rendering operations. However, any existing use cases of class `Svg` _should_ build as previously , since the property changes from PR #3956 haven't been published yet. All parameters/properties from PR #3956 have default values, so no build should break.
At runtime, the PR should _not_ break class `Svg` clients either: the actual `Image` objects in the `MemoryCache` _should_ maintain the previous dimensions and contents, since these were _already_ integral prior to PR #3956. A 3-way comparison for the `melos test --scope=flame_svg` results reveals no differences (all tests fail in the same way)...

I apologise if I've missed something, but at present I wouldn't know what migration steps to provide.


<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
