### PR TITLE
fix: Correct parent context lookup on LocationContextEvent

### DIFF
--- a/packages/flame/lib/src/events/messages/location_context_event.dart
+++ b/packages/flame/lib/src/events/messages/location_context_event.dart
@@ -20,10 +20,12 @@ abstract class LocationContextEvent<C, R> extends Event<R> {
 
   /// The context in the parent's coordinate space, containing start and end
   /// points.
+  ///
+  /// Null when the receiving component is the root of the delivery.
   C? get parentContext {
     if (renderingTrace.length >= 2) {
       final lastIndex = renderingTrace.length - 1;
-      return renderingTrace[lastIndex];
+      return renderingTrace[lastIndex - 1];
     } else {
       return null;
     }

--- a/packages/flame/test/events/component_mixins/tap_callbacks_test.dart
+++ b/packages/flame/test/events/component_mixins/tap_callbacks_test.dart
@@ -494,8 +494,92 @@ void main() {
       expect(trace[1], Vector2(100, 75));
       expect(trace[2], Vector2(190, 190));
       expect(trace[3], Vector2(200, 200));
+      expect(tapDownEvent!.parentContext, Vector2(100, 75));
     },
   );
+
+  testWidgets(
+    'parentContext is null when the game itself receives the event',
+    (tester) async {
+      Vector2? localPosition;
+      Vector2? parentContext;
+      final game = _TapWithCallbacksGame(
+        onTapDownCallback: (e) {
+          localPosition = e.localPosition;
+          parentContext = e.parentContext;
+        },
+      );
+      await tester.pumpWidget(GameWidget(game: game));
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tapAt(const Offset(200, 200));
+      await tester.pump(const Duration(seconds: 1));
+
+      // The game is the root of the delivery: it has local coordinates of its
+      // own, but nothing above it in the trace.
+      expect(localPosition, Vector2(200, 200));
+      expect(parentContext, isNull);
+    },
+  );
+
+  testWidgets(
+    'parentContext is also available on displacement events',
+    (tester) async {
+      Vector2? localStart;
+      Vector2? parentStart;
+      final game = FlameGame(
+        children: [
+          PositionComponent(
+            size: Vector2.all(400),
+            position: Vector2.all(10),
+            children: [
+              _DragWithParentContextComponent(
+                size: Vector2.all(200),
+                position: Vector2.all(40),
+                onDragUpdateCallback: (e) {
+                  localStart = e.localStartPosition;
+                  parentStart = e.parentContext?.start;
+                },
+              ),
+            ],
+          ),
+        ],
+      );
+      await tester.pumpWidget(GameWidget(game: game));
+      await tester.pump();
+      await tester.pump();
+
+      await tester.dragFrom(const Offset(100, 100), const Offset(20, 20));
+
+      // The dragged component sits at (40, 40) within its parent.
+      expect(localStart, isNotNull);
+      expect(parentStart! - localStart!, Vector2.all(40));
+    },
+  );
+}
+
+class _TapWithCallbacksGame extends FlameGame with TapCallbacks {
+  _TapWithCallbacksGame({required this.onTapDownCallback});
+
+  final void Function(TapDownEvent) onTapDownCallback;
+
+  @override
+  void onTapDown(TapDownEvent event) => onTapDownCallback(event);
+}
+
+class _DragWithParentContextComponent extends PositionComponent
+    with DragCallbacks {
+  _DragWithParentContextComponent({
+    required Vector2 super.position,
+    required Vector2 super.size,
+    required this.onDragUpdateCallback,
+  });
+
+  final void Function(DragUpdateEvent) onDragUpdateCallback;
+
+  @override
+  void onDragUpdate(DragUpdateEvent event) => onDragUpdateCallback(event);
 }
 
 class _TapWithCallbacksComponent extends PositionComponent with TapCallbacks {


### PR DESCRIPTION
<!-- Exclude from commit message -->
# Description


<!-- End of exclude from commit message -->
`parentContext` was returning `renderingTrace[length - 1]`, which is the current component's context, i.e., the last one (the exact same value `local*` gives) rather than the parent's. The `length >= 2` check was correct, but the access suffered from the famed off-by-one error.

It now returns the entry one level up, and I added a test, since this path was never exercised.
<!-- Exclude from commit message -->


## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org/
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->