### PR TITLE
refactor: Update _TestBlock on collision_callback_benchmark_test to use named parameters

### DIFF
--- a/packages/flame/test/collisions/collision_callback_benchmark_test.dart
+++ b/packages/flame/test/collisions/collision_callback_benchmark_test.dart
@@ -12,11 +12,11 @@ class _TestBlock extends PositionComponent with CollisionCallbacks {
   final Vector2 velocity;
   static int collisionCounter = 0;
 
-  _TestBlock(Vector2 position, Vector2 size, this.velocity)
-    : super(
-        position: position,
-        size: size,
-      ) {
+  _TestBlock({
+    required this.velocity,
+    required super.position,
+    required super.size,
+  }) {
     add(CircleHitbox());
   }
 
@@ -48,9 +48,9 @@ void main() {
         final blocks = List.generate(
           100,
           (_) => _TestBlock(
-            Vector2.random(rng) * game.size.x,
-            Vector2.random(rng) * 100,
-            Vector2(
+            position: Vector2.random(rng) * game.size.x,
+            size: Vector2.random(rng) * 100,
+            velocity: Vector2(
               rng.nextInt(100) * (rng.nextBool() ? 1 : -1),
               rng.nextInt(100) * (rng.nextBool() ? 1 : -1),
             ),


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Note while migrating to new dart as we got the new private field redirect syntax and was looking into constructors, this one could be enhanced as a tangent.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->