### PR TITLE
perf: Insertion-sort the sweep broadphase and swap-remove its active list

### DIFF
--- a/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
+++ b/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
@@ -17,7 +17,21 @@ class Sweep<T extends Hitbox<T>> extends Broadphase<T> {
 
   @override
   void update() {
-    items.sort((a, b) => a.aabb.min.x.compareTo(b.aabb.min.x));
+    // Between two ticks the hitboxes only move a little, so [items] is
+    // always nearly sorted: an insertion sort runs in close to linear time
+    // here, where a general-purpose sort would pay its full O(n log n) on
+    // every tick. This also avoids allocating a comparator closure per tick.
+    final items = this.items;
+    for (var i = 1; i < items.length; i++) {
+      final item = items[i];
+      final minX = item.aabb.min.x;
+      var previousIndex = i - 1;
+      while (previousIndex >= 0 && items[previousIndex].aabb.min.x > minX) {
+        items[previousIndex + 1] = items[previousIndex];
+        previousIndex--;
+      }
+      items[previousIndex + 1] = item;
+    }
   }
 
   @override
@@ -44,7 +58,10 @@ class Sweep<T extends Hitbox<T>> extends Broadphase<T> {
             _prospectPool.acquire(item, activeItem);
           }
         } else {
-          _active.remove(activeItem);
+          // The order of the active list does not matter, so the removal can
+          // swap in the last element instead of searching and shifting.
+          _active[i] = _active.last;
+          _active.removeLast();
         }
       }
       _active.add(item);

--- a/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
+++ b/packages/flame/lib/src/collisions/broadphase/sweep/sweep.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flame/collisions.dart';
 
 class Sweep<T extends Hitbox<T>> extends Broadphase<T> {
@@ -20,19 +21,13 @@ class Sweep<T extends Hitbox<T>> extends Broadphase<T> {
     // Between two ticks the hitboxes only move a little, so [items] is
     // always nearly sorted: an insertion sort runs in close to linear time
     // here, where a general-purpose sort would pay its full O(n log n) on
-    // every tick. This also avoids allocating a comparator closure per tick.
-    final items = this.items;
-    for (var i = 1; i < items.length; i++) {
-      final item = items[i];
-      final minX = item.aabb.min.x;
-      var previousIndex = i - 1;
-      while (previousIndex >= 0 && items[previousIndex].aabb.min.x > minX) {
-        items[previousIndex + 1] = items[previousIndex];
-        previousIndex--;
-      }
-      items[previousIndex + 1] = item;
-    }
+    // every tick. The comparator is a static tear-off, so nothing is
+    // allocated per tick.
+    insertionSort(items, compare: _compareMinX);
   }
+
+  static int _compareMinX(Hitbox<dynamic> a, Hitbox<dynamic> b) =>
+      a.aabb.min.x.compareTo(b.aabb.min.x);
 
   @override
   Iterable<CollisionProspect<T>> query() {

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -598,19 +598,16 @@ class Component {
   /// cleans them up afterwards.
   @protected
   void renderChild(Canvas canvas, Component child) {
-    int? originalLength;
-    final hasContext = _renderContexts.isNotEmpty;
-    if (hasContext) {
-      originalLength = child._renderContexts.length;
-      child._renderContexts.addAll(_renderContexts);
+    final contexts = _renderContexts;
+    if (contexts == null || contexts.isEmpty) {
+      child.renderTree(canvas);
+      return;
     }
+    final childContexts = child._renderContexts ??= [];
+    final originalLength = childContexts.length;
+    childContexts.addAll(contexts);
     child.renderTree(canvas);
-    if (hasContext) {
-      child._renderContexts.removeRange(
-        originalLength!,
-        child._renderContexts.length,
-      );
-    }
+    childContexts.removeRange(originalLength, childContexts.length);
   }
 
   /// Called once after all children have been rendered in [renderTree].
@@ -623,7 +620,7 @@ class Component {
   void renderTree(Canvas canvas) {
     final context = renderContext;
     if (context != null) {
-      _renderContexts.add(context);
+      (_renderContexts ??= []).add(context);
     }
 
     render(canvas);
@@ -641,7 +638,7 @@ class Component {
     }
 
     if (context != null) {
-      _renderContexts.removeLast();
+      _renderContexts!.removeLast();
     }
   }
 
@@ -1217,14 +1214,16 @@ class Component {
 
   //#region Context
 
-  final QueueList<ComponentRenderContext> _renderContexts = QueueList();
+  /// The stack of render contexts inherited from ancestors during the render
+  /// pass. Created lazily: most components never provide or receive one.
+  List<ComponentRenderContext>? _renderContexts;
 
   /// Override this method if you want your component to provide a custom
   /// render context to all its children (recursively).
   ComponentRenderContext? get renderContext => null;
 
   T? findRenderContext<T extends ComponentRenderContext>() {
-    return _renderContexts.whereType<T>().lastOrNull;
+    return _renderContexts?.whereType<T>().lastOrNull;
   }
 
   //#endregion
@@ -1255,8 +1254,9 @@ class Component {
   /// The color that the debug output should be rendered with.
   Color debugColor = const Color(0xFFFF00FF);
 
-  final ValueCache<Paint> _debugPaintCache = ValueCache<Paint>();
-  final ValueCache<TextPaint> _debugTextPaintCache = ValueCache<TextPaint>();
+  late final ValueCache<Paint> _debugPaintCache = ValueCache<Paint>();
+  late final ValueCache<TextPaint> _debugTextPaintCache =
+      ValueCache<TextPaint>();
 
   /// The [debugColor] represented as a [Paint] object.
   Paint get debugPaint {

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -598,8 +598,8 @@ class Component {
   /// cleans them up afterwards.
   @protected
   void renderChild(Canvas canvas, Component child) {
-    final contexts = _renderContexts;
-    if (contexts == null || contexts.isEmpty) {
+    final contexts = _renderContexts ?? const <ComponentRenderContext>[];
+    if (contexts.isEmpty) {
       child.renderTree(canvas);
       return;
     }
@@ -619,8 +619,10 @@ class Component {
 
   void renderTree(Canvas canvas) {
     final context = renderContext;
+    List<ComponentRenderContext>? renderContexts;
     if (context != null) {
-      (_renderContexts ??= []).add(context);
+      renderContexts = _renderContexts ??= [];
+      renderContexts.add(context);
     }
 
     render(canvas);
@@ -637,9 +639,7 @@ class Component {
       renderDebugMode(canvas);
     }
 
-    if (context != null) {
-      _renderContexts!.removeLast();
-    }
+    renderContexts?.removeLast();
   }
 
   //#endregion

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -1183,22 +1183,36 @@ class Component {
 
   void _remove(Component parent) {
     parent._internalChildren.remove(this);
-    propagateToChildren(
-      (Component component) {
-        component
-          ..onRemove()
-          .._unregisterKey()
-          .._clearMountedBit()
-          .._clearRemovingBit()
-          .._setRemovedBit()
-          .._removeCompleter?.complete()
-          .._removeCompleter = null
-          .._parent!.onChildrenChanged(component, ChildrenChangeType.removed);
-        return true;
-      },
-      includeSelf: true,
-    );
+    final buffer = <Component>[];
+    _collectTeardown(buffer);
+    for (var i = 0; i < buffer.length; i++) {
+      final component = buffer[i];
+      component
+        ..onRemove()
+        .._unregisterKey()
+        .._clearMountedBit()
+        .._clearRemovingBit()
+        .._setRemovedBit()
+        .._removeCompleter?.complete()
+        .._removeCompleter = null
+        .._parent!.onChildrenChanged(component, ChildrenChangeType.removed);
+    }
     _parent = null;
+  }
+
+  /// Collects this component and all its descendants into [out] in teardown
+  /// order: leaves first, siblings in reverse order, ancestors after their
+  /// subtrees. This matches the order that
+  /// `descendants(reversed: true, includeSelf: true)` would produce, without
+  /// allocating generator frames on every removal.
+  void _collectTeardown(List<Component> out) {
+    final children = _children;
+    if (children != null) {
+      for (final child in children.reversed()) {
+        child._collectTeardown(out);
+      }
+    }
+    out.add(this);
   }
 
   void _unregisterKey() {


### PR DESCRIPTION
# Description
<!-- End of exclude from commit message -->
`Sweep.update` re-sorted its items with a full `List.sort` and a closure comparator every tick, although the list is nearly sorted between ticks (hitboxes only move a little per frame); an insertion sort makes that near-linear. `Sweep.query` also pruned its active list with a searching `List.remove`; since active-list order does not matter, that is now an O(1) swap-remove.

Extracted from #3960 so the data-structure change there stands alone (as requested in [this comment](https://github.com/flame-engine/flame/issues/3957#issuecomment-5066267594)). Stacked on #3982.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues

Relates to #3957

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->

