### PR TITLE
feat!: Rename Game.paused to Game.isPaused

### DIFF
--- a/doc/flame/game.md
+++ b/doc/flame/game.md
@@ -299,7 +299,7 @@ void main() {
 A Flame `Game` can be paused and resumed in two ways:
 
 - With the use of the `pauseEngine` and `resumeEngine` methods.
-- By changing the `paused` attribute.
+- By changing the `isPaused` attribute.
 
 When pausing a `Game`, the `GameLoop` is effectively paused, meaning that no updates or new renders
 will happen until it is resumed.

--- a/doc/flame/migration.md
+++ b/doc/flame/migration.md
@@ -208,3 +208,23 @@ GameWidget.managed(
   gameFactory: MyGame.new,
 );
 ```
+
+
+### `Game.paused` renamed to `Game.isPaused`
+
+The `paused` getter and setter on `Game` have been renamed to `isPaused`, to be consistent with the
+other boolean properties in Flame. The behavior is unchanged; only the name is different.
+
+Replace every usage of `game.paused` with `game.isPaused`:
+
+```dart
+// Before
+if (game.paused) {
+  game.paused = false;
+}
+
+// After
+if (game.isPaused) {
+  game.isPaused = false;
+}
+```

--- a/examples/lib/stories/system/overlays_example.dart
+++ b/examples/lib/stories/system/overlays_example.dart
@@ -97,7 +97,7 @@ Widget _secondaryMenuBuilder(BuildContext buildContext, OverlaysExample game) {
 
 Widget overlayBuilder(DashbookContext ctx) {
   return GameWidget<OverlaysExample>(
-    game: OverlaysExample()..paused = true,
+    game: OverlaysExample()..isPaused = true,
     overlayBuilderMap: {
       'PauseMenu': (context, game) => _pauseMenuBuilder(
         context,

--- a/examples/lib/stories/system/pause_resume_example.dart
+++ b/examples/lib/stories/system/pause_resume_example.dart
@@ -5,14 +5,14 @@ import 'package:flame/game.dart';
 class PauseResumeExample extends FlameGame
     with TapCallbacks, DoubleTapCallbacks {
   static const description = '''
-    Demonstrate how to use the pause and resume engine methods and paused
+    Demonstrate how to use the pause and resume engine methods and isPaused
     attribute.
 
     Tap on the screen to toggle the execution of the engine using the
     `resumeEngine` and `pauseEngine`.
 
     Double Tap on the screen to toggle the execution of the engine using the
-    `paused` attribute.
+    `isPaused` attribute.
   ''';
 
   @override
@@ -38,7 +38,7 @@ class PauseResumeExample extends FlameGame
 
   @override
   void onTapDown(_) {
-    if (paused) {
+    if (isPaused) {
       resumeEngine();
     } else {
       pauseEngine();
@@ -47,6 +47,6 @@ class PauseResumeExample extends FlameGame
 
   @override
   void onDoubleTapDown(_) {
-    paused = !paused;
+    isPaused = !isPaused;
   }
 }

--- a/examples/lib/stories/system/step_engine_example.dart
+++ b/examples/lib/stories/system/step_engine_example.dart
@@ -64,7 +64,7 @@ class StepEngineExample extends FlameGame
     Set<LogicalKeyboardKey> keysPressed,
   ) {
     if (keysPressed.contains(LogicalKeyboardKey.keyP)) {
-      paused = !paused;
+      isPaused = !isPaused;
     } else if (keysPressed.contains(LogicalKeyboardKey.keyS)) {
       stepEngine(stepTime: _stepTime * _stepTimeMultiplier);
     } else if (keysPressed.contains(LogicalKeyboardKey.arrowUp)) {

--- a/packages/flame/lib/src/devtools/connectors/game_loop_connector.dart
+++ b/packages/flame/lib/src/devtools/connectors/game_loop_connector.dart
@@ -57,7 +57,7 @@ class GameLoopConnector extends DevToolsConnector {
   @override
   void initGame(FlameGame game) {
     super.initGame(game);
-    _pauseNotifier = ValueNotifier<bool>(game.paused);
+    _pauseNotifier = ValueNotifier<bool>(game.isPaused);
     _pauseNotifier.addListener(() {
       final newPaused = _pauseNotifier.value;
       if (newPaused) {

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -330,7 +330,7 @@ class FlameGame<W extends World> extends ComponentTreeRoot
       case AppLifecycleState.paused:
       case AppLifecycleState.detached:
       case AppLifecycleState.hidden:
-        if (pauseWhenBackgrounded && !paused) {
+        if (pauseWhenBackgrounded && !isPaused) {
           pauseEngine();
           _pausedBecauseBackgrounded = true;
         }

--- a/packages/flame/lib/src/game/game.dart
+++ b/packages/flame/lib/src/game/game.dart
@@ -342,14 +342,14 @@ abstract mixin class Game {
     );
   }
 
-  bool _paused = false;
+  bool _isPaused = false;
 
-  /// Returns is the engine if currently paused or running
-  bool get paused => _paused;
+  /// Whether the engine is currently paused or running.
+  bool get isPaused => _isPaused;
 
-  /// Pauses or resume the engine
-  set paused(bool value) {
-    _paused = value;
+  /// Pauses or resumes the engine.
+  set isPaused(bool value) {
+    _isPaused = value;
 
     final gameLoop = _gameRenderBox?.gameLoop;
     if (gameLoop != null) {
@@ -363,23 +363,23 @@ abstract mixin class Game {
 
   /// Pauses the engine game loop execution.
   void pauseEngine() {
-    _paused = true;
+    _isPaused = true;
     _gameRenderBox?.gameLoop?.stop();
   }
 
   /// Resumes the engine game loop execution.
   void resumeEngine() {
-    _paused = false;
+    _isPaused = false;
     _gameRenderBox?.gameLoop?.start();
   }
 
   /// Steps the engine game loop by one frame. Works only if the engine is in
   /// paused state. By default step time is assumed to be 1/60th of a second.
   void stepEngine({double stepTime = 1 / 60}) {
-    if (_paused) {
-      _paused = false;
+    if (_isPaused) {
+      _isPaused = false;
       _gameRenderBox?.gameLoop?.step(stepTime);
-      _paused = true;
+      _isPaused = true;
     }
   }
 

--- a/packages/flame/lib/src/game/game_render_box.dart
+++ b/packages/flame/lib/src/game/game_render_box.dart
@@ -105,7 +105,7 @@ class GameRenderBox extends RenderBox with WidgetsBindingObserver {
 
     final gameLoop = this.gameLoop = GameLoop(gameLoopCallback);
 
-    if (!game.paused) {
+    if (!game.isPaused) {
       gameLoop.start();
     }
 

--- a/packages/flame/lib/src/game/game_widget/game_widget.dart
+++ b/packages/flame/lib/src/game/game_widget/game_widget.dart
@@ -209,7 +209,7 @@ class GameWidgetState<T extends Game> extends State<GameWidget<T>> {
     assert(game.hasLayout);
     await game.load();
     game.mount();
-    if (!game.paused) {
+    if (!game.isPaused) {
       game.update(0);
     }
   })();
@@ -412,7 +412,7 @@ class GameWidgetState<T extends Game> extends State<GameWidget<T>> {
                       // This should only be called if the game has already been
                       // loaded (in the case of resizing for example), since
                       // update otherwise should be called after onMount.
-                      if (!currentGame.paused && currentGame.isAttached) {
+                      if (!currentGame.isPaused && currentGame.isAttached) {
                         currentGame.update(0);
                       }
                       return FutureBuilder(

--- a/packages/flame/test/components/advanced_button_component_test.dart
+++ b/packages/flame/test/components/advanced_button_component_test.dart
@@ -218,11 +218,11 @@ void main() {
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, true);
+        expect(game.isPaused, true);
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, false);
+        expect(game.isPaused, false);
       },
     );
   });

--- a/packages/flame/test/components/button_component_test.dart
+++ b/packages/flame/test/components/button_component_test.dart
@@ -167,11 +167,11 @@ void main() {
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, true);
+        expect(game.isPaused, true);
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, false);
+        expect(game.isPaused, false);
       },
     );
   });

--- a/packages/flame/test/components/input/sprite_button_component_test.dart
+++ b/packages/flame/test/components/input/sprite_button_component_test.dart
@@ -188,11 +188,11 @@ Future<void> main() async {
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, true);
+        expect(game.isPaused, true);
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, false);
+        expect(game.isPaused, false);
       },
     );
 
@@ -365,11 +365,11 @@ Future<void> main() async {
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, true);
+        expect(game.isPaused, true);
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, false);
+        expect(game.isPaused, false);
       },
     );
   });

--- a/packages/flame/test/components/toogle_button_component_test.dart
+++ b/packages/flame/test/components/toogle_button_component_test.dart
@@ -234,11 +234,11 @@ void main() {
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, true);
+        expect(game.isPaused, true);
 
         await tester.tapAt(const Offset(400, 300));
         await tester.pump(const Duration(seconds: 1));
-        expect(game.paused, false);
+        expect(game.isPaused, false);
       },
     );
   });

--- a/packages/flame/test/game/flame_game_test.dart
+++ b/packages/flame/test/game/flame_game_test.dart
@@ -320,15 +320,15 @@ void main() {
         final game = FlameGame();
 
         await tester.pumpWidget(GameWidget(game: game));
-        expect(game.paused, isFalse);
+        expect(game.isPaused, isFalse);
         expect(game.isPausedOnBackground, isFalse);
 
         await tester.pumpWidget(Container());
-        expect(game.paused, isTrue);
+        expect(game.isPaused, isTrue);
         expect(game.isPausedOnBackground, isTrue);
 
         await tester.pumpWidget(GameWidget(game: game));
-        expect(game.paused, isFalse, reason: 'Game should resume on remount');
+        expect(game.isPaused, isFalse, reason: 'Game should resume on remount');
         expect(
           game.isPausedOnBackground,
           isFalse,
@@ -341,20 +341,20 @@ void main() {
       game.pauseWhenBackgrounded = true;
 
       game.lifecycleStateChange(AppLifecycleState.paused);
-      expect(game.paused, isTrue);
+      expect(game.isPaused, isTrue);
 
       game.lifecycleStateChange(AppLifecycleState.resumed);
-      expect(game.paused, isFalse);
+      expect(game.isPaused, isFalse);
     });
 
     testWithFlameGame('false', (game) async {
       game.pauseWhenBackgrounded = false;
 
       game.lifecycleStateChange(AppLifecycleState.paused);
-      expect(game.paused, isFalse);
+      expect(game.isPaused, isFalse);
 
       game.lifecycleStateChange(AppLifecycleState.resumed);
-      expect(game.paused, isFalse);
+      expect(game.isPaused, isFalse);
     });
 
     for (final startingLifecycleState in AppLifecycleState.values) {
@@ -384,7 +384,7 @@ void main() {
 
           GameWidgetState.initGameStateListener(game, () {});
 
-          expect(game.paused, isFalse);
+          expect(game.isPaused, isFalse);
         },
       );
     }
@@ -399,15 +399,15 @@ void main() {
         await game.toBeLoaded();
         await tester.pump();
 
-        expect(game.paused, isFalse);
+        expect(game.isPaused, isFalse);
         WidgetsBinding.instance.handleAppLifecycleStateChanged(
           AppLifecycleState.paused,
         );
-        expect(game.paused, isTrue);
+        expect(game.isPaused, isTrue);
         WidgetsBinding.instance.handleAppLifecycleStateChanged(
           AppLifecycleState.resumed,
         );
-        expect(game.paused, isFalse);
+        expect(game.isPaused, isFalse);
       },
     );
 

--- a/packages/flame/test/game/game_render_box_test.dart
+++ b/packages/flame/test/game/game_render_box_test.dart
@@ -20,7 +20,7 @@ void main() {
     test('game/attach', () {
       final owner = PipelineOwner();
       final game = _MockFlameGame();
-      when(() => game.paused).thenReturn(true);
+      when(() => game.isPaused).thenReturn(true);
 
       final BuildContext context = _MockBuildContext();
       final renderBox = GameRenderBox(game, context, isRepaintBoundary: false);
@@ -28,22 +28,22 @@ void main() {
 
       verify(() => game.attach(owner, renderBox)).called(1);
       expect(renderBox.gameLoop, isNotNull);
-      verify(() => game.paused).called(1);
+      verify(() => game.isPaused).called(1);
 
       final anotherGame = _MockFlameGame();
-      when(() => anotherGame.paused).thenReturn(true);
+      when(() => anotherGame.isPaused).thenReturn(true);
 
       renderBox.game = anotherGame;
       verify(game.detach).called(1);
       verify(() => anotherGame.attach(owner, renderBox)).called(1);
-      verify(() => anotherGame.paused).called(1);
+      verify(() => anotherGame.isPaused).called(1);
       expect(renderBox.gameLoop, isNotNull);
     });
 
     test('buildContext', () {
       final owner = PipelineOwner();
       final game = _MockFlameGame();
-      when(() => game.paused).thenReturn(true);
+      when(() => game.isPaused).thenReturn(true);
 
       final BuildContext context = _MockBuildContext();
       final renderBox = GameRenderBox(game, context, isRepaintBoundary: false);
@@ -56,7 +56,7 @@ void main() {
       final owner = PipelineOwner();
 
       final game = _MockFlameGame();
-      when(() => game.paused).thenReturn(true);
+      when(() => game.isPaused).thenReturn(true);
 
       final BuildContext context = _MockBuildContext();
       final renderBox = GameRenderBox(game, context, isRepaintBoundary: false);

--- a/packages/flame/test/game/game_widget/game_widget_pause_test.dart
+++ b/packages/flame/test/game/game_widget/game_widget_pause_test.dart
@@ -71,9 +71,9 @@ class _MyGame extends FlameGame {
 }
 
 void main() {
-  FlameTester<_MyGame> myGame({bool paused = false}) {
+  FlameTester<_MyGame> myGame({bool isPaused = false}) {
     return FlameTester(
-      () => _MyGame()..paused = paused,
+      () => _MyGame()..isPaused = isPaused,
       pumpWidget: (gameWidget, tester) async {
         await tester.pumpWidget(_Wrapper(child: gameWidget));
       },
@@ -134,7 +134,7 @@ void main() {
     },
   );
 
-  myGame(paused: true).testGameWidget(
+  myGame(isPaused: true).testGameWidget(
     'can start paused',
     verify: (game, tester) async {
       // Run two frames
@@ -145,7 +145,7 @@ void main() {
     },
   );
 
-  myGame(paused: true).testGameWidget(
+  myGame(isPaused: true).testGameWidget(
     'can start paused and resumed later',
     verify: (game, tester) async {
       // Run two frames

--- a/packages/flame_console/lib/src/commands/pause_command.dart
+++ b/packages/flame_console/lib/src/commands/pause_command.dart
@@ -5,7 +5,7 @@ import 'package:flame_console/flame_console.dart';
 class PauseConsoleCommand<G extends FlameGame> extends FlameConsoleCommand<G> {
   @override
   (String?, String) execute(G game, ArgResults results) {
-    if (game.paused) {
+    if (game.isPaused) {
       return (
         'Game is already paused, use the resume command start it again',
         '',

--- a/packages/flame_console/lib/src/commands/resume_command.dart
+++ b/packages/flame_console/lib/src/commands/resume_command.dart
@@ -5,7 +5,7 @@ import 'package:flame_console/flame_console.dart';
 class ResumeConsoleCommand<G extends FlameGame> extends FlameConsoleCommand<G> {
   @override
   (String?, String) execute(G game, ArgResults results) {
-    if (!game.paused) {
+    if (!game.isPaused) {
       return ('Game is not paused, use the pause command to pause it', '');
     } else {
       game.resumeEngine();

--- a/packages/flame_console/test/src/pause_command_test.dart
+++ b/packages/flame_console/test/src/pause_command_test.dart
@@ -9,10 +9,10 @@ void main() {
       'pauses the game',
       FlameGame.new,
       (game) async {
-        expect(game.paused, isFalse);
+        expect(game.isPaused, isFalse);
         final command = PauseConsoleCommand();
         command.execute(game, command.parser.parse([]));
-        expect(game.paused, isTrue);
+        expect(game.isPaused, isTrue);
       },
     );
 
@@ -22,10 +22,10 @@ void main() {
         FlameGame.new,
         (game) async {
           game.pauseEngine();
-          expect(game.paused, isTrue);
+          expect(game.isPaused, isTrue);
           final command = PauseConsoleCommand();
           final result = command.execute(game, command.parser.parse([]));
-          expect(game.paused, isTrue);
+          expect(game.isPaused, isTrue);
 
           expect(
             result.$1,

--- a/packages/flame_console/test/src/resume_command_test.dart
+++ b/packages/flame_console/test/src/resume_command_test.dart
@@ -10,10 +10,10 @@ void main() {
       FlameGame.new,
       (game) async {
         game.pauseEngine();
-        expect(game.paused, isTrue);
+        expect(game.isPaused, isTrue);
         final command = ResumeConsoleCommand();
         command.execute(game, command.parser.parse([]));
-        expect(game.paused, isFalse);
+        expect(game.isPaused, isFalse);
       },
     );
 
@@ -22,10 +22,10 @@ void main() {
         'returns error',
         FlameGame.new,
         (game) async {
-          expect(game.paused, isFalse);
+          expect(game.isPaused, isFalse);
           final command = ResumeConsoleCommand();
           final result = command.execute(game, command.parser.parse([]));
-          expect(game.paused, isFalse);
+          expect(game.isPaused, isFalse);
 
           expect(
             result.$1,


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Renames the `paused` getter and setter on `Game` to `isPaused`, so that it follows the same
`is`-prefix convention as the other boolean properties in Flame (`isMounted`, `isLoaded`,
`isAttached`, `Effect.isPaused`, etc.).

The behavior is completely unchanged, only the name is different. The private backing field was
renamed from `_paused` to `_isPaused` accordingly, and the dartdocs on the getter/setter were
cleaned up (the getter doc previously read "Returns is the engine if currently paused or running").

All usages were updated across `flame` (`GameRenderBox`, `GameWidget`, `FlameGame`, the devtools
game loop connector), `flame_console` (pause/resume commands), the examples and the docs. The
`paused` key used by the devtools service extension protocol is left as-is since it is a wire
format, not a public Dart API.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

Replace every usage of `game.paused` with `game.isPaused`:

```dart
// Before
if (game.paused) {
  game.paused = false;
}

// After
if (game.isPaused) {
  game.isPaused = false;
}
```
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #3991

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
