### PR TITLE
fix!: Remove middle intersection point on shared line segments in collision detection

### DIFF
--- a/packages/flame/lib/src/geometry/line.dart
+++ b/packages/flame/lib/src/geometry/line.dart
@@ -27,7 +27,7 @@ class Line {
     final determinant = a * otherLine.b - otherLine.a * b;
     if (determinant == 0) {
       //The lines are parallel (potentially coincides) and have no intersection
-      return [];
+      return const [];
     }
     return [
       Vector2(

--- a/packages/flame/lib/src/geometry/line_segment.dart
+++ b/packages/flame/lib/src/geometry/line_segment.dart
@@ -64,9 +64,11 @@ class LineSegment {
     return inflate(-amount);
   }
 
-  /// Returns an empty list if there are no intersections between the segments
-  /// If the segments are concurrent, the intersecting point is returned as a
-  /// list with a single point
+  /// Returns an empty list if there are no intersections between the segments.
+  /// If the segments intersect in a single point, that point is returned in a
+  /// list with a single element.
+  /// If the segments are collinear and overlap, the end points of the
+  /// overlapping section are returned.
   List<Vector2> intersections(LineSegment otherSegment) {
     final result = toLine().intersections(otherSegment.toLine());
     if (result.isNotEmpty) {
@@ -85,13 +87,7 @@ class LineSegment {
         if (containsPoint(otherSegment.from)) otherSegment.from,
         if (containsPoint(otherSegment.to)) otherSegment.to,
       };
-      if (overlaps.isNotEmpty) {
-        final sum = Vector2.zero();
-        for (final overlap in overlaps) {
-          sum.add(overlap);
-        }
-        return [sum..scale(1 / overlaps.length)];
-      }
+      return overlaps.toList();
     }
     return [];
   }

--- a/packages/flame/lib/src/geometry/line_segment.dart
+++ b/packages/flame/lib/src/geometry/line_segment.dart
@@ -87,9 +87,11 @@ class LineSegment {
         if (containsPoint(otherSegment.from)) otherSegment.from,
         if (containsPoint(otherSegment.to)) otherSegment.to,
       };
-      return overlaps.toList();
+      if (overlaps.isNotEmpty) {
+        return overlaps.toList(growable: false);
+      }
     }
-    return [];
+    return const [];
   }
 
   /// Whether the given [point] lies in this line segment.

--- a/packages/flame/lib/src/geometry/shape_intersections.dart
+++ b/packages/flame/lib/src/geometry/shape_intersections.dart
@@ -31,8 +31,8 @@ class PolygonPolygonIntersections
     extends Intersections<PolygonComponent, PolygonComponent> {
   /// Returns the intersection points of [polygonA] and [polygonB]
   /// The two polygons are required to be convex
-  /// If they share a segment of a line, both end points and the center point of
-  /// that line segment will be counted as collision points
+  /// If they share a segment of a line, both end points of that segment will
+  /// be counted as collision points
   @override
   Set<Vector2> intersect(
     PolygonComponent polygonA,

--- a/packages/flame/test/collisions/collision_detection_test.dart
+++ b/packages/flame/test/collisions/collision_detection_test.dart
@@ -107,11 +107,10 @@ void main() {
       final segmentB = LineSegment(Vector2.all(0), Vector2.all(1));
       final intersection = segmentA.intersections(segmentB);
       expect(
-        intersection.isNotEmpty,
-        true,
-        reason: 'Should have intersection at (0.5, 0.5)',
+        intersection,
+        unorderedEquals([Vector2.all(0), Vector2.all(1)]),
+        reason: 'Should intersect at the end points of the overlap',
       );
-      expect(intersection.first == Vector2.all(0.5), true);
     });
 
     test('overlapping line segments', () {
@@ -119,11 +118,10 @@ void main() {
       final segmentB = LineSegment(Vector2.all(0.5), Vector2.all(1.5));
       final intersection = segmentA.intersections(segmentB);
       expect(
-        intersection.isNotEmpty,
-        true,
-        reason: 'Should intersect at (0.75, 0.75)',
+        intersection,
+        unorderedEquals([Vector2.all(0.5), Vector2.all(1)]),
+        reason: 'Should intersect at the end points of the overlap',
       );
-      expect(intersection.first == Vector2.all(0.75), true);
     });
 
     test('one pixel overlap in different angles', () {
@@ -311,14 +309,13 @@ void main() {
       expect(
         intersections.containsAll([
           Vector2(2.0, 2.0),
-          Vector2(2.0, 1.5),
           Vector2(2.0, 1.0),
         ]),
         true,
         reason: 'Does not have all the correct intersection points',
       );
       expect(
-        intersections.length == 3,
+        intersections.length == 2,
         true,
         reason: 'Wrong number of intersections',
       );
@@ -376,16 +373,14 @@ void main() {
         intersections.containsAll([
           Vector2(2, 0),
           Vector2(2, 2),
-          Vector2(1, 0),
           Vector2(0, 0),
-          Vector2(0, 1),
           Vector2(0, 2),
         ]),
         true,
         reason: 'Does not have all the correct intersection points',
       );
       expect(
-        intersections.length == 6,
+        intersections.length == 4,
         true,
         reason: 'Wrong number of intersections',
       );
@@ -452,14 +447,13 @@ void main() {
       expect(
         intersections.containsAll([
           Vector2(4, 0),
-          Vector2(4, 2),
           Vector2(4, 4),
         ]),
         true,
         reason: 'Missed intersections',
       );
       expect(
-        intersections.length == 3,
+        intersections.length == 2,
         true,
         reason: 'Wrong number of intersections',
       );


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
When two line segments were collinear and overlapping, `LineSegment.intersections` returned a single synthetic point: the average of the overlap's end points. For shape collision detection this meant that two shapes sharing an edge (for example two axis-aligned rectangles standing side by side) reported both the real corner points and an extra point in the middle of the shared edge.

This PR changes the collinear-overlap case of `LineSegment.intersections` to return the actual end points of the overlapping section instead of their average. Segments that only touch in a single point still return that one point. As a result, collision detection on shared edges now only reports the end points of the shared segment, without the synthetic middle point.

The dartdoc on `LineSegment.intersections` and `PolygonPolygonIntersections.intersect` has been updated to describe the new behavior, and the affected tests now assert the overlap end points.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

`LineSegment.intersections` now returns the end points of the overlapping section when the two segments are collinear and overlap, instead of a single averaged point in the middle of the overlap. Consequently, `Hitbox.intersections` and the top-level `geometry.intersections` no longer report a middle point for shapes that share an edge, only the end points of the shared segment. If you relied on the averaged point, compute it from the returned end points, for example with `LineSegment(points.first, points.last).midpoint`.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #4002

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
