### PR TITLE
chore: Update tutorials and examples to use new event system for pan

### DIFF
--- a/doc/flame/components/components.md
+++ b/doc/flame/components/components.md
@@ -429,8 +429,8 @@ to implement the `containsLocalPoint()` method yourself.
 Here is an example of how `componentsAtPoint()` can be used:
 
 ```dart
-void onDragUpdate(DragUpdateInfo info) {
-  game.componentsAtPoint(info.widget).forEach((component) {
+void onDragUpdate(DragUpdateEvent event) {
+  game.componentsAtPoint(event.canvasEndPosition).forEach((component) {
     if (component is DropTarget) {
       component.highlight();
     }

--- a/doc/tutorials/space_shooter/app/lib/step2/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step2/main.dart
@@ -1,14 +1,13 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 import 'package:flutter/material.dart';
 
 void main() {
   runApp(GameWidget(game: SpaceShooterGame()));
 }
 
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   @override
@@ -18,8 +17,8 @@ class SpaceShooterGame extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 }
 

--- a/doc/tutorials/space_shooter/app/lib/step3/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step3/main.dart
@@ -1,7 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 import 'package:flame/parallax.dart';
 import 'package:flutter/material.dart';
 
@@ -9,7 +8,7 @@ void main() {
   runApp(GameWidget(game: SpaceShooterGame()));
 }
 
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   @override
@@ -31,8 +30,8 @@ class SpaceShooterGame extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 }
 

--- a/doc/tutorials/space_shooter/app/lib/step4/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step4/main.dart
@@ -1,7 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 import 'package:flame/parallax.dart';
 import 'package:flutter/material.dart';
 
@@ -9,7 +8,7 @@ void main() {
   runApp(GameWidget(game: SpaceShooterGame()));
 }
 
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   @override
@@ -31,17 +30,19 @@ class SpaceShooterGame extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 
   @override
-  void onPanStart(DragStartInfo info) {
+  void onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
     player.startShooting();
   }
 
   @override
-  void onPanEnd(DragEndInfo info) {
+  void onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
     player.stopShooting();
   }
 }

--- a/doc/tutorials/space_shooter/app/lib/step5/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step5/main.dart
@@ -2,7 +2,6 @@ import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 import 'package:flame/parallax.dart';
 import 'package:flutter/material.dart';
 
@@ -10,7 +9,7 @@ void main() {
   runApp(GameWidget(game: SpaceShooterGame()));
 }
 
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   @override
@@ -42,17 +41,19 @@ class SpaceShooterGame extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 
   @override
-  void onPanStart(DragStartInfo info) {
+  void onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
     player.startShooting();
   }
 
   @override
-  void onPanEnd(DragEndInfo info) {
+  void onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
     player.stopShooting();
   }
 }

--- a/doc/tutorials/space_shooter/app/lib/step6/main.dart
+++ b/doc/tutorials/space_shooter/app/lib/step6/main.dart
@@ -3,7 +3,6 @@ import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 import 'package:flame/parallax.dart';
 import 'package:flutter/material.dart';
 
@@ -12,7 +11,7 @@ void main() {
 }
 
 class SpaceShooterGame extends FlameGame
-    with PanDetector, HasCollisionDetection {
+    with DragCallbacks, HasCollisionDetection {
   late Player player;
 
   @override
@@ -44,17 +43,19 @@ class SpaceShooterGame extends FlameGame
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 
   @override
-  void onPanStart(DragStartInfo info) {
+  void onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
     player.startShooting();
   }
 
   @override
-  void onPanEnd(DragEndInfo info) {
+  void onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
     player.stopShooting();
   }
 }

--- a/doc/tutorials/space_shooter/step_2.md
+++ b/doc/tutorials/space_shooter/step_2.md
@@ -3,18 +3,15 @@
 Now that we have the base for our game and a component for our player, let's add some interactivity
 to it. We can begin by allowing the player to be controlled by mouse/touch gestures.
 
-There are a couple of ways of doing that in Flame. For this tutorial, we will do that by using one
-of Flame's gesture detectors: `PanDetector`.
-
-This detector will make our game class receive pan (or drag) events. To do so, we just need to add
-the `PanDetector` mixin to our game class and override its listener methods; in our case, we will
-use the `onPanUpdate` method. The updated code will look like the following:
+Flame handles input with mixins that you add to a component, one for each kind of gesture. Dragging
+is `DragCallbacks`, and since `FlameGame` is itself a component we can add it straight to our game
+class and override its listener methods; in our case, we will use the `onDragUpdate` method. The
+updated code will look like the following:
 
 ```dart
-import 'package:flame/input.dart';
 import 'package:flame/events.dart';
 
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   @override
@@ -23,14 +20,14 @@ class SpaceShooterGame extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
+  void onDragUpdate(DragUpdateEvent event) {
   }
 }
 
 ```
 
-At this point, our game should be receiving all the pan update inputs, but we are not doing anything
-with these events.
+At this point, our game should be receiving all the drag update inputs, but we are not doing
+anything with these events.
 
 We now need a way to move our player. That can be achieved by simply saving our `Player` component
 to a variable inside our game class, adding a method `move` to our `Player`, and just connect
@@ -50,7 +47,7 @@ class Player extends PositionComponent {
   }
 }
 
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   @override
@@ -67,8 +64,8 @@ class SpaceShooterGame extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 }
 ```
@@ -101,7 +98,7 @@ class Player extends SpriteComponent {
   }
 }
 
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   @override
@@ -121,8 +118,8 @@ class SpaceShooterGame extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 }
 ```
@@ -173,7 +170,7 @@ class Player extends SpriteComponent with HasGameReference<SpaceShooterGame> {
   }
 }
 
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   @override
@@ -186,8 +183,8 @@ class SpaceShooterGame extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 }
 ```

--- a/doc/tutorials/space_shooter/step_3.md
+++ b/doc/tutorials/space_shooter/step_3.md
@@ -95,11 +95,10 @@ Now lets take a look at how we can add that new feature to the game:
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
-import 'package:flame/input.dart';
 import 'package:flame/parallax.dart';
 import 'package:flutter/material.dart';
 
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   @override
@@ -121,8 +120,8 @@ class SpaceShooterGame extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 }
 ```

--- a/doc/tutorials/space_shooter/step_4.md
+++ b/doc/tutorials/space_shooter/step_4.md
@@ -100,32 +100,37 @@ class Player extends SpriteAnimationComponent
 }
 ```
 
-And let's hook into those methods from the game class by using the `onPanStart()`
-and `onPanEnd()` methods from the `PanDetector` mixin that we already have been using for the ship
-movement:
+And let's hook into those methods from the game class by using the `onDragStart()`
+and `onDragEnd()` methods from the `DragCallbacks` mixin that we already have been using for the
+ship movement:
 
 ```dart
-class SpaceShooterGame extends FlameGame with PanDetector {
+class SpaceShooterGame extends FlameGame with DragCallbacks {
   late Player player;
 
   // Rest of implementation omitted
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta);
   }
 
   @override
-  void onPanStart(DragStartInfo info) {
+  void onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
     player.startShooting();
   }
 
   @override
-  void onPanEnd(DragEndInfo info) {
+  void onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
     player.stopShooting();
   }
 }
 ```
+
+Note that `onDragStart` and `onDragEnd` keep track of the drag state for us, so our overrides have
+to call `super` before doing their own work.
 
 We now have everything set up, so let's write the shooting routine in our player class.
 

--- a/doc/tutorials/space_shooter/step_6.md
+++ b/doc/tutorials/space_shooter/step_6.md
@@ -12,7 +12,7 @@ of the game class:
 
 ```dart
 class SpaceShooterGame extends FlameGame
-    with PanDetector, HasCollisionDetection {
+    with DragCallbacks, HasCollisionDetection {
     // ...
 }
 ```

--- a/examples/lib/stories/camera_and_viewport/camera_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_component_example.dart
@@ -43,28 +43,47 @@ class CameraComponentExample extends FlameGame<AntWorld> with DragCallbacks {
     magnifyingGlass.viewfinder.zoom = zoom;
   }
 
+  /// There is only one magnifying glass, so only the first pointer to start
+  /// dragging controls it; drags from any other pointers are ignored.
+  int? _controllingPointerId;
+
   @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
+    if (_controllingPointerId != null) {
+      return;
+    }
+    _controllingPointerId = event.pointerId;
     _updateMagnifyingGlassPosition(event.canvasPosition);
     add(magnifyingGlass);
   }
 
   @override
   void onDragUpdate(DragUpdateEvent event) {
+    if (event.pointerId != _controllingPointerId) {
+      return;
+    }
     _updateMagnifyingGlassPosition(event.canvasEndPosition);
   }
 
   @override
   void onDragEnd(DragEndEvent event) {
     super.onDragEnd(event);
-    remove(magnifyingGlass);
+    _releaseMagnifyingGlass(event.pointerId);
   }
 
   @override
   void onDragCancel(DragCancelEvent event) {
     super.onDragCancel(event);
-    remove(magnifyingGlass);
+    _releaseMagnifyingGlass(event.pointerId);
+  }
+
+  void _releaseMagnifyingGlass(int pointerId) {
+    if (pointerId != _controllingPointerId) {
+      return;
+    }
+    _controllingPointerId = null;
+    magnifyingGlass.removeFromParent();
   }
 
   void _updateMagnifyingGlassPosition(Vector2 point) {

--- a/examples/lib/stories/camera_and_viewport/camera_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_component_example.dart
@@ -6,10 +6,9 @@ import 'package:flame/events.dart';
 import 'package:flame/extensions.dart' show OffsetExtension, PathExtension;
 import 'package:flame/game.dart';
 import 'package:flame/geometry.dart';
-import 'package:flame/input.dart';
 import 'package:flutter/painting.dart';
 
-class CameraComponentExample extends FlameGame<AntWorld> with PanDetector {
+class CameraComponentExample extends FlameGame<AntWorld> with DragCallbacks {
   static const description = '''
     This example shows how a camera can be dynamically added into a game using
     a CameraComponent.
@@ -45,28 +44,27 @@ class CameraComponentExample extends FlameGame<AntWorld> with PanDetector {
   }
 
   @override
-  bool onPanStart(DragStartInfo info) {
-    _updateMagnifyingGlassPosition(info.eventPosition.widget);
+  void onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
+    _updateMagnifyingGlassPosition(event.canvasPosition);
     add(magnifyingGlass);
-    return false;
   }
 
   @override
-  bool onPanUpdate(DragUpdateInfo info) {
-    _updateMagnifyingGlassPosition(info.eventPosition.widget);
-    return false;
+  void onDragUpdate(DragUpdateEvent event) {
+    _updateMagnifyingGlassPosition(event.canvasEndPosition);
   }
 
   @override
-  bool onPanEnd(DragEndInfo info) {
-    onPanCancel();
-    return false;
-  }
-
-  @override
-  bool onPanCancel() {
+  void onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
     remove(magnifyingGlass);
-    return false;
+  }
+
+  @override
+  void onDragCancel(DragCancelEvent event) {
+    super.onDragCancel(event);
+    remove(magnifyingGlass);
   }
 
   void _updateMagnifyingGlassPosition(Vector2 point) {

--- a/examples/lib/stories/rendering/particles_interactive_example.dart
+++ b/examples/lib/stories/rendering/particles_interactive_example.dart
@@ -19,7 +19,7 @@ enum ParticleEffect {
   bubbles,
 }
 
-class ParticlesInteractiveExample extends FlameGame with PanDetector {
+class ParticlesInteractiveExample extends FlameGame with DragCallbacks {
   static const description =
       'Drag around the canvas to paint with particles, and pick an effect in '
       'the properties panel (the knobs icon in the top right) to try the '
@@ -56,14 +56,15 @@ class ParticlesInteractiveExample extends FlameGame with PanDetector {
   }
 
   @override
-  void onPanStart(DragStartInfo info) {
-    _emitter.position = info.eventPosition.widget;
+  void onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
+    _emitter.position = event.canvasPosition;
     _emitter.emit(_perDragStart);
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    _emitter.position = info.eventPosition.widget;
+  void onDragUpdate(DragUpdateEvent event) {
+    _emitter.position = event.canvasEndPosition;
     _emitter.emit(_perDragUpdate);
   }
 

--- a/examples/lib/stories/rendering/particles_interactive_example.dart
+++ b/examples/lib/stories/rendering/particles_interactive_example.dart
@@ -55,17 +55,46 @@ class ParticlesInteractiveExample extends FlameGame with DragCallbacks {
     add(_emitter);
   }
 
+  /// There is a single emitter, so only the first pointer to start dragging
+  /// paints; a second finger would otherwise make it jump back and forth.
+  int? _paintingPointerId;
+
   @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
+    if (_paintingPointerId != null) {
+      return;
+    }
+    _paintingPointerId = event.pointerId;
     _emitter.position = event.canvasPosition;
     _emitter.emit(_perDragStart);
   }
 
   @override
   void onDragUpdate(DragUpdateEvent event) {
+    if (event.pointerId != _paintingPointerId) {
+      return;
+    }
     _emitter.position = event.canvasEndPosition;
     _emitter.emit(_perDragUpdate);
+  }
+
+  @override
+  void onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
+    _releaseBrush(event.pointerId);
+  }
+
+  @override
+  void onDragCancel(DragCancelEvent event) {
+    super.onDragCancel(event);
+    _releaseBrush(event.pointerId);
+  }
+
+  void _releaseBrush(int pointerId) {
+    if (pointerId == _paintingPointerId) {
+      _paintingPointerId = null;
+    }
   }
 
   /// All presets share the same pooled setup: emission is driven purely by

--- a/packages/flame_bloc/example/lib/src/game/game.dart
+++ b/packages/flame_bloc/example/lib/src/game/game.dart
@@ -61,27 +61,47 @@ class SpaceShooterGame extends FlameGame
     add(EnemyCreator());
   }
 
+  /// The pointer currently flying the ship. Drag events are reported per
+  /// pointer, so without this a second finger would move the ship twice as
+  /// fast and stop the fire when lifted.
+  int? _controllingPointerId;
+
   @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
+    if (_controllingPointerId != null) {
+      return;
+    }
+    _controllingPointerId = event.pointerId;
     player.beginFire();
   }
 
   @override
   void onDragEnd(DragEndEvent event) {
     super.onDragEnd(event);
-    player.stopFire();
+    _releaseControl(event.pointerId);
   }
 
   @override
   void onDragCancel(DragCancelEvent event) {
     super.onDragCancel(event);
-    player.stopFire();
+    _releaseControl(event.pointerId);
   }
 
   @override
   void onDragUpdate(DragUpdateEvent event) {
+    if (event.pointerId != _controllingPointerId) {
+      return;
+    }
     player.move(event.localDelta.x, event.localDelta.y);
+  }
+
+  void _releaseControl(int pointerId) {
+    if (pointerId != _controllingPointerId) {
+      return;
+    }
+    _controllingPointerId = null;
+    player.stopFire();
   }
 
   void increaseScore() {

--- a/packages/flame_bloc/example/lib/src/game/game.dart
+++ b/packages/flame_bloc/example/lib/src/game/game.dart
@@ -27,7 +27,7 @@ class GameStatsController extends Component
 }
 
 class SpaceShooterGame extends FlameGame
-    with PanDetector, HasCollisionDetection, HasKeyboardHandlerComponents {
+    with DragCallbacks, HasCollisionDetection, HasKeyboardHandlerComponents {
   late PlayerComponent player;
 
   final GameStatsBloc statsBloc;
@@ -62,23 +62,26 @@ class SpaceShooterGame extends FlameGame
   }
 
   @override
-  void onPanStart(_) {
+  void onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
     player.beginFire();
   }
 
   @override
-  void onPanEnd(_) {
+  void onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
     player.stopFire();
   }
 
   @override
-  void onPanCancel() {
+  void onDragCancel(DragCancelEvent event) {
+    super.onDragCancel(event);
     player.stopFire();
   }
 
   @override
-  void onPanUpdate(DragUpdateInfo info) {
-    player.move(info.delta.global.x, info.delta.global.y);
+  void onDragUpdate(DragUpdateEvent event) {
+    player.move(event.localDelta.x, event.localDelta.y);
   }
 
   void increaseScore() {


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Update tutorials and examples to use new event system for pan, preparing for its ex-pan-gement.
The new system already covers all these with drags - so this is a no-op on all cases.
As per copilot's request, this also make all the examples safe from multi-touch causing issues - an edge case for the examples, but fine to fix (I might followup with a better solution).

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->