### PR TITLE
fix: Keep TextComponent glyphs in place when its paint changes

### DIFF
--- a/packages/flame/lib/src/components/text_component.dart
+++ b/packages/flame/lib/src/components/text_component.dart
@@ -43,13 +43,13 @@ class TextComponent<T extends TextRenderer> extends PositionComponent
 
   void _updateElement() {
     _textElement = _textRenderer.format(_text);
+    _textElement.translate(0, _textElement.metrics.ascent);
   }
 
   @internal
   void updateBounds() {
     _updateElement();
     final measurements = _textElement.metrics;
-    _textElement.translate(0, measurements.ascent);
     size.setValues(measurements.width, measurements.height);
   }
 

--- a/packages/flame/test/components/text_component_test.dart
+++ b/packages/flame/test/components/text_component_test.dart
@@ -1,6 +1,7 @@
-import 'package:flame/src/components/text_component.dart';
+import 'package:flame/components.dart';
+import 'package:flame/text.dart';
+import 'package:flutter/painting.dart';
 import 'package:test/test.dart';
-import 'package:vector_math/vector_math.dart';
 
 void main() {
   group('TextComponent', () {
@@ -8,5 +9,52 @@ void main() {
       final t = TextComponent(text: 'foobar');
       expect(t.size, isNot(equals(Vector2.zero())));
     });
+
+    test('keeps the glyphs translated by the ascent after a paint change', () {
+      final elements = <_RecordingTextElement>[];
+      final component = TextComponent(
+        text: 'foo',
+        textRenderer: _RecordingTextRenderer(elements),
+      );
+      expect(elements.single.translations, [const Offset(0, _ascent)]);
+
+      component.setOpacity(0.5);
+
+      expect(elements, hasLength(2));
+      expect(elements.last.translations, [const Offset(0, _ascent)]);
+    });
   });
+}
+
+const _ascent = 10.0;
+
+class _RecordingTextRenderer extends TextRenderer {
+  _RecordingTextRenderer(this.elements);
+
+  final List<_RecordingTextElement> elements;
+
+  @override
+  InlineTextElement format(String text) {
+    final element = _RecordingTextElement();
+    elements.add(element);
+    return element;
+  }
+
+  @override
+  TextRenderer copyWithPaint(Paint paint) => _RecordingTextRenderer(elements);
+}
+
+class _RecordingTextElement extends InlineTextElement {
+  final translations = <Offset>[];
+
+  @override
+  LineMetrics get metrics => LineMetrics(ascent: _ascent, width: 30);
+
+  @override
+  void draw(Canvas canvas) {}
+
+  @override
+  void translate(double dx, double dy) {
+    translations.add(Offset(dx, dy));
+  }
 }


### PR DESCRIPTION
# Description
<!-- End of exclude from commit message -->
The first time an `OpacityEffect` (or any paint change through `HasPaint`) updates a `TextComponent`, the glyphs jump up by one font ascent and stay there (#4014).

`updateBounds` translates the freshly formatted element down by its ascent, but `onChanged` rebuilt the element through `_updateElement` without that translation, so every element created after a paint change was drawn one ascent too high.

The translation now lives in `_updateElement`, which both paths share, so an element is always translated exactly once. `updateBounds` still reads the width and height after the update; `LineMetrics.translate` moves only `left` and `baseline`, so the size is unchanged.

The new test uses a recording `TextRenderer` and asserts that the element created by the constructor and the element created by `setOpacity` both receive the ascent translation. It fails on `main` and passes here.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues

Closes #4014

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
