### PR TITLE
feat!: Kill ScrollDetector in favour of ScrollCallbacks

### DIFF
--- a/doc/flame/inputs/gesture_input.md
+++ b/doc/flame/inputs/gesture_input.md
@@ -38,8 +38,6 @@ Mouse only events
 ```text
  - MouseMovementDetector
   - onMouseMove
- - ScrollDetector
-  - onScroll
 ```
 
 

--- a/doc/flame/migration.md
+++ b/doc/flame/migration.md
@@ -212,6 +212,45 @@ See [Tap Events](inputs/tap_events.md) and [Drag Events](inputs/drag_events.md) 
 replacement APIs.
 
 
+### `ScrollDetector` removed
+
+The `ScrollDetector` game mixin has been removed, together with the event class that only it used:
+
+| Removed | Use instead |
+| --- | --- |
+| `ScrollDetector` | `ScrollCallbacks` |
+| `PointerScrollInfo` | `ScrollEvent` |
+
+The scroll delta is now read directly off the event rather than through a nested wrapper, and the
+event carries the usual `PositionEvent` fields, so the position where the scroll occurred is
+available as `devicePosition` / `canvasPosition` / `localPosition`:
+
+```dart
+// Before
+class MyGame extends FlameGame with ScrollDetector {
+  @override
+  void onScroll(PointerScrollInfo info) {
+    camera.viewfinder.zoom += info.scrollDelta.global.y.sign * 0.02;
+  }
+}
+
+// After
+class MyGame extends FlameGame with ScrollCallbacks {
+  @override
+  void onScroll(ScrollEvent event) {
+    camera.viewfinder.zoom += event.scrollDelta.y.sign * 0.02;
+  }
+}
+```
+
+Unlike the old detector, which received every scroll event anywhere on the game surface,
+`ScrollCallbacks` is routed by position like the other component callbacks: a component only receives
+scrolls that occur on top of it, as determined by `containsLocalPoint()`. Mixing it into your
+`FlameGame` subclass directly, as above, keeps the old whole-surface behavior.
+
+See [Pointer Events](inputs/pointer_events.md) for the full replacement API.
+
+
 ### `onDragCancel` no longer delegates to `onDragEnd`
 
 `DragCallbacks.onDragCancel` used to convert the cancellation into an `onDragEnd` event by default,

--- a/examples/lib/stories/camera_and_viewport/coordinate_systems_example.dart
+++ b/examples/lib/stories/camera_and_viewport/coordinate_systems_example.dart
@@ -12,7 +12,7 @@ import 'package:flutter/services.dart';
 /// events information on the screen, to allow exploration of the 3 coordinate
 /// systems of Flame (global, widget, game).
 class CoordinateSystemsExample extends FlameGame
-    with TapCallbacks, DragCallbacks, ScrollDetector, KeyboardEvents {
+    with TapCallbacks, DragCallbacks, ScrollCallbacks, KeyboardEvents {
   static const String description = '''
     Displays event data in all 3 coordinate systems (global, widget and game).
     Use WASD to move the camera and Q/E to zoom in/out.
@@ -111,11 +111,11 @@ class CoordinateSystemsExample extends FlameGame
   }
 
   @override
-  void onScroll(PointerScrollInfo info) {
+  void onScroll(ScrollEvent event) {
     lastEventDescription = _describe(
       'Scroll',
-      info.eventPosition.global,
-      delta: info.scrollDelta.global,
+      event.devicePosition,
+      delta: event.scrollDelta,
       deltaName: 'Scroll Delta',
     );
   }

--- a/examples/lib/stories/camera_and_viewport/fixed_resolution_example.dart
+++ b/examples/lib/stories/camera_and_viewport/fixed_resolution_example.dart
@@ -6,7 +6,7 @@ import 'package:flame/palette.dart';
 import 'package:flame/text.dart';
 import 'package:flutter/material.dart';
 
-class FixedResolutionExample extends FlameGame with ScrollDetector {
+class FixedResolutionExample extends FlameGame {
   static const description = '''
     This example shows how to create a viewport with a fixed resolution.
     It is useful when you want the visible part of the game to be the same on

--- a/examples/lib/stories/camera_and_viewport/static_components_example.dart
+++ b/examples/lib/stories/camera_and_viewport/static_components_example.dart
@@ -5,10 +5,9 @@ import 'package:flame/effects.dart';
 import 'package:flame/events.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 import 'package:flame/parallax.dart';
 
-class StaticComponentsExample extends FlameGame with ScrollDetector {
+class StaticComponentsExample extends FlameGame {
   static const description = '''
   This example shows a parallax which is attached to the viewport (behind the
   world), four Flame logos that are added to the world, and a player added to

--- a/examples/lib/stories/camera_and_viewport/zoom_example.dart
+++ b/examples/lib/stories/camera_and_viewport/zoom_example.dart
@@ -1,10 +1,9 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 
 class ZoomExample extends FlameGame
-    with ScrollDetector, ScaleCallbacks, DragCallbacks {
+    with ScrollCallbacks, ScaleCallbacks, DragCallbacks {
   static const String description = '''
     On web: use scroll to zoom in and out.\n
     On mobile: use scale gesture to zoom in and out.
@@ -29,9 +28,8 @@ class ZoomExample extends FlameGame
   static const zoomPerScrollUnit = 0.02;
 
   @override
-  void onScroll(PointerScrollInfo info) {
-    camera.viewfinder.zoom +=
-        info.scrollDelta.global.y.sign * zoomPerScrollUnit;
+  void onScroll(ScrollEvent event) {
+    camera.viewfinder.zoom += event.scrollDelta.y.sign * zoomPerScrollUnit;
     clampZoom();
   }
 

--- a/examples/lib/stories/collision_detection/quadtree_example.dart
+++ b/examples/lib/stories/collision_detection/quadtree_example.dart
@@ -13,7 +13,7 @@ import 'package:flutter/services.dart';
 const tileSize = 8.0;
 
 class QuadTreeExample extends FlameGame
-    with HasQuadTreeCollisionDetection, KeyboardEvents, ScrollDetector {
+    with HasQuadTreeCollisionDetection, KeyboardEvents, ScrollCallbacks {
   QuadTreeExample();
 
   static const description = '''
@@ -191,8 +191,8 @@ Press T button to toggle player to collide with other objects.
   }
 
   @override
-  void onScroll(PointerScrollInfo info) {
-    camera.viewfinder.zoom += info.scrollDelta.global.y.sign * 0.08;
+  void onScroll(ScrollEvent event) {
+    camera.viewfinder.zoom += event.scrollDelta.y.sign * 0.08;
     camera.viewfinder.zoom = camera.viewfinder.zoom.clamp(0.05, 5.0);
   }
 }

--- a/packages/flame/lib/events.dart
+++ b/packages/flame/lib/events.dart
@@ -77,8 +77,7 @@ export 'src/events/multi_drag_scale_recognizer.dart'
     show MultiDragScaleGestureRecognizer;
 export 'src/game/mixins/keyboard.dart'
     show HasKeyboardHandlerComponents, KeyboardEvents;
-export 'src/gestures/detectors.dart'
-    show MouseMovementDetector, PanDetector, ScrollDetector;
+export 'src/gestures/detectors.dart' show MouseMovementDetector, PanDetector;
 export 'src/gestures/events.dart'
     show
         DragDownInfo,
@@ -86,7 +85,6 @@ export 'src/gestures/events.dart'
         DragStartInfo,
         DragUpdateInfo,
         PointerHoverInfo,
-        PointerScrollInfo,
         PositionInfo,
         TapDownInfo,
         TapUpInfo;

--- a/packages/flame/lib/src/game/game_widget/gesture_detector_builder.dart
+++ b/packages/flame/lib/src/game/game_widget/gesture_detector_builder.dart
@@ -61,7 +61,6 @@ class GestureDetectorBuilder {
 
 bool hasMouseDetectors(Game game) {
   return game is MouseMovementDetector ||
-      game is ScrollDetector ||
       game.mouseDetector != null ||
       game.mousePressDetector != null ||
       game.scrollDetector != null;
@@ -80,9 +79,6 @@ Widget applyMouseDetectors(Game game, Widget child) {
     onPointerDown: mousePressDetector,
     onPointerSignal: (event) {
       if (event is PointerScrollEvent) {
-        if (game is ScrollDetector) {
-          game.onScroll(PointerScrollInfo.fromDetails(game, event));
-        }
         scrollDetector?.call(event);
       }
     },

--- a/packages/flame/lib/src/gestures/detectors.dart
+++ b/packages/flame/lib/src/gestures/detectors.dart
@@ -29,7 +29,3 @@ mixin PanDetector on Game {
 mixin MouseMovementDetector on Game {
   void onMouseMove(PointerHoverInfo info) {}
 }
-
-mixin ScrollDetector on Game {
-  void onScroll(PointerScrollInfo info) {}
-}

--- a/packages/flame/lib/src/gestures/events.dart
+++ b/packages/flame/lib/src/gestures/events.dart
@@ -75,15 +75,6 @@ class TapUpInfo extends PositionInfo<TapUpDetails> {
   ) : super(game, raw.globalPosition, raw);
 }
 
-class PointerScrollInfo extends PositionInfo<PointerScrollEvent> {
-  late final EventDelta scrollDelta = EventDelta(raw.scrollDelta);
-
-  PointerScrollInfo.fromDetails(
-    Game game,
-    PointerScrollEvent raw,
-  ) : super(game, raw.position, raw);
-}
-
 class PointerHoverInfo extends PositionInfo<PointerHoverEvent> {
   PointerHoverInfo.fromDetails(
     Game game,

--- a/packages/flame/test/gestures/detectors_test.dart
+++ b/packages/flame/test/gestures/detectors_test.dart
@@ -84,24 +84,6 @@ void main() {
       },
     );
   });
-
-  group('ScrollDetector', () {
-    final scrollGame = FlameTester(_ScrollDetectorGame.new);
-
-    scrollGame.testGameWidget(
-      'Can register Scrolling',
-      verify: (game, tester) async {
-        const scrollEventLocation = Offset(0, 300);
-        final testPointer = TestPointer(1, PointerDeviceKind.mouse);
-        testPointer.hover(scrollEventLocation);
-        await tester.sendEventToBinding(
-          testPointer.scroll(const Offset(0.0, -300.0)),
-        );
-
-        expect(game.registeredScrolling, isTrue);
-      },
-    );
-  });
 }
 
 class _PanDetectorGame extends FlameGame with PanDetector {
@@ -143,14 +125,5 @@ class _MouseMovementDetectorGame extends FlameGame with MouseMovementDetector {
   @override
   void onMouseMove(PointerHoverInfo info) {
     hasReceivedMouseMove = true;
-  }
-}
-
-class _ScrollDetectorGame extends FlameGame with ScrollDetector {
-  bool registeredScrolling = false;
-
-  @override
-  void onScroll(PointerScrollInfo info) {
-    registeredScrolling = true;
   }
 }

--- a/packages/flame_3d/example/lib/example_game_3d.dart
+++ b/packages/flame_3d/example/lib/example_game_3d.dart
@@ -12,7 +12,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 class ExampleGame3D extends FlameGame3D<World3D, ExampleCamera3D>
-    with DragCallbacks, ScrollDetector, HasKeyboardHandlerComponents {
+    with DragCallbacks, ScrollCallbacks, HasKeyboardHandlerComponents {
   late final Player player;
 
   ExampleGame3D()
@@ -70,9 +70,9 @@ class ExampleGame3D extends FlameGame3D<World3D, ExampleCamera3D>
   }
 
   @override
-  void onScroll(PointerScrollInfo info) {
+  void onScroll(ScrollEvent event) {
     const scrollSensitivity = 0.01;
-    final delta = info.scrollDelta.global.y.clamp(-10, 10) * scrollSensitivity;
+    final delta = event.scrollDelta.y.clamp(-10, 10) * scrollSensitivity;
 
     camera.distance += delta;
   }


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Kill `ScrollDetector` (and `PointerScrollInfo`) in favour of `ScrollCallbacks`.

Note that unlike the old detector, which received every scroll anywhere on the game surface, `ScrollCallbacks` are routed by position like the other component callbacks (mixing it into a `FlameGame` preserves the old whole-surface behaviour, of course).

The `scrollDetector` field on the game is used by both systems, so it stays, but I do want to clean all those up later by having a centralized registry of events on the game widget.

Shockingly, the two examples declared `ScrollDetector` without ever overriding `onScroll` (that has always been the case since they were created), so I just removed it (but I can bring it back and add a camera zoom behaviour on a followup).
<!-- Exclude from commit message -->


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->