### PR TITLE
docs: Correct docs about drag/scale events on pointer leave

### DIFF
--- a/doc/flame/inputs/drag_events.md
+++ b/doc/flame/inputs/drag_events.md
@@ -70,11 +70,14 @@ This event is fired continuously as user drags their finger across the screen. I
 the user is holding their finger still.
 
 The default implementation delivers this event to all the components that received the previous
-`onDragStart` with the same pointer id. If the point of touch is still within the component, then
-`event.localPosition` will give the position of that point in the local coordinate system. However,
-if the user moves their finger away from the component, the property `event.localPosition` will
-return a point whose coordinates are NaNs. Likewise, the `event.renderingTrace` in this case will be
-empty. However, the `canvasPosition` and `devicePosition` properties of the event will be valid.
+`onDragStart` with the same pointer id. Moving the finger off the component **does not** stop
+the drag, and the local coordinates are still computed (potentially outside the component bounds).
+
+The exception is when hit testing stops reaching the component altogether while it still holds the
+drag, for example if an ancestor turns on `IgnoreEvents` mid-gesture. The component still receives
+the event, but with an empty `event.renderingTrace` behind it, so reading `localStartPosition`,
+`localEndPosition` or `localDelta` throws. `canvasStartPosition`, `canvasEndPosition`,
+`deviceStartPosition` and `deviceEndPosition` never depend on the trace and remain valid.
 
 In addition, the `DragUpdateEvent` will contain `delta`, the amount the finger has moved since
 the previous `onDragUpdate`, or since the `onDragStart` if this is the first drag-update after

--- a/doc/flame/inputs/scale_events.md
+++ b/doc/flame/inputs/scale_events.md
@@ -51,11 +51,15 @@ This event is fired continuously as user drags their finger across the screen. I
 the user is holding their finger still.
 
 The default implementation delivers this event to all the components that received the previous
-`onScaleStart`. If the point of touch is still within the component, then
-`event.localPosition` will give the position of that point in the local coordinate system. However,
-if the user moves their finger away from the component, the property `event.localPosition` will
-return a point whose coordinates are NaNs. Likewise, the `event.renderingTrace` in this case will be
-empty. However, the `canvasPosition` and `devicePosition` properties of the event will be valid.
+`onScaleStart`. Moving the focal point off the component **does not** stop the scale gesture,
+and the local coordinates are still computed (potentially outside the component bounds).
+
+The exception is when hit testing stops reaching the component altogether while it still holds the
+gesture, for example if an ancestor turns on `IgnoreEvents` mid-gesture. The component still
+receives the event, but with an empty `event.renderingTrace` behind it, so reading
+`localStartPosition`, `localEndPosition` or `localDelta` throws. `canvasStartPosition`,
+`canvasEndPosition`, `deviceStartPosition` and `deviceEndPosition` never depend on the trace and
+remain valid.
 
 In addition, the `ScaleUpdateEvent` will contain `focalPointDelta` --
 the amount the focal point has moved since the

--- a/packages/flame/lib/src/events/callbacks/drag_callbacks.dart
+++ b/packages/flame/lib/src/events/callbacks/drag_callbacks.dart
@@ -60,8 +60,15 @@ mixin DragCallbacks on Component implements PointerInputCallbacks {
   ///
   /// This event will be delivered to the component(s) that captured the initial
   /// [onDragStart], even if the point of touch moves outside of the boundaries
-  /// of the component. In the latter case `event.localPosition` will contain a
-  /// NaN point.
+  /// of the component; the local coordinates simply fall outside the
+  /// component's own bounds in that case.
+  ///
+  /// The exception is when hit testing stops reaching the component altogether
+  /// while it still holds the drag, for example if an ancestor turns on
+  /// [IgnoreEvents] mid-gesture. It still receives the event, but with no
+  /// rendering trace behind it, so reading `event.localStartPosition`,
+  /// `localEndPosition` or `localDelta` throws. Use `canvasStartPosition` /
+  /// `canvasEndPosition` if you need a position that is always available.
   void onDragUpdate(DragUpdateEvent event) {}
 
   /// The drag event has ended.

--- a/packages/flame/lib/src/events/dispatchers/multi_drag_scale_dispatcher.dart
+++ b/packages/flame/lib/src/events/dispatchers/multi_drag_scale_dispatcher.dart
@@ -173,7 +173,10 @@ class MultiDragScaleDispatcher extends Dispatcher<FlameGame>
   /// The default handler propagates this event to those components who received
   /// the initial [onDragStart] event. If the position of the pointer is outside
   /// of the bounds of the component, then this event will nevertheless be
-  /// delivered, however its `event.localPosition` property will contain NaNs.
+  /// delivered, with local coordinates that fall outside those bounds. A
+  /// component that hit testing no longer reaches at all -- because an ancestor
+  /// started ignoring events, say -- is delivered to from [_records] instead,
+  /// with an empty rendering trace, so its local coordinates are unavailable.
   @mustCallSuper
   void onDragUpdate(DragUpdateEvent event) {
     final updated = <TaggedComponent<DragCallbacks>>{};

--- a/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/drag_callbacks_test.dart
@@ -1,3 +1,4 @@
+import 'package:flame/camera.dart';
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame/game.dart';
@@ -289,6 +290,113 @@ void main() {
         // Outside component
         await tester.dragFrom(const Offset(101, 101), const Offset(110, 110));
         expect(component.isDraggedStateChange, equals(2));
+      },
+    );
+  });
+
+  group('local coordinates during a drag', () {
+    testWithFlameGame(
+      'stay available when the pointer leaves the viewport',
+      (game) async {
+        // A 100x100 viewport anchored at the top left of the canvas, so
+        // viewport coordinates and canvas coordinates line up.
+        game.camera = CameraComponent(
+          viewport: FixedSizeViewport(100, 100)..anchor = Anchor.topLeft,
+        )..viewfinder.anchor = Anchor.topLeft;
+        Vector2? localStart;
+        Vector2? canvasStart;
+        game.world.add(
+          DragWithCallbacksComponent(
+            position: Vector2.all(10),
+            size: Vector2.all(40),
+            onDragUpdate: (e) {
+              canvasStart = e.canvasStartPosition.clone();
+              localStart = e.localStartPosition.clone();
+            },
+          ),
+        );
+        await game.ready();
+
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            globalPosition: const Offset(20, 20),
+          ),
+        );
+        // The pointer is now well outside both the component and the viewport.
+        dispatcher.onDragUpdate(
+          createDragUpdateEvents(
+            game: game,
+            globalPosition: const Offset(500, 500),
+          ),
+        );
+
+        // Canvas coordinates are in the same space as the viewport, so this
+        // shows the pointer really did leave it.
+        expect(canvasStart, Vector2.all(500));
+        // And the component still received the point in its own coordinates,
+        // offset by its position, past both its bounds and the viewport's.
+        expect(localStart, Vector2.all(490));
+      },
+    );
+
+    testWithFlameGame(
+      'become unavailable if hit testing stops reaching the component',
+      (game) async {
+        var dragStarts = 0;
+        var updates = 0;
+        int? traceLength;
+        Vector2? canvasStart;
+        Vector2? deviceStart;
+        final component = DragWithCallbacksComponent(
+          position: Vector2.zero(),
+          size: Vector2.all(100),
+          onDragStart: (_) => dragStarts++,
+          onDragUpdate: (e) {
+            // Everything here is asserted during delivery: reading the event
+            // afterwards would find an unwound trace either way.
+            updates++;
+            traceLength = e.renderingTrace.length;
+            expect(() => e.localStartPosition, throwsStateError);
+            canvasStart = e.canvasStartPosition.clone();
+            deviceStart = e.deviceStartPosition.clone();
+          },
+        );
+        final gate = EventGate(
+          position: Vector2.zero(),
+          size: Vector2.all(200),
+          children: [component],
+        );
+        await game.ensureAdd(gate);
+        await game.ready();
+
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+        dispatcher.onDragStart(
+          createDragStartEvents(
+            game: game,
+            globalPosition: const Offset(10, 10),
+          ),
+        );
+        expect(dragStarts, equals(1));
+
+        // The ancestor now swallows events, so hit testing no longer reaches
+        // the component, but the drag record still points at it.
+        gate.ignoreEvents = true;
+
+        dispatcher.onDragUpdate(
+          createDragUpdateEvents(
+            game: game,
+            globalPosition: const Offset(20, 20),
+          ),
+        );
+
+        // It is still delivered to, but with nothing behind it in the trace.
+        expect(updates, equals(1));
+        expect(traceLength, equals(0));
+        // Canvas and device coordinates never depend on the trace.
+        expect(canvasStart, Vector2.all(20));
+        expect(deviceStart, Vector2.all(20));
       },
     );
   });

--- a/packages/flame/test/events/component_mixins/input_test_helper.dart
+++ b/packages/flame/test/events/component_mixins/input_test_helper.dart
@@ -422,3 +422,11 @@ class DragCallbacksComponent extends PositionComponent
     with DragCallbacks, DragCounter {}
 
 class DragCallbacksGame extends FlameGame with DragCallbacks, DragCounter {}
+
+/// An ancestor that starts out passing events through, but can be made to
+/// swallow them partway through a gesture by setting [ignoreEvents].
+class EventGate extends PositionComponent with IgnoreEvents {
+  EventGate({super.position, super.size, super.children}) {
+    ignoreEvents = false;
+  }
+}

--- a/packages/flame/test/events/component_mixins/scale_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/scale_callbacks_test.dart
@@ -350,6 +350,88 @@ void main() {
     );
   });
 
+  group('local coordinates during a scale', () {
+    testWithFlameGame(
+      'stay available when the focal point leaves the component bounds',
+      (game) async {
+        Vector2? localStart;
+        final component = ScaleWithCallbacksComponent(
+          position: Vector2.all(10),
+          size: Vector2.all(30),
+          onScaleUpdate: (e) => localStart = e.localStartPosition.clone(),
+        );
+        await game.ensureAdd(component);
+        await game.ready();
+
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+        dispatcher.onScaleStart(
+          createScaleStartEvents(game: game, focalPoint: const Offset(20, 20)),
+        );
+        // The focal point is now far outside the 30x30 component at (10, 10).
+        dispatcher.onScaleUpdate(
+          createScaleUpdateEvents(
+            game: game,
+            focalPoint: const Offset(500, 500),
+          ),
+        );
+
+        // Scales bypass the containment check, so the gesture is not lost and
+        // the coordinates keep being computed past the component's edge.
+        expect(localStart, Vector2.all(490));
+      },
+    );
+
+    testWithFlameGame(
+      'become unavailable if hit testing stops reaching the component',
+      (game) async {
+        var updates = 0;
+        int? traceLength;
+        Vector2? canvasStart;
+        Vector2? deviceStart;
+        final component = ScaleWithCallbacksComponent(
+          position: Vector2.zero(),
+          size: Vector2.all(100),
+          onScaleUpdate: (e) {
+            // Everything here is asserted during delivery: reading the event
+            // afterwards would find an unwound trace either way.
+            updates++;
+            traceLength = e.renderingTrace.length;
+            expect(() => e.localStartPosition, throwsStateError);
+            canvasStart = e.canvasStartPosition.clone();
+            deviceStart = e.deviceStartPosition.clone();
+          },
+        );
+        final gate = EventGate(
+          position: Vector2.zero(),
+          size: Vector2.all(200),
+          children: [component],
+        );
+        await game.ensureAdd(gate);
+        await game.ready();
+
+        final dispatcher = game.firstChild<MultiDragScaleDispatcher>()!;
+        dispatcher.onScaleStart(
+          createScaleStartEvents(game: game, focalPoint: const Offset(10, 10)),
+        );
+
+        // The ancestor now swallows events, so hit testing no longer reaches
+        // the component, but the scale record still points at it.
+        gate.ignoreEvents = true;
+
+        dispatcher.onScaleUpdate(
+          createScaleUpdateEvents(game: game, focalPoint: const Offset(20, 20)),
+        );
+
+        // It is still delivered to, but with nothing behind it in the trace.
+        expect(updates, equals(1));
+        expect(traceLength, equals(0));
+        // Canvas and device coordinates never depend on the trace.
+        expect(canvasStart, Vector2.all(20));
+        expect(deviceStart, Vector2.all(20));
+      },
+    );
+  });
+
   testWidgets(
     'scale event scale factor respects camera & zoom',
     (tester) async {


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
Correct docs and adds specific tests about drag/scale events regarding pointer leave.

They claimed that moving a finger off a component makes `event.localPosition` return a point of NaNs, with an empty `renderingTrace`.

But that is `MouseMoveEvent`'s behaviour only, not drag/scale (it is the only event class that explicitly guards the getter -

```dart
static final _nanPoint = Vector2.all(double.nan);
// ...
return renderingTrace.isEmpty ? _nanPoint : renderingTrace.last;
```

,- which we can consider revisiting later).

`PositionEvent` and `DisplacementEvent` have no such guard, and the scenario as described does not even empty the trace: displacement events are collected with `checkContains: (_, __) => true`, so a component the pointer has left is still
visited, with local coordinates that are valid and merely fall outside its own bounds.

The existing test "drag event can move outside the component bounds and still fire" already relies on that, reading coordinates up to 115 on a 95-wide component.

The case that really does leave an empty trace is different: hit testing stops reaching the component altogether while it still holds the gesture (an ancestor turning on `IgnoreEvents` mid-drag, say). It is then delivered to through the dispatcher's records loop, and reading `local*` throws, while `canvas*` remain valid.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->