### PR TITLE
feat!: Kill ScaleDetector in favour of ScaleCallbacks

### DIFF
--- a/doc/flame/inputs/gesture_input.md
+++ b/doc/flame/inputs/gesture_input.md
@@ -31,11 +31,6 @@ Detectors will be deprecated in the future. Prefer `Callbacks` instead.
   - onPanEnd
   - onPanCancel
 
-- ScaleDetector
-  - onScaleStart
-  - onScaleUpdate
-  - onScaleEnd
-
 - MultiTouchTapDetector
   - onTap
   - onTapCancel
@@ -69,53 +64,44 @@ also read more about
 [Flutter's gesture system](https://api.flutter.dev/flutter/gestures/gestures-library.html).
 
 
-## PanDetector and ScaleDetector
+## Panning and zooming
 
-If you add a `PanDetector` together with a `ScaleDetector` you will be prompted with a quite cryptic
-assertion from Flutter that says:
-
-```{note}
-Having both a pan gesture recognizer and a scale gesture recognizer is
-redundant; scale is a superset of pan.
-
-Just use the scale gesture recognizer.
-```
-
-This might seem strange, but `onScaleUpdate` is not only triggered when the scale should be changed,
-but for all pan/drag events too. So if you need to use both of those detectors you'll have to handle
-both of their logic inside `onScaleUpdate` (+`onScaleStart` and `onScaleEnd`).
-
-For example you could do something like this if you want to move the camera on pan events and zoom
-on scale events:
+To handle panning and pinch-to-zoom at the same time, use the
+[`DragCallbacks`](drag_events.md) and [`ScaleCallbacks`](scale_events.md) mixins together. Both are
+driven by the same recognizer, so they can be combined freely: drag events are reported per pointer,
+while scale events only start once two or more pointers are down.
 
 ```dart
+class MyGame extends FlameGame with DragCallbacks, ScaleCallbacks {
+  late double startZoom;
+
   void clampZoom() {
     camera.viewfinder.zoom = camera.viewfinder.zoom.clamp(0.05, 3.0);
   }
 
-  late double startZoom;
-
   @override
-  void onScaleStart(_) {
+  void onScaleStart(ScaleStartEvent event) {
+    super.onScaleStart(event);
     startZoom = camera.viewfinder.zoom;
   }
 
   @override
-  void onScaleUpdate(ScaleUpdateInfo info) {
-    final currentScale = info.scale.global;
-    if (!currentScale.isIdentity()) {
-      camera.viewfinder.zoom = startZoom * currentScale.y;
-      clampZoom();
-    } else {
-      final zoom = camera.viewfinder.zoom;
-      final delta = (info.delta.global..negate()) / zoom;
-      camera.moveBy(delta);
-    }
+  void onScaleUpdate(ScaleUpdateEvent event) {
+    camera.viewfinder.zoom = startZoom * event.verticalScale;
+    clampZoom();
   }
-```
 
-In the example above the pan events are handled with `info.delta` and the scale events with
-`info.scale`, although they are theoretically both from underlying scale events.
+  @override
+  void onDragUpdate(DragUpdateEvent event) {
+    // Two-finger pinches emit both drag and scale; skip pan while zooming
+    if (isScaling) {
+      return;
+    }
+    final zoom = camera.viewfinder.zoom;
+    camera.moveBy((event.localDelta..negate()) / zoom);
+  }
+}
+```
 
 This can also be seen in the
 [zoom example](https://github.com/flame-engine/flame/blob/main/examples/lib/stories/camera_and_viewport/zoom_example.dart).

--- a/examples/lib/stories/camera_and_viewport/fixed_resolution_example.dart
+++ b/examples/lib/stories/camera_and_viewport/fixed_resolution_example.dart
@@ -6,8 +6,7 @@ import 'package:flame/palette.dart';
 import 'package:flame/text.dart';
 import 'package:flutter/material.dart';
 
-class FixedResolutionExample extends FlameGame
-    with ScrollDetector, ScaleDetector {
+class FixedResolutionExample extends FlameGame with ScrollDetector {
   static const description = '''
     This example shows how to create a viewport with a fixed resolution.
     It is useful when you want the visible part of the game to be the same on

--- a/examples/lib/stories/camera_and_viewport/static_components_example.dart
+++ b/examples/lib/stories/camera_and_viewport/static_components_example.dart
@@ -8,8 +8,7 @@ import 'package:flame/game.dart';
 import 'package:flame/input.dart';
 import 'package:flame/parallax.dart';
 
-class StaticComponentsExample extends FlameGame
-    with ScrollDetector, ScaleDetector {
+class StaticComponentsExample extends FlameGame with ScrollDetector {
   static const description = '''
   This example shows a parallax which is attached to the viewport (behind the
   world), four Flame logos that are added to the world, and a player added to

--- a/examples/lib/stories/camera_and_viewport/zoom_example.dart
+++ b/examples/lib/stories/camera_and_viewport/zoom_example.dart
@@ -3,7 +3,8 @@ import 'package:flame/events.dart';
 import 'package:flame/game.dart';
 import 'package:flame/input.dart';
 
-class ZoomExample extends FlameGame with ScrollDetector, ScaleDetector {
+class ZoomExample extends FlameGame
+    with ScrollDetector, ScaleCallbacks, DragCallbacks {
   static const String description = '''
     On web: use scroll to zoom in and out.\n
     On mobile: use scale gesture to zoom in and out.
@@ -37,20 +38,24 @@ class ZoomExample extends FlameGame with ScrollDetector, ScaleDetector {
   late double startZoom;
 
   @override
-  void onScaleStart(_) {
+  void onScaleStart(ScaleStartEvent event) {
+    super.onScaleStart(event);
     startZoom = camera.viewfinder.zoom;
   }
 
   @override
-  void onScaleUpdate(ScaleUpdateInfo info) {
-    final currentScale = info.scale.global;
-    if (!currentScale.isIdentity()) {
-      camera.viewfinder.zoom = startZoom * currentScale.y;
-      clampZoom();
-    } else {
-      final zoom = camera.viewfinder.zoom;
-      final delta = (info.delta.global..negate()) / zoom;
-      camera.moveBy(delta);
+  void onScaleUpdate(ScaleUpdateEvent event) {
+    camera.viewfinder.zoom = startZoom * event.verticalScale;
+    clampZoom();
+  }
+
+  @override
+  void onDragUpdate(DragUpdateEvent event) {
+    // Two-finger pinches emit both drag and scale; skip pan while zooming
+    if (isScaling) {
+      return;
     }
+    final zoom = camera.viewfinder.zoom;
+    camera.moveBy((event.localDelta..negate()) / zoom);
   }
 }

--- a/packages/flame/lib/events.dart
+++ b/packages/flame/lib/events.dart
@@ -82,7 +82,7 @@ export 'src/events/multi_drag_scale_recognizer.dart'
 export 'src/game/mixins/keyboard.dart'
     show HasKeyboardHandlerComponents, KeyboardEvents;
 export 'src/gestures/detectors.dart'
-    show MouseMovementDetector, PanDetector, ScaleDetector, ScrollDetector;
+    show MouseMovementDetector, PanDetector, ScrollDetector;
 export 'src/gestures/events.dart'
     show
         DragDownInfo,
@@ -92,8 +92,5 @@ export 'src/gestures/events.dart'
         PointerHoverInfo,
         PointerScrollInfo,
         PositionInfo,
-        ScaleEndInfo,
-        ScaleStartInfo,
-        ScaleUpdateInfo,
         TapDownInfo,
         TapUpInfo;

--- a/packages/flame/lib/src/events/interfaces/scale_listener.dart
+++ b/packages/flame/lib/src/events/interfaces/scale_listener.dart
@@ -1,31 +1,27 @@
 import 'package:flame/events.dart';
 import 'package:flutter/gestures.dart';
 
-/// Interface that must be implemented by a game in order for it to be eligible
-/// to receive events from an [ScaleGestureRecognizer].
+/// Interface that must be implemented in order to be eligible to receive
+/// events from a [MultiDragScaleGestureRecognizer].
 ///
-/// Instead of implementing this class directly consider using one of the
-/// prebuilt mixins:
-///  - [MultiTouchDragDetector] for a custom `Game`
+/// Instead of implementing this class directly, consider using the
+/// [ScaleCallbacks] mixin on a `Component` (or `Game`).
 abstract class ScaleListener {
-  /// The beginning of a drag operation.
+  /// The beginning of a scale operation.
   ///
-  /// If the game is not listening to tap events, this event will occur as soon
-  /// as the user touches the screen. If the game uses both a [MultiTapListener]
-  /// and a [MultiDragListener] simultaneously, then this event will fire once
-  /// the user moves their finger away from the point of the initial touch.
+  /// This event fires once two or more pointers are touching the screen and
+  /// their movement exceeds the recognizer's scale threshold.
   void handleScaleStart(ScaleStartDetails details);
 
-  /// The pointer that was touching the screen has moved.
+  /// The pointers taking part in the scale gesture have moved.
   ///
-  /// This event occurs frequently during the drag, allowing you to keep track
-  /// of the position of the point of touch as it moves. This event will only
-  /// fire when the point of touch moves, and not when it stays still.
+  /// This event occurs frequently during the gesture, reporting the current
+  /// scale factors, the rotation and the focal point.
   void handleScaleUpdate(ScaleUpdateDetails details);
 
-  /// Marks the end of a drag operation.
+  /// Marks the end of a scale operation.
   ///
-  /// This event fires when the pointer stops touching the screen. It will fire
-  /// even if the pointer is currently outside of the game widget.
+  /// This event fires once fewer than two pointers are left touching the
+  /// screen.
   void handleScaleEnd(ScaleEndDetails details);
 }

--- a/packages/flame/lib/src/game/flame_game.dart
+++ b/packages/flame/lib/src/game/flame_game.dart
@@ -248,7 +248,6 @@ class FlameGame<W extends World> extends ComponentTreeRoot
     // Game-level detector mixins handle events for the entire game surface,
     // so any in-bounds point is a hit.
     if (this is PanDetector ||
-        this is ScaleDetector ||
         this is MultiTapListener ||
         this is MultiTouchDragDetector) {
       return true;

--- a/packages/flame/lib/src/game/game_widget/gesture_detector_builder.dart
+++ b/packages/flame/lib/src/game/game_widget/gesture_detector_builder.dart
@@ -56,16 +56,6 @@ class GestureDetectorBuilder {
         },
       );
     }
-    if (game is ScaleDetector) {
-      register(
-        ScaleGestureRecognizer.new,
-        (ScaleGestureRecognizer instance) {
-          instance.onStart = game.handleScaleStart;
-          instance.onUpdate = game.handleScaleUpdate;
-          instance.onEnd = game.handleScaleEnd;
-        },
-      );
-    }
     if (game is MultiTapListener) {
       register(
         MultiTapGestureRecognizer.new,

--- a/packages/flame/lib/src/gestures/detectors.dart
+++ b/packages/flame/lib/src/gestures/detectors.dart
@@ -26,24 +26,6 @@ mixin PanDetector on Game {
   }
 }
 
-mixin ScaleDetector on Game {
-  void onScaleStart(ScaleStartInfo info) {}
-  void onScaleUpdate(ScaleUpdateInfo info) {}
-  void onScaleEnd(ScaleEndInfo info) {}
-
-  void handleScaleStart(ScaleStartDetails details) {
-    onScaleStart(ScaleStartInfo.fromDetails(this, details));
-  }
-
-  void handleScaleUpdate(ScaleUpdateDetails details) {
-    onScaleUpdate(ScaleUpdateInfo.fromDetails(this, details));
-  }
-
-  void handleScaleEnd(ScaleEndDetails details) {
-    onScaleEnd(ScaleEndInfo.fromDetails(details));
-  }
-}
-
 mixin MouseMovementDetector on Game {
   void onMouseMove(PointerHoverInfo info) {}
 }

--- a/packages/flame/lib/src/gestures/events.dart
+++ b/packages/flame/lib/src/gestures/events.dart
@@ -120,34 +120,3 @@ class DragEndInfo extends BaseInfo<DragEndDetails> {
 
   DragEndInfo.fromDetails(super.raw);
 }
-
-class ScaleStartInfo extends PositionInfo<ScaleStartDetails> {
-  int get pointerCount => raw.pointerCount;
-
-  ScaleStartInfo.fromDetails(
-    Game game,
-    ScaleStartDetails raw,
-  ) : super(game, raw.focalPoint, raw);
-}
-
-class ScaleEndInfo extends BaseInfo<ScaleEndDetails> {
-  late final EventDelta velocity = EventDelta(raw.velocity.pixelsPerSecond);
-
-  int get pointerCount => raw.pointerCount;
-
-  ScaleEndInfo.fromDetails(super.raw);
-}
-
-class ScaleUpdateInfo extends PositionInfo<ScaleUpdateDetails> {
-  int get pointerCount => raw.pointerCount;
-  double get rotation => raw.rotation;
-  late final EventDelta delta = EventDelta(raw.focalPointDelta);
-  late final EventDelta scale = EventDelta(
-    Offset(raw.horizontalScale, raw.verticalScale),
-  );
-
-  ScaleUpdateInfo.fromDetails(
-    Game game,
-    ScaleUpdateDetails raw,
-  ) : super(game, raw.focalPoint, raw);
-}

--- a/packages/flame/test/gestures/detectors_test.dart
+++ b/packages/flame/test/gestures/detectors_test.dart
@@ -95,65 +95,6 @@ void main() {
     );
   });
 
-  group('ScaleDetector', () {
-    final scaleGame = FlameTester(_ScaleDetectorGame.new);
-
-    scaleGame.testGameWidget(
-      'can register Scale',
-      setUp: (game, tester) async {
-        final gesture1 = await tester.createGesture();
-        final gesture2 = await tester.createGesture();
-
-        await gesture1.down(const Offset(10, 10));
-        await gesture2.down(const Offset(20, 20));
-
-        await gesture1.moveTo(const Offset(15, 10));
-        await gesture2.moveTo(const Offset(15, 20));
-
-        await gesture1.up();
-        await gesture2.up();
-      },
-      verify: (game, tester) async {
-        expect(game.hasOnScaleStart, isTrue);
-        expect(game.hasOnScaleUpdate, isTrue);
-        expect(game.hasOnScaleEnd, isTrue);
-      },
-    );
-
-    testWithGame<_ScaleDetectorGame>(
-      'can receive onScaleStart',
-      _ScaleDetectorGame.new,
-      (game) async {
-        await game.ready();
-
-        game.handleScaleStart(ScaleStartDetails());
-        expect(game.hasOnScaleStart, isTrue);
-      },
-    );
-
-    testWithGame<_ScaleDetectorGame>(
-      'can receive onScaleUpdate',
-      _ScaleDetectorGame.new,
-      (game) async {
-        await game.ready();
-
-        game.handleScaleUpdate(ScaleUpdateDetails());
-        expect(game.hasOnScaleUpdate, isTrue);
-      },
-    );
-
-    testWithGame<_ScaleDetectorGame>(
-      'can receive onScaleEnd',
-      _ScaleDetectorGame.new,
-      (game) async {
-        await game.ready();
-
-        game.handleScaleEnd(ScaleEndDetails());
-        expect(game.hasOnScaleEnd, isTrue);
-      },
-    );
-  });
-
   group('MouseMovementDetector', () {
     final mouseMoveGame = FlameTester(_MouseMovementDetectorGame.new);
 
@@ -221,27 +162,6 @@ class _PanDetectorGame extends FlameGame with PanDetector {
   @override
   void onPanStart(DragStartInfo info) {
     hasPanStart = true;
-  }
-}
-
-class _ScaleDetectorGame extends FlameGame with ScaleDetector {
-  bool hasOnScaleStart = false;
-  bool hasOnScaleUpdate = false;
-  bool hasOnScaleEnd = false;
-
-  @override
-  void onScaleStart(ScaleStartInfo info) {
-    hasOnScaleStart = true;
-  }
-
-  @override
-  void onScaleUpdate(ScaleUpdateInfo info) {
-    hasOnScaleUpdate = true;
-  }
-
-  @override
-  void onScaleEnd(ScaleEndInfo info) {
-    hasOnScaleEnd = true;
   }
 }
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Kill `ScaleDetector` mixin and associated code from old infra in favour of `ScaleCallbacks`.

Minor differences:
* **On panning**: the old `ScaleGestureRecognizer` also fired scale events for a single pointer, which the zoom example exploited to pan. `MultiDragScaleGestureRecognizer` only fires scale once two or more pointers are down, so the example and the docs now combine `ScaleCallbacks` with `DragCallbacks`, which is the intended way to do pan + pinch in the new system and no longer needs the old `PanDetector`/`ScaleDetector` conflict workaround. The drag handler skips panning while isScaling, since a pinch emits drag events for each pointer as well.
* **On trackpad pinch**: `ScaleGestureRecognizer` handles `PointerPanZoom*` events via `addAllowedPointerPanZoom`, which is how a trackpad pinch reaches a scale recognizer. `MultiDragScaleGestureRecognizer` does not implement this, so nor does our new detectors; however that is an existing gap, and we can close it on followups. This is tangential to this cleanup.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->