### PR TITLE
fix: Notify the component when ColorEffect resets its color filter

### DIFF
--- a/packages/flame/lib/src/effects/color_effect.dart
+++ b/packages/flame/lib/src/effects/color_effect.dart
@@ -53,5 +53,6 @@ class ColorEffect extends ComponentEffect<HasPaint> {
   void reset() {
     super.reset();
     target.getPaint(paintId).colorFilter = _original;
+    target.onChanged();
   }
 }

--- a/packages/flame/test/effects/color_effect_test.dart
+++ b/packages/flame/test/effects/color_effect_test.dart
@@ -109,14 +109,14 @@ void main() {
         await component.ensureAdd(effect);
         game.update(0.5);
         expect(
-          component.textRenderer.style.foreground!.colorFilter,
+          component.paintedTextRenderer.style.foreground!.colorFilter,
           isNotNull,
         );
 
         effect.reset();
 
         expect(
-          component.textRenderer.style.foreground!.colorFilter,
+          component.paintedTextRenderer.style.foreground!.colorFilter,
           isNull,
         );
       },

--- a/packages/flame/test/effects/color_effect_test.dart
+++ b/packages/flame/test/effects/color_effect_test.dart
@@ -97,6 +97,32 @@ void main() {
     );
 
     testWithFlameGame(
+      'reset notifies the component of the restored color filter',
+      (game) async {
+        final component = TextComponent<TextPaint>(text: 'foo');
+        await game.ensureAdd(component);
+
+        final effect = ColorEffect(
+          Colors.red,
+          EffectController(duration: 1),
+        );
+        await component.ensureAdd(effect);
+        game.update(0.5);
+        expect(
+          component.textRenderer.style.foreground!.colorFilter,
+          isNotNull,
+        );
+
+        effect.reset();
+
+        expect(
+          component.textRenderer.style.foreground!.colorFilter,
+          isNull,
+        );
+      },
+    );
+
+    testWithFlameGame(
       'can be re-added in the component tree',
       (game) async {
         final component = _PaintComponent();


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
<!-- End of exclude from commit message -->
Stacked on #4043.

`ColorEffect.reset()` restored the original color filter directly on the paint without calling
`HasPaint.onChanged()`. Components that derive their rendering from the paint, such as
`TextComponent`, therefore kept the last tint after the effect was reset, until something else
changed the paint.

`reset()` now calls `onChanged()` after restoring the color filter, in line with `tint`, `setColor`
and the opacity setter in `HasPaint`.

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require Flame users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version in-between the two following tags:
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

- Closes #1234
-->

Related to #4013 and #4043.

[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/flame-engine/flame/blob/main/CHANGELOG.md
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
<!-- End of exclude from commit message -->
