### PR TITLE
perf!: Lean change notifier and version-tracked Transform2D for NotifyingVector2

### DIFF
--- a/packages/flame/benchmark/README.md
+++ b/packages/flame/benchmark/README.md
@@ -48,6 +48,9 @@ the benchmark results are printed above it.
   `register<T>()`/`query<T>()` type-query caches under mixed-type churn.
 - `update_components_benchmark.dart`: end-to-end update pass with game-like
   logic and inputs on a two-level tree.
+- `notifying_vector2_benchmark.dart`: mutation cost of the `position` and
+  `size` vectors of `PositionComponent`s, including listener dispatch to the
+  owning transform.
 - `render_components_benchmark.dart`: render pass over a randomized tree onto
   a mock canvas.
 - `components_at_point_benchmark.dart`: pointer hit testing

--- a/packages/flame/benchmark/main.dart
+++ b/packages/flame/benchmark/main.dart
@@ -2,6 +2,7 @@ import 'children_traversal_benchmark.dart' as children_traversal;
 import 'collision_detection_benchmark.dart' as collision_detection;
 import 'component_churn_benchmark.dart' as component_churn;
 import 'components_at_point_benchmark.dart' as components_at_point;
+import 'notifying_vector2_benchmark.dart' as notifying_vector2;
 import 'priority_change_benchmark.dart' as priority_change;
 import 'render_components_benchmark.dart' as render_components;
 import 'type_query_benchmark.dart' as type_query;
@@ -13,6 +14,7 @@ Future<void> main() async {
   await priority_change.main();
   await type_query.main();
   await update_components.main();
+  await notifying_vector2.main();
   await render_components.main();
   await components_at_point.main();
   await collision_detection.main();

--- a/packages/flame/benchmark/notifying_vector2_benchmark.dart
+++ b/packages/flame/benchmark/notifying_vector2_benchmark.dart
@@ -50,6 +50,24 @@ class PositionAddScaledBenchmark extends _NotifyingVector2Benchmark {
   }
 }
 
+class PositionAddExpressionBenchmark extends _NotifyingVector2Benchmark {
+  final _velocity = Vector2(30, -20);
+
+  PositionAddExpressionBenchmark()
+    : super('NotifyingVector2 add(velocity * dt), allocating');
+
+  static Future<void> main() async {
+    PositionAddExpressionBenchmark().report();
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < _amountComponents; i++) {
+      _components[i].position.add(_velocity * _dt);
+    }
+  }
+}
+
 class PositionSetXBenchmark extends _NotifyingVector2Benchmark {
   PositionSetXBenchmark() : super('NotifyingVector2 set x');
 
@@ -92,6 +110,7 @@ class SizeSetValuesBenchmark extends _NotifyingVector2Benchmark {
 
 Future<void> main() async {
   await PositionAddScaledBenchmark.main();
+  await PositionAddExpressionBenchmark.main();
   await PositionSetXBenchmark.main();
   await SizeSetValuesBenchmark.main();
 }

--- a/packages/flame/benchmark/notifying_vector2_benchmark.dart
+++ b/packages/flame/benchmark/notifying_vector2_benchmark.dart
@@ -1,0 +1,97 @@
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+
+const _amountComponents = 10000;
+const _dt = 1.0 / 60;
+
+/// Measures the cost of mutating the notifying vectors of real
+/// [PositionComponent]s, which is the path taken by `position.add(...)`,
+/// `position.x = ...`, and `size.setValues(...)` in every game.
+///
+/// Each vector has the listener that the owning [Transform2D] or
+/// [PositionComponent] registers, and the size benchmark adds one extra
+/// listener to exercise the multi-listener path.
+abstract class _NotifyingVector2Benchmark extends BenchmarkBase {
+  late final List<PositionComponent> _components;
+
+  _NotifyingVector2Benchmark(super.name);
+
+  @override
+  void setup() {
+    _components = List.generate(
+      _amountComponents,
+      (i) => PositionComponent(
+        position: Vector2(i.toDouble(), -i.toDouble()),
+        size: Vector2.all(10),
+      ),
+      growable: false,
+    );
+  }
+
+  @override
+  void exercise() => run();
+}
+
+class PositionAddScaledBenchmark extends _NotifyingVector2Benchmark {
+  final _velocity = Vector2(30, -20);
+
+  PositionAddScaledBenchmark() : super('NotifyingVector2 addScaled');
+
+  static Future<void> main() async {
+    PositionAddScaledBenchmark().report();
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < _amountComponents; i++) {
+      _components[i].position.addScaled(_velocity, _dt);
+    }
+  }
+}
+
+class PositionSetXBenchmark extends _NotifyingVector2Benchmark {
+  PositionSetXBenchmark() : super('NotifyingVector2 set x');
+
+  static Future<void> main() async {
+    PositionSetXBenchmark().report();
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < _amountComponents; i++) {
+      _components[i].position.x = i.toDouble();
+    }
+  }
+}
+
+class SizeSetValuesBenchmark extends _NotifyingVector2Benchmark {
+  int _extraListenerCalls = 0;
+
+  SizeSetValuesBenchmark() : super('NotifyingVector2 setValues (2 listeners)');
+
+  static Future<void> main() async {
+    SizeSetValuesBenchmark().report();
+  }
+
+  @override
+  void setup() {
+    super.setup();
+    for (final component in _components) {
+      component.size.addListener(() => _extraListenerCalls++);
+    }
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < _amountComponents; i++) {
+      _components[i].size.setValues(10, i.toDouble());
+    }
+  }
+}
+
+Future<void> main() async {
+  await PositionAddScaledBenchmark.main();
+  await PositionSetXBenchmark.main();
+  await SizeSetValuesBenchmark.main();
+}

--- a/packages/flame/lib/game.dart
+++ b/packages/flame/lib/game.dart
@@ -15,5 +15,6 @@ export 'src/game/game_widget/game_widget.dart';
 export 'src/game/mixins/has_performance_tracker.dart';
 export 'src/game/mixins/single_game_instance.dart';
 export 'src/game/notifying_vector2.dart';
+export 'src/game/simple_change_notifier.dart';
 export 'src/game/transform2d.dart';
 export 'src/text/renderers/text_paint.dart';

--- a/packages/flame/lib/src/components/position_component.dart
+++ b/packages/flame/lib/src/components/position_component.dart
@@ -483,7 +483,7 @@ class PositionComponent extends Component
   /// Internal handler that must be invoked whenever either the [size]
   /// or the [anchor] change.
   void _onModifiedSizeOrAnchor() {
-    transform.offset = Vector2(-_anchor.x * _size.x, -_anchor.y * _size.y);
+    transform.offset.setValues(-_anchor.x * _size.x, -_anchor.y * _size.y);
   }
 
   @override

--- a/packages/flame/lib/src/game/notifying_vector2.dart
+++ b/packages/flame/lib/src/game/notifying_vector2.dart
@@ -1,7 +1,9 @@
+import 'package:flame/src/game/simple_change_notifier.dart';
+import 'package:flame/src/game/transform2d.dart';
 import 'package:flutter/foundation.dart';
 import 'package:vector_math/vector_math.dart';
 
-/// Extension of the standard [Vector2] class, implementing the [ChangeNotifier]
+/// Extension of the standard [Vector2] class, implementing the [Listenable]
 /// functionality. This allows any interested party to be notified when the
 /// value of this vector changes.
 ///
@@ -9,8 +11,15 @@ import 'package:vector_math/vector_math.dart';
 /// subscribe to notifications, don't forget to eventually unsubscribe in
 /// order to avoid resource leaks.
 ///
+/// Listeners are dispatched through [SimpleChangeNotifier], which is tuned
+/// for the common case of a single listener (for example the transform that
+/// owns the vector) being notified many times per frame. Note that an
+/// exception thrown by a listener propagates to the caller of the mutating
+/// method instead of being reported and swallowed like a [ChangeNotifier]
+/// would do.
+///
 /// Direct modification of this vector's [storage] is not allowed.
-class NotifyingVector2 extends Vector2 with ChangeNotifier {
+class NotifyingVector2 extends Vector2 with SimpleChangeNotifier {
   factory NotifyingVector2(double x, double y) =>
       NotifyingVector2.zero()..setValues(x, y);
 
@@ -21,169 +30,187 @@ class NotifyingVector2 extends Vector2 with ChangeNotifier {
   factory NotifyingVector2.copy(Vector2 v) =>
       NotifyingVector2.zero()..setFrom(v);
 
+  Float32List? _unmodifiableStorage;
+  int _version = 0;
+
+  /// A counter that is incremented every time this vector is modified.
+  ///
+  /// Comparing the version against a previously seen value is a cheap way to
+  /// detect changes without registering a listener, which is what
+  /// [Transform2D] does to know when its cached matrix must be recalculated.
+  int get version => _version;
+
+  void _changed() {
+    _version++;
+    notifyListeners();
+  }
+
   @override
   void setValues(double x_, double y_) {
     super.setValues(x_, y_);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void setFrom(Vector2 other) {
     super.setFrom(other);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void setZero() {
     super.setZero();
-    notifyListeners();
+    _changed();
   }
 
   @override
   void splat(double arg) {
     super.splat(arg);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void operator []=(int i, double v) {
     super[i] = v;
-    notifyListeners();
+    _changed();
   }
 
   @override
   set length(double l) {
     super.length = l;
-    notifyListeners();
+    _changed();
   }
 
   @override
   double normalize() {
     final l = super.normalize();
-    notifyListeners();
+    _changed();
     return l;
   }
 
   @override
   void postmultiply(Matrix2 arg) {
     super.postmultiply(arg);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void add(Vector2 arg) {
     super.add(arg);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void addScaled(Vector2 arg, double factor) {
     super.addScaled(arg, factor);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void sub(Vector2 arg) {
     super.sub(arg);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void multiply(Vector2 arg) {
     super.multiply(arg);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void divide(Vector2 arg) {
     super.divide(arg);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void scale(double arg) {
     super.scale(arg);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void negate() {
     super.negate();
-    notifyListeners();
+    _changed();
   }
 
   @override
   void absolute() {
     super.absolute();
-    notifyListeners();
+    _changed();
   }
 
   @override
   void clamp(Vector2 min, Vector2 max) {
     super.clamp(min, max);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void clampScalar(double min, double max) {
     super.clampScalar(min, max);
-    notifyListeners();
+    _changed();
   }
 
   @override
   void floor() {
     super.floor();
-    notifyListeners();
+    _changed();
   }
 
   @override
   void ceil() {
     super.ceil();
-    notifyListeners();
+    _changed();
   }
 
   @override
   void round() {
     super.round();
-    notifyListeners();
+    _changed();
   }
 
   @override
   void roundToZero() {
     super.roundToZero();
-    notifyListeners();
+    _changed();
   }
 
   @override
   void copyFromArray(List<double> array, [int offset = 0]) {
     super.copyFromArray(array, offset);
-    notifyListeners();
+    _changed();
   }
 
   @override
   set xy(Vector2 arg) {
     super.xy = arg;
-    notifyListeners();
+    _changed();
   }
 
   @override
   set yx(Vector2 arg) {
     super.yx = arg;
-    notifyListeners();
+    _changed();
   }
 
   @override
   set x(double x) {
     super.x = x;
-    notifyListeners();
+    _changed();
   }
 
   @override
   set y(double y) {
     super.y = y;
-    notifyListeners();
+    _changed();
   }
 
+  /// A read-only view of the underlying storage. The view is created once
+  /// and reused, and it always reflects the current values of the vector.
   @override
-  Float32List get storage => super.storage.asUnmodifiableView();
+  Float32List get storage =>
+      _unmodifiableStorage ??= super.storage.asUnmodifiableView();
 }

--- a/packages/flame/lib/src/game/simple_change_notifier.dart
+++ b/packages/flame/lib/src/game/simple_change_notifier.dart
@@ -1,0 +1,124 @@
+import 'package:flame/src/game/notifying_vector2.dart';
+import 'package:flame/src/game/transform2d.dart';
+import 'package:flutter/foundation.dart';
+
+/// A lightweight [Listenable] implementation optimized for objects that are
+/// mutated many times per frame and that usually have a single listener, such
+/// as [NotifyingVector2] and [Transform2D].
+///
+/// Compared to Flutter's [ChangeNotifier] this class:
+/// - keeps the first listener in a plain field, so notifying it is a single
+///   null check and a call, and only allocates a list when a second listener
+///   is added;
+/// - does not catch exceptions thrown by listeners. An exception propagates
+///   to the code that performed the mutation, the same as for any other
+///   callback in Flame;
+/// - does not participate in Flutter's memory allocation tracking and has no
+///   disposed state.
+///
+/// Listeners that are added while a notification is being dispatched are not
+/// invoked during that notification, and listeners that are removed while a
+/// notification is being dispatched are not invoked either, mirroring the
+/// guarantees of [ChangeNotifier].
+mixin class SimpleChangeNotifier implements Listenable {
+  VoidCallback? _listener;
+  List<VoidCallback?>? _extraListeners;
+  int _notificationDepth = 0;
+  bool _hasRemovedListeners = false;
+
+  /// Whether any listeners are currently registered.
+  @protected
+  bool get hasListeners {
+    if (_listener != null) {
+      return true;
+    }
+    final extraListeners = _extraListeners;
+    if (extraListeners == null) {
+      return false;
+    }
+    for (final listener in extraListeners) {
+      if (listener != null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @override
+  void addListener(VoidCallback listener) {
+    if (_listener == null && _extraListeners == null) {
+      _listener = listener;
+    } else {
+      (_extraListeners ??= <VoidCallback?>[]).add(listener);
+    }
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    if (_listener == listener) {
+      _listener = null;
+      _hasRemovedListeners = true;
+    } else {
+      final extraListeners = _extraListeners;
+      if (extraListeners != null) {
+        final index = extraListeners.indexOf(listener);
+        if (index >= 0) {
+          extraListeners[index] = null;
+          _hasRemovedListeners = true;
+        }
+      }
+    }
+    if (_notificationDepth == 0) {
+      _compact();
+    }
+  }
+
+  /// Removes all listeners. The object can still be used afterwards, but
+  /// nobody will be notified of changes until new listeners are added.
+  @mustCallSuper
+  void dispose() {
+    _listener = null;
+    _extraListeners = null;
+    _hasRemovedListeners = false;
+  }
+
+  /// Calls all the registered listeners.
+  @protected
+  @visibleForTesting
+  void notifyListeners() {
+    final extraListeners = _extraListeners;
+    if (extraListeners == null) {
+      _listener?.call();
+      return;
+    }
+    _notifyAll(extraListeners);
+  }
+
+  void _notifyAll(List<VoidCallback?> extraListeners) {
+    _notificationDepth++;
+    _listener?.call();
+    final end = extraListeners.length;
+    for (var i = 0; i < end; i++) {
+      extraListeners[i]?.call();
+    }
+    _notificationDepth--;
+    if (_notificationDepth == 0 && _hasRemovedListeners) {
+      _compact();
+    }
+  }
+
+  void _compact() {
+    _hasRemovedListeners = false;
+    final extraListeners = _extraListeners;
+    if (extraListeners == null) {
+      return;
+    }
+    extraListeners.removeWhere((listener) => listener == null);
+    if (_listener == null && extraListeners.isNotEmpty) {
+      _listener = extraListeners.removeAt(0);
+    }
+    if (extraListeners.isEmpty) {
+      _extraListeners = null;
+    }
+  }
+}

--- a/packages/flame/lib/src/game/transform2d.dart
+++ b/packages/flame/lib/src/game/transform2d.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flame/geometry.dart' as geometry;
 import 'package:flame/src/game/notifying_vector2.dart';
+import 'package:flame/src/game/simple_change_notifier.dart';
 import 'package:flutter/foundation.dart';
 import 'package:vector_math/vector_math.dart';
 
@@ -24,11 +25,17 @@ import 'package:vector_math/vector_math.dart';
 /// requested by the user. Thus, modifying multiple properties at once does
 /// not incur the penalty of unnecessary recalculations.
 ///
-/// This class implements the [ChangeNotifier] API, allowing you to subscribe
-/// for notifications whenever the transform matrix changes. In addition, you
-/// can subscribe to get notified when individual components of the transform
-/// change: [position], [scale], and [offset] (but not [angle]).
-class Transform2D extends ChangeNotifier {
+/// Changes to [position], [scale] and [offset] are detected through their
+/// [NotifyingVector2.version] counters when the matrix is requested, so
+/// modifying them does not invoke any callbacks unless somebody is listening
+/// to this transform.
+///
+/// This class implements the [Listenable] API (through
+/// [SimpleChangeNotifier]), allowing you to subscribe for notifications
+/// whenever the transform matrix changes. In addition, you can subscribe to
+/// get notified when individual components of the transform change:
+/// [position], [scale], and [offset] (but not [angle]).
+class Transform2D with SimpleChangeNotifier {
   final Matrix4 _transformMatrix;
   bool _recalculate;
   bool _isBatchUpdating = false;
@@ -36,6 +43,9 @@ class Transform2D extends ChangeNotifier {
   final NotifyingVector2 _position;
   final NotifyingVector2 _scale;
   final NotifyingVector2 _offset;
+  int _positionVersion = -1;
+  int _scaleVersion = -1;
+  int _offsetVersion = -1;
 
   Transform2D()
     : _transformMatrix = Matrix4.identity(),
@@ -43,10 +53,42 @@ class Transform2D extends ChangeNotifier {
       _angle = 0,
       _position = NotifyingVector2.zero(),
       _scale = NotifyingVector2.all(1),
-      _offset = NotifyingVector2.zero() {
-    _position.addListener(_markAsModified);
-    _scale.addListener(_markAsModified);
-    _offset.addListener(_markAsModified);
+      _offset = NotifyingVector2.zero();
+
+  @override
+  void addListener(VoidCallback listener) {
+    if (!hasListeners) {
+      _position.addListener(_forwardNotification);
+      _scale.addListener(_forwardNotification);
+      _offset.addListener(_forwardNotification);
+    }
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    super.removeListener(listener);
+    if (!hasListeners) {
+      _stopForwarding();
+    }
+  }
+
+  @override
+  void dispose() {
+    _stopForwarding();
+    super.dispose();
+  }
+
+  void _stopForwarding() {
+    _position.removeListener(_forwardNotification);
+    _scale.removeListener(_forwardNotification);
+    _offset.removeListener(_forwardNotification);
+  }
+
+  void _forwardNotification() {
+    if (!_isBatchUpdating) {
+      notifyListeners();
+    }
   }
 
   factory Transform2D.copy(Transform2D other) => Transform2D()
@@ -159,7 +201,10 @@ class Transform2D extends ChangeNotifier {
   ///
   /// The returned matrix must not be modified by the user.
   Matrix4 get transformMatrix {
-    if (_recalculate) {
+    if (_recalculate ||
+        _position.version != _positionVersion ||
+        _scale.version != _scaleVersion ||
+        _offset.version != _offsetVersion) {
       // The transforms below are equivalent to:
       //   _transformMatrix = Matrix4.identity()
       //       .. translate(_position.x, _position.y)
@@ -175,9 +220,16 @@ class Transform2D extends ChangeNotifier {
       m[5] = cosA * _scale.y;
       m[12] = _position.x + m[0] * _offset.x + m[4] * _offset.y;
       m[13] = _position.y + m[1] * _offset.x + m[5] * _offset.y;
-      _recalculate = false;
+      _markAsCalculated();
     }
     return _transformMatrix;
+  }
+
+  void _markAsCalculated() {
+    _recalculate = false;
+    _positionVersion = _position.version;
+    _scaleVersion = _scale.version;
+    _offsetVersion = _offset.version;
   }
 
   set transformMatrix(Matrix4 value) {
@@ -195,7 +247,6 @@ class Transform2D extends ChangeNotifier {
       'The provided matrix is not a valid 2D transformation',
     );
     _transformMatrix.setFrom(value);
-    _recalculate = false;
 
     final storage = _transformMatrix.storage;
     _isBatchUpdating = true;
@@ -214,6 +265,7 @@ class Transform2D extends ChangeNotifier {
     _position.y =
         storage[13] - (storage[1] * _offset.x + storage[5] * _offset.y);
     _isBatchUpdating = false;
+    _markAsCalculated();
     notifyListeners();
   }
 
@@ -273,8 +325,6 @@ class Transform2D extends ChangeNotifier {
 
   void _markAsModified() {
     _recalculate = true;
-    if (!_isBatchUpdating) {
-      notifyListeners();
-    }
+    _forwardNotification();
   }
 }

--- a/packages/flame/test/game/notifying_vector2_test.dart
+++ b/packages/flame/test/game/notifying_vector2_test.dart
@@ -102,5 +102,27 @@ void main() {
       expect(storage[0], 0);
       expect(storage[1], 0);
     });
+
+    test('storage view reflects later modifications', () {
+      final nv = NotifyingVector2.zero();
+      final storage = nv.storage;
+      nv.setValues(3, 4);
+      expect(storage[0], 3);
+      expect(storage[1], 4);
+      expect(identical(storage, nv.storage), isTrue);
+    });
+
+    test('version increments on every modification', () {
+      final nv = NotifyingVector2.zero();
+      expect(nv.version, 0);
+      nv.x = 1;
+      expect(nv.version, 1);
+      nv.setValues(1, 1);
+      expect(nv.version, 2);
+      nv.add(Vector2(1, 1));
+      expect(nv.version, 3);
+      nv.scale(2);
+      expect(nv.version, 4);
+    });
   });
 }

--- a/packages/flame/test/game/simple_change_notifier_test.dart
+++ b/packages/flame/test/game/simple_change_notifier_test.dart
@@ -1,0 +1,189 @@
+import 'package:flame/game.dart';
+import 'package:test/test.dart';
+
+class _Notifier with SimpleChangeNotifier {
+  void notify() => notifyListeners();
+
+  bool get hasAnyListeners => hasListeners;
+}
+
+void main() {
+  group('SimpleChangeNotifier', () {
+    test('notifies a single listener', () {
+      final notifier = _Notifier();
+      var count = 0;
+      notifier.addListener(() => count++);
+      notifier.notify();
+      notifier.notify();
+      expect(count, 2);
+    });
+
+    test('notifies without listeners', () {
+      final notifier = _Notifier();
+      expect(notifier.notify, returnsNormally);
+      expect(notifier.hasAnyListeners, isFalse);
+    });
+
+    test('notifies multiple listeners in registration order', () {
+      final notifier = _Notifier();
+      final calls = <int>[];
+      notifier.addListener(() => calls.add(1));
+      notifier.addListener(() => calls.add(2));
+      notifier.addListener(() => calls.add(3));
+      notifier.notify();
+      expect(calls, [1, 2, 3]);
+    });
+
+    test('same listener can be added multiple times', () {
+      final notifier = _Notifier();
+      var count = 0;
+      void listener() => count++;
+      notifier.addListener(listener);
+      notifier.addListener(listener);
+      notifier.notify();
+      expect(count, 2);
+      notifier.removeListener(listener);
+      notifier.notify();
+      expect(count, 3);
+      notifier.removeListener(listener);
+      notifier.notify();
+      expect(count, 3);
+    });
+
+    test('removing a listener stops notifications', () {
+      final notifier = _Notifier();
+      var first = 0;
+      var second = 0;
+      void firstListener() => first++;
+      void secondListener() => second++;
+      notifier.addListener(firstListener);
+      notifier.addListener(secondListener);
+      notifier.removeListener(firstListener);
+      notifier.notify();
+      expect(first, 0);
+      expect(second, 1);
+      notifier.removeListener(secondListener);
+      notifier.notify();
+      expect(second, 1);
+      expect(notifier.hasAnyListeners, isFalse);
+    });
+
+    test('removing an unknown listener is a no-op', () {
+      final notifier = _Notifier();
+      var count = 0;
+      notifier.addListener(() => count++);
+      notifier.removeListener(() {});
+      notifier.notify();
+      expect(count, 1);
+    });
+
+    test('listener removing itself during notification', () {
+      final notifier = _Notifier();
+      var first = 0;
+      var second = 0;
+      late void Function() firstListener;
+      firstListener = () {
+        first++;
+        notifier.removeListener(firstListener);
+      };
+      notifier.addListener(firstListener);
+      notifier.addListener(() => second++);
+      notifier.notify();
+      expect(first, 1);
+      expect(second, 1);
+      notifier.notify();
+      expect(first, 1);
+      expect(second, 2);
+    });
+
+    test('single listener removing itself during notification', () {
+      final notifier = _Notifier();
+      var count = 0;
+      late void Function() listener;
+      listener = () {
+        count++;
+        notifier.removeListener(listener);
+      };
+      notifier.addListener(listener);
+      notifier.notify();
+      notifier.notify();
+      expect(count, 1);
+      expect(notifier.hasAnyListeners, isFalse);
+    });
+
+    test('listener removing a later listener during notification', () {
+      final notifier = _Notifier();
+      var second = 0;
+      var third = 0;
+      void secondListener() => second++;
+      void thirdListener() => third++;
+      notifier.addListener(() => notifier.removeListener(secondListener));
+      notifier.addListener(secondListener);
+      notifier.addListener(thirdListener);
+      notifier.notify();
+      expect(second, 0);
+      expect(third, 1);
+      notifier.notify();
+      expect(second, 0);
+      expect(third, 2);
+    });
+
+    test('listener added during notification is not called in that round', () {
+      final notifier = _Notifier();
+      var late = 0;
+      void lateListener() => late++;
+      notifier.addListener(() => notifier.addListener(lateListener));
+      notifier.notify();
+      expect(late, 0);
+      notifier.removeListener(lateListener);
+      notifier.notify();
+      expect(late, 0);
+    });
+
+    test('reentrant notification', () {
+      final notifier = _Notifier();
+      var depth = 0;
+      var count = 0;
+      notifier.addListener(() {
+        count++;
+        if (depth == 0) {
+          depth++;
+          notifier.notify();
+          depth--;
+        }
+      });
+      notifier.addListener(() => count++);
+      notifier.notify();
+      expect(count, 4);
+    });
+
+    test('exceptions propagate to the caller', () {
+      final notifier = _Notifier();
+      notifier.addListener(() => throw StateError('boom'));
+      expect(notifier.notify, throwsStateError);
+    });
+
+    test('dispose removes all listeners', () {
+      final notifier = _Notifier();
+      var count = 0;
+      notifier.addListener(() => count++);
+      notifier.addListener(() => count++);
+      expect(notifier.hasAnyListeners, isTrue);
+      notifier.dispose();
+      expect(notifier.hasAnyListeners, isFalse);
+      notifier.notify();
+      expect(count, 0);
+    });
+
+    test('hasListeners', () {
+      final notifier = _Notifier();
+      void listener() {}
+      expect(notifier.hasAnyListeners, isFalse);
+      notifier.addListener(listener);
+      expect(notifier.hasAnyListeners, isTrue);
+      notifier.addListener(() {});
+      notifier.removeListener(listener);
+      expect(notifier.hasAnyListeners, isTrue);
+    });
+  });
+}

--- a/packages/flame/test/game/transform2d_test.dart
+++ b/packages/flame/test/game/transform2d_test.dart
@@ -315,5 +315,50 @@ void main() {
         expect(notifications, 1);
       });
     });
+
+    group('listener forwarding', () {
+      test('matrix is recalculated without any listeners', () {
+        final transform = Transform2D();
+        expect(transform.transformMatrix.storage[12], 0);
+        transform.position.x = 5;
+        expect(transform.transformMatrix.storage[12], 5);
+        transform.scale.setValues(2, 3);
+        expect(transform.transformMatrix.storage[0], 2);
+        transform.offset.y = 1;
+        expect(transform.transformMatrix.storage[13], 3);
+      });
+
+      test('vector changes are forwarded only while there are listeners', () {
+        final transform = Transform2D();
+        var notified = 0;
+        void listener() => notified++;
+
+        transform.position.x = 1;
+        transform.addListener(listener);
+        transform.position.x = 2;
+        transform.scale.y = 2;
+        transform.offset.setValues(1, 1);
+        expect(notified, 3);
+
+        transform.removeListener(listener);
+        transform.position.x = 3;
+        expect(notified, 3);
+
+        transform.addListener(listener);
+        transform.position.x = 4;
+        expect(notified, 4);
+        expect(transform.transformMatrix.storage[12], closeTo(4 + 1, 1e-9));
+      });
+
+      test('listener on position sees a fresh matrix', () {
+        final transform = Transform2D();
+        late double x;
+        transform.position.addListener(() {
+          x = transform.transformMatrix.storage[12];
+        });
+        transform.position.x = 7;
+        expect(x, 7);
+      });
+    });
   });
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Makes the **notification path** of `NotifyingVector2` (`position`, `size`, `scale`, `offset` of every `PositionComponent`) 5-6x cheaper. It does not change how vectors are stored or how vector math allocates: `position += velocity * dt` and `position.add(velocity * dt)` create the same temporary `Vector2` objects as before. Removing those allocations is the follow-up PR stacked on this one (see #3966).

What changes:

- **`SimpleChangeNotifier`** replaces Flutter's `ChangeNotifier` in `NotifyingVector2` and `Transform2D`. It keeps the first listener in a plain field and only allocates a list for the second one, and drops the disposed-state asserts, memory-allocation instrumentation and per-listener `try/catch` that `ChangeNotifier` carries for widgets. Dispatch semantics are the same (registration order, add/remove during dispatch, reentrancy). It is exported for components that want it.
- **`Transform2D` tracks changes with a version counter.** `NotifyingVector2.version` increments on every mutation. The transform compares versions when `transformMatrix` is requested instead of subscribing to its vectors, and only forwards vector notifications to its own listeners while it has any. A component nobody listens to now pays no callback at all when its position moves.
- Two cold-path allocation fixes: `NotifyingVector2.storage` caches its unmodifiable view instead of allocating one per call, and `PositionComponent` no longer allocates a temporary `Vector2` on size or anchor changes.

## Benchmarks

`benchmark/notifying_vector2_benchmark.dart` (new), 10 000 `PositionComponent`s, `flutter test` on macOS arm64:

| Workload | `main` | This PR | Per component |
|---|---:|---:|---|
| `position.addScaled(velocity, dt)` | 285 µs | **62 µs** | 28.5 → 6.2 ns |
| `position.add(velocity * dt)`, allocates a temporary | 331 µs | **92 µs** | 33.1 → 9.2 ns |
| `position.x = v` | 306 µs | **49 µs** | 30.6 → 4.9 ns |
| `size.setValues(w, h)` with two listeners | 522 µs | **324 µs** | 52.2 → 32.4 ns |

The 30 µs gap between the first two rows is the cost of the temporary vector, which this PR leaves as is. The `size` row keeps two real listeners, so only the cheaper dispatch helps it. `flutter test` runs in JIT with asserts enabled, which exaggerates the notifier part; in AOT the same change measures at roughly 2x rather than 5x.

## For users

Nothing in game code has to change. New:

- `NotifyingVector2.version` gives change detection with an integer compare instead of a listener and a dirty flag (`if (size.version != _seen) { _seen = size.version; rebuild(); }`).
- Listener order on `position`/`scale`/`offset` no longer matters: `transformMatrix` is version-checked, so it is fresh whenever a listener reads it.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.

### Migration instructions

- `NotifyingVector2` and `Transform2D` are no longer subtypes of `ChangeNotifier`. They are still `Listenable` with `addListener`/`removeListener`/`dispose`, so `ListenableBuilder` and `AnimatedBuilder` keep working; code that checks `is ChangeNotifier` or stores them as `ChangeNotifier` should use `Listenable`.
- An exception thrown by a listener now propagates out of the mutating call (for example `position.x = 5`) instead of being reported through `FlutterError.reportError` and swallowed.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Part of #3966.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->

https://claude.ai/code/session_01PixXaRTPs8v1P2mQF2QHGG
