### PR TITLE
perf: Track mounted pointer-event handlers so hit tests can early-out

### DIFF
--- a/packages/flame/lib/src/events/callbacks/double_tap_callbacks.dart
+++ b/packages/flame/lib/src/events/callbacks/double_tap_callbacks.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
+import 'package:meta/meta.dart';
 
 /// [DoubleTapCallbacks] adds the ability to receive double-tap events in a
 /// component.
@@ -25,8 +26,17 @@ mixin DoubleTapCallbacks on Component implements PointerInputCallbacks {
   void onDoubleTapCancel(DoubleTapCancelEvent event) {}
 
   @override
+  @mustCallSuper
   void onMount() {
     super.onMount();
     DoubleTapDispatcher.addDispatcher(this);
+    findRootGame()?.adjustPointerEventHandlerCount(1);
+  }
+
+  @override
+  @mustCallSuper
+  void onRemove() {
+    findRootGame()?.adjustPointerEventHandlerCount(-1);
+    super.onRemove();
   }
 }

--- a/packages/flame/lib/src/events/callbacks/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/callbacks/drag_callbacks.dart
@@ -75,11 +75,13 @@ mixin DragCallbacks on Component implements PointerInputCallbacks {
       hasDrag: true,
       hasScale: false,
     );
+    findRootGame()?.adjustPointerEventHandlerCount(1);
   }
 
   @override
   @mustCallSuper
   void onRemove() {
+    findRootGame()?.adjustPointerEventHandlerCount(-1);
     MultiDragScaleDispatcher.removeDispatcher(
       this,
       hasDrag: true,

--- a/packages/flame/lib/src/events/callbacks/scale_callbacks.dart
+++ b/packages/flame/lib/src/events/callbacks/scale_callbacks.dart
@@ -30,11 +30,13 @@ mixin ScaleCallbacks on Component implements PointerInputCallbacks {
       hasDrag: false,
       hasScale: true,
     );
+    findRootGame()?.adjustPointerEventHandlerCount(1);
   }
 
   @override
   @mustCallSuper
   void onRemove() {
+    findRootGame()?.adjustPointerEventHandlerCount(-1);
     MultiDragScaleDispatcher.removeDispatcher(
       this,
       hasDrag: false,

--- a/packages/flame/lib/src/events/callbacks/secondary_tap_callbacks.dart
+++ b/packages/flame/lib/src/events/callbacks/secondary_tap_callbacks.dart
@@ -23,5 +23,13 @@ mixin SecondaryTapCallbacks on Component implements PointerInputCallbacks {
   void onMount() {
     super.onMount();
     NonPrimaryTapDispatcher.addDispatcher(this);
+    findRootGame()?.adjustPointerEventHandlerCount(1);
+  }
+
+  @override
+  @mustCallSuper
+  void onRemove() {
+    findRootGame()?.adjustPointerEventHandlerCount(-1);
+    super.onRemove();
   }
 }

--- a/packages/flame/lib/src/events/callbacks/tap_callbacks.dart
+++ b/packages/flame/lib/src/events/callbacks/tap_callbacks.dart
@@ -23,5 +23,13 @@ mixin TapCallbacks on Component implements PointerInputCallbacks {
   void onMount() {
     super.onMount();
     MultiTapDispatcher.addDispatcher(this);
+    findRootGame()?.adjustPointerEventHandlerCount(1);
+  }
+
+  @override
+  @mustCallSuper
+  void onRemove() {
+    findRootGame()?.adjustPointerEventHandlerCount(-1);
+    super.onRemove();
   }
 }

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -243,12 +243,29 @@ class FlameGame<W extends World> extends ComponentTreeRoot
         point.y < canvasSize.y;
   }
 
+  /// The number of currently mounted components (in this game or any nested
+  /// game) that can receive pointer events. Maintained by the event callback
+  /// mixins ([TapCallbacks], [DragCallbacks], [DoubleTapCallbacks],
+  /// [ScaleCallbacks], [SecondaryTapCallbacks]) on the root game, so that
+  /// [containsEventHandlerAt] can skip hit testing entirely for games
+  /// without any pointer-event handlers.
+  int _pointerEventHandlerCount = 0;
+
+  @internal
+  void adjustPointerEventHandlerCount(int delta) {
+    _pointerEventHandlerCount += delta;
+    assert(_pointerEventHandlerCount >= 0);
+  }
+
   @override
   bool containsEventHandlerAt(Vector2 position) {
     // Game-level detector mixins handle events for the entire game surface,
     // so any in-bounds point is a hit.
     if (this is PanDetector) {
       return true;
+    }
+    if (_pointerEventHandlerCount == 0) {
+      return false;
     }
     for (final component in super.componentsAtPoint(position)) {
       if (component is PointerInputCallbacks) {


### PR DESCRIPTION
# Description
<!-- End of exclude from commit message -->
The root game now counts mounted components that can receive pointer events (`TapCallbacks`, `DragCallbacks`, `DoubleTapCallbacks`, `ScaleCallbacks`, `SecondaryTapCallbacks`), so `containsEventHandlerAt`, which Flutter calls on every hit test, returns immediately without walking the component tree for games without any pointer-event handlers.

Extracted from #3960 so the data-structure change there stands alone (as requested in [this comment](https://github.com/flame-engine/flame/issues/3957#issuecomment-5066267594)). Stacked on #3981.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues

Relates to #3957

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->

