### PR TITLE
refactor!: Make descendants return an eagerly collected snapshot list

### DIFF
--- a/packages/flame/lib/src/components/core/component.dart
+++ b/packages/flame/lib/src/components/core/component.dart
@@ -393,26 +393,15 @@ class Component {
   /// on every game cycle. The optional parameter [reversed] allows iterating
   /// through the same set of descendants in reverse order.
   ///
-  /// The [Iterable] produced by this method is "lazy", which means it will only
-  /// traverse the component tree when required. This allows efficient chaining
-  /// of various iterable methods, such as filtering, early stopping, folding,
-  /// and so on -- see the documentation of the [Iterable] class for details.
-  Iterable<Component> descendants({
+  /// The returned list is an eagerly collected snapshot of the tree at the
+  /// moment of the call. This means that the whole subtree is always
+  /// traversed, but also that it is safe to add or remove components while
+  /// iterating over the result.
+  List<Component> descendants({
     bool includeSelf = false,
     bool reversed = false,
-  }) sync* {
-    if (includeSelf && !reversed) {
-      yield this;
-    }
-    if (hasChildren) {
-      final childrenIterable = reversed ? children.reversed() : children;
-      for (final child in childrenIterable) {
-        yield* child.descendants(includeSelf: true, reversed: reversed);
-      }
-    }
-    if (includeSelf && reversed) {
-      yield this;
-    }
+  }) {
+    return _collectDescendants(includeSelf: includeSelf, reversed: reversed);
   }
 
   /// This method first calls the passed handler on the leaves in the tree,
@@ -1194,7 +1183,7 @@ class Component {
 
   void _remove(Component parent) {
     parent._internalChildren.remove(this);
-    for (final component in _collectDescendants()) {
+    for (final component in _collectDescendants(reversed: true)) {
       component
         ..onRemove()
         .._unregisterKey()
@@ -1208,24 +1197,32 @@ class Component {
     _parent = null;
   }
 
-  /// Collects this component and all its descendants into a list, in the
-  /// order that `descendants(reversed: true, includeSelf: true)` would
-  /// produce: leaves first, siblings in reverse order, ancestors after their
-  /// subtrees. The snapshot allows [_remove] to run user callbacks that
-  /// mutate the tree while it walks the subtree, without allocating generator
-  /// frames per tree level the way [descendants] does.
+  /// Collects all descendants (and this component itself, unless
+  /// [includeSelf] is false) into a list, in the order that [descendants]
+  /// documents: preorder, or leaves-first with siblings in reverse order when
+  /// [reversed] is true. Working on a snapshot also allows [_remove] to run
+  /// user callbacks that mutate the tree while it walks the subtree.
   ///
   /// The [out] parameter is only used by the recursive calls, so that the
   /// whole subtree is collected into a single list.
-  List<Component> _collectDescendants([List<Component>? out]) {
+  List<Component> _collectDescendants({
+    bool includeSelf = true,
+    bool reversed = false,
+    List<Component>? out,
+  }) {
     out ??= [];
+    if (includeSelf && !reversed) {
+      out.add(this);
+    }
     final children = _children;
     if (children != null) {
-      for (final child in children.reversed()) {
-        child._collectDescendants(out);
+      for (final child in reversed ? children.reversed() : children) {
+        child._collectDescendants(reversed: reversed, out: out);
       }
     }
-    out.add(this);
+    if (includeSelf && reversed) {
+      out.add(this);
+    }
     return out;
   }
 

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -1485,7 +1485,7 @@ void main() {
         },
       );
 
-      testWithFlameGame('descendants() iterator is lazy', (game) async {
+      testWithFlameGame('descendants() supports early stopping', (game) async {
         final componentA = _Visitor()..addToParent(game);
         final componentB = _Visitor()..addToParent(game);
         final componentC = _Visitor()..addToParent(componentB);


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
`descendants()` was a lazy `sync*` generator, which allocates an iterator per tree level and pays a delegation chain walk per element. After #3981 it was the last generator-shaped traversal of the component tree; this PR makes it delegate to the same `_collectDescendants` collection pass, so there is only one traversal shape left to care about.

The method now returns a `List<Component>` that is an eagerly collected snapshot of the tree at the moment of the call. This means the whole subtree is always traversed (early stopping no longer saves traversal work), and iterating while adding or removing components is safe instead of surfacing a `ConcurrentModificationError`.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

Most call sites need no changes, since `List` implements `Iterable`. Overrides of `descendants` must update their return type from `Iterable<Component>` to `List<Component>`. Code that relied on the lazy iteration semantics (early stopping to avoid traversing large trees, or catching `ConcurrentModificationError` on mutation during iteration) now gets a full-tree snapshot instead; query methods such as `firstWhere` still stop early, they just iterate an already collected list.
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Relates to #3957

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
