### PR TITLE
feat: Support allowsMultiPointerDrag on DragCallbacks

### DIFF
--- a/doc/flame/inputs/drag_events.md
+++ b/doc/flame/inputs/drag_events.md
@@ -129,6 +129,39 @@ actively being dragged. This is set to `true` at `onDragStart` and back to `fals
 It can be used, for example, to change the component's visual appearance during a drag.
 
 
+### allowsMultiPointerDrag
+
+Drags are tracked per pointer, so a component that is already being dragged will start a second,
+independent drag when another finger touches it. That is what you want when each drag manipulates
+something of its own, but not when they all drive a single piece of state (such as a camera or
+a draggable object), where a second finger just fights the first.
+
+Override `allowsMultiPointerDrag` to `false` to accept only one drag at a time:
+
+```dart
+class MagnifyingGlass extends PositionComponent with DragCallbacks {
+  @override
+  bool get allowsMultiPointerDrag => false;
+
+  @override
+  void onDragUpdate(DragUpdateEvent event) {
+    position = event.canvasEndPosition;
+  }
+}
+```
+
+While a drag is in progress, no other pointer gets an `onDragStart` on this component, and no
+`onDragUpdate`, `onDragEnd` or `onDragCancel` follow for it either; the event is offered to the
+components below instead. Once the accepted drag ends or is cancelled, the component is free to
+accept a new one.
+
+Control is not handed over: if the accepted pointer is lifted while another is still down, the drag
+ends rather than continuing on the remaining finger.
+
+This only gates drags. A component that also uses `ScaleCallbacks` keeps receiving scale events
+normally, so one-finger drag plus two-finger pinch still works.
+
+
 ## Combining with ScaleCallbacks
 
 `DragCallbacks` and `ScaleCallbacks` can be used at the same time: single-finger gestures produce

--- a/examples/lib/stories/camera_and_viewport/camera_component_example.dart
+++ b/examples/lib/stories/camera_and_viewport/camera_component_example.dart
@@ -43,46 +43,31 @@ class CameraComponentExample extends FlameGame<AntWorld> with DragCallbacks {
     magnifyingGlass.viewfinder.zoom = zoom;
   }
 
-  /// There is only one magnifying glass, so only the first pointer to start
-  /// dragging controls it; drags from any other pointers are ignored.
-  int? _controllingPointerId;
+  /// Multiple pointers would flip-flop the glass and drop it on the first lift.
+  @override
+  bool get allowsMultiPointerDrag => false;
 
   @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
-    if (_controllingPointerId != null) {
-      return;
-    }
-    _controllingPointerId = event.pointerId;
     _updateMagnifyingGlassPosition(event.canvasPosition);
     add(magnifyingGlass);
   }
 
   @override
   void onDragUpdate(DragUpdateEvent event) {
-    if (event.pointerId != _controllingPointerId) {
-      return;
-    }
     _updateMagnifyingGlassPosition(event.canvasEndPosition);
   }
 
   @override
   void onDragEnd(DragEndEvent event) {
     super.onDragEnd(event);
-    _releaseMagnifyingGlass(event.pointerId);
+    magnifyingGlass.removeFromParent();
   }
 
   @override
   void onDragCancel(DragCancelEvent event) {
     super.onDragCancel(event);
-    _releaseMagnifyingGlass(event.pointerId);
-  }
-
-  void _releaseMagnifyingGlass(int pointerId) {
-    if (pointerId != _controllingPointerId) {
-      return;
-    }
-    _controllingPointerId = null;
     magnifyingGlass.removeFromParent();
   }
 

--- a/examples/lib/stories/rendering/particles_interactive_example.dart
+++ b/examples/lib/stories/rendering/particles_interactive_example.dart
@@ -55,46 +55,21 @@ class ParticlesInteractiveExample extends FlameGame with DragCallbacks {
     add(_emitter);
   }
 
-  /// There is a single emitter, so only the first pointer to start dragging
-  /// paints; a second finger would otherwise make it jump back and forth.
-  int? _paintingPointerId;
+  /// Multiple pointers would flip-flop the emitter, spraying between them.
+  @override
+  bool get allowsMultiPointerDrag => false;
 
   @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
-    if (_paintingPointerId != null) {
-      return;
-    }
-    _paintingPointerId = event.pointerId;
     _emitter.position = event.canvasPosition;
     _emitter.emit(_perDragStart);
   }
 
   @override
   void onDragUpdate(DragUpdateEvent event) {
-    if (event.pointerId != _paintingPointerId) {
-      return;
-    }
     _emitter.position = event.canvasEndPosition;
     _emitter.emit(_perDragUpdate);
-  }
-
-  @override
-  void onDragEnd(DragEndEvent event) {
-    super.onDragEnd(event);
-    _releaseBrush(event.pointerId);
-  }
-
-  @override
-  void onDragCancel(DragCancelEvent event) {
-    super.onDragCancel(event);
-    _releaseBrush(event.pointerId);
-  }
-
-  void _releaseBrush(int pointerId) {
-    if (pointerId == _paintingPointerId) {
-      _paintingPointerId = null;
-    }
   }
 
   /// All presets share the same pooled setup: emission is driven purely by

--- a/packages/flame/lib/src/events/callbacks/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/callbacks/drag_callbacks.dart
@@ -18,6 +18,28 @@ mixin DragCallbacks on Component implements PointerInputCallbacks {
   /// Returns true while the component is being dragged.
   bool get isDragged => _isDragged;
 
+  /// Whether this component accepts multiple simultaneous drags.
+  ///
+  /// Drags are tracked per pointer; so, by default, a component that is already
+  /// being dragged can start a second, independent drag from another pointer,
+  /// which might or might not be desirable.
+  ///
+  /// Override this to `false` to accept only one drag at a time. While a drag
+  /// is in progress, [onDragStart] is not delivered for any other pointer, and
+  /// no [onDragUpdate], [onDragEnd] or [onDragCancel] follow for it either;
+  /// the event is offered to the components below it in propagation order 
+  /// Once the accepted drag finishes, the component is freed to accept further
+  /// drags.
+  ///
+  /// Note that control is not handed over: if the accepted pointer is lifted
+  /// while another that was first rejected is still down, the drag ends rather
+  /// than continuing on the remaining finger.
+  ///
+  /// Note that this only gates drags: a component that also mixes in
+  /// [ScaleCallbacks] keeps receiving scale events normally, so one-finger drag
+  /// plus two-finger pinch still works.
+  bool get allowsMultiPointerDrag => true;
+
   /// The user initiated a drag gesture on top of this component.
   ///
   /// By default, only one component will receive a drag event. However, setting

--- a/packages/flame/lib/src/events/callbacks/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/callbacks/drag_callbacks.dart
@@ -27,7 +27,7 @@ mixin DragCallbacks on Component implements PointerInputCallbacks {
   /// Override this to `false` to accept only one drag at a time. While a drag
   /// is in progress, [onDragStart] is not delivered for any other pointer, and
   /// no [onDragUpdate], [onDragEnd] or [onDragCancel] follow for it either;
-  /// the event is offered to the components below it in propagation order 
+  /// the event is offered to the components below it in propagation order.
   /// Once the accepted drag finishes, the component is freed to accept further
   /// drags.
   ///

--- a/packages/flame/lib/src/events/dispatchers/multi_drag_scale_dispatcher.dart
+++ b/packages/flame/lib/src/events/dispatchers/multi_drag_scale_dispatcher.dart
@@ -145,15 +145,27 @@ class MultiDragScaleDispatcher extends Dispatcher<FlameGame>
   ///
   /// Each [event] has an `event.pointerId` to keep track of multiple touches
   /// that may occur simultaneously.
+  ///
+  /// A component that sets [DragCallbacks.allowsMultiPointerDrag] to false is
+  /// skipped while it already has a drag in progress, and the event carries on
+  /// to the components below it.
   @mustCallSuper
   void onDragStart(DragStartEvent event) {
     event.deliverAtPoint(
       rootComponent: gameRef,
       eventHandler: (DragCallbacks component) {
+        if (!component.allowsMultiPointerDrag && _isDragging(component)) {
+          event.continuePropagation = true;
+          return;
+        }
         _records.add(TaggedComponent(event.pointerId, component));
         component.onDragStart(event);
       },
     );
+  }
+
+  bool _isDragging(DragCallbacks component) {
+    return _records.any((record) => record.component == component);
   }
 
   /// Called continuously during the drag as the user moves their finger.

--- a/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
@@ -293,6 +293,206 @@ void main() {
     );
   });
 
+  group('allowsMultiPointerDrag', () {
+    testWithFlameGame(
+      'defaults to true, so a second pointer starts a second drag',
+      (game) async {
+        final component = DragCallbacksComponent()
+          ..position = Vector2.all(10)
+          ..size = Vector2.all(50);
+        await game.ensureAdd(component);
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            globalPosition: const Offset(20, 20),
+          ),
+        );
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            pointerId: 2,
+            globalPosition: const Offset(30, 30),
+          ),
+        );
+
+        expect(component.dragStartEvent, equals(2));
+      },
+    );
+
+    testWithFlameGame(
+      'when false, a second pointer is not delivered while a drag is active',
+      (game) async {
+        final component = _SingleDragComponent()
+          ..position = Vector2.all(10)
+          ..size = Vector2.all(50);
+        await game.ensureAdd(component);
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            globalPosition: const Offset(20, 20),
+          ),
+        );
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            pointerId: 2,
+            globalPosition: const Offset(30, 30),
+          ),
+        );
+        expect(component.dragStartEvent, equals(1));
+
+        // No follow-ups for the rejected pointer either.
+        dispatcher.onDragUpdate(
+          createDragUpdateEvents(
+            game: game,
+            pointerId: 2,
+            globalPosition: const Offset(35, 35),
+          ),
+        );
+        dispatcher.onDragEnd(DragEndEvent(2, DragEndDetails()));
+        expect(component.dragUpdateEvent, equals(0));
+        expect(component.dragEndEvent, equals(0));
+
+        // The accepted pointer still works normally.
+        dispatcher.onDragUpdate(
+          createDragUpdateEvents(
+            game: game,
+            globalPosition: const Offset(25, 25),
+          ),
+        );
+        dispatcher.onDragEnd(DragEndEvent(1, DragEndDetails()));
+        expect(component.dragUpdateEvent, equals(1));
+        expect(component.dragEndEvent, equals(1));
+      },
+    );
+
+    testWithFlameGame(
+      'a new drag is accepted once the previous one ends',
+      (game) async {
+        final component = _SingleDragComponent()
+          ..position = Vector2.all(10)
+          ..size = Vector2.all(50);
+        await game.ensureAdd(component);
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            globalPosition: const Offset(20, 20),
+          ),
+        );
+        dispatcher.onDragEnd(DragEndEvent(1, DragEndDetails()));
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            pointerId: 2,
+            globalPosition: const Offset(30, 30),
+          ),
+        );
+
+        expect(component.dragStartEvent, equals(2));
+      },
+    );
+
+    testWithFlameGame(
+      'a cancelled drag also frees the component up',
+      (game) async {
+        final component = _SingleDragComponent()
+          ..position = Vector2.all(10)
+          ..size = Vector2.all(50);
+        await game.ensureAdd(component);
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            globalPosition: const Offset(20, 20),
+          ),
+        );
+        dispatcher.onDragCancel(DragCancelEvent(1));
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            pointerId: 2,
+            globalPosition: const Offset(30, 30),
+          ),
+        );
+
+        expect(component.dragStartEvent, equals(2));
+      },
+    );
+
+    testWithFlameGame(
+      'the rejected pointer falls through to the component below',
+      (game) async {
+        final below = DragCallbacksComponent()
+          ..position = Vector2.all(10)
+          ..size = Vector2.all(50);
+        final above = _SingleDragComponent()
+          ..position = Vector2.all(10)
+          ..size = Vector2.all(50);
+        game.add(below);
+        game.add(above);
+        await game.ready();
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            globalPosition: const Offset(20, 20),
+          ),
+        );
+        expect(above.dragStartEvent, equals(1));
+        expect(below.dragStartEvent, equals(0));
+
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            pointerId: 2,
+            globalPosition: const Offset(30, 30),
+          ),
+        );
+        expect(above.dragStartEvent, equals(1));
+        expect(below.dragStartEvent, equals(1));
+      },
+    );
+
+    testWithFlameGame(
+      'gating drags does not gate scale events',
+      (game) async {
+        final component = _SingleDragScaleComponent()
+          ..position = Vector2.all(10)
+          ..size = Vector2.all(50);
+        await game.ensureAdd(component);
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            globalPosition: const Offset(20, 20),
+          ),
+        );
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            pointerId: 2,
+            globalPosition: const Offset(30, 30),
+          ),
+        );
+        expect(component.dragStartEvent, equals(1));
+
+        dispatcher.onScaleStart(
+          createScaleStartEvents(game: game, focalPoint: const Offset(25, 25)),
+        );
+        expect(component.scaleStartEvent, equals(1));
+      },
+    );
+  });
+
   group('HasDraggableComponents', () {
     testWidgets(
       'drags are delivered to DragCallbacks components',
@@ -626,6 +826,18 @@ void main() {
       expect(totalDelta, Vector2(16, 0));
     },
   );
+}
+
+class _SingleDragComponent extends PositionComponent
+    with DragCallbacks, DragCounter {
+  @override
+  bool get allowsMultiPointerDrag => false;
+}
+
+class _SingleDragScaleComponent extends PositionComponent
+    with DragCallbacks, DragCounter, ScaleCallbacks, ScaleCounter {
+  @override
+  bool get allowsMultiPointerDrag => false;
 }
 
 class _TapCounterComponent extends PositionComponent with TapCallbacks {

--- a/packages/flame_bloc/example/lib/src/game/game.dart
+++ b/packages/flame_bloc/example/lib/src/game/game.dart
@@ -60,47 +60,31 @@ class SpaceShooterGame extends FlameGame
     add(EnemyCreator());
   }
 
-  /// The pointer currently flying the ship. Drag events are reported per
-  /// pointer, so without this a second finger would move the ship twice as
-  /// fast and stop the fire when lifted.
-  int? _controllingPointerId;
+  /// Multiple pointers would each apply their delta, accumulating ship speed.
+  @override
+  bool get allowsMultiPointerDrag => false;
 
   @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
-    if (_controllingPointerId != null) {
-      return;
-    }
-    _controllingPointerId = event.pointerId;
     player.beginFire();
   }
 
   @override
   void onDragEnd(DragEndEvent event) {
     super.onDragEnd(event);
-    _releaseControl(event.pointerId);
+    player.stopFire();
   }
 
   @override
   void onDragCancel(DragCancelEvent event) {
     super.onDragCancel(event);
-    _releaseControl(event.pointerId);
+    player.stopFire();
   }
 
   @override
   void onDragUpdate(DragUpdateEvent event) {
-    if (event.pointerId != _controllingPointerId) {
-      return;
-    }
     player.move(event.localDelta.x, event.localDelta.y);
-  }
-
-  void _releaseControl(int pointerId) {
-    if (pointerId != _controllingPointerId) {
-      return;
-    }
-    _controllingPointerId = null;
-    player.stopFire();
   }
 
   void increaseScore() {


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Add support for a `allowsMultiPointerDrag` on `DragCallbacks`, for easy of use for components that would break under multiple concurrent drags.

When a drag controls the component itself, or a camera for panning, initiating a multi-fingered interaction might cause an elated state on the component, which might or might not be desirable depending on circumstances. Many existing examples were fixed as part of the new system migration (https://github.com/flame-engine/flame/pull/4028; as per requested by Copilot), but all with ad-hoc code that Flame could vastly simplify. Note that is is _not_ to discourage two-, three- or even five-fingered manipulations; but rather just to empower users to choose what feels best for their application.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->