### PR TITLE
fix: Fade TextComponent shadows and fill together under OpacityEffect

### DIFF
--- a/packages/flame/lib/src/components/text_box_component.dart
+++ b/packages/flame/lib/src/components/text_box_component.dart
@@ -401,7 +401,7 @@ class TextBoxComponent<T extends TextRenderer> extends TextComponent {
         line = line.substring(0, nChars);
       }
 
-      final textElement = textRenderer.format(line);
+      final textElement = paintedTextRenderer.format(line);
       final metrics = textElement.metrics;
 
       final position = Vector2(

--- a/packages/flame/lib/src/components/text_component.dart
+++ b/packages/flame/lib/src/components/text_component.dart
@@ -20,6 +20,8 @@ class TextComponent<T extends TextRenderer> extends PositionComponent
     super.key,
   }) : _text = text ?? '',
        _textRenderer = textRenderer ?? TextRendererFactory.createDefault<T>() {
+    _paintedTextRenderer = _textRenderer;
+    _seedPaintColor();
     updateBounds();
   }
 
@@ -32,17 +34,41 @@ class TextComponent<T extends TextRenderer> extends PositionComponent
     }
   }
 
+  /// The renderer as given by the user. Setting it also starts [paint] from
+  /// the style's own color, see [paintedTextRenderer].
   T get textRenderer => _textRenderer;
   T _textRenderer;
   set textRenderer(T textRenderer) {
     _textRenderer = textRenderer;
+    _paintedTextRenderer = textRenderer;
+    _seedPaintColor();
     updateBounds();
+  }
+
+  /// [textRenderer] with the component's [paint] applied, which is what the
+  /// text is drawn with. It is derived from [textRenderer] again on every
+  /// paint change, so the paint never compounds across changes.
+  @internal
+  T get paintedTextRenderer => _paintedTextRenderer;
+  late T _paintedTextRenderer;
+
+  /// Starts [paint] from the style's own color, so that the first paint change
+  /// (for example an `OpacityEffect`) fades the text in its color instead of
+  /// replacing it with the default white paint.
+  void _seedPaintColor() {
+    final renderer = _textRenderer;
+    if (renderer is TextPaint) {
+      final color = renderer.style.color;
+      if (color != null) {
+        paint.color = color;
+      }
+    }
   }
 
   late InlineTextElement _textElement;
 
   void _updateElement() {
-    _textElement = _textRenderer.format(_text);
+    _textElement = _paintedTextRenderer.format(_text);
   }
 
   @internal
@@ -60,7 +86,7 @@ class TextComponent<T extends TextRenderer> extends PositionComponent
 
   @override
   void onChanged() {
-    _textRenderer = _textRenderer.copyWithPaint(paint) as T;
+    _paintedTextRenderer = _textRenderer.copyWithPaint(paint) as T;
     _updateElement();
   }
 }

--- a/packages/flame/lib/src/text/renderers/text_paint.dart
+++ b/packages/flame/lib/src/text/renderers/text_paint.dart
@@ -58,8 +58,20 @@ class TextPaint extends TextRenderer {
   TextRenderer copyWithPaint(Paint paint) {
     return copyWith(
       (style) {
+        final shadows = style.shadows;
         return style.copyWith(
           foreground: paint,
+          shadows: shadows
+              ?.map(
+                (shadow) => Shadow(
+                  color: shadow.color.withValues(
+                    alpha: shadow.color.a * paint.color.a,
+                  ),
+                  offset: shadow.offset,
+                  blurRadius: shadow.blurRadius,
+                ),
+              )
+              .toList(),
         );
       },
     );

--- a/packages/flame/test/components/text_component_test.dart
+++ b/packages/flame/test/components/text_component_test.dart
@@ -1,12 +1,80 @@
-import 'package:flame/src/components/text_component.dart';
+import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
+import 'package:flame/text.dart';
+import 'package:flame_test/flame_test.dart';
+import 'package:flutter/rendering.dart';
 import 'package:test/test.dart';
-import 'package:vector_math/vector_math.dart';
 
 void main() {
   group('TextComponent', () {
     test('sets the size of the text component', () {
       final t = TextComponent(text: 'foobar');
       expect(t.size, isNot(equals(Vector2.zero())));
+    });
+
+    testWithFlameGame(
+      'fades the text in its own color and the shadows with it under an '
+      'OpacityEffect',
+      (game) async {
+        const color = Color(0xFF2E9940);
+        const shadowColor = Color(0x99FFFFFF);
+        final component = TextComponent(
+          text: '+1 kr',
+          textRenderer: TextPaint(
+            style: const TextStyle(
+              color: color,
+              shadows: [Shadow(color: shadowColor, blurRadius: 4)],
+            ),
+          ),
+        );
+        await game.ensureAdd(component);
+        component.add(OpacityEffect.fadeOut(EffectController(duration: 1)));
+
+        game.update(0.5);
+        var style = component.paintedTextRenderer.style;
+        final fill = style.foreground!.color;
+        expect(fill.toARGB32() & 0xFFFFFF, color.toARGB32() & 0xFFFFFF);
+        expectDouble(fill.a, 0.5, epsilon: 0.05);
+        var shadow = style.shadows!.single;
+        expect(
+          shadow.color.toARGB32() & 0xFFFFFF,
+          shadowColor.toARGB32() & 0xFFFFFF,
+        );
+        expectDouble(shadow.color.a, shadowColor.a * 0.5, epsilon: 0.05);
+
+        game.update(0.5);
+        style = component.paintedTextRenderer.style;
+        expectDouble(style.foreground!.color.a, 0.0, epsilon: 0.05);
+        shadow = style.shadows!.single;
+        expectDouble(shadow.color.a, 0.0, epsilon: 0.05);
+      },
+    );
+
+    test('applies the paint to the renderer the user set, not to a copy', () {
+      const color = Color(0xFF2E9940);
+      const shadowColor = Color(0x99FFFFFF);
+      final component = TextComponent(
+        text: '+1 kr',
+        textRenderer: TextPaint(
+          style: const TextStyle(
+            color: color,
+            shadows: [Shadow(color: shadowColor, blurRadius: 4)],
+          ),
+        ),
+      );
+
+      component.setOpacity(0.5);
+      component.textRenderer = component.textRenderer.copyWith(
+        (style) => style.copyWith(fontSize: 30),
+      );
+      component.setOpacity(0.25);
+
+      expect(component.textRenderer.style.color, color);
+      expect(component.textRenderer.style.shadows!.single.color, shadowColor);
+      final painted = component.paintedTextRenderer.style;
+      expect(painted.fontSize, 30);
+      expectDouble(painted.foreground!.color.a, 0.25);
+      expectDouble(painted.shadows!.single.color.a, shadowColor.a * 0.25);
     });
   });
 }

--- a/packages/flame/test/components/text_component_test.dart
+++ b/packages/flame/test/components/text_component_test.dart
@@ -75,6 +75,7 @@ void main() {
       expect(painted.fontSize, 30);
       expectDouble(painted.foreground!.color.a, 0.25);
       expectDouble(painted.shadows!.single.color.a, shadowColor.a * 0.25);
+    });
 
     test('keeps the glyphs translated by the ascent after a paint change', () {
       final elements = <_RecordingTextElement>[];


### PR DESCRIPTION
# Description
<!-- End of exclude from commit message -->
When an `OpacityEffect` runs on a `TextComponent` whose `TextPaint` style defines `shadows`, the glyphs fade but the shadows keep their original alpha, and the first paint change replaces the text colour with the component's default white paint, so coloured text snaps to white as the fade begins (#4013).

`TextPaint.copyWithPaint` only swapped the style's `foreground` for the component's paint, so `style.shadows` never followed the paint's alpha. The component also derived each new renderer from the previous derived one, so any per-update scaling would have compounded.

This PR:

- scales every shadow's alpha by the paint's alpha in `TextPaint.copyWithPaint`, keeping the paint itself as the foreground so colour filters and other paint properties still apply;
- derives every paint change from the renderer the user gave, so the alpha is always relative to the original style and never compounds. `textRenderer` now returns that renderer rather than the last derived copy, which also makes `textRenderer = textRenderer.copyWith(...)` safe after an effect has run; the copy with the paint applied is the new `@internal` `paintedTextRenderer`, used for drawing by `TextComponent` and `TextBoxComponent`;
- seeds the component's paint colour from the style's colour at construction and when `textRenderer` is set, so the fade starts from the text's own colour instead of white. Setting `paint.color` afterwards still overrides it; note that assigning a new `textRenderer` reseeds it.

The new tests run `OpacityEffect.fadeOut` for half its duration and check that the fill keeps its RGB at half alpha and the shadow keeps its RGB at half its own alpha, then that both reach zero; and that a `textRenderer` round-trip between two opacity changes keeps the original colour and shadow and scales only once. Both fail on `main` and pass here.

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues

Closes #4013

<!-- Links -->
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
