### PR TITLE
perf: Make render contexts and debug caches lazily allocated

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -598,19 +598,16 @@ class Component {
   /// cleans them up afterwards.
   @protected
   void renderChild(Canvas canvas, Component child) {
-    int? originalLength;
-    final hasContext = _renderContexts.isNotEmpty;
-    if (hasContext) {
-      originalLength = child._renderContexts.length;
-      child._renderContexts.addAll(_renderContexts);
+    final contexts = _renderContexts;
+    if (contexts == null || contexts.isEmpty) {
+      child.renderTree(canvas);
+      return;
     }
+    final childContexts = child._renderContexts ??= [];
+    final originalLength = childContexts.length;
+    childContexts.addAll(contexts);
     child.renderTree(canvas);
-    if (hasContext) {
-      child._renderContexts.removeRange(
-        originalLength!,
-        child._renderContexts.length,
-      );
-    }
+    childContexts.removeRange(originalLength, childContexts.length);
   }
 
   /// Called once after all children have been rendered in [renderTree].
@@ -623,7 +620,7 @@ class Component {
   void renderTree(Canvas canvas) {
     final context = renderContext;
     if (context != null) {
-      _renderContexts.add(context);
+      (_renderContexts ??= []).add(context);
     }
 
     render(canvas);
@@ -641,7 +638,7 @@ class Component {
     }
 
     if (context != null) {
-      _renderContexts.removeLast();
+      _renderContexts!.removeLast();
     }
   }
 
@@ -1217,14 +1214,16 @@ class Component {
 
   //#region Context
 
-  final QueueList<ComponentRenderContext> _renderContexts = QueueList();
+  /// The stack of render contexts inherited from ancestors during the render
+  /// pass. Created lazily: most components never provide or receive one.
+  List<ComponentRenderContext>? _renderContexts;
 
   /// Override this method if you want your component to provide a custom
   /// render context to all its children (recursively).
   ComponentRenderContext? get renderContext => null;
 
   T? findRenderContext<T extends ComponentRenderContext>() {
-    return _renderContexts.whereType<T>().lastOrNull;
+    return _renderContexts?.whereType<T>().lastOrNull;
   }
 
   //#endregion
@@ -1255,8 +1254,9 @@ class Component {
   /// The color that the debug output should be rendered with.
   Color debugColor = const Color(0xFFFF00FF);
 
-  final ValueCache<Paint> _debugPaintCache = ValueCache<Paint>();
-  final ValueCache<TextPaint> _debugTextPaintCache = ValueCache<TextPaint>();
+  late final ValueCache<Paint> _debugPaintCache = ValueCache<Paint>();
+  late final ValueCache<TextPaint> _debugTextPaintCache =
+      ValueCache<TextPaint>();
 
   /// The [debugColor] represented as a [Paint] object.
   Paint get debugPaint {

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -598,8 +598,8 @@ class Component {
   /// cleans them up afterwards.
   @protected
   void renderChild(Canvas canvas, Component child) {
-    final contexts = _renderContexts;
-    if (contexts == null || contexts.isEmpty) {
+    final contexts = _renderContexts ?? const <ComponentRenderContext>[];
+    if (contexts.isEmpty) {
       child.renderTree(canvas);
       return;
     }
@@ -619,8 +619,10 @@ class Component {
 
   void renderTree(Canvas canvas) {
     final context = renderContext;
+    List<ComponentRenderContext>? renderContexts;
     if (context != null) {
-      (_renderContexts ??= []).add(context);
+      renderContexts = _renderContexts ??= [];
+      renderContexts.add(context);
     }
 
     render(canvas);
@@ -637,9 +639,7 @@ class Component {
       renderDebugMode(canvas);
     }
 
-    if (context != null) {
-      _renderContexts!.removeLast();
-    }
+    renderContexts?.removeLast();
   }
 
   //#endregion


### PR DESCRIPTION
# Description
<!-- End of exclude from commit message -->
Every `Component` eagerly allocated a `QueueList` for render contexts plus two debug-paint `ValueCache`s. The context stack is now a lazily created plain list (most components never provide or receive a render context) and the debug caches are `late final`, so plain components allocate none of them.

Extracted from #3960 so the data-structure change there stands alone (as requested in [this comment](https://github.com/flame-engine/flame/issues/3957#issuecomment-5066267594)). Stacked on #3979.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues

Relates to #3957

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->

