### PR TITLE
feat: Add VectorValue for allocation-free vector math

### DIFF
--- a/doc/flame/other/util.md
+++ b/doc/flame/other/util.md
@@ -325,6 +325,47 @@ Operators:
   right.
 - `%`: Modulo/Remainder of x and y separately of two `Vector2`s.
 
+Every `Vector2` also has a `value` property that reads and writes its components as a
+`VectorValue`, see below.
+
+
+### VectorValue
+
+`VectorValue` is an immutable vector value that is free to create and combine: it is an extension
+type over `Float64x2`, which the Dart VM keeps out of the heap, so a whole expression such as
+
+```dart
+position.value = size.value / 2 + offset + velocity * dt;
+```
+
+runs without allocating anything, while the same expression written with `Vector2` operators
+allocates a new vector per operator. Use `VectorValue` for math and `Vector2` (or
+`NotifyingVector2`) for storage that can be observed and modified in place. The two are bridged by
+the `value` property on `Vector2`:
+
+```dart
+final direction = (target.value - position.value).normalized();
+position.value += direction * speed * dt;
+```
+
+Assigning to `value` goes through `setValues`, so a `NotifyingVector2` notifies its listeners
+exactly once per assignment, and `VectorValue.copyInto` writes into an existing `Vector2` without
+allocating.
+
+`VectorValue` keeps full double precision (`VectorValue(0.1, 0).x == 0.1`, whereas `Vector2`
+stores floats). Since extension types cannot declare `==`, comparing two `VectorValue`s with `==`
+compares by identity; use `equals` or `closeTo` instead, and do not use `VectorValue` as a map key.
+
+Methods and getters: `x`, `y`, `withX`, `withY`, `+`, `-`, unary `-`, `*`, `/`, `multiplied`,
+`divided`, `dot`, `cross`, `length`, `length2`, `normalized`, `withLength`, `withLengthClamped`,
+`perpendicular`, `distanceTo`, `distanceToSquared`, `lerp`, `rotated`, `angleTo`, `angleToSigned`,
+`screenAngle`, `abs`, `min`, `max`, `clamp`, `floor`, `ceil`, `round`, `isZero`, `isFinite`,
+`equals`, `closeTo`, `copyInto`, `toVector2`, `toOffset`, `toSize`, `describe`.
+
+Constructors: `VectorValue(x, y)`, `VectorValue.all`, `VectorValue.fromVector2`,
+`VectorValue.fromOffset`, `VectorValue.fromSize`, `VectorValue.fromRadians`, and the constants
+`VectorValue.zero` and `VectorValue.one`.
+
 
 ### Matrix4
 

--- a/packages/flame/benchmark/notifying_vector2_benchmark.dart
+++ b/packages/flame/benchmark/notifying_vector2_benchmark.dart
@@ -68,6 +68,69 @@ class PositionAddExpressionBenchmark extends _NotifyingVector2Benchmark {
   }
 }
 
+class PositionValueAddBenchmark extends _NotifyingVector2Benchmark {
+  final _velocity = VectorValue(30, -20);
+
+  PositionValueAddBenchmark()
+    : super('NotifyingVector2 value += velocity * dt, allocation-free');
+
+  static Future<void> main() async {
+    PositionValueAddBenchmark().report();
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < _amountComponents; i++) {
+      _components[i].position.value += _velocity * _dt;
+    }
+  }
+}
+
+class PositionValueExpressionBenchmark extends _NotifyingVector2Benchmark {
+  final _velocity = VectorValue(30, -20);
+  final _offset = VectorValue(3, 4);
+
+  PositionValueExpressionBenchmark()
+    : super('NotifyingVector2 value = size.value / 2 + offset + velocity * dt');
+
+  static Future<void> main() async {
+    PositionValueExpressionBenchmark().report();
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < _amountComponents; i++) {
+      final component = _components[i];
+      component.position.value =
+          component.size.value / 2 + _offset + _velocity * _dt;
+    }
+  }
+}
+
+class PositionChainedExpressionBenchmark extends _NotifyingVector2Benchmark {
+  final _velocity = Vector2(30, -20);
+  final _offset = Vector2(3, 4);
+
+  PositionChainedExpressionBenchmark()
+    : super('NotifyingVector2 setFrom((size / 2)..add(offset)..addScaled())');
+
+  static Future<void> main() async {
+    PositionChainedExpressionBenchmark().report();
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < _amountComponents; i++) {
+      final component = _components[i];
+      component.position.setFrom(
+        (component.size / 2)
+          ..add(_offset)
+          ..addScaled(_velocity, _dt),
+      );
+    }
+  }
+}
+
 class PositionSetXBenchmark extends _NotifyingVector2Benchmark {
   PositionSetXBenchmark() : super('NotifyingVector2 set x');
 
@@ -111,6 +174,9 @@ class SizeSetValuesBenchmark extends _NotifyingVector2Benchmark {
 Future<void> main() async {
   await PositionAddScaledBenchmark.main();
   await PositionAddExpressionBenchmark.main();
+  await PositionValueAddBenchmark.main();
+  await PositionChainedExpressionBenchmark.main();
+  await PositionValueExpressionBenchmark.main();
   await PositionSetXBenchmark.main();
   await SizeSetValuesBenchmark.main();
 }

--- a/packages/flame/lib/math.dart
+++ b/packages/flame/lib/math.dart
@@ -2,3 +2,4 @@ export 'src/math/block.dart';
 export 'src/math/random_fallback.dart';
 export 'src/math/solve_cubic.dart';
 export 'src/math/solve_quadratic.dart';
+export 'src/math/vector_value.dart';

--- a/packages/flame/lib/src/extensions/vector2.dart
+++ b/packages/flame/lib/src/extensions/vector2.dart
@@ -1,8 +1,11 @@
 import 'dart:math';
 import 'dart:ui';
 
+import 'package:flame/src/game/notifying_vector2.dart';
+import 'package:flame/src/math/vector_value.dart';
 import 'package:vector_math/vector_math.dart';
 
+export 'package:flame/src/math/vector_value.dart';
 export 'package:vector_math/vector_math.dart' hide Colors;
 
 extension Vector2Extension on Vector2 {
@@ -12,6 +15,25 @@ extension Vector2Extension on Vector2 {
   /// Avoid using this in async extension methods, as it can lead to race
   /// conditions.
   static final _reusableVector = Vector2.zero();
+
+  /// The current components of this vector as an immutable [VectorValue].
+  ///
+  /// Reading [value] does not allocate, and neither does assigning a
+  /// [VectorValue] expression back to it, so this is the allocation-free way
+  /// to write vector math on a stored vector:
+  ///
+  /// ```dart
+  /// position.value += velocity * dt;
+  /// position.value = size.value / 2 + offset + velocity * dt;
+  /// ```
+  ///
+  /// Assigning goes through [setValues], so a [NotifyingVector2] notifies its
+  /// listeners exactly once per assignment.
+  @pragma('vm:prefer-inline')
+  VectorValue get value => VectorValue(x, y);
+
+  @pragma('vm:prefer-inline')
+  set value(VectorValue value) => setValues(value.x, value.y);
 
   /// Creates an [Offset] from the [Vector2]
   Offset toOffset() => Offset(x, y);

--- a/packages/flame/lib/src/math/vector_value.dart
+++ b/packages/flame/lib/src/math/vector_value.dart
@@ -1,0 +1,294 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' show Offset, Size;
+
+import 'package:flame/src/extensions/vector2.dart';
+import 'package:flame/src/game/notifying_vector2.dart';
+
+/// An immutable 2D vector that is free to create and combine.
+///
+/// [VectorValue] is an extension type over [Float64x2], which the Dart VM keeps
+/// unboxed in locals, arguments, return values and non-nullable fields. As a
+/// result, a whole expression such as
+///
+/// ```dart
+/// position.value = size.value / 2 + offset + velocity * dt;
+/// ```
+///
+/// runs without allocating a single object, whereas the same expression with
+/// [Vector2] allocates one vector (and its [Float32List]) per operator.
+///
+/// [VectorValue] is the value counterpart of the mutable [Vector2]: use
+/// [VectorValue] for math, and [Vector2] (or [NotifyingVector2]) as storage
+/// that can be observed and modified in place. The two are bridged by
+/// [Vector2Extension.value]:
+///
+/// ```dart
+/// final VectorValue direction = (target.value - position.value).normalized();
+/// position.value += direction * speed * dt;
+/// ```
+///
+/// Every member is marked `@pragma('vm:prefer-inline')` because the
+/// allocation-free behavior relies on the operators being inlined into the
+/// caller. Do not remove the pragmas.
+///
+/// Because extension types cannot declare `==` or `hashCode`, the `==`
+/// operator on a [VectorValue] compares by identity, like [Float64x2] does.
+/// Use [equals] or [closeTo] to compare values, and do not use [VectorValue]
+/// as a map key.
+extension type VectorValue._(Float64x2 _v) {
+  /// Creates a vector with the given components.
+  @pragma('vm:prefer-inline')
+  VectorValue(double x, double y) : _v = Float64x2(x, y);
+
+  /// Creates a vector with both components set to [value].
+  @pragma('vm:prefer-inline')
+  VectorValue.all(double value) : _v = Float64x2.splat(value);
+
+  /// Creates a vector with the components of [vector].
+  @pragma('vm:prefer-inline')
+  VectorValue.fromVector2(Vector2 vector) : _v = Float64x2(vector.x, vector.y);
+
+  /// Creates a vector from an [Offset].
+  @pragma('vm:prefer-inline')
+  VectorValue.fromOffset(Offset offset) : _v = Float64x2(offset.dx, offset.dy);
+
+  /// Creates a vector from a [Size].
+  @pragma('vm:prefer-inline')
+  VectorValue.fromSize(Size size) : _v = Float64x2(size.width, size.height);
+
+  /// Creates a unit vector pointing in the direction of [radians], where 0
+  /// points up (negative y) and positive angles rotate clockwise on screen,
+  /// matching [Vector2Extension.fromRadians].
+  @pragma('vm:prefer-inline')
+  VectorValue.fromRadians(double radians)
+    : _v = Float64x2(math.sin(radians), -math.cos(radians));
+
+  /// The vector (0, 0).
+  static final VectorValue zero = VectorValue(0, 0);
+
+  /// The vector (1, 1).
+  static final VectorValue one = VectorValue(1, 1);
+
+  /// The x component.
+  @pragma('vm:prefer-inline')
+  double get x => _v.x;
+
+  /// The y component.
+  @pragma('vm:prefer-inline')
+  double get y => _v.y;
+
+  /// A copy of this vector with the x component replaced by [x].
+  @pragma('vm:prefer-inline')
+  VectorValue withX(double x) => VectorValue._(_v.withX(x));
+
+  /// A copy of this vector with the y component replaced by [y].
+  @pragma('vm:prefer-inline')
+  VectorValue withY(double y) => VectorValue._(_v.withY(y));
+
+  /// Component-wise sum.
+  @pragma('vm:prefer-inline')
+  VectorValue operator +(VectorValue other) => VectorValue._(_v + other._v);
+
+  /// Component-wise difference.
+  @pragma('vm:prefer-inline')
+  VectorValue operator -(VectorValue other) => VectorValue._(_v - other._v);
+
+  /// Negation.
+  @pragma('vm:prefer-inline')
+  VectorValue operator -() => VectorValue._(-_v);
+
+  /// Scales both components by [factor].
+  @pragma('vm:prefer-inline')
+  VectorValue operator *(double factor) => VectorValue._(_v.scale(factor));
+
+  /// Divides both components by [divisor].
+  @pragma('vm:prefer-inline')
+  VectorValue operator /(double divisor) =>
+      VectorValue._(_v.scale(1 / divisor));
+
+  /// Component-wise product.
+  @pragma('vm:prefer-inline')
+  VectorValue multiplied(VectorValue other) => VectorValue._(_v * other._v);
+
+  /// Component-wise quotient.
+  @pragma('vm:prefer-inline')
+  VectorValue divided(VectorValue other) => VectorValue._(_v / other._v);
+
+  /// The dot product with [other].
+  @pragma('vm:prefer-inline')
+  double dot(VectorValue other) {
+    final product = _v * other._v;
+    return product.x + product.y;
+  }
+
+  /// The 2D cross product (the z component of the 3D cross product).
+  @pragma('vm:prefer-inline')
+  double cross(VectorValue other) => x * other.y - y * other.x;
+
+  /// The squared length of the vector.
+  @pragma('vm:prefer-inline')
+  double get length2 => dot(this);
+
+  /// The length of the vector.
+  @pragma('vm:prefer-inline')
+  double get length => math.sqrt(length2);
+
+  /// Whether both components are zero.
+  @pragma('vm:prefer-inline')
+  bool get isZero => x == 0 && y == 0;
+
+  /// Whether both components are finite.
+  @pragma('vm:prefer-inline')
+  bool get isFinite => x.isFinite && y.isFinite;
+
+  /// The vector with the same direction and length 1. The zero vector is
+  /// returned unchanged.
+  @pragma('vm:prefer-inline')
+  VectorValue normalized() {
+    final l = length;
+    return l == 0 ? this : VectorValue._(_v.scale(1 / l));
+  }
+
+  /// The vector with the same direction and length [newLength]. The zero
+  /// vector is returned unchanged.
+  @pragma('vm:prefer-inline')
+  VectorValue withLength(double newLength) {
+    final l = length;
+    return l == 0 ? this : VectorValue._(_v.scale(newLength.abs() / l));
+  }
+
+  /// The vector with its length clamped to the range [min] to [max].
+  @pragma('vm:prefer-inline')
+  VectorValue withLengthClamped(double min, double max) {
+    final l2 = length2;
+    if (l2 > max * max) {
+      return withLength(max);
+    }
+    if (l2 < min * min) {
+      return withLength(min);
+    }
+    return this;
+  }
+
+  /// The vector perpendicular to this one, rotated a quarter turn clockwise
+  /// on screen (positive y down).
+  @pragma('vm:prefer-inline')
+  VectorValue perpendicular() => VectorValue(-y, x);
+
+  /// The distance to [other].
+  @pragma('vm:prefer-inline')
+  double distanceTo(VectorValue other) => (this - other).length;
+
+  /// The squared distance to [other].
+  @pragma('vm:prefer-inline')
+  double distanceToSquared(VectorValue other) => (this - other).length2;
+
+  /// Linear interpolation towards [to] by the fraction [t].
+  @pragma('vm:prefer-inline')
+  VectorValue lerp(VectorValue to, double t) => this + (to - this) * t;
+
+  /// The vector rotated by [angle] radians around [center] (the origin by
+  /// default). On screen, where the y axis points down, positive angles rotate
+  /// clockwise, matching [Vector2Extension.rotate].
+  @pragma('vm:prefer-inline')
+  VectorValue rotated(double angle, {VectorValue? center}) {
+    if (angle == 0) {
+      return this;
+    }
+    final cos = math.cos(angle);
+    final sin = math.sin(angle);
+    if (center == null) {
+      return VectorValue(x * cos - y * sin, x * sin + y * cos);
+    }
+    final dx = x - center.x;
+    final dy = y - center.y;
+    return VectorValue(
+      cos * dx - sin * dy + center.x,
+      sin * dx + cos * dy + center.y,
+    );
+  }
+
+  /// The unsigned angle in radians between this vector and [other], in the
+  /// range 0 to π.
+  @pragma('vm:prefer-inline')
+  double angleTo(VectorValue other) {
+    final denominator = math.sqrt(length2 * other.length2);
+    if (denominator == 0) {
+      return 0;
+    }
+    return math.acos((dot(other) / denominator).clamp(-1.0, 1.0));
+  }
+
+  /// The signed angle in radians from this vector to [other], in the range
+  /// -π to π. Positive when [other] is clockwise from this vector on screen.
+  @pragma('vm:prefer-inline')
+  double angleToSigned(VectorValue other) =>
+      math.atan2(cross(other), dot(other));
+
+  /// The angle of this vector in a screen coordinate system where (0, -1)
+  /// points up and has angle 0, matching [Vector2Extension.screenAngle].
+  @pragma('vm:prefer-inline')
+  double get screenAngle => math.atan2(x, -y);
+
+  /// Component-wise absolute value.
+  @pragma('vm:prefer-inline')
+  VectorValue abs() => VectorValue._(_v.abs());
+
+  /// Component-wise minimum with [other].
+  @pragma('vm:prefer-inline')
+  VectorValue min(VectorValue other) => VectorValue._(_v.min(other._v));
+
+  /// Component-wise maximum with [other].
+  @pragma('vm:prefer-inline')
+  VectorValue max(VectorValue other) => VectorValue._(_v.max(other._v));
+
+  /// Component-wise clamp between [lower] and [upper].
+  @pragma('vm:prefer-inline')
+  VectorValue clamp(VectorValue lower, VectorValue upper) =>
+      VectorValue._(_v.clamp(lower._v, upper._v));
+
+  /// Both components rounded down.
+  @pragma('vm:prefer-inline')
+  VectorValue floor() => VectorValue(x.floorToDouble(), y.floorToDouble());
+
+  /// Both components rounded up.
+  @pragma('vm:prefer-inline')
+  VectorValue ceil() => VectorValue(x.ceilToDouble(), y.ceilToDouble());
+
+  /// Both components rounded to the nearest integer.
+  @pragma('vm:prefer-inline')
+  VectorValue round() => VectorValue(x.roundToDouble(), y.roundToDouble());
+
+  /// Whether this vector has exactly the same components as [other].
+  ///
+  /// Use this instead of `==`, which compares by identity.
+  @pragma('vm:prefer-inline')
+  bool equals(VectorValue other) => x == other.x && y == other.y;
+
+  /// Whether every component of this vector is within [epsilon] of the
+  /// corresponding component of [other].
+  @pragma('vm:prefer-inline')
+  bool closeTo(VectorValue other, {double epsilon = 1e-9}) =>
+      (x - other.x).abs() <= epsilon && (y - other.y).abs() <= epsilon;
+
+  /// Copies the components into [target], notifying its listeners if it is a
+  /// [NotifyingVector2]. This does not allocate.
+  @pragma('vm:prefer-inline')
+  void copyInto(Vector2 target) => target.setValues(x, y);
+
+  /// Creates a new mutable [Vector2] with these components.
+  Vector2 toVector2() => Vector2(x, y);
+
+  /// Creates an [Offset] with these components.
+  @pragma('vm:prefer-inline')
+  Offset toOffset() => Offset(x, y);
+
+  /// Creates a [Size] with these components.
+  @pragma('vm:prefer-inline')
+  Size toSize() => Size(x, y);
+
+  /// A readable representation, since `toString` cannot be overridden on an
+  /// extension type and would print the underlying [Float64x2].
+  String describe() => 'VectorValue($x, $y)';
+}

--- a/packages/flame/test/math/vector_value_test.dart
+++ b/packages/flame/test/math/vector_value_test.dart
@@ -1,0 +1,237 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('VectorValue', () {
+    test('constructors', () {
+      expect(VectorValue(1, 2).x, 1);
+      expect(VectorValue(1, 2).y, 2);
+      expect(VectorValue.all(3).equals(VectorValue(3, 3)), isTrue);
+      expect(VectorValue.zero.equals(VectorValue(0, 0)), isTrue);
+      expect(VectorValue.one.equals(VectorValue(1, 1)), isTrue);
+      expect(
+        VectorValue.fromVector2(Vector2(4, 5)).equals(VectorValue(4, 5)),
+        isTrue,
+      );
+      expect(
+        VectorValue.fromOffset(const Offset(6, 7)).equals(VectorValue(6, 7)),
+        isTrue,
+      );
+      expect(
+        VectorValue.fromSize(const Size(8, 9)).equals(VectorValue(8, 9)),
+        isTrue,
+      );
+    });
+
+    test('fromRadians matches Vector2Extension.fromRadians', () {
+      for (final angle in [0.0, 0.5, math.pi / 2, math.pi, -1.2, 4.0]) {
+        final expected = Vector2Extension.fromRadians(angle);
+        final actual = VectorValue.fromRadians(angle);
+        expect(actual.x, closeTo(expected.x, 1e-6));
+        expect(actual.y, closeTo(expected.y, 1e-6));
+      }
+    });
+
+    test('keeps double precision', () {
+      expect(VectorValue(0.1, 0.2).x, 0.1);
+      expect(Vector2(0.1, 0.2).x, isNot(0.1));
+    });
+
+    test('withX and withY', () {
+      expect(VectorValue(1, 2).withX(5).equals(VectorValue(5, 2)), isTrue);
+      expect(VectorValue(1, 2).withY(5).equals(VectorValue(1, 5)), isTrue);
+    });
+
+    test('arithmetic operators', () {
+      final a = VectorValue(1, 2);
+      final b = VectorValue(3, -4);
+      expect((a + b).equals(VectorValue(4, -2)), isTrue);
+      expect((a - b).equals(VectorValue(-2, 6)), isTrue);
+      expect((-a).equals(VectorValue(-1, -2)), isTrue);
+      expect((a * 2).equals(VectorValue(2, 4)), isTrue);
+      expect((a / 2).equals(VectorValue(0.5, 1)), isTrue);
+      expect(a.multiplied(b).equals(VectorValue(3, -8)), isTrue);
+      expect(b.divided(a).equals(VectorValue(3, -2)), isTrue);
+    });
+
+    test('compound expression', () {
+      final size = VectorValue(10, 20);
+      final offset = VectorValue(3, 4);
+      final velocity = VectorValue(30, -20);
+      const dt = 0.5;
+      final result = size / 2 + offset + velocity * dt;
+      expect(result.equals(VectorValue(5 + 3 + 15, 10 + 4 - 10)), isTrue);
+    });
+
+    test('dot, cross, length', () {
+      final a = VectorValue(3, 4);
+      final b = VectorValue(-4, 3);
+      expect(a.dot(b), 0);
+      expect(a.dot(a), 25);
+      expect(a.cross(b), 25);
+      expect(a.length2, 25);
+      expect(a.length, 5);
+      expect(VectorValue.zero.isZero, isTrue);
+      expect(a.isZero, isFalse);
+      expect(a.isFinite, isTrue);
+      expect(VectorValue(double.nan, 0).isFinite, isFalse);
+    });
+
+    test('normalized and withLength', () {
+      final a = VectorValue(3, 4);
+      expect(a.normalized().closeTo(VectorValue(0.6, 0.8)), isTrue);
+      expect(a.withLength(10).closeTo(VectorValue(6, 8)), isTrue);
+      expect(a.withLength(-10).closeTo(VectorValue(6, 8)), isTrue);
+      expect(VectorValue.zero.normalized().isZero, isTrue);
+      expect(VectorValue.zero.withLength(3).isZero, isTrue);
+      expect(a.withLengthClamped(1, 2).length, closeTo(2, 1e-9));
+      expect(a.withLengthClamped(6, 8).length, closeTo(6, 1e-9));
+      expect(a.withLengthClamped(1, 8).length, closeTo(5, 1e-9));
+    });
+
+    test('perpendicular, distance, lerp', () {
+      expect(
+        VectorValue(1, 0).perpendicular().equals(VectorValue(0, 1)),
+        isTrue,
+      );
+      expect(VectorValue(1, 1).distanceTo(VectorValue(4, 5)), 5);
+      expect(VectorValue(1, 1).distanceToSquared(VectorValue(4, 5)), 25);
+      expect(
+        VectorValue(
+          0,
+          0,
+        ).lerp(VectorValue(10, 20), 0.25).equals(VectorValue(2.5, 5)),
+        isTrue,
+      );
+    });
+
+    test('rotated matches Vector2Extension.rotate', () {
+      final center = VectorValue(2, -1);
+      for (final angle in [0.0, 0.3, math.pi / 2, math.pi, -2.5]) {
+        final expected = Vector2(3, 4)..rotate(angle);
+        final actual = VectorValue(3, 4).rotated(angle);
+        expect(actual.x, closeTo(expected.x, 1e-5));
+        expect(actual.y, closeTo(expected.y, 1e-5));
+
+        final expectedAroundCenter = Vector2(3, 4)
+          ..rotate(angle, center: center.toVector2());
+        final actualAroundCenter = VectorValue(
+          3,
+          4,
+        ).rotated(angle, center: center);
+        expect(actualAroundCenter.x, closeTo(expectedAroundCenter.x, 1e-5));
+        expect(actualAroundCenter.y, closeTo(expectedAroundCenter.y, 1e-5));
+      }
+    });
+
+    test('angles', () {
+      expect(
+        VectorValue(1, 0).angleTo(VectorValue(0, 1)),
+        closeTo(math.pi / 2, 1e-9),
+      );
+      expect(
+        VectorValue(1, 0).angleTo(VectorValue(-1, 0)),
+        closeTo(math.pi, 1e-9),
+      );
+      expect(VectorValue(1, 0).angleTo(VectorValue.zero), 0);
+      expect(
+        VectorValue(1, 0).angleToSigned(VectorValue(0, 1)),
+        closeTo(math.pi / 2, 1e-9),
+      );
+      expect(
+        VectorValue(0, 1).angleToSigned(VectorValue(1, 0)),
+        closeTo(-math.pi / 2, 1e-9),
+      );
+      for (final vector in [Vector2(0, -1), Vector2(1, 0), Vector2(-3, 2)]) {
+        expect(
+          vector.value.screenAngle,
+          closeTo(vector.screenAngle(), 1e-6),
+        );
+      }
+    });
+
+    test('component-wise helpers', () {
+      final a = VectorValue(-1.5, 2.5);
+      final b = VectorValue(1, 1);
+      expect(a.abs().equals(VectorValue(1.5, 2.5)), isTrue);
+      expect(a.min(b).equals(VectorValue(-1.5, 1)), isTrue);
+      expect(a.max(b).equals(VectorValue(1, 2.5)), isTrue);
+      expect(
+        a
+            .clamp(VectorValue(-1, 0), VectorValue(0, 2))
+            .equals(VectorValue(-1, 2)),
+        isTrue,
+      );
+      expect(a.floor().equals(VectorValue(-2, 2)), isTrue);
+      expect(a.ceil().equals(VectorValue(-1, 3)), isTrue);
+      expect(a.round().equals(VectorValue(-2, 3)), isTrue);
+    });
+
+    test('equals and closeTo', () {
+      expect(VectorValue(1, 2).equals(VectorValue(1, 2)), isTrue);
+      expect(VectorValue(1, 2).equals(VectorValue(1, 2.0000001)), isFalse);
+      expect(
+        VectorValue(1, 2).closeTo(VectorValue(1, 2.0000001), epsilon: 1e-6),
+        isTrue,
+      );
+      expect(VectorValue(1, 2).closeTo(VectorValue(1, 2.1)), isFalse);
+    });
+
+    test('conversions', () {
+      final v = VectorValue(1.5, -2);
+      expect(v.toVector2(), Vector2(1.5, -2));
+      expect(v.toOffset(), const Offset(1.5, -2));
+      expect(v.toSize(), const Size(1.5, -2));
+      expect(v.describe(), 'VectorValue(1.5, -2.0)');
+      final target = Vector2.zero();
+      v.copyInto(target);
+      expect(target, Vector2(1.5, -2));
+    });
+  });
+
+  group('Vector2Extension.value', () {
+    test('reads the current components', () {
+      final vector = Vector2(3, 4);
+      expect(vector.value.equals(VectorValue(3, 4)), isTrue);
+      vector.x = 5;
+      expect(vector.value.equals(VectorValue(5, 4)), isTrue);
+    });
+
+    test('assigning sets the components', () {
+      final vector = Vector2.zero();
+      vector.value = VectorValue(1, 2);
+      expect(vector, Vector2(1, 2));
+      vector.value += VectorValue(1, 1) * 2;
+      expect(vector, Vector2(3, 4));
+    });
+
+    test('NotifyingVector2 notifies once per assignment', () {
+      final vector = NotifyingVector2(1, 1);
+      final version = vector.version;
+      var notified = 0;
+      vector.addListener(() => notified++);
+      vector.value =
+          vector.value / 2 + VectorValue(3, 4) + VectorValue(30, -20) * 0.5;
+      expect(notified, 1);
+      expect(vector, Vector2(0.5 + 3 + 15, 0.5 + 4 - 10));
+      expect(vector.version, version + 1);
+    });
+
+    test('works through a PositionComponent', () {
+      final component = PositionComponent(
+        position: Vector2(10, 10),
+        size: Vector2(4, 6),
+      );
+      final velocity = VectorValue(2, -1);
+      component.position.value += velocity * 0.5;
+      expect(component.position, Vector2(11, 9.5));
+      component.position.value = component.size.value / 2;
+      expect(component.position, Vector2(2, 3));
+      expect(component.transformMatrix.storage[12], 2);
+    });
+  });
+}


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Stacked on #4022. Adds `VectorValue`, an immutable 2D vector that is free to create and combine, and a `value` property on every `Vector2` that reads and writes its components as a `VectorValue`. Together they make vector expressions allocation-free while keeping `Vector2`/`NotifyingVector2` as the observable, mutable storage that components expose today. Nothing existing changes; this is additive.

`VectorValue` is an extension type over `Float64x2`, which the Dart VM keeps unboxed in locals, arguments, return values and fields, so a whole expression stays in registers. Every member carries `@pragma('vm:prefer-inline')`; without inlining each operator would return a boxed value, so the pragmas are part of the design. It keeps full double precision (`VectorValue(0.1, 0).x == 0.1`; `Vector2` stores floats).

Assigning to `value` goes through `setValues`, so a `NotifyingVector2` notifies its listeners exactly once per assignment, `version` increments once, and `Transform2D` picks the change up as usual.

## What it looks like

| Today | With this PR | Allocates |
|---|---|---|
| `position.add(velocity * dt);` | `position.value += velocity * dt;` | 2 objects → 0 |
| `position.setFrom((size / 2)..add(offset)..addScaled(velocity, dt));` | `position.value = size.value / 2 + offset + velocity * dt;` | 2 objects → 0 |
| `final d = target - position..normalize();` | `final d = (target.value - position.value).normalized();` | 2 objects → 0 |
| `position.addScaled(velocity, dt);` | unchanged, still the fastest form for this one case | 0 |
| `size.addListener(_relayout);`, `size.x = 32;`, `position.setFrom(v);` | unchanged | |

`velocity` and `offset` above are `VectorValue` fields (`final velocity = VectorValue(30, -20);`); a stored `Vector2` on the right-hand side of an operator needs `.value` (`a.position.value - b.position.value`), because Dart has no operator overloading by argument type. `VectorValue` also has the usual helpers (`dot`, `cross`, `length`, `normalized`, `withLength`, `rotated`, `lerp`, `distanceTo`, `angleTo`, `clamp`, `floor`, `equals`, `closeTo`, `copyInto`, `toOffset`, …), all documented in `doc/flame/other/util.md`.

## Benchmarks

`benchmark/notifying_vector2_benchmark.dart`, 10 000 `PositionComponent`s, `flutter test` on macOS arm64, on top of #4022:

| Workload | Time | Per component | Allocates |
|---|---:|---|---|
| `position.add(velocity * dt)` | 86 µs | 8.6 ns | yes |
| `position.value += velocity * dt` | **50 µs** | 5.0 ns | no |
| `position.addScaled(velocity, dt)` | 56 µs | 5.6 ns | no |
| `position.setFrom((size / 2)..add(offset)..addScaled(velocity, dt))` | 91 µs | 9.1 ns | yes |
| `position.value = size.value / 2 + offset + velocity * dt` | **65 µs** | 6.5 ns | no |

For reference, on `main` the `position.add(velocity * dt)` row measures 331 µs, so the readable form is now the fast form. Standalone AOT measurements of the same shapes (`dart compile exe`, minimum of 21 samples) put the `.value` expression at 6.5-8 ns per component against 17 ns for today's `NotifyingVector2` chain, and confirm that the `Float64x2` temporaries do not reach the heap.

## Caveats

- Extension types cannot declare `==`, `hashCode` or `toString`, and `Float64x2` compares by identity, so `VectorValue(1, 2) == VectorValue(1, 2)` is `false`. Use `equals`/`closeTo`; `describe()` gives a readable string; do not use it as a map key. Worth a lint in `flame_lint` later.
- `Float64x2` has no const constructor, so `VectorValue.zero`/`one` are `static final` and it cannot be a default parameter value.
- On the web `Float64x2` is emulated; measured with dart2js it is still the fastest ergonomic option (8 ns for the full expression versus 22 ns for the `Vector2` chain) as long as values are not stored in fields, which `Vector2` storage guarantees.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Part of #3966. Stacked on #4022.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->

https://claude.ai/code/session_01PixXaRTPs8v1P2mQF2QHGG
