### PR TITLE
perf: Skip lifecycle processing work when the queue is empty

### DIFF
--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -144,9 +144,11 @@ class ComponentTreeRoot extends Component {
 
   void processLifecycleEvents() {
     if (!hasLifecycleEvents) {
-      // The completer is only ever created while events are queued, so there
-      // is nothing to complete here either.
-      assert(_lifecycleEventsCompleter == null);
+      assert(
+        _lifecycleEventsCompleter == null,
+        'The completer is only ever created while events are queued, so it '
+        'should never exist while the queue is empty',
+      );
       return;
     }
     // reorder events to process later grouped by parent
@@ -189,10 +191,8 @@ class ComponentTreeRoot extends Component {
       _blocked.clear();
     }
 
-    if (reorderParents != null) {
-      for (final parent in reorderParents!) {
-        parent.rebalanceChildren();
-      }
+    for (final parent in reorderParents ?? const <Component>{}) {
+      parent.rebalanceChildren();
     }
 
     if (!hasLifecycleEvents && _lifecycleEventsCompleter != null) {

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -143,10 +143,16 @@ class ComponentTreeRoot extends Component {
   }
 
   void processLifecycleEvents() {
+    if (!hasLifecycleEvents) {
+      // The completer is only ever created while events are queued, so there
+      // is nothing to complete here either.
+      assert(_lifecycleEventsCompleter == null);
+      return;
+    }
     // reorder events to process later grouped by parent
-    final reorderParents = <Component>{};
+    Set<Component>? reorderParents;
     LifecycleEventStatus handleReorderEvent(Component parent) {
-      reorderParents.add(parent);
+      (reorderParents ??= {}).add(parent);
       return LifecycleEventStatus.done;
     }
 
@@ -157,7 +163,8 @@ class ComponentTreeRoot extends Component {
       for (final event in queue) {
         final child = event.child!;
         final parent = event.parent!;
-        if (_blocked.contains(child) || _blocked.contains(parent)) {
+        if (_blocked.isNotEmpty &&
+            (_blocked.contains(child) || _blocked.contains(parent))) {
           continue;
         }
 
@@ -182,8 +189,10 @@ class ComponentTreeRoot extends Component {
       _blocked.clear();
     }
 
-    for (final parent in reorderParents) {
-      parent.rebalanceChildren();
+    if (reorderParents != null) {
+      for (final parent in reorderParents!) {
+        parent.rebalanceChildren();
+      }
     }
 
     if (!hasLifecycleEvents && _lifecycleEventsCompleter != null) {

--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -165,8 +165,7 @@ class ComponentTreeRoot extends Component {
       for (final event in queue) {
         final child = event.child!;
         final parent = event.parent!;
-        if (_blocked.isNotEmpty &&
-            (_blocked.contains(child) || _blocked.contains(parent))) {
+        if (_blocked.contains(child) || _blocked.contains(parent)) {
           continue;
         }
 


### PR DESCRIPTION
# Description
<!-- End of exclude from commit message -->
`processLifecycleEvents` now returns immediately when the queue is empty instead of allocating a set and a closure on every tick, the reorder-parents set is only allocated when a priority change is actually queued, and the blocked-set hash lookups are skipped while the set is empty (the common single-pass case).

Extracted from #3960 so the data-structure change there stands alone (as requested in [this comment](https://github.com/flame-engine/flame/issues/3957#issuecomment-5066267594)). Behavior is unchanged; this only removes per-tick allocations and lookups from the game loop.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues

Relates to #3957

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
