### PR TITLE
fix!: Wait for children added in onLoad before marking a component as loaded

### DIFF
--- a/doc/flame/components/components.md
+++ b/doc/flame/components/components.md
@@ -94,7 +94,8 @@ class MyComponent extends Component {
 A component's lifecycle state can be checked by a series of getters:
 
 - `isLoaded`: Returns a bool with the current loaded state.
-- `loaded`: Returns a future that will complete once the component has finished loading.
+- `loaded`: Returns a future that will complete once the component has finished loading, including
+  the loading of any children that were added during its `onLoad`.
 - `isMounted`: Returns a bool with the current mounted state.
 - `mounted`: Returns a future that will complete once the component has finished mounting.
 - `isRemoved`: Returns a bool with the current removed state.
@@ -262,6 +263,14 @@ Awaiting `mounted` or `removed` there is not safe: a child can only be mounted a
 been, and the parent is only mounted once its `onLoad` has completed, so those futures would
 deadlock. The same goes for `game.lifecycleEventsProcessed`, since the parent's own pending mount is
 part of the queue it waits for.
+
+A component does not count as loaded until every child that was added during its `onLoad` has
+finished loading as well, even without awaiting their `loaded` futures explicitly. This means that
+by the time the component mounts, the subtree it created during `onLoad` is fully loaded, and those
+children mount together with it in the same lifecycle processing pass. A child that fails to load
+is the exception: it is dropped from the tree without blocking its parent. Because the parent now
+waits for its children, a child's `onLoad` must not await the parent's `loaded` future, that would
+deadlock.
 
 Note that the children added via either method are only guaranteed to be available eventually:
 after they are loaded and mounted. We can only assure that they will appear in the children list

--- a/doc/flame/components/components.md
+++ b/doc/flame/components/components.md
@@ -292,9 +292,9 @@ A component does not count as loaded until every child that was added during its
 finished loading as well, even without awaiting their `loaded` futures explicitly. This means that
 by the time the component mounts, the subtree it created during `onLoad` is fully loaded, and those
 children mount together with it in the same lifecycle processing pass. A child that fails to load
-is the exception: it is dropped from the tree without blocking its parent. Because the parent now
-waits for its children, a child's `onLoad` must not await the parent's `loaded` future, that would
-deadlock.
+is the exception: it is dropped from the tree without blocking its parent. Because the parent
+waits for its children, a child's `onLoad` must not await the parent's `loaded` or `mounted`
+future, that would deadlock.
 
 Note that the children added via either method are only guaranteed to be available eventually:
 after they are loaded and mounted. We can only assure that they will appear in the children list

--- a/doc/flame/components/components.md
+++ b/doc/flame/components/components.md
@@ -94,7 +94,8 @@ class MyComponent extends Component {
 A component's lifecycle state can be checked by a series of getters:
 
 - `isLoaded`: Returns a bool with the current loaded state.
-- `loaded`: Returns a future that will complete once the component has finished loading.
+- `loaded`: Returns a future that will complete once the component has finished loading, including
+  the loading of any children that were added during its `onLoad`.
 - `isMounted`: Returns a bool with the current mounted state.
 - `mounted`: Returns a future that will complete once the component has finished mounting.
 - `isRemoved`: Returns a bool with the current removed state.
@@ -286,6 +287,14 @@ Awaiting `mounted` or `removed` there is not safe: a child can only be mounted a
 been, and the parent is only mounted once its `onLoad` has completed, so those futures would
 deadlock. The same goes for `game.lifecycleEventsProcessed`, since the parent's own pending mount is
 part of the queue it waits for.
+
+A component does not count as loaded until every child that was added during its `onLoad` has
+finished loading as well, even without awaiting their `loaded` futures explicitly. This means that
+by the time the component mounts, the subtree it created during `onLoad` is fully loaded, and those
+children mount together with it in the same lifecycle processing pass. A child that fails to load
+is the exception: it is dropped from the tree without blocking its parent. Because the parent now
+waits for its children, a child's `onLoad` must not await the parent's `loaded` future, that would
+deadlock.
 
 Note that the children added via either method are only guaranteed to be available eventually:
 after they are loaded and mounted. We can only assure that they will appear in the children list

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -192,7 +192,8 @@ class Component {
   void _setLoadingBit() => _state |= _loading;
   void _clearLoadingBit() => _state &= ~_loading;
 
-  /// Whether this component has completed its [onLoad] step.
+  /// Whether this component has completed its [onLoad] step, including the
+  /// loading of every child that was added during [onLoad].
   bool get isLoaded => (_state & _loaded) != 0;
   void _setLoadedBit() => _state |= _loaded;
 
@@ -231,6 +232,11 @@ class Component {
   ({Object error, StackTrace stackTrace})? _loadError;
 
   /// A future that completes when this component finishes loading.
+  ///
+  /// A component only counts as finished loading once every child that was
+  /// added during its [onLoad] has finished loading as well, so awaiting
+  /// this future guarantees that the subtree created during [onLoad] is
+  /// loaded.
   ///
   /// If the component is already loaded (see [isLoaded]), this returns an
   /// already completed future. If [onLoad] threw, this returns a future that
@@ -814,6 +820,9 @@ class Component {
     } else {
       _children?.remove(child);
       child._parent = null;
+      if (isLoading) {
+        _notifyChildrenChangedWhileLoading();
+      }
     }
   }
 
@@ -1073,7 +1082,68 @@ class Component {
     }
   }
 
+  /// Finishes the load step once every child that is still loading has
+  /// settled as well, so that a component is only marked as loaded when the
+  /// children that were added during its [onLoad] have finished loading too.
   void _finishLoading() {
+    if (_loadingChildren().isEmpty) {
+      _completeLoading();
+    } else {
+      _waitForLoadingChildren().then((_) => _completeLoading());
+    }
+  }
+
+  /// Waits until no child of this component is loading anymore.
+  ///
+  /// Children whose load has failed do not count as loading; they are
+  /// dropped when this component mounts, the same way as when they fail to
+  /// load under a parent that is already mounted.
+  Future<void> _waitForLoadingChildren() async {
+    var wake = Completer<void>();
+    void wakeUp() {
+      if (!wake.isCompleted) {
+        wake.complete();
+      }
+    }
+
+    final watchedChildren = <Component>{};
+    while (true) {
+      final loadingChildren = _loadingChildren();
+      if (loadingChildren.isEmpty) {
+        return;
+      }
+      if (wake.isCompleted) {
+        wake = Completer<void>();
+      }
+      for (final child in loadingChildren) {
+        if (watchedChildren.add(child)) {
+          child.loadSettled.then((_) => wakeUp());
+        }
+      }
+      // Sleep until a child settles its load, or until a child is removed
+      // while this component is loading, and re-evaluate.
+      await Future.any([
+        wake.future,
+        (_childrenChangedWhileLoading ??= Completer<void>()).future,
+      ]);
+    }
+  }
+
+  /// The children whose loads still have to settle before this component can
+  /// be considered loaded.
+  List<Component> _loadingChildren() {
+    final children = _children;
+    if (children == null || children.isEmpty) {
+      return const [];
+    }
+    return [
+      for (final child in children)
+        if (child.isLoading && child._loadError == null) child,
+    ];
+  }
+
+  void _completeLoading() {
+    _childrenChangedWhileLoading = null;
     _clearLoadingBit();
     _setLoadedBit();
     _loadCompleter?.complete();
@@ -1084,6 +1154,16 @@ class Component {
   void _completeLoadSettled() {
     _loadSettledCompleter?.complete();
     _loadSettledCompleter = null;
+  }
+
+  /// Completed when the children set changes while this component is
+  /// loading, so that the pending [_finishLoading] gate re-evaluates, for
+  /// example when a child that never finishes loading is removed.
+  Completer<void>? _childrenChangedWhileLoading;
+
+  void _notifyChildrenChangedWhileLoading() {
+    _childrenChangedWhileLoading?.complete();
+    _childrenChangedWhileLoading = null;
   }
 
   /// Surfaces an error thrown by [onLoad].
@@ -1183,7 +1263,7 @@ class Component {
   /// Used by the [FlameGame] to set the loaded state of the component, since
   /// the game isn't going through the whole normal component life cycle.
   @internal
-  void setLoaded() => _finishLoading();
+  void setLoaded() => _completeLoading();
 
   /// Used by the [FlameGame] to set the mounted state of the component, since
   /// the game isn't going through the whole normal component life cycle.

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -825,7 +825,7 @@ class Component {
   void _addChild(Component child) {
     final game = findGame() ?? child.findGame();
     if ((!isMounted && !child.isMounted) || game == null) {
-      child._parent?.children._remove(child);
+      child._parent?._detachChild(child);
       child._parent = this;
       children._add(child);
     } else if (child._parent != null) {
@@ -901,11 +901,18 @@ class Component {
         child._parent = null;
       }
     } else {
-      _children?._remove(child);
+      _detachChild(child);
       child._parent = null;
-      if (isLoading) {
-        _notifyChildrenChangedWhileLoading();
-      }
+    }
+  }
+
+  /// Takes [child] out of the children of this not yet mounted component,
+  /// and re-evaluates the load gate in case this component is waiting for
+  /// that child to finish loading.
+  void _detachChild(Component child) {
+    _children?._remove(child);
+    if (isLoading) {
+      _notifyChildrenChangedWhileLoading();
     }
   }
 
@@ -1170,16 +1177,18 @@ class Component {
     if (_loadingChildren().isEmpty) {
       _completeLoading();
     } else {
-      _waitForLoadingChildren().then((_) => _completeLoading());
+      _completeLoadingAfterChildren();
     }
   }
 
-  /// Waits until no child of this component is loading anymore.
+  /// Waits until no child of this component is loading anymore, and then
+  /// completes the load, synchronously with that observation so that no
+  /// child can start loading in between.
   ///
   /// Children whose load has failed do not count as loading; they are
   /// dropped when this component mounts, the same way as when they fail to
   /// load under a parent that is already mounted.
-  Future<void> _waitForLoadingChildren() async {
+  Future<void> _completeLoadingAfterChildren() async {
     var wake = Completer<void>();
     void wakeUp() {
       if (!wake.isCompleted) {
@@ -1191,6 +1200,7 @@ class Component {
     while (true) {
       final loadingChildren = _loadingChildren();
       if (loadingChildren.isEmpty) {
+        _completeLoading();
         return;
       }
       if (wake.isCompleted) {

--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -195,7 +195,8 @@ class Component {
   void _setLoadingBit() => _state |= _loading;
   void _clearLoadingBit() => _state &= ~_loading;
 
-  /// Whether this component has completed its [onLoad] step.
+  /// Whether this component has completed its [onLoad] step, including the
+  /// loading of every child that was added during [onLoad].
   bool get isLoaded => (_state & _loaded) != 0;
   void _setLoadedBit() => _state |= _loaded;
 
@@ -234,6 +235,11 @@ class Component {
   ({Object error, StackTrace stackTrace})? _loadError;
 
   /// A future that completes when this component finishes loading.
+  ///
+  /// A component only counts as finished loading once every child that was
+  /// added during its [onLoad] has finished loading as well, so awaiting
+  /// this future guarantees that the subtree created during [onLoad] is
+  /// loaded.
   ///
   /// If the component is already loaded (see [isLoaded]), this returns an
   /// already completed future. If [onLoad] threw, this returns a future that
@@ -897,6 +903,9 @@ class Component {
     } else {
       _children?._remove(child);
       child._parent = null;
+      if (isLoading) {
+        _notifyChildrenChangedWhileLoading();
+      }
     }
   }
 
@@ -1154,7 +1163,68 @@ class Component {
     }
   }
 
+  /// Finishes the load step once every child that is still loading has
+  /// settled as well, so that a component is only marked as loaded when the
+  /// children that were added during its [onLoad] have finished loading too.
   void _finishLoading() {
+    if (_loadingChildren().isEmpty) {
+      _completeLoading();
+    } else {
+      _waitForLoadingChildren().then((_) => _completeLoading());
+    }
+  }
+
+  /// Waits until no child of this component is loading anymore.
+  ///
+  /// Children whose load has failed do not count as loading; they are
+  /// dropped when this component mounts, the same way as when they fail to
+  /// load under a parent that is already mounted.
+  Future<void> _waitForLoadingChildren() async {
+    var wake = Completer<void>();
+    void wakeUp() {
+      if (!wake.isCompleted) {
+        wake.complete();
+      }
+    }
+
+    final watchedChildren = <Component>{};
+    while (true) {
+      final loadingChildren = _loadingChildren();
+      if (loadingChildren.isEmpty) {
+        return;
+      }
+      if (wake.isCompleted) {
+        wake = Completer<void>();
+      }
+      for (final child in loadingChildren) {
+        if (watchedChildren.add(child)) {
+          child.loadSettled.then((_) => wakeUp());
+        }
+      }
+      // Sleep until a child settles its load, or until a child is removed
+      // while this component is loading, and re-evaluate.
+      await Future.any([
+        wake.future,
+        (_childrenChangedWhileLoading ??= Completer<void>()).future,
+      ]);
+    }
+  }
+
+  /// The children whose loads still have to settle before this component can
+  /// be considered loaded.
+  List<Component> _loadingChildren() {
+    final children = _children;
+    if (children == null || children.isEmpty) {
+      return const [];
+    }
+    return [
+      for (final child in children)
+        if (child.isLoading && child._loadError == null) child,
+    ];
+  }
+
+  void _completeLoading() {
+    _childrenChangedWhileLoading = null;
     _clearLoadingBit();
     _setLoadedBit();
     _loadCompleter?.complete();
@@ -1165,6 +1235,16 @@ class Component {
   void _completeLoadSettled() {
     _loadSettledCompleter?.complete();
     _loadSettledCompleter = null;
+  }
+
+  /// Completed when the children set changes while this component is
+  /// loading, so that the pending [_finishLoading] gate re-evaluates, for
+  /// example when a child that never finishes loading is removed.
+  Completer<void>? _childrenChangedWhileLoading;
+
+  void _notifyChildrenChangedWhileLoading() {
+    _childrenChangedWhileLoading?.complete();
+    _childrenChangedWhileLoading = null;
   }
 
   /// Surfaces an error thrown by [onLoad].
@@ -1264,7 +1344,7 @@ class Component {
   /// Used by the [FlameGame] to set the loaded state of the component, since
   /// the game isn't going through the whole normal component life cycle.
   @internal
-  void setLoaded() => _finishLoading();
+  void setLoaded() => _completeLoading();
 
   /// Used by the [FlameGame] to set the mounted state of the component, since
   /// the game isn't going through the whole normal component life cycle.

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -597,6 +597,133 @@ void main() {
         });
       });
 
+      group('loading with children', () {
+        testWithFlameGame(
+          'a component is not loaded until a child added in onLoad is loaded',
+          (game) async {
+            final childLoadGate = Completer<void>();
+            final parent = _ParentWithGatedChild(childLoadGate);
+            game.world.add(parent);
+            game.update(0);
+
+            expect(parent.isLoading, isTrue);
+            expect(parent.isLoaded, isFalse);
+            expect(parent.isMounted, isFalse);
+
+            childLoadGate.complete();
+            await parent.loaded;
+
+            expect(parent.child.isLoaded, isTrue);
+            game.update(0);
+            expect(parent.isMounted, isTrue);
+            expect(parent.child.isMounted, isTrue);
+          },
+        );
+
+        testWithFlameGame(
+          'a component is not loaded until its whole subtree is loaded',
+          (game) async {
+            final grandChildLoadGate = Completer<void>();
+            final grandParent = _GrandParentWithGatedGrandChild(
+              grandChildLoadGate,
+            );
+            game.world.add(grandParent);
+            game.update(0);
+
+            expect(grandParent.isLoading, isTrue);
+            expect(grandParent.child.isLoading, isTrue);
+            expect(grandParent.isLoaded, isFalse);
+
+            grandChildLoadGate.complete();
+            await grandParent.loaded;
+
+            expect(grandParent.child.isLoaded, isTrue);
+            expect(grandParent.child.child.isLoaded, isTrue);
+
+            await game.ready();
+            expect(grandParent.isMounted, isTrue);
+            expect(grandParent.child.isMounted, isTrue);
+            expect(grandParent.child.child.isMounted, isTrue);
+          },
+        );
+
+        testWithFlameGame(
+          'children added before the parent starts loading do not gate it',
+          (game) async {
+            // Children that are not loading yet when the parent finishes its
+            // own onLoad, such as children given to the constructor of a
+            // detached component, keep loading when the parent mounts.
+            final childLoadGate = Completer<void>();
+            final child = _GatedLoadComponent(childLoadGate);
+            final parent = Component(children: [child]);
+            game.world.add(parent);
+            game.update(0);
+
+            expect(parent.isMounted, isTrue);
+            expect(child.isLoading, isTrue);
+
+            childLoadGate.complete();
+            await game.ready();
+            expect(child.isMounted, isTrue);
+          },
+        );
+
+        testWithFlameGame(
+          'when the parent mounts the whole subtree is mounted',
+          (game) async {
+            final childLoadGate = Completer<void>();
+            final parent = _ParentWithGatedChild(childLoadGate);
+            game.world.add(parent);
+
+            childLoadGate.complete();
+            final readyFuture = game.ready();
+            await parent.mounted;
+
+            // The child mounts in the same lifecycle processing pass as the
+            // parent, so once the parent is mounted the whole subtree is.
+            expect(parent.child.isMounted, isTrue);
+            await readyFuture;
+          },
+        );
+
+        testWithFlameGame(
+          'a child that fails loading does not block its parent',
+          (game) async {
+            final parent = _ParentWithFailingChild();
+            game.world.add(parent);
+            final loaded = parent.child.loaded;
+
+            await expectLater(loaded, throwsA(isA<_LoadException>()));
+            await parent.loaded;
+            await game.ready();
+
+            expect(parent.isMounted, isTrue);
+            expect(parent.children, isEmpty);
+            expect(parent.child.isMounted, isFalse);
+            expect(parent.child.parent, isNull);
+          },
+        );
+
+        testWithFlameGame(
+          'removing a child that never loads unblocks the parent',
+          (game) async {
+            final neverCompletingGate = Completer<void>();
+            final parent = _ParentWithGatedChild(neverCompletingGate);
+            game.world.add(parent);
+            game.update(0);
+            expect(parent.isLoaded, isFalse);
+
+            parent.remove(parent.child);
+            await parent.loaded;
+            await game.ready();
+
+            expect(parent.isMounted, isTrue);
+            expect(parent.child.parent, isNull);
+            expect(parent.child.isMounted, isFalse);
+          },
+        );
+      });
+
       testWithFlameGame('Can wait for lifecycleEventsProcessed', (game) async {
         await game.ready();
         final component = Component();
@@ -2157,6 +2284,51 @@ class _SlowComponent extends Component {
 
   @override
   String toString() => 'SlowComponent($name, loadTime=$loadTime)';
+}
+
+class _GatedLoadComponent extends Component {
+  _GatedLoadComponent(this.loadGate);
+
+  final Completer<void> loadGate;
+
+  @override
+  Future<void> onLoad() => loadGate.future;
+}
+
+class _ParentWithGatedChild extends Component {
+  _ParentWithGatedChild(this.childLoadGate);
+
+  final Completer<void> childLoadGate;
+  late final _GatedLoadComponent child;
+
+  @override
+  void onLoad() {
+    child = _GatedLoadComponent(childLoadGate);
+    add(child);
+  }
+}
+
+class _ParentWithFailingChild extends Component {
+  late final _FailingLoadComponent child;
+
+  @override
+  void onLoad() {
+    child = _FailingLoadComponent();
+    add(child);
+  }
+}
+
+class _GrandParentWithGatedGrandChild extends Component {
+  _GrandParentWithGatedGrandChild(this.grandChildLoadGate);
+
+  final Completer<void> grandChildLoadGate;
+  late final _ParentWithGatedChild child;
+
+  @override
+  void onLoad() {
+    child = _ParentWithGatedChild(grandChildLoadGate);
+    add(child);
+  }
 }
 
 class _SelfRemovingOnLoadComponent extends Component {

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -716,6 +716,27 @@ void main() {
             expect(parent.child.isMounted, isFalse);
           },
         );
+
+        testWithFlameGame(
+          'moving a child that never loads to another parent unblocks the '
+          'old parent',
+          (game) async {
+            final neverCompletingGate = Completer<void>();
+            final parent = _ParentWithGatedChild(neverCompletingGate);
+            final otherParent = Component();
+            game.world.add(parent);
+            game.update(0);
+            expect(parent.isLoaded, isFalse);
+
+            otherParent.add(parent.child);
+            await parent.loaded;
+            await game.ready();
+
+            expect(parent.isMounted, isTrue);
+            expect(parent.children, isEmpty);
+            expect(parent.child.parent, otherParent);
+          },
+        );
       });
 
       testWithFlameGame('Can wait for lifecycleEventsProcessed', (game) async {

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -591,6 +591,133 @@ void main() {
         });
       });
 
+      group('loading with children', () {
+        testWithFlameGame(
+          'a component is not loaded until a child added in onLoad is loaded',
+          (game) async {
+            final childLoadGate = Completer<void>();
+            final parent = _ParentWithGatedChild(childLoadGate);
+            game.world.add(parent);
+            game.update(0);
+
+            expect(parent.isLoading, isTrue);
+            expect(parent.isLoaded, isFalse);
+            expect(parent.isMounted, isFalse);
+
+            childLoadGate.complete();
+            await parent.loaded;
+
+            expect(parent.child.isLoaded, isTrue);
+            game.update(0);
+            expect(parent.isMounted, isTrue);
+            expect(parent.child.isMounted, isTrue);
+          },
+        );
+
+        testWithFlameGame(
+          'a component is not loaded until its whole subtree is loaded',
+          (game) async {
+            final grandChildLoadGate = Completer<void>();
+            final grandParent = _GrandParentWithGatedGrandChild(
+              grandChildLoadGate,
+            );
+            game.world.add(grandParent);
+            game.update(0);
+
+            expect(grandParent.isLoading, isTrue);
+            expect(grandParent.child.isLoading, isTrue);
+            expect(grandParent.isLoaded, isFalse);
+
+            grandChildLoadGate.complete();
+            await grandParent.loaded;
+
+            expect(grandParent.child.isLoaded, isTrue);
+            expect(grandParent.child.child.isLoaded, isTrue);
+
+            await game.ready();
+            expect(grandParent.isMounted, isTrue);
+            expect(grandParent.child.isMounted, isTrue);
+            expect(grandParent.child.child.isMounted, isTrue);
+          },
+        );
+
+        testWithFlameGame(
+          'children added before the parent starts loading do not gate it',
+          (game) async {
+            // Children that are not loading yet when the parent finishes its
+            // own onLoad, such as children given to the constructor of a
+            // detached component, keep loading when the parent mounts.
+            final childLoadGate = Completer<void>();
+            final child = _GatedLoadComponent(childLoadGate);
+            final parent = Component(children: [child]);
+            game.world.add(parent);
+            game.update(0);
+
+            expect(parent.isMounted, isTrue);
+            expect(child.isLoading, isTrue);
+
+            childLoadGate.complete();
+            await game.ready();
+            expect(child.isMounted, isTrue);
+          },
+        );
+
+        testWithFlameGame(
+          'when the parent mounts the whole subtree is mounted',
+          (game) async {
+            final childLoadGate = Completer<void>();
+            final parent = _ParentWithGatedChild(childLoadGate);
+            game.world.add(parent);
+
+            childLoadGate.complete();
+            final readyFuture = game.ready();
+            await parent.mounted;
+
+            // The child mounts in the same lifecycle processing pass as the
+            // parent, so once the parent is mounted the whole subtree is.
+            expect(parent.child.isMounted, isTrue);
+            await readyFuture;
+          },
+        );
+
+        testWithFlameGame(
+          'a child that fails loading does not block its parent',
+          (game) async {
+            final parent = _ParentWithFailingChild();
+            game.world.add(parent);
+            final loaded = parent.child.loaded;
+
+            await expectLater(loaded, throwsA(isA<_LoadException>()));
+            await parent.loaded;
+            await game.ready();
+
+            expect(parent.isMounted, isTrue);
+            expect(parent.children, isEmpty);
+            expect(parent.child.isMounted, isFalse);
+            expect(parent.child.parent, isNull);
+          },
+        );
+
+        testWithFlameGame(
+          'removing a child that never loads unblocks the parent',
+          (game) async {
+            final neverCompletingGate = Completer<void>();
+            final parent = _ParentWithGatedChild(neverCompletingGate);
+            game.world.add(parent);
+            game.update(0);
+            expect(parent.isLoaded, isFalse);
+
+            parent.remove(parent.child);
+            await parent.loaded;
+            await game.ready();
+
+            expect(parent.isMounted, isTrue);
+            expect(parent.child.parent, isNull);
+            expect(parent.child.isMounted, isFalse);
+          },
+        );
+      });
+
       testWithFlameGame('Can wait for lifecycleEventsProcessed', (game) async {
         final component = Component();
         game.world.add(component);
@@ -2193,6 +2320,51 @@ class _SlowComponent extends Component {
 
   @override
   String toString() => 'SlowComponent($name, loadTime=$loadTime)';
+}
+
+class _GatedLoadComponent extends Component {
+  _GatedLoadComponent(this.loadGate);
+
+  final Completer<void> loadGate;
+
+  @override
+  Future<void> onLoad() => loadGate.future;
+}
+
+class _ParentWithGatedChild extends Component {
+  _ParentWithGatedChild(this.childLoadGate);
+
+  final Completer<void> childLoadGate;
+  late final _GatedLoadComponent child;
+
+  @override
+  void onLoad() {
+    child = _GatedLoadComponent(childLoadGate);
+    add(child);
+  }
+}
+
+class _ParentWithFailingChild extends Component {
+  late final _FailingLoadComponent child;
+
+  @override
+  void onLoad() {
+    child = _FailingLoadComponent();
+    add(child);
+  }
+}
+
+class _GrandParentWithGatedGrandChild extends Component {
+  _GrandParentWithGatedGrandChild(this.grandChildLoadGate);
+
+  final Completer<void> grandChildLoadGate;
+  late final _ParentWithGatedChild child;
+
+  @override
+  void onLoad() {
+    child = _ParentWithGatedChild(grandChildLoadGate);
+    add(child);
+  }
 }
 
 class _SelfRemovingOnLoadComponent extends Component {


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Stacked on #3998.

Previously, when a component was added to a running game and its `onLoad` added children of its own, the component was marked as loaded (and could mount) as soon as its own `onLoad` future completed, while its children were still loading. The children then mounted one or more ticks later, so the component was visible and updating with an incomplete subtree.

With this PR a component only counts as loaded once every child that was loading when its own `onLoad` settled has finished loading too, recursively (children gate the same way, so grandchildren added in a child's `onLoad` are covered). Concretely:

- `Component._finishLoading` now waits, through the internal `loadSettled` future of each loading child, until no child is loading anymore, before completing `loaded`/`isLoaded`. Everything stays fully synchronous when there are no loading children.
- Since the whole subtree is loaded by the time the component mounts, the children mount in the same lifecycle processing pass as their parent: once the parent's `mounted` future resolves, the subtree is mounted.
- A child that fails to load does not block its parent; it is dropped when the parent mounts, exactly like a failing child of an already-mounted parent, and its error reporting through `Component.loaded`/the current `Zone` is unchanged.
- Removing a child that never finishes loading from a still-loading parent re-evaluates the wait and unblocks the parent.
- Children that are not loading yet when the parent finishes its own `onLoad` (for example children passed to the constructor of a detached component) keep the existing behavior of loading when the parent mounts.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

A component's `loaded` future and `isLoaded` getter now also wait for the children that were added during its `onLoad`:

- If you relied on a component mounting while its children were still loading (for example to show a placeholder while a child streams in assets), add such children after the component has mounted (for example in `onMount`) instead of in `onLoad`.
- A child's `onLoad` must not await its parent's `loaded` future, since the parent now waits for the child, that would deadlock.
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Related to #3997

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
