### PR TITLE
chore: Bump flame_svg to 2.0.0 on main after the hotfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-08-30
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`flame_svg` - `v2.0.0`](#flame_svg---v200)
+
+Packages with other changes:
+
+ - There are no other changes in this release.
+
+---
+
+#### `flame_svg` - `v2.0.0`
+
+ - **FIX**: Adapt to Flutter 3.47 ([#3995](https://github.com/flame-engine/flame/issues/3995)). ([0453bad6](https://github.com/flame-engine/flame/commit/0453bad6e726ff90610baec86e5c24dc4c89a5a4))
+ - **BREAKING** **FEAT**: Remove integralSize property from class Svg, enforcing 'always true' behaviour ([#3969](https://github.com/flame-engine/flame/issues/3969)). ([fa788209](https://github.com/flame-engine/flame/commit/fa788209db5f77072a76263853c4171203e65728))
+
+
 ## 2026-08-16
 
 ### Changes

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flame_lottie: ^0.4.3+23
   flame_noise: ^0.3.3+23
   flame_spine: ^0.3.1+6
-  flame_svg: ^1.12.2
+  flame_svg: ^2.0.0
   flame_tiled: ^3.1.2
   flutter:
     sdk: flutter

--- a/packages/flame_svg/CHANGELOG.md
+++ b/packages/flame_svg/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0
+
+> Note: This release has breaking changes.
+
+ - **FIX**: Adapt to Flutter 3.47 ([#3995](https://github.com/flame-engine/flame/issues/3995)). ([0453bad6](https://github.com/flame-engine/flame/commit/0453bad6e726ff90610baec86e5c24dc4c89a5a4))
+ - **BREAKING** **FEAT**: Remove integralSize property from class Svg, enforcing 'always true' behaviour ([#3969](https://github.com/flame-engine/flame/issues/3969)). ([fa788209](https://github.com/flame-engine/flame/commit/fa788209db5f77072a76263853c4171203e65728))
+
 ## 1.13.0
 
  - **FEAT**: Prevent cache thrashing in class Svg by adding cache parameters/properties. ([#3956](https://github.com/flame-engine/flame/issues/3956)). ([cc47ed41](https://github.com/flame-engine/flame/commit/cc47ed41e39a40a6f5965399fed420192cb207c1))

--- a/packages/flame_svg/example/pubspec.yaml
+++ b/packages/flame_svg/example/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   flame: ^1.38.0
-  flame_svg: ^1.13.0
+  flame_svg: ^2.0.0
   flutter:
     sdk: flutter
 

--- a/packages/flame_svg/pubspec.yaml
+++ b/packages/flame_svg/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flame_svg
 resolution: workspace
 description: Package to add SVG rendering support for the Flame game engine
-version: 1.13.0
+version: 2.0.0
 homepage: https://github.com/flame-engine/flame/tree/main/packages/flame_svg
 funding:
   - https://opencollective.com/blue-fire


### PR DESCRIPTION
## Description

flame_svg 2.0.0 was published from the `hotfix/flame_svg-v2.0.0` branch (based on `flame-v1.38.2`, containing #3956 and #3969) so it could be released without a new flame release. This ports the version bump, the changelog entries, and the `^2.0.0` constraint bumps for `examples` and the flame_svg example back to `main`, so the next `melos version` on `main` computes a version above the one already on pub.dev.

The flame_svg 1.13.0 entry is kept since it was already recorded here, so the 2.0.0 entry only lists the commits not already covered by it.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Follow-up to the flame_svg-v2.0.0 release: https://github.com/flame-engine/flame/releases/tag/flame_svg-v2.0.0

[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
