### PR TITLE
fix: Scan the lifecycle queue without its iterator in dequeueAdd/dequeueRemove

### DIFF
--- a/packages/flame/lib/src/components/core/component_tree_root.dart
+++ b/packages/flame/lib/src/components/core/component_tree_root.dart
@@ -35,19 +35,30 @@ class ComponentTreeRoot extends Component {
       ..parent = parent;
   }
 
+  /// Cancels the pending ADD event for [child] into [parent].
+  ///
+  /// Scans the queue without using its iterator, so this is safe to call while
+  /// [processLifecycleEvents] is iterating over the queue (for example from a
+  /// component's [Component.onMount]).
   @internal
   void dequeueAdd(Component child, Component parent) {
-    for (final event in queue) {
-      if (event.kind == LifecycleEventKind.add &&
+    var found = false;
+    queue.forEachWhere(
+      (event) =>
+          !found &&
+          event.kind == LifecycleEventKind.add &&
           event.child == child &&
-          event.parent == parent) {
+          event.parent == parent,
+      (event) {
         event.kind = LifecycleEventKind.unknown;
-        return;
-      }
-    }
-    throw AssertionError(
-      'Cannot find a lifecycle event Add(child=$child, parent=$parent)',
+        found = true;
+      },
     );
+    if (!found) {
+      throw AssertionError(
+        'Cannot find a lifecycle event Add(child=$child, parent=$parent)',
+      );
+    }
   }
 
   @internal
@@ -58,13 +69,18 @@ class ComponentTreeRoot extends Component {
       ..parent = parent;
   }
 
+  /// Cancels all pending REMOVE events for [child].
+  ///
+  /// Scans the queue without using its iterator, so this is safe to call while
+  /// [processLifecycleEvents] is iterating over the queue (for example from a
+  /// component's [Component.onMount]).
   @internal
   void dequeueRemove(Component child) {
-    for (final event in queue) {
-      if (event.kind == LifecycleEventKind.remove && event.child == child) {
-        event.kind = LifecycleEventKind.unknown;
-      }
-    }
+    queue.forEachWhere(
+      (event) =>
+          event.kind == LifecycleEventKind.remove && event.child == child,
+      (event) => event.kind = LifecycleEventKind.unknown,
+    );
   }
 
   /// Finds all children in [candidates] that have a pending REMOVE event,
@@ -205,12 +221,10 @@ class ComponentTreeRoot extends Component {
   @internal
   void handleResize(Vector2 size) {
     super.handleResize(size);
-    for (final event in queue) {
-      if ((event.kind == LifecycleEventKind.add) &&
-          (event.child!.isLoading || event.child!.isLoaded)) {
-        event.child!.onGameResize(size);
-      }
-    }
+    queue.forEachWhere(
+      _isPendingAddOfLoadingOrLoadedChild,
+      (event) => event.child!.onGameResize(size),
+    );
   }
 
   @mustCallSuper
@@ -218,12 +232,15 @@ class ComponentTreeRoot extends Component {
   @internal
   void handleHotReload() {
     super.handleHotReload();
-    for (final event in queue) {
-      if ((event.kind == LifecycleEventKind.add) &&
-          (event.child!.isLoading || event.child!.isLoaded)) {
-        event.child!.onHotReload();
-      }
-    }
+    queue.forEachWhere(
+      _isPendingAddOfLoadingOrLoadedChild,
+      (event) => event.child!.onHotReload(),
+    );
+  }
+
+  static bool _isPendingAddOfLoadingOrLoadedChild(LifecycleEvent event) {
+    return event.kind == LifecycleEventKind.add &&
+        (event.child!.isLoading || event.child!.isLoaded);
   }
 
   @mustCallSuper

--- a/packages/flame/test/components/component_test.dart
+++ b/packages/flame/test/components/component_test.dart
@@ -1205,6 +1205,41 @@ void main() {
           expect(parent.parent, isNull);
         },
       );
+
+      testWithFlameGame(
+        'removing a queued sibling from onMount does not mount twice',
+        (game) async {
+          final sibling = _LifecycleComponent('sibling');
+          final component = _SiblingRemovingOnMountComponent(sibling);
+          game.world.add(component);
+          game.world.add(sibling);
+          await game.ready();
+
+          expect(component.isMounted, true);
+          expect(component.countEvents('onMount'), 1);
+          expect(sibling.isMounted, false);
+          expect(sibling.parent, isNull);
+          expect(game.world.children, [component]);
+        },
+      );
+
+      testWithFlameGame(
+        're-adding a removing component from onMount keeps it in the tree',
+        (game) async {
+          final existing = _LifecycleComponent('existing');
+          await game.world.ensureAdd(existing);
+          final component = _ReAddingOnMountComponent(existing);
+          game.world.add(component);
+          game.world.remove(existing);
+          await game.ready();
+
+          expect(component.isMounted, true);
+          expect(existing.isMounted, true);
+          expect(existing.isRemoving, false);
+          expect(existing.parent, game.world);
+          expect(game.world.children, containsAll([component, existing]));
+        },
+      );
     });
 
     group('Moving components', () {
@@ -2171,6 +2206,29 @@ class _SelfRemovingOnMountComponent extends Component {
   @override
   void onMount() {
     removeFromParent();
+  }
+}
+
+class _SiblingRemovingOnMountComponent extends _LifecycleComponent {
+  _SiblingRemovingOnMountComponent(this.sibling) : super('remover');
+
+  final Component sibling;
+
+  @override
+  void onMount() {
+    super.onMount();
+    parent!.remove(sibling);
+  }
+}
+
+class _ReAddingOnMountComponent extends Component {
+  _ReAddingOnMountComponent(this.component);
+
+  final Component component;
+
+  @override
+  void onMount() {
+    parent!.add(component);
   }
 }
 


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
`RecycledQueue` only supports a single iterator at a time: its `iterator` getter resets the cursor and runs garbage collection. `ComponentTreeRoot.dequeueAdd` and `dequeueRemove` scanned the queue with a plain `for (final event in queue)`, and both are reachable from inside `processLifecycleEvents`:

- `Component._removeChild` calls `dequeueAdd` when removing a component that is queued but not yet mounted.
- `Component._addChild` calls `dequeueRemove` when re-adding a component that is currently removing.

When user code did either of those from `onMount` (or `onLoad`), the nested iteration clobbered the outer cursor. In the `dequeueAdd` case the outer loop then called `removeCurrent()` on the wrong element, so the already processed `add` event survived in the queue, was handled a second time and tripped `assert(!isMounted)` in `handleLifecycleEventAdd`. In the `dequeueRemove` case the nested scan ran to the end and the outer `removeCurrent()` hit `Cannot remove current element if not iterating`.

`dequeueAdd`, `dequeueRemove`, `handleResize` and `handleHotReload` now go through `RecycledQueue.forEachWhere`, which walks the backing storage directly and is safe to call during iteration (it is what `cancelQueuedRemoves` already used for the same reason). Behavior is unchanged: `dequeueAdd` still cancels only the first matching event and still throws if none is found, `dequeueRemove` still cancels all matching events.

Two regression tests reproduce both crashes deterministically: one mounts a component whose `onMount` removes a queued sibling, the other mounts a component whose `onMount` re-adds a component that is being removed in the same tick.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #4018

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
