### PR TITLE
fix: Use full asset paths in the remaining examples and docs

### DIFF
--- a/doc/bridge_packages/flame_audio/audio.md
+++ b/doc/bridge_packages/flame_audio/audio.md
@@ -15,8 +15,8 @@ The latest version can be found on [pub.dev](https://pub.dev/packages/flame_audi
 After installing the `flame_audio` package, you can add audio files in the assets section of your
 `pubspec.yaml` file. Make sure that the audio files exists in the paths that you provide.
 
-The default directory for `FlameAudio` is `assets/audio` (which can be changed by providing your own
-instance of `AudioCache`).
+Every path is given in full, exactly as declared in the `pubspec.yaml`, nothing is prepended.
+The examples below keep the audio files in `assets/audio`, but any directory works.
 
 For the examples below, your `pubspec.yaml` file needs to contain something like this:
 
@@ -105,7 +105,7 @@ await FlameAudio.audioCache.loadAll([
 Finally, you can use the `clear` method to remove a file that has been loaded into the cache:
 
 ```dart
-FlameAudio.audioCache.clear('explosion.mp3');
+FlameAudio.audioCache.clear('assets/audio/explosion.mp3');
 ```
 
 There is also a `clearCache` method, that clears the whole cache.

--- a/doc/bridge_packages/flame_audio/audio_pool.md
+++ b/doc/bridge_packages/flame_audio/audio_pool.md
@@ -64,7 +64,7 @@ import 'package:flame_audio/flame_audio.dart';
 Future<void> loadSounds() async {
   // Create a pool with a specific Source
   AudioPool explosionSoundPool = await AudioPool.create(
-    source: AssetSource('explosion.mp3'),
+    source: AssetSource('assets/audio/explosion.mp3'),
     minPlayers: 1,
     maxPlayers: 2,
     audioCache: FlameAudio.audioCache, // Optional
@@ -82,7 +82,7 @@ import 'package:flame_audio/flame_audio.dart';
 
 Future<void> loadSounds() async {
   AudioPool explosionSoundPool = await AudioPool.createFromAsset(
-    path: 'explosion.mp3',
+    path: 'assets/audio/explosion.mp3',
     minPlayers: 1,
     maxPlayers: 2,
     audioCache: FlameAudio.audioCache, // Optional

--- a/doc/flame/components/sprite_components.md
+++ b/doc/flame/components/sprite_components.md
@@ -47,7 +47,7 @@ This will create a simple three frame animation using 3 different images:
 @override
 Future<void> onLoad() async {
   final sprites = [0, 1, 2]
-      .map((i) => Sprite.load('player_$i.png'));
+      .map((i) => Sprite.load('assets/images/player_$i.png'));
   final animation = SpriteAnimation.spriteList(
     await Future.wait(sprites),
     stepTime: 0.01,

--- a/examples/lib/stories/svg/svg_component.dart
+++ b/examples/lib/stories/svg/svg_component.dart
@@ -14,7 +14,7 @@ class Player extends SvgComponent with HasGameReference<SvgComponentExample> {
   Future<void>? onLoad() async {
     await super.onLoad();
 
-    svg = await game.loadSvg('svgs/happy_player.svg');
+    svg = await game.loadSvg('assets/svgs/happy_player.svg');
   }
 
   @override
@@ -46,7 +46,7 @@ class Background extends SvgComponent
   Future<void>? onLoad() async {
     await super.onLoad();
 
-    svg = await game.loadSvg('svgs/checkerboard.svg');
+    svg = await game.loadSvg('assets/svgs/checkerboard.svg');
   }
 }
 
@@ -64,7 +64,7 @@ class Balloons extends SvgComponent with HasGameReference<SvgComponentExample> {
 
     final color = Random().nextBool() ? 'red' : 'green';
 
-    svg = await game.loadSvg('svgs/${color}_balloons.svg');
+    svg = await game.loadSvg('assets/svgs/${color}_balloons.svg');
   }
 }
 

--- a/packages/flame_3d/example/lib/components/crate.dart
+++ b/packages/flame_3d/example/lib/components/crate.dart
@@ -13,7 +13,9 @@ class Crate extends MeshComponent {
 
   @override
   FutureOr<void> onLoad() async {
-    final crateTexture = await Flame.images.loadTexture('crate.jpg');
+    final crateTexture = await Flame.images.loadTexture(
+      'assets/images/crate.jpg',
+    );
     mesh.updateSurfaces((surfaces) {
       surfaces[0].material = SpatialMaterial(
         albedoTexture: crateTexture,

--- a/packages/flame_3d/example/lib/scenarios/models_scenario.dart
+++ b/packages/flame_3d/example/lib/scenarios/models_scenario.dart
@@ -10,7 +10,7 @@ class ModelsScenario implements GameScenario {
   @override
   Future<void> onLoad() async {
     // source: https://kaylousberg.itch.io/kaykit-skeletons
-    model = await ModelParser.parse('objects/skeleton.glb');
+    model = await ModelParser.parse('assets/objects/skeleton.glb');
   }
 
   @override

--- a/packages/flame_audio/README.md
+++ b/packages/flame_audio/README.md
@@ -32,12 +32,16 @@ ambient sounds, sound effects, etc. For the full documentation, visit [flame_aud
 
 ## How to use
 
-Add sound files to `assets/audio`. Remember to run `pub get` after updating pubspec.yaml with:
+Add your sound files to the assets section of your `pubspec.yaml`, and remember to run `pub get`
+afterwards:
 
-```dart
-assets:
-    - assets/audio
+```yaml
+flutter:
+  assets:
+    - assets/audio/
 ```
+
+Every path is given in full, exactly as declared in the `pubspec.yaml`, nothing is prepended.
 
 
 ### General sounds
@@ -48,16 +52,16 @@ Use these built-in methods to play sounds in your Flame game:
 import 'package:flame_audio/flame_audio.dart';
 
 // For shorter reused audio clips, like sound effects
-FlameAudio.play('explosion.mp3');
+FlameAudio.play('assets/audio/explosion.mp3');
 
 // For looping an audio file
-FlameAudio.loop('music.mp3');
+FlameAudio.loop('assets/audio/music.mp3');
 
 // For playing a longer audio file
-FlameAudio.playLongAudio('music.mp3');
+FlameAudio.playLongAudio('assets/audio/music.mp3');
 
 // For looping a longer audio file
-FlameAudio.loopLongAudio('music.mp3');
+FlameAudio.loopLongAudio('assets/audio/music.mp3');
 ```
 
 
@@ -81,7 +85,7 @@ To play a looping background music
 import 'package:flame_audio/flame_audio.dart';
 
 // play with optional volume param
-FlameAudio.bgm.play('music/world-map.mp3', volume: .25);
+FlameAudio.bgm.play('assets/audio/music/world-map.mp3', volume: .25);
 ```
 
 To stop background music
@@ -106,17 +110,20 @@ The files are cached automatically after the first time.
 
 ```dart
 // cache single track
-await FlameAudio.audioCache.load('explosion.mp3');
+await FlameAudio.audioCache.load('assets/audio/explosion.mp3');
 
 // cache multiple tracks
-await FlameAudio.audioCache.loadAll(['explosion.mp3', 'music.mp3']);
+await FlameAudio.audioCache.loadAll([
+  'assets/audio/explosion.mp3',
+  'assets/audio/music.mp3',
+]);
 ```
 
 To clear the cache
 
 ```dart
 // clear specific track
-FlameAudio.audioCache.clear('explosion.mp3');
+FlameAudio.audioCache.clear('assets/audio/explosion.mp3');
 
 // clear whole cache
 FlameAudio.audioCache.clearCache();
@@ -129,6 +136,9 @@ Use AudioPools if you have extremely quick firing, repetitive or simultaneous so
 To create an AudioPool:
 
 ```dart
-AudioPool audioPool = await FlameAudio.createPool('explosion.mp3', maxPlayers: 2);
+AudioPool audioPool = await FlameAudio.createPool(
+  'assets/audio/explosion.mp3',
+  maxPlayers: 2,
+);
 audioPool.start();
 ```

--- a/packages/flame_bloc/example/lib/src/game/components/bullet.dart
+++ b/packages/flame_bloc/example/lib/src/game/components/bullet.dart
@@ -34,9 +34,9 @@ class BulletComponent extends SpriteAnimationComponent
 
   String _mapSpritePath() {
     return switch (weapon) {
-      Weapon.bullet => 'bullet.png',
-      Weapon.laser => 'laser.png',
-      Weapon.plasma => 'plasma.png',
+      Weapon.bullet => 'assets/images/bullet.png',
+      Weapon.laser => 'assets/images/laser.png',
+      Weapon.plasma => 'assets/images/plasma.png',
     };
   }
 

--- a/packages/flame_fire_atlas/README.md
+++ b/packages/flame_fire_atlas/README.md
@@ -35,14 +35,14 @@ Then, load the atlas from your assets:
 
 ```dart
 // file at assets/atlas.fa
-final atlas = await FireAtlas.loadAsset('atlas.fa');
+final atlas = await FireAtlas.loadAsset('assets/atlas.fa');
 ```
 
 or when inside a game instance, the `loadFireAtlas` can be used:
 
 ```dart
 // file at assets/atlas.fa
-final atlas = await loadFireAtlas('atlas.fa');
+final atlas = await loadFireAtlas('assets/atlas.fa');
 ```
 
 With the instance loaded you can now get sprites and animations like:

--- a/packages/flame_kenney_xml/README.md
+++ b/packages/flame_kenney_xml/README.md
@@ -35,7 +35,7 @@ Then load the image and the spritesheet using:
 
 ```dart
 final spritesheet = await XmlSpriteSheet.load(
-  imagePath: 'spritesheet.png',
-  xmlPath: 'spritesheet.xml',
+  imagePath: 'assets/images/spritesheet.png',
+  xmlPath: 'assets/spritesheet.xml',
 );
 ```

--- a/packages/flame_kenney_xml/lib/flame_kenney_xml.dart
+++ b/packages/flame_kenney_xml/lib/flame_kenney_xml.dart
@@ -29,8 +29,9 @@ class XmlSpriteSheet {
 
   /// Load an [XmlSpriteSheet] from an image and an XML file.
   ///
-  /// The [imagePath] should be in relation to `assets/images/`.
-  /// The [xmlPath] should be in relation to `assets/`.
+  /// Both [imagePath] and [xmlPath] are full paths, as declared in the
+  /// `pubspec.yaml`, for example `assets/images/spritesheet.png` and
+  /// `assets/spritesheet.xml`.
   static Future<XmlSpriteSheet> load({
     required String imagePath,
     required String xmlPath,

--- a/packages/flame_sprite_fusion/README.md
+++ b/packages/flame_sprite_fusion/README.md
@@ -47,8 +47,8 @@ and `assets/images/` directory of your project respectively.
 ```dart
 // Load the map.
 final map = await SpriteFusionTilemapComponent.load(
-  mapJsonFile: 'map.json',
-  spriteSheetFile: 'spritesheet.png'
+  mapJsonFile: 'assets/tiles/map.json',
+  spriteSheetFile: 'assets/images/spritesheet.png',
 );
 
 //Add it to the game world.

--- a/packages/flame_texturepacker/README.md
+++ b/packages/flame_texturepacker/README.md
@@ -56,7 +56,7 @@ Import the plugin like this:
 Load the TextureAtlas passing the path of the sprite sheet atlas file:
 
 ```Dart
-final atlas = await TexturePackerAtlas.load('atlas_map.atlas');
+final atlas = await TexturePackerAtlas.load('assets/images/atlas_map.atlas');
 ```
 
 
@@ -71,10 +71,23 @@ that allows you to load an atlas directly:
 class MyGame extends FlameGame {
   @override
   Future<void> onLoad() async {
-    final atlas = await atlasFromAssets('atlas_map.atlas');
+    final atlas = await atlasFromAssets('assets/images/atlas_map.atlas');
     // ...
   }
 }
+```
+
+
+### Atlas Location
+
+
+The path is a full asset path, exactly as declared in the `pubspec.yaml`, so the atlas file can
+live anywhere. Page textures listed inside the atlas are resolved relative to the atlas's own
+directory:
+
+```dart
+// Path: assets/atlases/hero.atlas
+final atlas = await TexturePackerAtlas.load('assets/atlases/hero.atlas');
 ```
 
 
@@ -83,69 +96,11 @@ class MyGame extends FlameGame {
 
 To load an atlas from another Flutter package, use the `package` parameter:
 
-```Dart
+```dart
 final atlas = await TexturePackerAtlas.load(
-  'atlas_map.atlas',
+  'assets/images/atlas_map.atlas',
   package: 'my_assets_package',
 );
-```
-
-
-### Paths and Prefixes
-
-
-By default, `TexturePackerAtlas.load` looks for files in `assets/images/`. This is controlled by the
-`assetsPrefix` parameter, which defaults to `'images'`.
-
-
-#### 1. Default usage (relative to `assets/images/`)
-
-
-```dart
-// Path: assets/images/hero.atlas
-final atlas = await TexturePackerAtlas.load('hero.atlas');
-```
-
-
-#### 2. Custom prefix (relative to `assets/`)
-
-
-```dart
-// Path: assets/atlases/hero.atlas
-final atlas = await TexturePackerAtlas.load(
-  'hero.atlas',
-  assetsPrefix: 'atlases',
-);
-```
-
-
-#### 3. Full path (stripping standard prefix)
-
-
-If you provide a path that already includes the standard `assets/`
-or `images/` prefix, the library will automatically strip them to avoid duplication.
-This is particularly useful when working with full asset paths.
-
-
-```dart
-// Path: assets/images/mega_explosions.atlas
-final atlas = await TexturePackerAtlas.load(
-  'assets/images/mega_explosions.atlas',
-  assetsPrefix: '',
-);
-```
-
-
-#### 4. Automatic Package Detection
-
-
-If you provide a path that starts with `packages/package_name/...`,
-the library will automatically detect the package name
-and adjust the internal loading logic.
-
-```dart
-// Path: packages/my_assets_package/assets/images/heroes.atlas
-final atlas = await TexturePackerAtlas.load('packages/my_assets_package/assets/images/heroes.atlas');
 ```
 
 
@@ -155,7 +110,7 @@ This is optional, but recommended to avoid loading every sprite from your textur
 Use a list of relative paths to load only the Sprites you need into memory.
 
 ```Dart
-final regions = await TexturePackerAtlas.loadAtlas('atlas_map.atlas');
+final regions = await TexturePackerAtlas.loadAtlas('assets/images/atlas_map.atlas');
 final atlas = TexturePackerAtlas.fromAtlas(regions, whiteList: [
   'weapons/',
   'ships/',
@@ -197,7 +152,7 @@ final animation = atlas.getAnimation('robot_walk', stepTime: 0.1, loop: true);
 If your atlas contains multiple animations, load it once and reuse it:
 
 ```Dart
-final atlas = await TexturePackerAtlas.load('atlas_map.atlas');
+final atlas = await TexturePackerAtlas.load('assets/images/atlas_map.atlas');
 
 final walkAnim = atlas.getAnimation('robot_walk');
 final runAnim  = atlas.getAnimation('robot_run');


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description
<!-- End of exclude from commit message -->
Follow-up to #4015, which removed the implicit `assets/` and `assets/images/` prefixes from the asset loaders. A few call sites and docs still passed the old relative paths, so they now point at bundle keys that do not exist. The most visible one is the Svg example, which loads nothing on web (#4026).

Code:

- `examples/lib/stories/svg`: `svgs/...` to `assets/svgs/...` (the reported bug).
- `packages/flame_3d/example`: `crate.jpg` and `objects/skeleton.glb` now use their full paths.
- `packages/flame_bloc/example`: bullet, laser and plasma sprites now use `assets/images/...`, matching the other components in that example.
- `flame_kenney_xml`: the `XmlSpriteSheet.load` dartdoc still said the paths were relative to `assets/images/` and `assets/`.

Docs (paths in code snippets that were not updated in #4015, plus stale prose about default directories and prefixes):

- `flame_audio` README and `doc/bridge_packages/flame_audio/{audio,audio_pool}.md`.
- `flame_texturepacker` README, where the whole "Paths and Prefixes" section documented the removed `assetsPrefix` parameter. Replaced it with an "Atlas Location" section that matches `doc/bridge_packages/flame_texturepacker`.
- `flame_fire_atlas`, `flame_kenney_xml` and `flame_sprite_fusion` READMEs.
- `doc/flame/components/sprite_components.md`.

Intentionally left as is: the `gfx/sprites/player.png` snippet in `doc/flame/structure.md` (it demonstrates a custom layout), the `readFile(...)` calls in the jenny docs (a user-supplied helper, not `Flame.assets`), and the `'shield.png'` key in the base64 sprite example (a cache key, not a bundle path).

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues

Closes #4026

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
