### PR TITLE
refactor!: Clean up deprecated MultiDragDispatcher / MultiDragDispatcher aliases

### DIFF
--- a/doc/flame/migration.md
+++ b/doc/flame/migration.md
@@ -23,6 +23,7 @@ game.findByKey(const MultiDragScaleDispatcherKey())
     as MultiDragScaleDispatcher?;
 ```
 
+
 ### `Event.handled` removed in favour of `continuePropagation`
 
 Events used to carry two independent booleans: `handled`, which Flame never set nor read, and

--- a/doc/flame/migration.md
+++ b/doc/flame/migration.md
@@ -74,6 +74,7 @@ If you were using `handled` to let an event reach several components, set
 The equivalent field on the deprecated `*Info` event classes (`TapDownInfo.handled` and friends) has
 been removed as well.
 
+
 ### `GameWidget.controlled` renamed to `GameWidget.managed`
 
 The `GameWidget.controlled` constructor has been renamed to `GameWidget.managed`. The behavior is

--- a/doc/flame/migration.md
+++ b/doc/flame/migration.md
@@ -7,6 +7,23 @@ major versions of Flame, together with the steps required to migrate your code.
 ## Migrating from v1.38.0 to v2.0.0
 
 
+### `MultiDragDispatcher` removed
+
+The deprecated `MultiDragDispatcher` and `MultiDragDispatcherKey` aliases have been removed. Use
+`MultiDragScaleDispatcher` and `MultiDragScaleDispatcherKey` instead, if you were using them
+directly at all (normally you should just use the mixins).
+
+```dart
+// Before
+game.findByKey(const MultiDragDispatcherKey())
+    as MultiDragDispatcher?;
+
+// After
+game.findByKey(const MultiDragScaleDispatcherKey())
+    as MultiDragScaleDispatcher?;
+```
+
+
 ### `GameWidget.controlled` renamed to `GameWidget.managed`
 
 The `GameWidget.controlled` constructor has been renamed to `GameWidget.managed`. The behavior is

--- a/packages/flame/lib/events.dart
+++ b/packages/flame/lib/events.dart
@@ -11,8 +11,6 @@ export 'src/events/callbacks/secondary_tap_callbacks.dart'
 export 'src/events/callbacks/tap_callbacks.dart' show TapCallbacks;
 export 'src/events/callbacks/tertiary_tap_callbacks.dart'
     show TertiaryTapCallbacks;
-export 'src/events/deprecated.dart'
-    show MultiDragDispatcher, MultiDragDispatcherKey;
 export 'src/events/dispatchers/dispatcher.dart' show Dispatcher;
 export 'src/events/dispatchers/double_tap_dispatcher.dart'
     show DoubleTapDispatcher, DoubleTapDispatcherKey;

--- a/packages/flame/lib/src/events/deprecated.dart
+++ b/packages/flame/lib/src/events/deprecated.dart
@@ -1,7 +1,0 @@
-import 'package:flame/src/events/dispatchers/multi_drag_scale_dispatcher.dart';
-
-@Deprecated('Use MultiDragScaleDispatcher instead.')
-typedef MultiDragDispatcher = MultiDragScaleDispatcher;
-
-@Deprecated('Use MultiDragScaleDispatcherKey instead.')
-typedef MultiDragDispatcherKey = MultiDragScaleDispatcherKey;


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->

Clean up deprecated `MultiDragDispatcher` and `MultiDragDispatcher` aliases, including migration note.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
