### PR TITLE
perf: Replace generator-based tree teardown and propagation with an explicit collection pass

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -430,10 +430,21 @@ class Component {
     bool Function(T) handler, {
     bool includeSelf = false,
   }) {
-    return descendants(
-      reversed: true,
-      includeSelf: includeSelf,
-    ).whereType<T>().every(handler);
+    final children = _children;
+    if (children != null) {
+      for (final child in children.reversed()) {
+        if (!child.propagateToChildren(handler, includeSelf: true)) {
+          return false;
+        }
+      }
+    }
+    if (includeSelf) {
+      final self = this;
+      if (self is T && !handler(self)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @internal
@@ -1183,22 +1194,39 @@ class Component {
 
   void _remove(Component parent) {
     parent._internalChildren.remove(this);
-    propagateToChildren(
-      (Component component) {
-        component
-          ..onRemove()
-          .._unregisterKey()
-          .._clearMountedBit()
-          .._clearRemovingBit()
-          .._setRemovedBit()
-          .._removeCompleter?.complete()
-          .._removeCompleter = null
-          .._parent!.onChildrenChanged(component, ChildrenChangeType.removed);
-        return true;
-      },
-      includeSelf: true,
-    );
+    for (final component in _collectDescendants()) {
+      component
+        ..onRemove()
+        .._unregisterKey()
+        .._clearMountedBit()
+        .._clearRemovingBit()
+        .._setRemovedBit()
+        .._removeCompleter?.complete()
+        .._removeCompleter = null
+        .._parent!.onChildrenChanged(component, ChildrenChangeType.removed);
+    }
     _parent = null;
+  }
+
+  /// Collects this component and all its descendants into a list, in the
+  /// order that `descendants(reversed: true, includeSelf: true)` would
+  /// produce: leaves first, siblings in reverse order, ancestors after their
+  /// subtrees. The snapshot allows [_remove] to run user callbacks that
+  /// mutate the tree while it walks the subtree, without allocating generator
+  /// frames per tree level the way [descendants] does.
+  ///
+  /// The [out] parameter is only used by the recursive calls, so that the
+  /// whole subtree is collected into a single list.
+  List<Component> _collectDescendants([List<Component>? out]) {
+    out ??= [];
+    final children = _children;
+    if (children != null) {
+      for (final child in children.reversed()) {
+        child._collectDescendants(out);
+      }
+    }
+    out.add(this);
+    return out;
   }
 
   void _unregisterKey() {

--- a/packages/flame/lib/src/events/messages/event.dart
+++ b/packages/flame/lib/src/events/messages/event.dart
@@ -27,15 +27,13 @@ abstract class Event<R> {
     Component rootComponent,
     void Function(T component) eventHandler,
   ) {
-    for (final child
-        in rootComponent
-            .descendants(reversed: true, includeSelf: true)
-            .whereType<T>()) {
-      continuePropagation = false;
-      eventHandler(child);
-      if (!continuePropagation) {
-        break;
-      }
-    }
+    rootComponent.propagateToChildren<T>(
+      (component) {
+        continuePropagation = false;
+        eventHandler(component);
+        return continuePropagation;
+      },
+      includeSelf: true,
+    );
   }
 }


### PR DESCRIPTION
# Description
<!-- End of exclude from commit message -->
The removal teardown and `propagateToChildren` walked the subtree through the recursive `descendants` sync* generator, allocating generator frames per tree level on every traversal. The teardown now collects the subtree into a local buffer (same leaves-first order) via `_collectDescendants` and iterates that snapshot, since `onRemove` callbacks may mutate the tree mid-walk. `propagateToChildren` instead walks the tree with direct recursion and unwinds as soon as a handler stops propagation, so it neither allocates a buffer nor visits more components than the lazy generator did. Event delivery (`deliverToComponents`) is routed through `propagateToChildren`, so tap, drag, and keyboard propagation benefit as well.

The public `descendants()` method keeps its documented lazy semantics, since user code relies on early stopping and live iteration there.

Extracted from #3960 so the data-structure change there stands alone (as requested in [this comment](https://github.com/flame-engine/flame/issues/3957#issuecomment-5066267594)).

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues

Relates to #3957

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->



