### PR TITLE
fix: Require touch slop before DragCallbacks accepts a drag

### DIFF
--- a/doc/flame/inputs/drag_events.md
+++ b/doc/flame/inputs/drag_events.md
@@ -58,6 +58,11 @@ local coordinate system.
 Any component that receives `onDragStart` will later be receiving `onDragUpdate` and `onDragEnd`
 events as well.
 
+A drag only starts once the pointer has moved further than the platform's touch slop from the
+point where it went down, so a tap with a slightly wobbling finger is still delivered as a tap and
+not as a drag. When the drag starts, the movement accumulated before that point is delivered in the
+first `onDragUpdate`.
+
 
 ### onDragUpdate
 

--- a/packages/flame/lib/src/events/multi_drag_scale_recognizer.dart
+++ b/packages/flame/lib/src/events/multi_drag_scale_recognizer.dart
@@ -480,10 +480,17 @@ class _DragPointerState {
     if (!_resolved) {
       _pendingDelta += delta;
       if (!recognizer.hasScale) {
-        // Drag-only mode: accept on any movement. If accepted synchronously,
-        // _accepted fires the initial update with _pendingDelta; no extra
-        // update fires here because we are still in the if(!_resolved) branch.
-        _arenaEntry?.resolve(GestureDisposition.accepted);
+        // Drag-only mode: accept once the accumulated movement exceeds the
+        // hit slop, matching ImmediateMultiDragGestureRecognizer. Some
+        // platforms emit zero-delta move events during a tap, so accepting on
+        // any move would steal the gesture from tap recognizers. If accepted
+        // synchronously, _accepted fires the initial update with
+        // _pendingDelta; no extra update fires here because we are still in
+        // the if(!_resolved) branch.
+        final hitSlop = computeHitSlop(kind, recognizer.gestureSettings);
+        if (_pendingDelta.distance > hitSlop) {
+          _arenaEntry?.resolve(GestureDisposition.accepted);
+        }
       } else {
         final distance = (currentPosition - initialPosition).distance;
         if (distance > computePanSlop(kind, recognizer.gestureSettings)) {
@@ -511,12 +518,10 @@ class _DragPointerState {
     if (_drag != null) {
       _drag!.end(DragEndDetails(velocity: velocityTracker.getVelocity()));
     }
-    _resolved = true;
   }
 
   void _cancel(PointerCancelEvent event) {
     _drag?.cancel();
-    _resolved = true;
   }
 
   void _accepted(Drag? Function() starter) {

--- a/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
@@ -333,13 +333,134 @@ void main() {
 
         // cancelled drag
         final gesture = await tester.startGesture(const Offset(50, 50));
-        await gesture.moveBy(const Offset(10, 10));
+        await gesture.moveBy(const Offset(20, 20));
         await gesture.cancel();
         await tester.pump(const Duration(seconds: 1));
         expect(nDragStartCalled, 2);
         expect(nDragCancelCalled, 1);
         // The cancellation must not be reported as a drag end.
         expect(nDragEndCalled, 1);
+      },
+    );
+
+    testWidgets(
+      'tap is not cancelled when a DragCallbacks component is mounted first',
+      (tester) async {
+        var nDragStartCalled = 0;
+        final tapComponent = _TapCounterComponent(
+          position: Vector2(20, 20),
+          size: Vector2(100, 100),
+        );
+        final game = FlameGame(
+          children: [
+            DragWithCallbacksComponent(
+              position: Vector2(200, 200),
+              size: Vector2(100, 100),
+              onDragStart: (e) => nDragStartCalled++,
+            ),
+            tapComponent,
+          ],
+        );
+        await tester.pumpWidget(GameWidget(game: game));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 10));
+
+        await tester.tapAt(const Offset(50, 50));
+        await tester.pump(const Duration(seconds: 1));
+
+        expect(nDragStartCalled, 0);
+        expect(tapComponent.nTapDown, 1);
+        expect(tapComponent.nTapUp, 1);
+        expect(tapComponent.nTapCancel, 0);
+      },
+    );
+
+    testWidgets(
+      'zero-delta pointer moves do not start a drag or cancel a tap',
+      (tester) async {
+        var nDragStartCalled = 0;
+        final tapComponent = _TapCounterComponent(
+          position: Vector2(20, 20),
+          size: Vector2(100, 100),
+        );
+        final game = FlameGame(
+          children: [
+            DragWithCallbacksComponent(
+              position: Vector2(200, 200),
+              size: Vector2(100, 100),
+              onDragStart: (e) => nDragStartCalled++,
+            ),
+            tapComponent,
+          ],
+        );
+        await tester.pumpWidget(GameWidget(game: game));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 10));
+
+        final gesture = await tester.startGesture(const Offset(50, 50));
+        await gesture.moveBy(Offset.zero);
+        await gesture.moveBy(Offset.zero);
+        await gesture.moveBy(Offset.zero);
+        await gesture.up();
+        await tester.pump(const Duration(seconds: 1));
+
+        expect(nDragStartCalled, 0);
+        expect(tapComponent.nTapDown, 1);
+        expect(tapComponent.nTapUp, 1);
+        expect(tapComponent.nTapCancel, 0);
+      },
+    );
+
+    testWidgets(
+      'pointer moves below the touch slop do not start a drag',
+      (tester) async {
+        var nDragStartCalled = 0;
+        var nDragUpdateCalled = 0;
+        var nDragEndCalled = 0;
+        final tapComponent = _TapCounterComponent(
+          position: Vector2(20, 20),
+          size: Vector2(100, 100),
+        );
+        final game = FlameGame(
+          children: [
+            DragWithCallbacksComponent(
+              position: Vector2(20, 20),
+              size: Vector2(100, 100),
+              onDragStart: (e) => nDragStartCalled++,
+              onDragUpdate: (e) => nDragUpdateCalled++,
+              onDragEnd: (e) => nDragEndCalled++,
+            ),
+            tapComponent,
+          ],
+        );
+        await tester.pumpWidget(GameWidget(game: game));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 10));
+
+        // Movement below the touch slop is a tap, not a drag.
+        var gesture = await tester.startGesture(const Offset(50, 50));
+        await gesture.moveBy(const Offset(5, 5));
+        await gesture.moveBy(const Offset(5, 5));
+        await gesture.up();
+        await tester.pump(const Duration(seconds: 1));
+        expect(nDragStartCalled, 0);
+        expect(nDragUpdateCalled, 0);
+        expect(nDragEndCalled, 0);
+        expect(tapComponent.nTapUp, 1);
+        expect(tapComponent.nTapCancel, 0);
+
+        // Once the accumulated movement exceeds the touch slop the drag
+        // starts, and the pending movement is delivered as one update.
+        gesture = await tester.startGesture(const Offset(50, 50));
+        await gesture.moveBy(const Offset(5, 5));
+        await gesture.moveBy(const Offset(20, 20));
+        await gesture.up();
+        await tester.pump(const Duration(seconds: 1));
+        expect(nDragStartCalled, 1);
+        expect(nDragUpdateCalled, 1);
+        expect(nDragEndCalled, 1);
+        expect(tapComponent.nTapUp, 1);
+        expect(tapComponent.nTapCancel, 1);
       },
     );
 
@@ -505,4 +626,21 @@ void main() {
       expect(totalDelta, Vector2(16, 0));
     },
   );
+}
+
+class _TapCounterComponent extends PositionComponent with TapCallbacks {
+  _TapCounterComponent({super.position, super.size});
+
+  int nTapDown = 0;
+  int nTapUp = 0;
+  int nTapCancel = 0;
+
+  @override
+  void onTapDown(TapDownEvent event) => nTapDown++;
+
+  @override
+  void onTapUp(TapUpEvent event) => nTapUp++;
+
+  @override
+  void onTapCancel(TapCancelEvent event) => nTapCancel++;
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Since 1.38.0 the `MultiDragScaleGestureRecognizer` accepted a drag gesture on the very first
`PointerMoveEvent` in drag-only mode, without checking whether the pointer had actually moved.
Some Android devices emit zero-delta `PointerMoveEvent`s between pointer down and up during a plain
tap, so the drag recognizer won the gesture arena and every `TapCallbacks` component on the
`GameWidget` received `onTapCancel` instead of `onTapUp` as soon as a single `DragCallbacks`
component was mounted.

The drag-only path now accepts the gesture only once the accumulated movement exceeds
`computeHitSlop`, matching the `ImmediateMultiDragGestureRecognizer` that was used before, and the
pending movement is still delivered as the first drag update.

While writing tests for this, a second cause of cancelled taps showed up: `_up` and `_cancel` marked
the pointer state as resolved, so `_dispose` never rejected the recognizer from the gesture arena.
When the drag recognizer was registered before the tap recognizer (a `DragCallbacks` component
mounted before any `TapCallbacks` component), the arena sweep on pointer up picked the drag
recognizer and cancelled the tap even without any move events. The pointer state is now left
unresolved on up and cancel so that `_dispose` rejects it, the same way Flutter's
`MultiDragPointerState` does.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #4016

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->

https://claude.ai/code/session_01EJANnBFMk4Cfh3JRbUboQZ
