### PR TITLE
feat!: Return a list instead of a set from the collision detection methods

### DIFF
--- a/doc/bridge_packages/flame_behaviors/collision-detection.md
+++ b/doc/bridge_packages/flame_behaviors/collision-detection.md
@@ -33,7 +33,7 @@ class MyEntityCollisionBehavior
     extends CollisionBehavior<MyCollidingEntity, MyParentEntity> {
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     MyCollidingEntity other,
   ) {
     // We are starting colliding with MyCollidingEntity

--- a/doc/flame/collision_detection.md
+++ b/doc/flame/collision_detection.md
@@ -81,7 +81,7 @@ Example:
 ```dart
 class MyCollidable extends PositionComponent with CollisionCallbacks {
   @override
-  void onCollision(Set<Vector2> points, PositionComponent other) {
+  void onCollision(List<Vector2> points, PositionComponent other) {
     if (other is ScreenHitbox) {
       //...
     } else if (other is YourOtherComponent) {
@@ -101,7 +101,7 @@ class MyCollidable extends PositionComponent with CollisionCallbacks {
 ```
 
 In this example we use Dart's `is` keyword to check what kind of component we collided with.
-The set of points is where the edges of the hitboxes intersect.
+The list of points is where the edges of the hitboxes intersect.
 
 Note that the `onCollision` method will be called on both `PositionComponent`s if they have both
 implemented the `onCollision` method, and also on both hitboxes. The same goes for the
@@ -137,7 +137,7 @@ save all the other `PositionComponent`s to this list:
 
 ```dart
 @override
-void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
   collisionComponents.add(other);
   super.onCollision(intersectionPoints, other);
 }
@@ -395,7 +395,7 @@ class Bullet extends PositionComponent with CollisionCallbacks {
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     // Removes the component when it comes in contact with a Brick.

--- a/doc/flame/examples/lib/collision_detection.dart
+++ b/doc/flame/examples/lib/collision_detection.dart
@@ -55,7 +55,7 @@ class RectangleCollidable extends PositionComponent with CollisionCallbacks {
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/doc/flame/other/performance.md
+++ b/doc/flame/other/performance.md
@@ -177,7 +177,7 @@ class Bullet extends SpriteComponent with CollisionCallbacks {
   }
 
   @override
-  void onCollisionStart(Set<Vector2> points, PositionComponent other) {
+  void onCollisionStart(List<Vector2> points, PositionComponent other) {
     super.onCollisionStart(points, other);
     // Return to pool on collision. No manual release needed.
     removeFromParent();

--- a/doc/tutorials/platformer/app/lib/actors/ember.dart
+++ b/doc/tutorials/platformer/app/lib/actors/ember.dart
@@ -112,7 +112,7 @@ class EmberPlayer extends SpriteAnimationComponent
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+  void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
     if (other is GroundBlock || other is PlatformBlock) {
       if (intersectionPoints.length == 2) {
         // Calculate the collision normal and separation distance.

--- a/doc/tutorials/platformer/step_5.md
+++ b/doc/tutorials/platformer/step_5.md
@@ -131,7 +131,7 @@ Now add the following `onCollision` method:
 
 ```dart
 @override
-void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
   if (other is GroundBlock || other is PlatformBlock) {
     if (intersectionPoints.length == 2) {
       // Calculate the collision normal and separation distance.

--- a/doc/tutorials/space_shooter/app/lib/step6/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step6/main.dart
@@ -197,7 +197,7 @@ class Enemy extends SpriteAnimationComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/doc/tutorials/space_shooter/step_6.md
+++ b/doc/tutorials/space_shooter/step_6.md
@@ -80,7 +80,7 @@ class Enemy extends SpriteAnimationComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);
@@ -148,7 +148,7 @@ in order to add the explosion to the game:
 ```dart
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/games/crystal_ball/lib/src/game/entities/the_ball.dart
+++ b/examples/games/crystal_ball/lib/src/game/entities/the_ball.dart
@@ -58,7 +58,7 @@ class TheBall extends PositionComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/games/rogue_shooter/lib/components/bullet_component.dart
+++ b/examples/games/rogue_shooter/lib/components/bullet_component.dart
@@ -29,7 +29,7 @@ class BulletComponent extends SpriteAnimationComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/games/rogue_shooter/lib/components/player_component.dart
+++ b/examples/games/rogue_shooter/lib/components/player_component.dart
@@ -59,7 +59,7 @@ class PlayerComponent extends SpriteAnimationComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/games/trex/lib/player.dart
+++ b/examples/games/trex/lib/player.dart
@@ -101,7 +101,7 @@ class Player extends SpriteAnimationGroupComponent<PlayerState>
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/lib/stories/camera_and_viewport/follow_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/follow_component_example.dart
@@ -85,7 +85,7 @@ class MovableEmber extends Ember<FollowComponentExample>
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/lib/stories/collision_detection/bouncing_ball_example.dart
+++ b/examples/lib/stories/collision_detection/bouncing_ball_example.dart
@@ -72,7 +72,7 @@ class Ball extends CircleComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/lib/stories/collision_detection/circles_example.dart
+++ b/examples/lib/stories/collision_detection/circles_example.dart
@@ -58,7 +58,7 @@ class MyCollidable extends PositionComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/lib/stories/collision_detection/collidable_animation_example.dart
+++ b/examples/lib/stories/collision_detection/collidable_animation_example.dart
@@ -108,7 +108,7 @@ class AnimatedComponent extends SpriteAnimationComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/lib/stories/collision_detection/multiple_shapes_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_shapes_example.dart
@@ -147,7 +147,7 @@ abstract class MyCollidable extends PositionComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);
@@ -229,7 +229,7 @@ class SnowmanPart extends CircleHitbox {
   }
 
   @override
-  void onCollisionStart(Set<Vector2> intersectionPoints, ShapeHitbox other) {
+  void onCollisionStart(List<Vector2> intersectionPoints, ShapeHitbox other) {
     super.onCollisionStart(intersectionPoints, other);
 
     if (other.hitboxParent is ScreenHitbox) {

--- a/examples/lib/stories/collision_detection/multiple_worlds_example.dart
+++ b/examples/lib/stories/collision_detection/multiple_worlds_example.dart
@@ -61,7 +61,7 @@ class CollidableEmber extends Ember with CollisionCallbacks {
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/lib/stories/collision_detection/quadtree_example.dart
+++ b/examples/lib/stories/collision_detection/quadtree_example.dart
@@ -226,7 +226,7 @@ class Player extends SpriteComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     final myCenter = Vector2(
@@ -295,7 +295,7 @@ class Bullet extends PositionComponent with CollisionCallbacks, HasPaint {
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     if (other is Brick) {

--- a/examples/lib/stories/components/time_scale_example.dart
+++ b/examples/lib/stories/components/time_scale_example.dart
@@ -109,7 +109,7 @@ class _Chopper extends SpriteAnimationComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     if (other is _Chopper) {

--- a/examples/lib/stories/input/joystick_player.dart
+++ b/examples/lib/stories/input/joystick_player.dart
@@ -32,7 +32,7 @@ class JoystickPlayer extends SpriteComponent
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/examples/lib/stories/system/step_engine_example.dart
+++ b/examples/lib/stories/system/step_engine_example.dart
@@ -132,7 +132,7 @@ class _DetectorComponents extends CircleComponent with CollisionCallbacks {
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     paint.color = BasicPalette.black.color;

--- a/packages/flame/lib/src/collisions/collision_callbacks.dart
+++ b/packages/flame/lib/src/collisions/collision_callbacks.dart
@@ -54,14 +54,14 @@ mixin GenericCollisionCallbacks<T> {
   /// [onCollision] is called in every tick when this object is colliding with
   /// [other].
   @mustCallSuper
-  void onCollision(Set<Vector2> intersectionPoints, T other) {
+  void onCollision(List<Vector2> intersectionPoints, T other) {
     onCollisionCallback?.call(intersectionPoints, other);
   }
 
   /// [onCollisionStart] is called in the first tick when this object starts
   /// colliding with [other].
   @mustCallSuper
-  void onCollisionStart(Set<Vector2> intersectionPoints, T other) {
+  void onCollisionStart(List<Vector2> intersectionPoints, T other) {
     activeCollisions.add(other);
     onCollisionStartCallback?.call(intersectionPoints, other);
   }
@@ -115,14 +115,14 @@ mixin CollisionCallbacks on Component
 
   @override
   @mustCallSuper
-  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+  void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
     onCollisionCallback?.call(intersectionPoints, other);
   }
 
   @override
   @mustCallSuper
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     activeCollisions.add(other);
@@ -167,7 +167,7 @@ mixin CollisionCallbacks on Component
 /// `onCollisionStartCallback`.
 typedef CollisionCallback<T> =
     void Function(
-      Set<Vector2> intersectionPoints,
+      List<Vector2> intersectionPoints,
       T other,
     );
 

--- a/packages/flame/lib/src/collisions/collision_detection.dart
+++ b/packages/flame/lib/src/collisions/collision_detection.dart
@@ -80,11 +80,11 @@ abstract class CollisionDetection<
 
   /// Check what the intersection points of two items are,
   /// returns an empty list if there are no intersections.
-  Set<Vector2> intersections(T itemA, T itemB);
+  List<Vector2> intersections(T itemA, T itemB);
 
-  void handleCollisionStart(Set<Vector2> intersectionPoints, T itemA, T itemB);
+  void handleCollisionStart(List<Vector2> intersectionPoints, T itemA, T itemB);
 
-  void handleCollision(Set<Vector2> intersectionPoints, T itemA, T itemB);
+  void handleCollision(List<Vector2> intersectionPoints, T itemA, T itemB);
 
   void handleCollisionEnd(T itemA, T itemB);
 

--- a/packages/flame/lib/src/collisions/collision_passthrough.dart
+++ b/packages/flame/lib/src/collisions/collision_passthrough.dart
@@ -24,7 +24,7 @@ mixin CollisionPassthrough on CollisionCallbacks {
 
   @override
   @mustCallSuper
-  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+  void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
     super.onCollision(intersectionPoints, other);
     passthroughParent?.onCollision(intersectionPoints, other);
   }
@@ -32,7 +32,7 @@ mixin CollisionPassthrough on CollisionCallbacks {
   @override
   @mustCallSuper
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/packages/flame/lib/src/collisions/hitboxes/hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/hitbox.dart
@@ -30,7 +30,7 @@ abstract class Hitbox<T extends Hitbox<T>>
   bool containsPoint(Vector2 point);
 
   /// Where this [Hitbox] has intersection points with another [Hitbox].
-  Set<Vector2> intersections(T other);
+  List<Vector2> intersections(T other);
 
   /// This should be a cheaper calculation than comparing the exact boundaries
   /// if the exact calculation is expensive.

--- a/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
+++ b/packages/flame/lib/src/collisions/hitboxes/shape_hitbox.dart
@@ -158,7 +158,7 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
 
   /// Where this [ShapeComponent] has intersection points with another shape
   @override
-  Set<Vector2> intersections(Hitbox other) {
+  List<Vector2> intersections(Hitbox other) {
     assert(
       other is ShapeComponent,
       'The intersection can only be performed between shapes',
@@ -218,7 +218,7 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
 
   @override
   @mustCallSuper
-  void onCollision(Set<Vector2> intersectionPoints, ShapeHitbox other) {
+  void onCollision(List<Vector2> intersectionPoints, ShapeHitbox other) {
     onCollisionCallback?.call(intersectionPoints, other);
     if (hitboxParent is CollisionCallbacks &&
         triggersParentCollision &&
@@ -232,7 +232,7 @@ mixin ShapeHitbox on ShapeComponent implements Hitbox<ShapeHitbox> {
 
   @override
   @mustCallSuper
-  void onCollisionStart(Set<Vector2> intersectionPoints, ShapeHitbox other) {
+  void onCollisionStart(List<Vector2> intersectionPoints, ShapeHitbox other) {
     activeCollisions.add(other);
     onCollisionStartCallback?.call(intersectionPoints, other);
     if (hitboxParent is CollisionCallbacks &&

--- a/packages/flame/lib/src/collisions/standard_collision_detection.dart
+++ b/packages/flame/lib/src/collisions/standard_collision_detection.dart
@@ -18,7 +18,7 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
   /// Check what the intersection points of two collidables are,
   /// returns an empty list if there are no intersections.
   @override
-  Set<Vector2> intersections(
+  List<Vector2> intersections(
     ShapeHitbox hitboxA,
     ShapeHitbox hitboxB,
   ) {
@@ -31,7 +31,7 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
   /// [ShapeHitbox.hitboxParent] that they have collided with.
   @override
   void handleCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     ShapeHitbox hitboxA,
     ShapeHitbox hitboxB,
   ) {
@@ -45,7 +45,7 @@ class StandardCollisionDetection<B extends Broadphase<ShapeHitbox>>
   /// [ShapeHitbox.hitboxParent] that they have collided with.
   @override
   void handleCollision(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     ShapeHitbox hitboxA,
     ShapeHitbox hitboxB,
   ) {

--- a/packages/flame/lib/src/experimental/geometry/shapes/rectangle.dart
+++ b/packages/flame/lib/src/experimental/geometry/shapes/rectangle.dart
@@ -157,8 +157,16 @@ class Rectangle extends Shape {
 
   /// Returns all intersections between this rectangle's edges and the given
   /// line segment.
-  Set<Vector2> intersections(LineSegment line) {
-    return edges.expand((e) => e.intersections(line)).toSet();
+  List<Vector2> intersections(LineSegment line) {
+    final intersectionPoints = <Vector2>[];
+    for (final edge in edges) {
+      for (final intersection in edge.intersections(line)) {
+        if (!intersectionPoints.contains(intersection)) {
+          intersectionPoints.add(intersection);
+        }
+      }
+    }
+    return intersectionPoints;
   }
 
   @override

--- a/packages/flame/lib/src/geometry/shape_intersections.dart
+++ b/packages/flame/lib/src/geometry/shape_intersections.dart
@@ -7,13 +7,13 @@ abstract class Intersections<
   T1 extends ShapeComponent,
   T2 extends ShapeComponent
 > {
-  Set<Vector2> intersect(T1 shapeA, T2 shapeB);
+  List<Vector2> intersect(T1 shapeA, T2 shapeB);
 
   bool supportsShapes(ShapeComponent shapeA, ShapeComponent shapeB) {
     return shapeA is T1 && shapeB is T2 || shapeA is T2 && shapeB is T1;
   }
 
-  Set<Vector2> unorderedIntersect(
+  List<Vector2> unorderedIntersect(
     ShapeComponent shapeA,
     ShapeComponent shapeB,
   ) {
@@ -34,12 +34,12 @@ class PolygonPolygonIntersections
   /// If they share a segment of a line, both end points and the center point of
   /// that line segment will be counted as collision points
   @override
-  Set<Vector2> intersect(
+  List<Vector2> intersect(
     PolygonComponent polygonA,
     PolygonComponent polygonB, {
     Rect? overlappingRect,
   }) {
-    final intersectionPoints = <Vector2>{};
+    final intersectionPoints = <Vector2>[];
     final intersectionsA = polygonA.possibleIntersectionVertices(
       overlappingRect,
     );
@@ -49,7 +49,11 @@ class PolygonPolygonIntersections
     for (final lineA in intersectionsA) {
       for (final lineB in intersectionsB) {
         final lineIntersections = lineA.intersections(lineB);
-        intersectionPoints.addAll(lineIntersections);
+        for (final intersection in lineIntersections) {
+          if (!intersectionPoints.contains(intersection)) {
+            intersectionPoints.add(intersection);
+          }
+        }
       }
     }
     if (intersectionPoints.isEmpty && (polygonA.isSolid || polygonB.isSolid)) {
@@ -60,7 +64,7 @@ class PolygonPolygonIntersections
                 : null);
       if (outerShape != null && outerShape.isSolid) {
         final innerShape = outerShape == polygonA ? polygonB : polygonA;
-        return {innerShape.absoluteCenter};
+        return [innerShape.absoluteCenter];
       }
     }
     return intersectionPoints;
@@ -70,17 +74,21 @@ class PolygonPolygonIntersections
 class CirclePolygonIntersections
     extends Intersections<CircleComponent, PolygonComponent> {
   @override
-  Set<Vector2> intersect(
+  List<Vector2> intersect(
     CircleComponent circle,
     PolygonComponent polygon, {
     Rect? overlappingRect,
   }) {
-    final intersectionPoints = <Vector2>{};
+    final intersectionPoints = <Vector2>[];
     final possibleVertices = polygon.possibleIntersectionVertices(
       overlappingRect,
     );
     for (final line in possibleVertices) {
-      intersectionPoints.addAll(circle.lineSegmentIntersections(line));
+      for (final intersection in circle.lineSegmentIntersections(line)) {
+        if (!intersectionPoints.contains(intersection)) {
+          intersectionPoints.add(intersection);
+        }
+      }
     }
     if (intersectionPoints.isEmpty && (circle.isSolid || polygon.isSolid)) {
       final outerShape = circle.containsPoint(polygon.globalVertices().first)
@@ -88,7 +96,7 @@ class CirclePolygonIntersections
           : (polygon.containsPoint(circle.absoluteCenter) ? polygon : null);
       if (outerShape != null && outerShape.isSolid) {
         final innerShape = outerShape == circle ? polygon : circle;
-        return {innerShape.absoluteCenter};
+        return [innerShape.absoluteCenter];
       }
     }
     return intersectionPoints;
@@ -98,7 +106,7 @@ class CirclePolygonIntersections
 class CircleCircleIntersections
     extends Intersections<CircleComponent, CircleComponent> {
   @override
-  Set<Vector2> intersect(CircleComponent shapeA, CircleComponent shapeB) {
+  List<Vector2> intersect(CircleComponent shapeA, CircleComponent shapeB) {
     final centerA = shapeA.absoluteCenter;
     final centerB = shapeB.absoluteCenter;
     final distance = centerA.distanceTo(centerB);
@@ -106,28 +114,28 @@ class CircleCircleIntersections
     final radiusB = shapeB.scaledRadius;
     if (distance > radiusA + radiusB) {
       // Since the circles are too far away from each other to intersect we
-      // return the empty set.
-      return {};
+      // return the empty list.
+      return [];
     } else if (distance < (radiusA - radiusB).abs()) {
       // When one circle is contained within the other there is only a collision
       // if the outer circle isn't hollow.
       final outerShape = radiusA > radiusB ? shapeA : shapeB;
       if (outerShape.isSolid) {
         final center = outerShape == shapeA ? centerB : centerA;
-        return {center};
+        return [center];
       } else {
-        return {};
+        return [];
       }
     } else if (distance == 0 && radiusA == radiusB) {
       // The circles are identical and on top of each other, so there are an
       // infinite number of solutions. Since it is problematic to return a
-      // set of infinite size, we'll return 4 distinct points here.
-      return {
+      // list of infinite size, we'll return 4 distinct points here.
+      return [
         shapeA.absoluteCenter + Vector2(radiusA, 0),
         shapeA.absoluteCenter + Vector2(0, -radiusA),
         shapeA.absoluteCenter + Vector2(-radiusA, 0),
         shapeA.absoluteCenter + Vector2(0, radiusA),
-      };
+      ];
     } else {
       // There are definitely collision points if we end up in here.
       // To calculate these we use the fact that we can form two triangles going
@@ -159,10 +167,13 @@ class CircleCircleIntersections
             (shapeB.absoluteCenter.x - shapeA.absoluteCenter.x).abs() /
             distance,
       );
-      return {
-        centerPoint + delta,
-        centerPoint - delta,
-      };
+      final intersectionA = centerPoint + delta;
+      final intersectionB = centerPoint - delta;
+      if (intersectionA == intersectionB) {
+        // The circles are tangent and only touch in one point.
+        return [intersectionA];
+      }
+      return [intersectionA, intersectionB];
     }
   }
 }
@@ -173,7 +184,7 @@ final List<Intersections> _intersectionSystems = [
   PolygonPolygonIntersections(),
 ];
 
-Set<Vector2> intersections(ShapeComponent shapeA, ShapeComponent shapeB) {
+List<Vector2> intersections(ShapeComponent shapeA, ShapeComponent shapeB) {
   final intersectionSystem = _intersectionSystems.firstWhere(
     (system) => system.supportsShapes(shapeA, shapeB),
     orElse: () {

--- a/packages/flame/test/collisions/collision_callback_benchmark_test.dart
+++ b/packages/flame/test/collisions/collision_callback_benchmark_test.dart
@@ -22,7 +22,7 @@ class _TestBlock extends PositionComponent with CollisionCallbacks {
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);

--- a/packages/flame/test/collisions/collision_detection_test.dart
+++ b/packages/flame/test/collisions/collision_detection_test.dart
@@ -309,12 +309,12 @@ void main() {
       ]);
       final intersections = geometry.intersections(polygonA, polygonB);
       expect(
-        intersections.containsAll([
+        intersections,
+        containsAll([
           Vector2(2.0, 2.0),
           Vector2(2.0, 1.5),
           Vector2(2.0, 1.0),
         ]),
-        true,
         reason: 'Does not have all the correct intersection points',
       );
       expect(
@@ -373,7 +373,8 @@ void main() {
       );
       final intersections = geometry.intersections(polygonA, polygonB);
       expect(
-        intersections.containsAll([
+        intersections,
+        containsAll([
           Vector2(2, 0),
           Vector2(2, 2),
           Vector2(1, 0),
@@ -381,7 +382,6 @@ void main() {
           Vector2(0, 1),
           Vector2(0, 2),
         ]),
-        true,
         reason: 'Does not have all the correct intersection points',
       );
       expect(
@@ -407,12 +407,16 @@ void main() {
         Vector2(2, 1),
       ]);
       final intersections = geometry.intersections(polygonA, polygonB);
-      intersections.containsAll([
-        Vector2(-0.2857142857142857, 2.4285714285714284),
-        Vector2(1.7500000000000002, 1.2500000000000002),
-        Vector2(1.5555555555555556, 0.6666666666666667),
-        Vector2(1.1999999999999997, 0.39999999999999997),
-      ]);
+      expect(
+        intersections,
+        containsAll([
+          Vector2(-0.2857142857142857, 2.4285714285714284),
+          Vector2(1.7500000000000002, 1.2500000000000002),
+          Vector2(1.5555555555555556, 0.6666666666666667),
+          Vector2(1.1999999999999997, 0.39999999999999997),
+        ]),
+        reason: 'Does not have all the correct intersection points',
+      );
       expect(
         intersections.length == 4,
         true,
@@ -450,12 +454,12 @@ void main() {
       );
       final intersections = geometry.intersections(rectangleA, rectangleB);
       expect(
-        intersections.containsAll([
+        intersections,
+        containsAll([
           Vector2(4, 0),
           Vector2(4, 2),
           Vector2(4, 4),
         ]),
-        true,
         reason: 'Missed intersections',
       );
       expect(
@@ -709,13 +713,13 @@ void main() {
       final circleB = CircleComponent(radius: 4.0, position: Vector2.all(3));
       final intersections = geometry.intersections(circleA, circleB);
       expect(
-        intersections.containsAll([
+        intersections,
+        containsAll([
           Vector2(11, 7),
           Vector2(7, 3),
           Vector2(3, 7),
           Vector2(7, 11),
         ]),
-        true,
         reason: 'Missed intersections',
       );
       expect(
@@ -817,8 +821,8 @@ void main() {
       );
       final intersections = geometry.intersections(circle, polygon);
       expect(
-        intersections.containsAll([Vector2(0, 1), Vector2(1, 0)]),
-        true,
+        intersections,
+        containsAll([Vector2(0, 1), Vector2(1, 0)]),
         reason: 'Missed intersections',
       );
       expect(intersections.length, 2, reason: 'Wrong number of intersections');
@@ -863,13 +867,13 @@ void main() {
       ]);
       final intersections = geometry.intersections(circle, polygon);
       expect(
-        intersections.containsAll([
+        intersections,
+        containsAll([
           Vector2(1, 2),
           Vector2(2, 1),
           Vector2(1, 0),
           Vector2(0, 1),
         ]),
-        true,
         reason: 'Missed intersections',
       );
       expect(

--- a/packages/flame/test/collisions/collision_test_helpers.dart
+++ b/packages/flame/test/collisions/collision_test_helpers.dart
@@ -138,8 +138,8 @@ class TestBlock extends PositionComponent with CollisionCallbacks {
         : '_TestBlock[$name]';
   }
 
-  Set<Vector2> intersections(TestBlock other) {
-    final result = <Vector2>{};
+  List<Vector2> intersections(TestBlock other) {
+    final result = <Vector2>[];
     for (final hitboxA in children.query<ShapeHitbox>()) {
       for (final hitboxB in other.children.query<ShapeHitbox>()) {
         result.addAll(hitboxA.intersections(hitboxB));
@@ -150,7 +150,7 @@ class TestBlock extends PositionComponent with CollisionCallbacks {
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);
@@ -158,7 +158,7 @@ class TestBlock extends PositionComponent with CollisionCallbacks {
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+  void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
     super.onCollision(intersectionPoints, other);
     onCollisionCounter++;
   }

--- a/packages/flame_behaviors/example/lib/entities/circle/behaviors/circle_collision_behavior.dart
+++ b/packages/flame_behaviors/example/lib/entities/circle/behaviors/circle_collision_behavior.dart
@@ -7,7 +7,7 @@ class CircleCollisionBehavior extends CollisionBehavior<Circle, Circle> {
   final _collisionColor = Colors.green.withValues(alpha: 0.8);
 
   @override
-  void onCollisionStart(Set<Vector2> intersectionPoints, Circle other) {
+  void onCollisionStart(List<Vector2> intersectionPoints, Circle other) {
     parent.paint.color = _collisionColor;
   }
 

--- a/packages/flame_behaviors/example/lib/entities/circle/behaviors/rectangle_collision_behavior.dart
+++ b/packages/flame_behaviors/example/lib/entities/circle/behaviors/rectangle_collision_behavior.dart
@@ -7,7 +7,7 @@ class RectangleCollisionBehavior extends CollisionBehavior<Rectangle, Circle> {
   final _collisionColor = Colors.yellow.withValues(alpha: 0.8);
 
   @override
-  void onCollisionStart(Set<Vector2> intersectionPoints, Rectangle other) {
+  void onCollisionStart(List<Vector2> intersectionPoints, Rectangle other) {
     parent.paint.color = _collisionColor;
   }
 

--- a/packages/flame_behaviors/example/lib/entities/rectangle/behaviors/circle_colliding_behavior.dart
+++ b/packages/flame_behaviors/example/lib/entities/rectangle/behaviors/circle_colliding_behavior.dart
@@ -7,7 +7,7 @@ class CircleCollidingBehavior extends CollisionBehavior<Circle, Rectangle> {
   final _collisionColor = Colors.green.withValues(alpha: 0.8);
 
   @override
-  void onCollisionStart(Set<Vector2> intersectionPoints, Circle other) {
+  void onCollisionStart(List<Vector2> intersectionPoints, Circle other) {
     parent.paint.color = _collisionColor;
   }
 

--- a/packages/flame_behaviors/example/lib/entities/rectangle/behaviors/rectangle_colliding_behavior.dart
+++ b/packages/flame_behaviors/example/lib/entities/rectangle/behaviors/rectangle_colliding_behavior.dart
@@ -8,7 +8,7 @@ class RectangleCollidingBehavior
   final _collisionColor = Colors.yellow.withValues(alpha: 0.8);
 
   @override
-  void onCollisionStart(Set<Vector2> intersectionPoints, Rectangle other) {
+  void onCollisionStart(List<Vector2> intersectionPoints, Rectangle other) {
     parent.paint.color = _collisionColor;
   }
 

--- a/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
+++ b/packages/flame_behaviors/lib/src/behaviors/propagating_collision_behavior.dart
@@ -20,10 +20,10 @@ abstract class CollisionBehavior<
   bool isValid(Component c) => c is Collider;
 
   /// Called when the entity collides with [Collider].
-  void onCollision(Set<Vector2> intersectionPoints, Collider other) {}
+  void onCollision(List<Vector2> intersectionPoints, Collider other) {}
 
   /// Called when the entity starts to collides with [Collider].
-  void onCollisionStart(Set<Vector2> intersectionPoints, Collider other) {}
+  void onCollisionStart(List<Vector2> intersectionPoints, Collider other) {}
 
   /// Called when the entity stops to collides with [Collider].
   void onCollisionEnd(Collider other) {}
@@ -122,7 +122,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
 
   @override
   void onCollisionStart(
-    Set<Vector2> intersectionPoints,
+    List<Vector2> intersectionPoints,
     PositionComponent other,
   ) {
     activeCollisions.add(other);
@@ -141,7 +141,7 @@ class PropagatingCollisionBehavior<Parent extends EntityMixin>
 
   @override
   @mustCallSuper
-  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+  void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
     final otherEntity = findEntity(other);
     if (otherEntity == null) {
       return;

--- a/packages/flame_behaviors/test/src/behaviors/propagating_collision_behavior_test.dart
+++ b/packages/flame_behaviors/test/src/behaviors/propagating_collision_behavior_test.dart
@@ -31,13 +31,13 @@ abstract class _CollisionBehavior<
   bool onCollisionEndCalled = false;
 
   @override
-  void onCollisionStart(Set<Vector2> intersectionPoints, A other) {
+  void onCollisionStart(List<Vector2> intersectionPoints, A other) {
     super.onCollisionStart(intersectionPoints, other);
     onCollisionStartCalled = true;
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, A other) {
+  void onCollision(List<Vector2> intersectionPoints, A other) {
     super.onCollision(intersectionPoints, other);
     onCollisionCalled = true;
   }

--- a/packages/flame_behaviors/test/src/behaviors/screen_collision_behavior_test.dart
+++ b/packages/flame_behaviors/test/src/behaviors/screen_collision_behavior_test.dart
@@ -18,14 +18,14 @@ class _TrackingScreenCollisionBehavior
   ScreenHitbox? lastOther;
 
   @override
-  void onCollisionStart(Set<Vector2> intersectionPoints, ScreenHitbox other) {
+  void onCollisionStart(List<Vector2> intersectionPoints, ScreenHitbox other) {
     super.onCollisionStart(intersectionPoints, other);
     startCalled = true;
     lastOther = other;
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, ScreenHitbox other) {
+  void onCollision(List<Vector2> intersectionPoints, ScreenHitbox other) {
     super.onCollision(intersectionPoints, other);
     collisionCalled = true;
   }

--- a/packages/flame_bloc/example/lib/src/game/components/bullet.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/bullet.dart
@@ -61,7 +61,7 @@ class BulletComponent extends SpriteAnimationComponent
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+  void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
     super.onCollision(intersectionPoints, other);
     if (other is EnemyComponent) {
       destroyed = true;

--- a/packages/flame_bloc/example/lib/src/game/components/player.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/player.dart
@@ -118,7 +118,7 @@ class PlayerComponent extends SpriteAnimationComponent
   }
 
   @override
-  void onCollision(Set<Vector2> intersectionPoints, PositionComponent other) {
+  void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
     super.onCollision(intersectionPoints, other);
     if (other is EnemyComponent) {
       takeHit();


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
The collision detection system previously passed the intersection points around as a
`Set<Vector2>`, which meant that every collision check in the hot loop had to hash
`Vector2`s and allocate hash sets. This PR changes all of these APIs to use
`List<Vector2>` instead.

The returned points are still guaranteed to be unique: the polygon and circle-polygon
intersection accumulation now deduplicates with a linear `contains` check (the point
lists are tiny, so this is cheaper than hashing), and tangent circles now explicitly
return a single point instead of relying on the set to collapse the two identical
solutions.

Changed APIs (all from `Set<Vector2>` to `List<Vector2>`):

- `CollisionCallbacks.onCollision`/`onCollisionStart` and the corresponding methods on
  `GenericCollisionCallbacks`, `ShapeHitbox` and `CollisionPassthrough`, as well as the
  `CollisionCallback` typedef.
- `CollisionDetection.intersections`, `handleCollisionStart` and `handleCollision`
  (and the `StandardCollisionDetection` overrides).
- `Hitbox.intersections` and `ShapeHitbox.intersections`.
- `Intersections.intersect`/`unorderedIntersect` and the top-level `intersections`
  function in the geometry package.
- The experimental `Rectangle.intersections`.

Benchmarked the accumulation strategies against each other with the real intersection
workloads (200k iterations per case): the list version is roughly 2x faster for
circle-circle intersections, faster for overlapping axis-aligned rectangles (which
produce collinear duplicate candidates), and equal within noise for tilted polygons.

`flame_behaviors` and all examples, docs and tutorials have been updated accordingly.

Migration: change the `Set<Vector2> intersectionPoints` parameter type to
`List<Vector2>` in `onCollision`/`onCollisionStart` overrides (and in custom
`CollisionDetection`/`Hitbox` implementations).

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

Replace `Set<Vector2>` with `List<Vector2>` in your `onCollision` and `onCollisionStart`
overrides and collision callbacks:

```dart
@override
void onCollision(List<Vector2> intersectionPoints, PositionComponent other) {
  // ...
}
```

The same applies to custom `CollisionDetection`, `Hitbox` and `Intersections`
implementations, which now return `List<Vector2>` from their intersection methods.
The points in the list are still unique.
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #4001

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
